### PR TITLE
Fix(PromQL): Validate label names in label_join and label_replace

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLabelManipulationFunction.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLabelManipulationFunction.cpp
@@ -4,6 +4,8 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/Prometheus/stepsInTimeSeriesRange.h>
+#include <Common/isValidUTF8.h>
+#include <Common/quoteString.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
 #include <Storages/TimeSeries/timeSeriesTypesToAST.h>
@@ -24,6 +26,20 @@ namespace DB::PrometheusQueryToSQL
 
 namespace
 {
+    void checkLabelName(std::string_view function_name, const SQLQueryPiece & argument, size_t argument_number)
+    {
+        const auto & label_name = argument.string_value;
+        if (label_name.empty() || !UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(label_name.data()), label_name.size()))
+        {
+            throw Exception(
+                ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                "Function '{}' received invalid label name {} in argument #{}",
+                function_name,
+                quoteString(label_name),
+                argument_number);
+        }
+    }
+
     /// Checks if the types of the specified arguments are valid for a label manipulation function.
     void checkArgumentTypes(
         const PrometheusQueryTree::Function * function_node, const std::vector<SQLQueryPiece> & arguments, const ConverterContext & context)
@@ -65,6 +81,18 @@ namespace
                                 "Function '{}' expects argument #{} of type {}, but expression {} has type {}",
                                 function_name, i + 1, ResultType::STRING, getPromQLText(argument, context), argument.type);
             }
+        }
+
+        if (function_name == "label_replace")
+        {
+            checkLabelName(function_name, arguments[1], 2);
+        }
+        else
+        {
+            for (size_t i = 3; i < arguments.size(); ++i)
+                checkLabelName(function_name, arguments[i], i + 1);
+
+            checkLabelName(function_name, arguments[1], 2);
         }
     }
 

--- a/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.reference
+++ b/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.reference
@@ -1,0 +1,6 @@
+-- valid UTF-8 label names are accepted
+1
+1
+-- label_replace keeps the empty source-label behavior
+1
+-- invalid label names are rejected

--- a/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.reference
+++ b/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.reference
@@ -3,4 +3,5 @@
 1
 -- label_replace keeps the empty source-label behavior
 1
+1
 -- invalid label names are rejected

--- a/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.sql
+++ b/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.sql
@@ -17,6 +17,7 @@ SELECT count() FROM prometheusQuery('prometheus', 'label_replace(m, "é", "$1", 
 
 SELECT '-- label_replace keeps the empty source-label behavior';
 SELECT count() FROM prometheusQuery('prometheus', 'label_replace(m, "dst", "constant", "", ".*")', 110);
+SELECT count() FROM prometheusQuery('prometheus', 'label_replace(m, "dst", "constant", "\\xff", ".*")', 110);
 
 SELECT '-- invalid label names are rejected';
 SELECT * FROM prometheusQuery('prometheus', 'label_join(m, "dst", "-", "\\xff")', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }

--- a/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.sql
+++ b/tests/queries/0_stateless/05076_promql_label_manipulation_label_names.sql
@@ -1,0 +1,28 @@
+-- Tags: no-fasttest
+-- PromQL needs ANTLR4, which is disabled in the fast-test build.
+
+DROP TABLE IF EXISTS prometheus;
+
+SET session_timezone = 'UTC';
+SET allow_experimental_time_series_table = 1;
+
+CREATE TABLE prometheus ENGINE = TimeSeries;
+
+INSERT INTO prometheus (metric_name, tags, time_series) VALUES
+    ('m', map('src', 'value'), [(toDateTime64(100, 3), 1.5), (toDateTime64(110, 3), 2.5)]);
+
+SELECT '-- valid UTF-8 label names are accepted';
+SELECT count() FROM prometheusQuery('prometheus', 'label_join(m, "é", "-", "src")', 110);
+SELECT count() FROM prometheusQuery('prometheus', 'label_replace(m, "é", "$1", "src", "(.*)")', 110);
+
+SELECT '-- label_replace keeps the empty source-label behavior';
+SELECT count() FROM prometheusQuery('prometheus', 'label_replace(m, "dst", "constant", "", ".*")', 110);
+
+SELECT '-- invalid label names are rejected';
+SELECT * FROM prometheusQuery('prometheus', 'label_join(m, "dst", "-", "\\xff")', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'label_join(m, "\\xff", "-", "src")', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'label_join(m, "", "-", "src")', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'label_replace(m, "\\xff", "$1", "src", ".*")', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'label_replace(m, "", "$1", "src", ".*")', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+
+DROP TABLE prometheus;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
PromQL: validate label names in `label_join` and `label_replace`.

### Summary

ClickHouse accepted some `label_join` and `label_replace` queries that Prometheus rejects because their label-name arguments were not validated.

- `label_join` validates its destination and every source label name.
- `label_replace` validates only its destination label, matching Prometheus.
- Valid UTF-8 names remain supported.
- Empty or invalid UTF-8 `label_replace` source names remain accepted and behave like missing labels.
- Invalid validated names fail with `CANNOT_EXECUTE_PROMQL_QUERY`.

### References

- [`label_replace` validation](https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L2495-L2497)
- [`label_join` source and destination validation](https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L2538-L2547)
- [Prometheus UTF-8 label-name validation](https://github.com/prometheus/common/blob/main/model/labels.go#L106-L108)

### Tests

Added stateless coverage for valid UTF-8 names, empty or invalid `label_replace` source names, invalid `label_replace` destinations, and invalid `label_join` source or destination names.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118190&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118190](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118190+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
