### PR TITLE
Perf: reserve arrayFirst and arrayLast results

### DIFF
--- a/src/Functions/array/arrayFirstLast.cpp
+++ b/src/Functions/array/arrayFirstLast.cpp
@@ -64,11 +64,10 @@ struct ArrayFirstLastImpl
             if (column_filter_const->getValue<UInt8>())
             {
                 const auto & offsets = array.getOffsets();
+                size_t offsets_size = offsets.size();
                 const auto & data = array.getData();
                 auto out = data.cloneEmpty();
-                out->reserve(data.size());
-
-                size_t offsets_size = offsets.size();
+                out->reserve(offsets_size);
 
                 ColumnUInt8::MutablePtr col_null_map_to;
                 ColumnUInt8::Container * vec_null_map_to = nullptr;
@@ -120,11 +119,10 @@ struct ArrayFirstLastImpl
 
         const auto & filter = column_filter->getData();
         const auto & offsets = array.getOffsets();
+        size_t offsets_size = offsets.size();
         const auto & data = array.getData();
         auto out = data.cloneEmpty();
-        out->reserve(data.size());
-
-        size_t offsets_size = offsets.size();
+        out->reserve(offsets_size);
 
         ColumnUInt8::MutablePtr col_null_map_to;
         ColumnUInt8::Container * vec_null_map_to = nullptr;
@@ -298,4 +296,3 @@ Returns the last element in the source array for which a lambda `func(x [, y1, y
 }
 
 }
-

--- a/tests/performance/array_first_last.xml
+++ b/tests/performance/array_first_last.xml
@@ -1,16 +1,30 @@
 <test>
+    <!--
+        arrayFirst and arrayLast build one result value per input array with a generic insertFrom loop.
+        The result used to reserve the number of nested source elements instead of the number of arrays.
+    -->
     <settings>
         <max_threads>1</max_threads>
     </settings>
 
-    <!-- The source arrays are deliberately wider than the one-element-per-row result. -->
-    <query>SELECT sum(arrayFirst(x -> 1, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT sum(arrayLast(x -> 1, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT sum(arrayFirst(x -> x % 2 = 0, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT sum(arrayLast(x -> x % 2 = 0, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
+    <substitutions>
+        <substitution>
+            <name>type</name>
+            <values>
+                <value>Decimal64(3)</value>
+                <value>Int128</value>
+                <value>Decimal256(3)</value>
+            </values>
+        </substitution>
+    </substitutions>
 
-    <query>SELECT sum(arrayFirst(x -> 1, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
-    <query>SELECT sum(arrayLast(x -> 1, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
-    <query>SELECT sum(arrayFirst(x -> x % 2 = 0, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
-    <query>SELECT sum(arrayLast(x -> x % 2 = 0, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; 1, materialize(range(8)::Array({type}))) FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, materialize(range(8)::Array({type}))) FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; x &gt; 3, materialize(range(32)::Array({type}))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; x &gt; 3, materialize(range(32)::Array({type}))) FROM numbers(2000000) FORMAT Null</query>
+
+    <query>SELECT arrayFirst(x -&gt; 1, materialize(arrayMap(x -&gt; (x, x), range(32)))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, materialize(arrayMap(x -&gt; (x, x), range(32)))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; 1, materialize(arrayMap(x -&gt; [x, x], range(32)))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, materialize(arrayMap(x -&gt; [x, x], range(32)))) FROM numbers(2000000) FORMAT Null</query>
 </test>

--- a/tests/performance/array_first_last.xml
+++ b/tests/performance/array_first_last.xml
@@ -1,0 +1,16 @@
+<test>
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <!-- The source arrays are deliberately wider than the one-element-per-row result. -->
+    <query>SELECT sum(arrayFirst(x -> 1, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT sum(arrayLast(x -> 1, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT sum(arrayFirst(x -> x % 2 = 0, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT sum(arrayLast(x -> x % 2 = 0, arrayResize([toUInt64(number)], 32))) FROM numbers(2000000) FORMAT Null</query>
+
+    <query>SELECT sum(arrayFirst(x -> 1, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
+    <query>SELECT sum(arrayLast(x -> 1, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
+    <query>SELECT sum(arrayFirst(x -> x % 2 = 0, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
+    <query>SELECT sum(arrayLast(x -> x % 2 = 0, arrayResize([toUInt64(number)], 128))) FROM numbers(500000) FORMAT Null</query>
+</test>

--- a/tests/performance/array_first_last.xml
+++ b/tests/performance/array_first_last.xml
@@ -1,30 +1,74 @@
 <test>
     <!--
-        arrayFirst and arrayLast build one result value per input array with a generic insertFrom loop.
-        The result used to reserve the number of nested source elements instead of the number of arrays.
+        Populate the arrays before the timed queries. Constructing temporary arrays with arrayResize inside
+        the query would add allocation and copy work that is unrelated to arrayFirst/arrayLast.
     -->
     <settings>
         <max_threads>1</max_threads>
     </settings>
 
-    <substitutions>
-        <substitution>
-            <name>type</name>
-            <values>
-                <value>Decimal64(3)</value>
-                <value>Int128</value>
-                <value>Decimal256(3)</value>
-            </values>
-        </substitution>
-    </substitutions>
+    <create_query>
+        CREATE TABLE array_first_last_32
+        (
+            x Array(UInt64)
+        )
+        ENGINE = Memory
+    </create_query>
 
-    <query>SELECT arrayFirst(x -&gt; 1, materialize(range(8)::Array({type}))) FROM numbers(10000000) FORMAT Null</query>
-    <query>SELECT arrayLast(x -&gt; 1, materialize(range(8)::Array({type}))) FROM numbers(10000000) FORMAT Null</query>
-    <query>SELECT arrayFirst(x -&gt; x &gt; 3, materialize(range(32)::Array({type}))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT arrayLast(x -&gt; x &gt; 3, materialize(range(32)::Array({type}))) FROM numbers(2000000) FORMAT Null</query>
+    <create_query>
+        CREATE TABLE array_first_last_128
+        (
+            x Array(UInt64)
+        )
+        ENGINE = Memory
+    </create_query>
 
-    <query>SELECT arrayFirst(x -&gt; 1, materialize(arrayMap(x -&gt; (x, x), range(32)))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT arrayLast(x -&gt; 1, materialize(arrayMap(x -&gt; (x, x), range(32)))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT arrayFirst(x -&gt; 1, materialize(arrayMap(x -&gt; [x, x], range(32)))) FROM numbers(2000000) FORMAT Null</query>
-    <query>SELECT arrayLast(x -&gt; 1, materialize(arrayMap(x -&gt; [x, x], range(32)))) FROM numbers(2000000) FORMAT Null</query>
+    <create_query>
+        CREATE TABLE array_first_last_complex
+        (
+            tuple_values Array(Tuple(UInt64, UInt64)),
+            nested_values Array(Array(UInt64))
+        )
+        ENGINE = Memory
+    </create_query>
+
+    <fill_query>
+        INSERT INTO array_first_last_32
+        SELECT arrayResize([toUInt64(number)], 32)
+        FROM numbers(2000000)
+    </fill_query>
+
+    <fill_query>
+        INSERT INTO array_first_last_128
+        SELECT arrayResize([toUInt64(number)], 128)
+        FROM numbers(500000)
+    </fill_query>
+
+    <fill_query>
+        INSERT INTO array_first_last_complex
+        SELECT
+            arrayMap(x -&gt; (x, x), range(32)),
+            arrayMap(x -&gt; [x, x], range(32))
+        FROM numbers(250000)
+    </fill_query>
+
+    <!-- Constant predicate path. -->
+    <query>SELECT arrayFirst(x -&gt; 1, x) FROM array_first_last_32 FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, x) FROM array_first_last_32 FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; 1, x) FROM array_first_last_128 FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, x) FROM array_first_last_128 FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; 1, tuple_values) FROM array_first_last_complex FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, tuple_values) FROM array_first_last_complex FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; 1, nested_values) FROM array_first_last_complex FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; 1, nested_values) FROM array_first_last_complex FORMAT Null</query>
+
+    <!-- Regular filter path. -->
+    <query>SELECT arrayFirst(x -&gt; x &gt; 3, x) FROM array_first_last_32 FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; x &gt; 3, x) FROM array_first_last_32 FORMAT Null</query>
+    <query>SELECT arrayFirst(x -&gt; x &gt; 3, x) FROM array_first_last_128 FORMAT Null</query>
+    <query>SELECT arrayLast(x -&gt; x &gt; 3, x) FROM array_first_last_128 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS array_first_last_32</drop_query>
+    <drop_query>DROP TABLE IF EXISTS array_first_last_128</drop_query>
+    <drop_query>DROP TABLE IF EXISTS array_first_last_complex</drop_query>
 </test>


### PR DESCRIPTION
Related performance PR: #115011

The same implementation was previously updated for Variant correctness in #100255. This PR is separate and only changes output capacity planning.

### Description

- **Problem:** the generic `arrayFirst` and `arrayLast` paths reserve the output column using the total number of nested source elements.
- **Actual output:** the loop inserts one value for each outer array.
- **Change:** reserve `offsets.size()`, which is the exact output size.
- **Scope:** both the constant-predicate and normal filter paths. The shared implementation also covers `arrayFirstOrNull` and `arrayLastOrNull`.
- **Behavior:** unchanged. Only the output capacity planning changes.

### Benchmark

- **Added:** `tests/performance/array_first_last.xml`
- **Setup:** arrays are populated once in `Memory` tables, so timed queries do not include temporary-array construction.
- **Coverage:** `arrayFirst` and `arrayLast`, constant and non-constant predicates, arrays with 32 and 128 elements, plus `Tuple` and nested `Array` values.
- **Workload:** 12 single-threaded queries with `FORMAT Null`.
- **Method:** CI compares the before/after ClickHouse binaries with the performance-test harness.
- **Results:** see the performance dashboard below.

### Performance dashboard

[Performance dashboard](https://performance.ci.clickhouse.com/runs?q=118188) results for the latest comparison (`aa0d9383` → `e9f1919e`):

| Metric | `array_first_last` result |
| --- | --- |
| Client time | No material change detected; small mixed deltas across AMD and ARM. |
| Memory usage | **84.5%–96.0% lower** across AMD and ARM. |
| CPU time | No consistent change detected; results are mixed. |
| Real time | No consistent change detected; results are mixed. |
| Overall run | 6 slowdowns, 8 speedups, 30 unstable queries, 630 tests. |

The clear signal is the memory reduction expected from reserving space for the result rows. Timing metrics remain within normal variation for this workload.

### Tests

- `git diff --check`
- Parsed `tests/performance/array_first_last.xml` successfully.

### Changelog category

- Performance Improvement

### Changelog entry

Improve generic `arrayFirst` and `arrayLast` performance by reserving space for the result rows.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118188&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118188](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118188+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1357` (included in `26.9` and later)
<!-- ch-version-info:end -->