### PR TITLE
Docs: distinguish Inkeep documentation subcategories

### DIFF
--- a/docs/_site/customizations/inkeep-init.js
+++ b/docs/_site/customizations/inkeep-init.js
@@ -106,17 +106,24 @@
     return [
       // Let the row wrap and stop the single-line horizontal scroll.
       LIST + ' { flex-wrap: wrap !important; overflow-x: visible !important; row-gap: 0.375rem; }',
+      // Categories share a compact tag size; a mild radius keeps their edges
+      // distinct from the fully rounded search controls.
+      TAB + ' { font-size: 0.8125rem !important; min-height: 1.75rem !important; padding-inline: 0.625rem !important; border-radius: 12px !important; }',
       // Force ordering: row-1 tabs, then a break, then the sub-area tabs.
       row1 + ' { order: 0; }',
-      SUB + ' { order: 2; display: none !important; }',
+      // Sub-areas use an outline and muted inactive state to distinguish them
+      // from their parent categories.
+      SUB + ' { order: 2; display: none !important; box-shadow: inset 0 0 0 1px currentColor !important; }',
+      SUB + ':not([data-state="active"]) { background: transparent !important; opacity: 0.7; }',
       // Reveal the sub-area tabs only when Docs (or a sub-area) is active.
       docsActive + ' ' + SUB + ', ' + subActive + ' ' + SUB + ' { display: inline-flex !important; }',
       // A full-width pseudo-element (a flex item of the tab-list) ordered
       // between row-1 and the sub-areas forces the sub-areas onto their own
-      // second line — only while that row is showing. No DOM injection, so it
-      // survives Inkeep's re-renders.
+      // second line — only while that row is showing. It also supplies a
+      // subtle visual divider. No DOM injection, so it survives Inkeep's
+      // re-renders.
       docsActive + '::before, ' + subActive + '::before' +
-        ' { content: ""; order: 1; flex: 0 0 100%; height: 0; }',
+        ' { content: ""; order: 1; flex: 0 0 100%; height: 1px; margin-block: 0.125rem; background: currentColor; opacity: 0.18; }',
     ].join('');
   }
 


### PR DESCRIPTION
Separates the `Docs` category from its nested documentation areas in the `Inkeep` search filter bar. Both levels use the same compact 12px-rounded tag size; subcategories are outlined and muted while inactive, and a subtle divider separates the two rows. Without this it isn't clear that these are sub-filters of the top level filter.

<img width="649" height="479" alt="image" src="https://github.com/user-attachments/assets/efc60345-efc3-425b-92ea-ed54418c5dbd" />


### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
N/A

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118191&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118191](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118191+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
