### PR TITLE
Perf: skip redundant timeSeries*ToGrid sample validation

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -151,11 +151,13 @@ public:
         sort();
     }
 
-    /// Throws if any sample's timestamp is outside the range.
+    /// Throws if any sample's timestamp is outside the closed range.
+    /// For a sorted buffer, checking the first and last timestamps is sufficient.
     template <typename RangeType>
     void checkTimestampsInRange(const RangeType & range) const
     {
-        if (sorted && !buffer.empty() && range.contains(buffer.front().first) && range.contains(buffer.back().first))
+        if (sorted && !buffer.empty() && range.contains(buffer.front().first)
+            && (buffer.size() == 1 || range.contains(buffer.back().first)))
             return;
 
         forEachSample([&range](TimestampType timestamp, ValueType)

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -155,6 +155,9 @@ public:
     template <typename RangeType>
     void checkTimestampsInRange(const RangeType & range) const
     {
+        if (sorted && !buffer.empty() && range.contains(buffer.front().first) && range.contains(buffer.back().first))
+            return;
+
         forEachSample([&range](TimestampType timestamp, ValueType)
         {
             if (!range.contains(timestamp))

--- a/tests/performance/timeseries_to_grid_deserialization.xml
+++ b/tests/performance/timeseries_to_grid_deserialization.xml
@@ -1,0 +1,39 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_aggregate_functions>1</allow_experimental_time_series_aggregate_functions>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <!--
+        Benchmarks deserialization of timeSeries*ToGrid aggregate states. The input rows are ordered by series and
+        timestamp, so every state is serialized with a sorted sample buffer and its first and last timestamps prove
+        that all samples belong to their bucket ranges. This isolates the endpoint fast path in
+        AggregateFunctionTimeseriesSamples::checkTimestampsInRange from the grid calculation itself.
+    -->
+
+    <create_query>
+        CREATE TABLE ts_deserialization
+        (
+            id UInt16,
+            state AggregateFunction(timeSeriesRateToGrid(0, 100000, 10, 300), DateTime, Float64)
+        )
+        ENGINE = MergeTree
+        ORDER BY id
+    </create_query>
+
+    <!-- 1000 series, 10000 sorted samples per state, 10M samples total. -->
+    <fill_query>
+        INSERT INTO ts_deserialization
+        SELECT
+            (number % 1000)::UInt16 AS id,
+            timeSeriesRateToGridState(0, 100000, 10, 300)(
+                toDateTime(intDiv(number, 1000) * 10),
+                (number % 1000)::Float64) AS state
+        FROM numbers(1000 * 10000)
+        GROUP BY id
+    </fill_query>
+
+    <query>SELECT state FROM ts_deserialization FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS ts_deserialization</drop_query>
+</test>

--- a/tests/performance/timeseries_to_grid_deserialization.xml
+++ b/tests/performance/timeseries_to_grid_deserialization.xml
@@ -15,19 +15,19 @@
         CREATE TABLE ts_deserialization
         (
             id UInt16,
-            state AggregateFunction(timeSeriesRateToGrid(0, 100000, 10, 300), DateTime, Float64)
+            state AggregateFunction(timeSeriesRateToGrid(0, 100000, 100, 300), DateTime, Float64)
         )
         ENGINE = MergeTree
         ORDER BY id
     </create_query>
 
-    <!-- 1000 series, 10000 sorted samples per state, 10M samples total. -->
+    <!-- 1000 series, 10000 sorted samples per state, 10M samples total. The 100-second step puts about 100 samples in each bucket. -->
     <fill_query>
         INSERT INTO ts_deserialization
         SELECT
             (number % 1000)::UInt16 AS id,
-            timeSeriesRateToGridState(0, 100000, 10, 300)(
-                toDateTime(intDiv(number, 1000) * 10),
+            timeSeriesRateToGridState(0, 100000, 100, 300)(
+                toDateTime(intDiv(number, 1000)),
                 (number % 1000)::Float64) AS state
         FROM numbers(1000 * 10000)
         GROUP BY id

--- a/tests/performance/timeseries_to_grid_deserialization.xml
+++ b/tests/performance/timeseries_to_grid_deserialization.xml
@@ -5,9 +5,9 @@
     </settings>
 
     <!--
-        Benchmarks deserialization of timeSeries*ToGrid aggregate states. The input rows are ordered by series and
-        timestamp, so every state is serialized with a sorted sample buffer and its first and last timestamps prove
-        that all samples belong to their bucket ranges. This isolates the endpoint fast path in
+        Benchmarks deserialization of timeSeries*ToGrid aggregate states. Each series receives timestamps in
+        ascending order, so every state is serialized with a sorted sample buffer and its first and last timestamps
+        prove that all samples belong to their bucket ranges. This isolates the endpoint fast path in
         AggregateFunctionTimeseriesSamples::checkTimestampsInRange from the grid calculation itself.
     -->
 
@@ -15,7 +15,7 @@
         CREATE TABLE ts_deserialization
         (
             id UInt16,
-            state AggregateFunction(timeSeriesRateToGrid(0, 100000, 100, 300), DateTime, Float64)
+            state AggregateFunction(timeSeriesRateToGrid(0, 10000, 100, 300), DateTime, Float64)
         )
         ENGINE = MergeTree
         ORDER BY id
@@ -26,7 +26,7 @@
         INSERT INTO ts_deserialization
         SELECT
             (number % 1000)::UInt16 AS id,
-            timeSeriesRateToGridState(0, 100000, 100, 300)(
+            timeSeriesRateToGridState(0, 10000, 100, 300)(
                 toDateTime(intDiv(number, 1000)),
                 (number % 1000)::Float64) AS state
         FROM numbers(1000 * 10000)


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Skip per-sample timestamp validation when sorted `timeSeries*ToGrid` bucket endpoints prove the closed range.

### Description

`timeSeries*ToGrid` aggregate states validate every sample while deserializing. Samples in the normal sorted state are stored in timestamp order, so the first and last timestamps are enough to prove that the complete buffer belongs to the bucket range.

This change:

- checks the first timestamp and, for larger buffers, the last timestamp;
- avoids checking the same timestamp twice for a singleton buffer;
- keeps the existing per-sample validation for unsorted buffers;
- keeps the existing error for invalid serialized data;
- does not change the serialized format.

### Performance coverage

The new `tests/performance/timeseries_to_grid_deserialization.xml` fixture writes 1,000 aggregate states with 10,000 sorted samples per state. Samples for each series are 1 second apart, while the grid step is 100 seconds, so each populated bucket contains about 100 samples. The grid ends at 10,000 seconds and the state column is then read to exercise aggregate-state deserialization over large sorted sample buffers.

### Related work

- [#114889](https://github.com/ClickHouse/ClickHouse/pull/114889) adds a cheaper per-sample add path.
- [#115041](https://github.com/ClickHouse/ClickHouse/pull/115041) buckets samples in runs.
- [#118163](https://github.com/ClickHouse/ClickHouse/pull/118163) fuses the `addMany()` copy and order check.
- [#57545](https://github.com/ClickHouse/ClickHouse/issues/57545) tracks the broader PromQL support work.

This PR only changes validation during time-series aggregate-state deserialization.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118189&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118189](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118189+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.875` (included in `26.9` and later)
<!-- ch-version-info:end -->