### PR TITLE
Tolerate non-UTF-8 bytes when the integration harness decodes captured output

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -234,7 +234,7 @@ def run_and_check(
             logging.debug("Env:%s", env)
         if not nothrow:
             raise Exception(
-                f"Command [{shell_args}] return non-zero code {res.returncode}: {res.stderr.decode('utf-8')}"
+                f"Command [{shell_args}] return non-zero code {res.returncode}: {err}"
             )
     return out
 
@@ -4456,7 +4456,7 @@ class ClickHouseCluster:
 
             if not sanitizer_assert_instance:
                 # Search for sinitizer signs in docker.log if it's still empty
-                with open(self.docker_logs_path, "r") as f:
+                with open(self.docker_logs_path, "r", errors="replace") as f:
                     for line in f:
                         if SANITIZER_SIGN in line:
                             sanitizer_assert_instance = line.split("|")[0].strip()
@@ -6156,7 +6156,7 @@ class ClickHouseInstance:
             status = handle.status
             if status == "exited":
                 raise Exception(
-                    f"Instance `{self.name}' failed to start. Container status: {status}, logs: {handle.logs().decode('utf-8')}"
+                    f"Instance `{self.name}' failed to start. Container status: {status}, logs: {handle.logs().decode('utf-8', errors='replace')}"
                 )
 
             deadline = start_time + timeout
@@ -6169,7 +6169,7 @@ class ClickHouseInstance:
             if current_time >= deadline:
                 raise Exception(
                     f"Timed out while waiting for instance `{self.name}' with ip address {self.ip_address} to start. "
-                    f"Container status: {status}, logs: {handle.logs().decode('utf-8')}"
+                    f"Container status: {status}, logs: {handle.logs().decode('utf-8', errors='replace')}"
                 )
 
             socket_timeout = min(timeout, deadline - current_time)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4454,7 +4454,7 @@ class ClickHouseCluster:
             if self.docker_logs_proc is not None:
                 self.docker_logs_proc.kill()
 
-            if not sanitizer_assert_instance:
+            if not sanitizer_assert_instance and not ignore_sanitizer:
                 # Search for sinitizer signs in docker.log if it's still empty
                 with open(self.docker_logs_path, "r", errors="replace") as f:
                     for line in f:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117974

One non-UTF-8 byte in `docker.log` aborts integration-test teardown and takes the sanitizer scan down with it.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Integration-test harness: tolerate non-UTF-8 bytes when decoding captured container output, so a single bad byte no longer aborts cluster teardown and the sanitizer scan, and honor `shutdown(ignore_sanitizer=True)` in the `docker.log` fallback scan.

### Description

**Observed.** `test_unknown_config_option/test.py::test_graphite_default_rule_type_not_all_rejected` passed, then failed in teardown with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8a in position 1655` at `helpers/cluster.py:4460` ([CI report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117974&sha=292e0d3fa52333a76a1028beaa0a682bc95965f4&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29)).

**Root cause: a silently reverted fix.** #74334 fixed this same `UnicodeDecodeError` in `shutdown` by adding `errors="replace"` to the single handle used for both directions. `3deae2dc5d90f6d0` (2025-02-14) then split it: capture moved into `save_logs`, and the scan got its own `open(..., "r")` with no `errors=`. The keyword travelled with the write half, where a subprocess writes to the raw descriptor and the handler never runs, so only the side that mattered lost it.

**Cost.** That statement is the fallback sanitizer detector and nothing catches it, so teardown also abandons `cleanup`. Raw sanitizer output is itself a prime source of non-UTF-8 bytes, so the scan is likeliest to die when it has something to find.

**Scope.** Two commits. The first restores tolerance at four sites, chosen by one rule: the decoded text only reaches a message or an ASCII-marker scan. Sites where the decoded value is the caller's datum, such as `get_container_logs`, stay strict, since tolerating bad bytes there could mask a defect. The second closes an adjacent gap raised in review: of the three sanitizer scans in `shutdown`, only the `docker.log` fallback was not gated on `not ignore_sanitizer`, so it could raise even when the caller asked to ignore reports. That gap predates this branch (`291dd76d7739487`).

**Validation.** Each decode site was exercised both directions over a `0x8a` fixture; reverting any one edit reddens only its own arm. Driving the real `shutdown` over five fixtures with `ignore_sanitizer=True`: master raises on 4 of 5, the decode fix alone on 3 of 5, with the guard 0 of 5. With `ignore_sanitizer=False` all three sign-bearing fixtures are still detected, so no signal is lost. CIDB: one occurrence in 90 days, none on `master`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118195&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118195](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118195+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1356` (included in `26.9` and later)
<!-- ch-version-info:end -->