### PR TITLE
Require the whole `ALTER TABLE` grant to imply `ALTER VIEW`

### DIFF
--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -119,7 +119,7 @@ AccessRights ContextAccess::addImplicitAccessRights(const AccessRights & access,
         if (res & drop_table)
             res |= drop_view;
 
-        if (res & alter_table)
+        if (res.contains(alter_table))
             res |= alter_view;
 
         /// CREATE TABLE (on any database/table) => CREATE_TEMPORARY_TABLE (global)

--- a/tests/queries/0_stateless/04990_implicit_alter_view_requires_full_alter_table.reference
+++ b/tests/queries/0_stateless/04990_implicit_alter_view_requires_full_alter_table.reference
@@ -1,0 +1,13 @@
+one ALTER TABLE child on the view:
+ACCESS_DENIED
+ALTER VIEW MODIFY QUERY
+no ALTER grant at all:
+ACCESS_DENIED
+whole ALTER TABLE group on the view:
+OK
+one ALTER TABLE child on the database:
+ACCESS_DENIED
+whole ALTER TABLE group on the database:
+OK
+the granted privilege still works:
+OK

--- a/tests/queries/0_stateless/04990_implicit_alter_view_requires_full_alter_table.sh
+++ b/tests/queries/0_stateless/04990_implicit_alter_view_requires_full_alter_table.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `ALTER VIEW` is implicitly enabled by the `ALTER TABLE` group as a whole, not by a single child
+# of that group. So one child privilege such as `ALTER MODIFY COMMENT` must not confer
+# `ALTER VIEW MODIFY QUERY`, while the full `ALTER TABLE` grant must. The same holds for a grant
+# on a whole database.
+
+src="t_src_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+dst="t_dst_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+mview="mv_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+user_partial="u_partial_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+user_none="u_none_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+user_full="u_full_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+user_wild="u_wild_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+users=("${user_partial}" "${user_none}" "${user_full}" "${user_wild}")
+
+${CLICKHOUSE_CLIENT} --query "DROP VIEW IF EXISTS ${mview}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${src}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${dst}"
+for u in "${users[@]}"; do
+    ${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${u}"
+done
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${src} (a UInt32) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${dst} (a UInt32) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} --query "CREATE MATERIALIZED VIEW ${mview} TO ${dst} AS SELECT a FROM ${src}"
+
+# The only difference between the users is their ALTER grant.
+for u in "${users[@]}"; do
+    ${CLICKHOUSE_CLIENT} --query "CREATE USER ${u}"
+    ${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON ${src} TO ${u}"
+    ${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON ${dst} TO ${u}"
+done
+
+${CLICKHOUSE_CLIENT} --query "GRANT ALTER MODIFY COMMENT ON ${mview} TO ${user_partial}"
+${CLICKHOUSE_CLIENT} --query "GRANT ALTER TABLE ON ${mview} TO ${user_full}"
+${CLICKHOUSE_CLIENT} --query "GRANT ALTER UPDATE ON ${CLICKHOUSE_DATABASE}.* TO ${user_wild}"
+
+echo "one ALTER TABLE child on the view:"
+err=$(${CLICKHOUSE_CLIENT} --user "${user_partial}" --query "ALTER TABLE ${mview} MODIFY QUERY SELECT a FROM ${src}" 2>&1)
+echo "$err" | grep -o -m1 "ACCESS_DENIED"
+echo "$err" | grep -o -m1 "ALTER VIEW MODIFY QUERY"
+
+echo "no ALTER grant at all:"
+${CLICKHOUSE_CLIENT} --user "${user_none}" --query "ALTER TABLE ${mview} MODIFY QUERY SELECT a FROM ${src}" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+echo "whole ALTER TABLE group on the view:"
+${CLICKHOUSE_CLIENT} --user "${user_full}" --query "ALTER TABLE ${mview} MODIFY QUERY SELECT a FROM ${src}" && echo "OK"
+
+echo "one ALTER TABLE child on the database:"
+${CLICKHOUSE_CLIENT} --user "${user_wild}" --query "ALTER TABLE ${mview} MODIFY QUERY SELECT a FROM ${src}" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+${CLICKHOUSE_CLIENT} --query "GRANT ALTER TABLE ON ${CLICKHOUSE_DATABASE}.* TO ${user_wild}"
+
+echo "whole ALTER TABLE group on the database:"
+${CLICKHOUSE_CLIENT} --user "${user_wild}" --query "ALTER TABLE ${mview} MODIFY QUERY SELECT a FROM ${src}" && echo "OK"
+
+echo "the granted privilege still works:"
+${CLICKHOUSE_CLIENT} --user "${user_partial}" --query "ALTER TABLE ${mview} MODIFY COMMENT 'c'" && echo "OK"
+
+${CLICKHOUSE_CLIENT} --query "DROP VIEW ${mview}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ${src}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ${dst}"
+for u in "${users[@]}"; do
+    ${CLICKHOUSE_CLIENT} --query "DROP USER ${u}"
+done


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/14674


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a privilege escalation in implicit access-rights computation: holding any single child privilege of the `ALTER TABLE` group (for example `ALTER MODIFY COMMENT`) on a view implicitly conferred the entire `ALTER VIEW` group, so such a user could run `ALTER TABLE <view> MODIFY QUERY` and rewrite the view's query. `ALTER VIEW` is now implied only by the complete `ALTER TABLE` grant. A deployment that relied on a partial `ALTER TABLE` grant to alter views must now grant `ALTER VIEW` (or one of its members) or the full `ALTER TABLE` explicitly.


### Description

`ContextAccess::addImplicitAccessRights` tested whether the effective rights *overlap* the `ALTER TABLE` mask before implying `ALTER VIEW`:

```cpp
if (res & alter_table)
    res |= alter_view;
```

`AccessFlags::operator bool` is `!isEmpty()`, and `ALTER TABLE` is a `GROUP` whose bitmask is the union of its 17 children, so holding **any one** child satisfied the test. A user granted only `ALTER MODIFY COMMENT` on a view therefore received the whole `ALTER VIEW` group, and `ALTER VIEW MODIFY QUERY` is the privilege that `ALTER TABLE <view> MODIFY QUERY` declares (`InterpreterAlterQuery.cpp`), so that user could rewrite the view's query. A user holding no `ALTER`-family grant is correctly refused the same statement, so the check was genuinely bypassed rather than absent. The modifier also runs at every node of the rights tree, so `GRANT ALTER UPDATE ON db.*` conferred `ALTER VIEW MODIFY QUERY` on every view in `db`.

The intended semantics is containment, and `AccessType.h` already documents `ALTER VIEW` as "implicitly enabled by the grant ALTER_TABLE", i.e. the group grant. The fix uses `AccessFlags::contains`. The sibling `CREATE TABLE` and `DROP TABLE` implications are deliberately left alone: both antecedents are leaf flags with 0 children, so `contains` there is a provable no-op.

Validation: a new stateless test whose two escalation arms fail before the fix and pass after, plus four controls that pass on both binaries. Measured separately on both builds: all 17 children of the group flip from allowed to denied, all three `ALTER VIEW` members are refused, and `ALTER VIEW` disappears from `SHOW GRANTS ... WITH IMPLICIT`. Column-level and role-split behaviour is unchanged.

This does not close #14674: a legitimate holder of `ALTER VIEW MODIFY QUERY` on a `SQL SECURITY DEFINER` view can still read through it, because table functions bypass the per-table `SELECT` check.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118194&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118194](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118194+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.79`, `26.7.7.68`, `26.6.5.56`, `26.3.32.13`
<!-- ch-version-info:end -->