### PR TITLE
Do not decide what data a TTL merge removes from the TTL info stored in the part

### DIFF
--- a/src/Processors/TTL/ITTLAlgorithm.h
+++ b/src/Processors/TTL/ITTLAlgorithm.h
@@ -32,8 +32,9 @@ public:
     /// Updates TTL metadata of the data_part.
     virtual void finalize(const MutableDataPartPtr & data_part) const = 0;
 
+    /// `old_ttl_info` summarizes a past evaluation of the TTL expression, so it may schedule work
+    /// but must not decide what data survives.
     bool isMinTTLExpired() const { return force || isTTLExpired(old_ttl_info.min); }
-    bool isMaxTTLExpired() const { return isTTLExpired(old_ttl_info.max); }
 
     /// Resolve the column type once and fill `timestamps` for the whole block. Every TTL algorithm
     /// and `TTLDeleteFilterTransform` map a TTL result column to Unix timestamps through here.

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -128,9 +128,6 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
         /* adaptive_aggregator_freeze_threshold_bytes */ 0);
 
     aggregator = std::make_unique<Aggregator>(header, params);
-
-    if (isMaxTTLExpired())
-        new_ttl_info.ttl_finished = true;
 }
 
 void TTLAggregationAlgorithm::execute(Block & block)
@@ -219,6 +216,13 @@ void TTLAggregationAlgorithm::execute(Block & block)
             }
             else
             {
+                if (where_filter_passed)
+                {
+                    /// Rows that don't pass the filter should not affect TTL.
+                    new_ttl_info.update(cur_ttl);
+                    any_row_kept_unexpired = true;
+                }
+
                 for (const auto & name : column_names)
                 {
                     const IColumn * values_column = block.getByName(name).column.get();
@@ -227,6 +231,8 @@ void TTLAggregationAlgorithm::execute(Block & block)
                 }
             }
         }
+
+        rows_seen += block.rows();
 
         if (rows_with_current_key)
         {
@@ -332,14 +338,15 @@ void TTLAggregationAlgorithm::finalizeAggregates(MutableColumns & result_columns
 
 void TTLAggregationAlgorithm::finalize(const MutableDataPartPtr & data_part) const
 {
-    if (new_ttl_info.finished())
-    {
-        data_part->ttl_infos.group_by_ttl[description.result_column] = new_ttl_info;
-        data_part->ttl_infos.updatePartMinMaxTTL(new_ttl_info);
-        return;
-    }
-    data_part->ttl_infos.group_by_ttl[description.result_column] = old_ttl_info;
-    data_part->ttl_infos.updatePartMinMaxTTL(old_ttl_info);
+    auto ttl_info = new_ttl_info;
+
+    /// `ttl_finished` stops the part from being selected for this rule again, so only a pass that
+    /// actually saw rows may set it, and only when every one of them was rolled up.
+    if (rows_seen)
+        ttl_info.ttl_finished = !any_row_kept_unexpired;
+
+    data_part->ttl_infos.group_by_ttl[description.result_column] = ttl_info;
+    data_part->ttl_infos.updatePartMinMaxTTL(ttl_info);
 }
 
 }

--- a/src/Processors/TTL/TTLAggregationAlgorithm.h
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.h
@@ -38,6 +38,8 @@ private:
     ColumnRawPtrs key_columns;
     Aggregator::AggregateColumns columns_for_aggregator;
     bool no_more_keys = false;
+    bool any_row_kept_unexpired = false;
+    size_t rows_seen = 0;
 };
 
 }

--- a/src/Processors/TTL/TTLColumnAlgorithm.cpp
+++ b/src/Processors/TTL/TTLColumnAlgorithm.cpp
@@ -11,22 +11,17 @@ TTLColumnAlgorithm::TTLColumnAlgorithm(
     bool force_,
     const String & column_name_,
     const ExpressionActionsPtr & default_expression_,
-    const String & default_column_name_,
-    bool is_compact_part_)
+    const String & default_column_name_)
     : ITTLAlgorithm(ttl_expressions_, description_, old_ttl_info_, current_time_, force_)
     , column_name(column_name_)
     , default_expression(default_expression_)
     , default_column_name(default_column_name_)
-    , is_compact_part(is_compact_part_)
 {
     if (!isMinTTLExpired())
     {
         new_ttl_info = old_ttl_info;
         is_fully_empty = false;
     }
-
-    if (isMaxTTLExpired())
-        new_ttl_info.ttl_finished = true;
 }
 
 void TTLColumnAlgorithm::execute(Block & block)
@@ -44,32 +39,6 @@ void TTLColumnAlgorithm::execute(Block & block)
 
     auto & column_with_type = block.getByName(column_name);
 
-    /// The whole block is past the column TTL. Reset the column to its default so that
-    /// dependent skip indices or projections recalculate against the value the base table
-    /// will logically read. Evaluate the DDL `DEFAULT` expression (matching the per-row slow
-    /// path below), falling back to the type default only when the column has no `DEFAULT`.
-    /// Filling the type default here would make a rebuilt projection materialize the type
-    /// default (e.g. `0`) while the base reads the DDL default (e.g. `-1`) via `expired_columns`.
-    if (isMaxTTLExpired() && !is_compact_part)
-    {
-        auto result_column = column_with_type.column->cloneEmpty();
-        result_column->reserve(block.rows());
-
-        auto default_column = executeExpressionAndGetColumn(default_expression, block, default_column_name);
-        if (default_column)
-        {
-            default_column = default_column->convertToFullColumnIfConst();
-            result_column->insertRangeFrom(*default_column, 0, block.rows());
-        }
-        else
-        {
-            result_column->insertManyDefaults(block.rows());
-        }
-
-        column_with_type.column = std::move(result_column);
-        return;
-    }
-
     auto default_column = executeExpressionAndGetColumn(default_expression, block, default_column_name);
     if (default_column)
         default_column = default_column->convertToFullColumnIfConst();
@@ -77,6 +46,7 @@ void TTLColumnAlgorithm::execute(Block & block)
     auto ttl_column = executeExpressionAndGetColumn(ttl_expressions.expression, block, description.result_column);
 
     const size_t rows = block.rows();
+    rows_seen += rows;
     PaddedPODArray<Int64> timestamps;
     extractTimestamps(ttl_column.get(), timestamps);
 
@@ -107,9 +77,17 @@ void TTLColumnAlgorithm::execute(Block & block)
 
 void TTLColumnAlgorithm::finalize(const MutableDataPartPtr & data_part) const
 {
-    data_part->ttl_infos.columns_ttl[column_name] = new_ttl_info;
-    data_part->ttl_infos.updatePartMinMaxTTL(new_ttl_info);
-    if (is_fully_empty)
+    auto ttl_info = new_ttl_info;
+
+    /// Dropping the column, and marking the rule finished so the part is never examined for it
+    /// again, both need a pass that saw rows: `is_fully_empty` is still true when none arrived.
+    const bool evaluated_rows = isMinTTLExpired() && rows_seen;
+    if (evaluated_rows)
+        ttl_info.ttl_finished = is_fully_empty;
+
+    data_part->ttl_infos.columns_ttl[column_name] = ttl_info;
+    data_part->ttl_infos.updatePartMinMaxTTL(ttl_info);
+    if (is_fully_empty && evaluated_rows)
         data_part->expired_columns.insert(column_name);
 }
 

--- a/src/Processors/TTL/TTLColumnAlgorithm.h
+++ b/src/Processors/TTL/TTLColumnAlgorithm.h
@@ -18,8 +18,7 @@ public:
         bool force_,
         const String & column_name_,
         const ExpressionActionsPtr & default_expression_,
-        const String & default_column_name_,
-        bool is_compact_part_
+        const String & default_column_name_
     );
 
     void execute(Block & block) override;
@@ -31,7 +30,7 @@ private:
     const String default_column_name;
 
     bool is_fully_empty = true;
-    bool is_compact_part;
+    size_t rows_seen = 0;
 };
 
 }

--- a/src/Processors/TTL/TTLDeleteAlgorithm.cpp
+++ b/src/Processors/TTL/TTLDeleteAlgorithm.cpp
@@ -9,9 +9,6 @@ TTLDeleteAlgorithm::TTLDeleteAlgorithm(
 {
     if (!isMinTTLExpired())
         new_ttl_info = old_ttl_info;
-
-    if (isMaxTTLExpired())
-        new_ttl_info.ttl_finished = true;
 }
 
 void TTLDeleteAlgorithm::execute(Block & block)
@@ -52,6 +49,7 @@ void TTLDeleteAlgorithm::execute(Block & block)
         }
     }
 
+    rows_seen += rows;
     rows_removed += removed;
 
     if (removed == 0)
@@ -63,13 +61,20 @@ void TTLDeleteAlgorithm::execute(Block & block)
 
 void TTLDeleteAlgorithm::finalize(const MutableDataPartPtr & data_part) const
 {
+    auto ttl_info = new_ttl_info;
+
+    /// `ttl_finished` stops the part from being selected for this rule again, so only a pass that
+    /// actually saw rows may set it, and only when none of them survived.
+    if (isMinTTLExpired() && rows_seen)
+        ttl_info.ttl_finished = (rows_removed == rows_seen);
+
     if (ttl_expressions.where_expression)
         /// Rules sharing a time expression share this slot, so merge instead of overwriting.
-        data_part->ttl_infos.rows_where_ttl[description.result_column].update(new_ttl_info);
+        data_part->ttl_infos.rows_where_ttl[description.result_column].update(ttl_info);
     else
-        data_part->ttl_infos.table_ttl = new_ttl_info;
+        data_part->ttl_infos.table_ttl = ttl_info;
 
-    data_part->ttl_infos.updatePartMinMaxTTL(new_ttl_info);
+    data_part->ttl_infos.updatePartMinMaxTTL(ttl_info);
 }
 
 }

--- a/src/Processors/TTL/TTLDeleteAlgorithm.h
+++ b/src/Processors/TTL/TTLDeleteAlgorithm.h
@@ -18,6 +18,7 @@ public:
 
 private:
     size_t rows_removed = 0;
+    size_t rows_seen = 0;
 };
 
 }

--- a/src/Processors/Transforms/TTLDeleteFilterTransform.cpp
+++ b/src/Processors/Transforms/TTLDeleteFilterTransform.cpp
@@ -59,29 +59,22 @@ TTLDeleteFilterTransform::build(
         if (force || isTTLExpired(old_ttl_infos.table_ttl.min, current_time))
         {
             auto expressions = buildTTLExpressions(rows_ttl, subqueries, context);
-
-            if (isTTLExpired(old_ttl_infos.table_ttl.max, current_time) && !rows_ttl.where_expression_ast)
-                state->all_data_dropped = true;
-
             state->entries.push_back({std::move(expressions), rows_ttl});
         }
     }
 
-    if (!state->all_data_dropped)
+    for (const auto & where_ttl : metadata_snapshot->getRowsWhereTTLs())
     {
-        for (const auto & where_ttl : metadata_snapshot->getRowsWhereTTLs())
-        {
-            IMergeTreeDataPart::TTLInfo old_ttl_info;
-            auto it = old_ttl_infos.rows_where_ttl.find(where_ttl.result_column);
-            if (it != old_ttl_infos.rows_where_ttl.end())
-                old_ttl_info = it->second;
+        IMergeTreeDataPart::TTLInfo old_ttl_info;
+        auto it = old_ttl_infos.rows_where_ttl.find(where_ttl.result_column);
+        if (it != old_ttl_infos.rows_where_ttl.end())
+            old_ttl_info = it->second;
 
-            if (!force && !isTTLExpired(old_ttl_info.min, current_time))
-                continue;
+        if (!force && !isTTLExpired(old_ttl_info.min, current_time))
+            continue;
 
-            auto expressions = buildTTLExpressions(where_ttl, subqueries, context);
-            state->entries.push_back({std::move(expressions), where_ttl});
-        }
+        auto expressions = buildTTLExpressions(where_ttl, subqueries, context);
+        state->entries.push_back({std::move(expressions), where_ttl});
     }
 
     return {std::move(state), std::move(subqueries)};
@@ -104,12 +97,6 @@ void TTLDeleteFilterTransform::extractTimestamps(const IColumn * ttl_column)
 void TTLDeleteFilterTransform::transform(Chunk & chunk)
 {
     size_t num_rows = chunk.getNumRows();
-
-    if (shared_state->all_data_dropped)
-    {
-        chunk.addColumn(ColumnUInt8::create(num_rows, UInt8(0)));
-        return;
-    }
 
     if (num_rows == 0)
     {

--- a/src/Processors/Transforms/TTLDeleteFilterTransform.h
+++ b/src/Processors/Transforms/TTLDeleteFilterTransform.h
@@ -29,7 +29,6 @@ public:
             TTLDescription description;
         };
         std::vector<Entry> entries;
-        bool all_data_dropped = false;
         time_t current_time = 0;
     };
 

--- a/src/Processors/Transforms/TTLTransform.cpp
+++ b/src/Processors/Transforms/TTLTransform.cpp
@@ -72,10 +72,6 @@ TTLTransform::TTLTransform(
             getExpressions(rows_ttl, subqueries_for_sets, context), rows_ttl,
             old_ttl_infos.table_ttl, current_time_, force_);
 
-        /// Skip all data if table ttl is expired for part
-        if (algorithm->isMaxTTLExpired() && !rows_ttl.where_expression_ast)
-            all_data_dropped = true;
-
         algorithms.emplace_back(std::move(algorithm));
         delete_algorithm = static_cast<const TTLDeleteAlgorithm *>(algorithms.back().get());
     }
@@ -131,8 +127,7 @@ TTLTransform::TTLTransform(
                     force_,
                     name,
                     default_expression,
-                    default_column_name,
-                    isCompactPart(data_part)));
+                    default_column_name));
             }
         }
     }
@@ -159,12 +154,6 @@ static Block reorderColumns(Block block, const Block & header)
 
 void TTLTransform::consume(Chunk chunk)
 {
-    if (all_data_dropped)
-    {
-        finishConsume();
-        return;
-    }
-
     removeSpecialColumnRepresentations(chunk);
     auto block = getInputPort().getHeader().cloneWithColumns(chunk.detachColumns());
 
@@ -217,12 +206,7 @@ void TTLTransform::finalize()
         algorithm->finalize(data_part);
 
     if (delete_algorithm)
-    {
-        if (all_data_dropped)
-            LOG_DEBUG(log, "Removed all rows from part {} due to expired TTL", data_part->name);
-        else
-            LOG_DEBUG(log, "Removed {} rows with expired TTL from part {}", delete_algorithm->getNumberOfRemovedRows(), data_part->name);
-    }
+        LOG_DEBUG(log, "Removed {} rows with expired TTL from part {}", delete_algorithm->getNumberOfRemovedRows(), data_part->name);
     else
         LOG_DEBUG(log, "No delete algorithm was applied for part {}", data_part->name);
 }

--- a/src/Processors/Transforms/TTLTransform.h
+++ b/src/Processors/Transforms/TTLTransform.h
@@ -43,7 +43,6 @@ protected:
 private:
     std::vector<TTLAlgorithmPtr> algorithms;
     const TTLDeleteAlgorithm * delete_algorithm = nullptr;
-    bool all_data_dropped = false;
 
     PreparedSets::Subqueries subqueries_for_sets;
 

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -81,8 +81,7 @@ MergeSelectorChoices tryChooseTTLMerge(const ChooseContext & ctx)
             return pack(ctx, std::move(merge_ranges), MergeType::TTLDrop);
 
         /// A part larger than the byte budget is refused by every range, so expired data on a full
-        /// disk could never be freed. Only the byte budget is exempted here: `max_size_rows` is
-        /// finite exactly when a text or vector index would throw while being built above it.
+        /// disk could never be freed.
         std::vector<MergeConstraint> single_part_constraints;
         single_part_constraints.reserve(ctx.merge_constraints.size());
         for (const auto & constraint : ctx.merge_constraints)

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -75,11 +75,22 @@ MergeSelectorChoices tryChooseTTLMerge(const ChooseContext & ctx)
     /// Drop parts - 1 priority
     if (!ctx.merge_constraints.empty())
     {
-        /// The size of the completely expired part of TTL drop is not affected by the merge pressure and the size of the storage space.
-        std::vector<MergeConstraint> ttl_constraints(ctx.merge_constraints.size(), {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()});
         TTLPartDropMergeSelector drop_ttl_selector(ctx.current_time, ctx.merge_tree_settings[MergeTreeSetting::max_parts_to_merge_at_once]);
 
-        if (auto merge_ranges = drop_ttl_selector.select(ctx.ranges, ttl_constraints, ctx.range_filter); !merge_ranges.empty())
+        if (auto merge_ranges = drop_ttl_selector.select(ctx.ranges, ctx.merge_constraints, ctx.range_filter); !merge_ranges.empty())
+            return pack(ctx, std::move(merge_ranges), MergeType::TTLDrop);
+
+        /// A part larger than the byte budget is refused by every range, so expired data on a full
+        /// disk could never be freed. Only the byte budget is exempted here: `max_size_rows` is
+        /// finite exactly when a text or vector index would throw while being built above it.
+        std::vector<MergeConstraint> single_part_constraints;
+        single_part_constraints.reserve(ctx.merge_constraints.size());
+        for (const auto & constraint : ctx.merge_constraints)
+            single_part_constraints.emplace_back(std::numeric_limits<size_t>::max(), constraint.max_size_rows);
+
+        TTLPartDropMergeSelector single_part_selector(ctx.current_time, /*max_parts_to_drop_at_once_=*/ 1);
+
+        if (auto merge_ranges = single_part_selector.select(ctx.ranges, single_part_constraints, ctx.range_filter); !merge_ranges.empty())
             return pack(ctx, std::move(merge_ranges), MergeType::TTLDrop);
     }
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1116,77 +1116,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         && !use_const_adaptive_granularity
         && global_ctx->chosen_merge_algorithm == MergeAlgorithm::Vertical;
 
-    /// For TTLDrop merges, all source parts are fully expired.
-    /// Skip creating the read pipeline to avoid opening source parts
-    /// and allocating read/prefetch buffers.
-    ///
-    /// We restrict this to tables that have only an unconditional rows TTL
-    /// (no column TTL, moves, recompression, GROUP BY, or WHERE-clause TTL).
-    /// When other TTL families are present, TTLTransform::finalize rebuilds
-    /// their maps from scratch, and replicating that logic here would be
-    /// fragile. hasOnlyRowsTTL already excludes WHERE-clause TTLs.
-    const bool can_short_circuit_ttl_drop =
-        global_ctx->future_part->merge_type == MergeType::TTLDrop
-        && global_ctx->metadata_snapshot->hasOnlyRowsTTL();
-
-    if (can_short_circuit_ttl_drop)
-    {
-        LOG_DEBUG(ctx->log, "TTLDrop merge: skipping data pipeline, "
-            "all {} source parts are fully expired", global_ctx->future_part->parts.size());
-
-        global_ctx->ttl_drop_short_circuit = true;
-
-        /// Reset all ttl_infos and mark table TTL as finished, matching what
-        /// TTLTransform::finalize produces in the normal all_data_dropped path:
-        /// it clears everything with `data_part->ttl_infos = {}`, then
-        /// TTLDeleteAlgorithm::finalize sets table_ttl = {0, 0, finished}.
-        global_ctx->new_data_part->ttl_infos = {};
-        global_ctx->new_data_part->ttl_infos.table_ttl = {0, 0, true};
-
-        /// Clear projections — no rows means no projection data to merge or rebuild.
-        global_ctx->projections_to_rebuild.clear();
-        global_ctx->projections_to_merge.clear();
-        global_ctx->projections_to_merge_parts.clear();
-
-        /// Force Horizontal algorithm. This prevents the Vertical stage from trying
-        /// to finalize an empty rows_sources file, and ensures finalizePart takes
-        /// the correct code path. Reinitialize the column/index state to match the
-        /// Horizontal branch of the switch above — if chooseMergeAlgorithm picked
-        /// Vertical, merging_columns would be key-only and gathering_columns non-empty,
-        /// which would leave MergedBlockOutputStream with incomplete column metadata.
-        global_ctx->chosen_merge_algorithm = MergeAlgorithm::Horizontal;
-        global_ctx->merge_list_element_ptr->merge_algorithm.store(global_ctx->chosen_merge_algorithm, std::memory_order_relaxed);
-
-        global_ctx->merging_columns = global_ctx->storage_columns;
-        global_ctx->merging_columns_expired_by_ttl = global_ctx->storage_columns_expired_by_ttl;
-        global_ctx->gathering_columns.clear();
-
-        /// Reinitialize skip indexes to match the Horizontal branch setup.
-        /// We must NOT simply clear them: MergedBlockOutputStream writes empty
-        /// skip-index files (with checksums) even for 0-row parts. Clearing
-        /// would produce different checksums than the normal TTLDrop path,
-        /// causing divergence during rolling upgrades on replicated tables.
-        global_ctx->merging_skip_indexes.clear();
-        global_ctx->skip_indexes_by_column.clear();
-        global_ctx->text_indexes_to_merge.clear();
-
-        auto all_skip_indexes = global_ctx->metadata_snapshot->getSecondaryIndices();
-        for (const auto & index : all_skip_indexes)
-        {
-            if (!exclude_index_names.contains(index.name))
-            {
-                if (index.type == "text")
-                    global_ctx->text_indexes_to_merge.push_back(index);
-                else
-                    global_ctx->merging_skip_indexes.push_back(index);
-            }
-        }
-    }
-    else
-    {
-        /// Merged stream will be created and available as merged_stream variable
-        createMergedStream();
-    }
+    /// Merged stream will be created and available as merged_stream variable
+    createMergedStream();
 
     auto index_granularity_ptr = createMergeTreeIndexGranularity(
         ctx->sum_input_rows_upper_bound,
@@ -1771,13 +1702,6 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::executeMergeProjections() cons
 
 bool MergeTask::ExecuteAndFinalizeHorizontalPart::executeImpl() const
 {
-    /// TTLDrop short-circuit: no pipeline was created, skip directly to finalize.
-    if (global_ctx->ttl_drop_short_circuit)
-    {
-        finalize();
-        return false;
-    }
-
     Stopwatch watch(CLOCK_MONOTONIC_COARSE);
     UInt64 step_time_ms
         = (*global_ctx->data_settings)[MergeTreeSetting::background_task_preferred_step_execution_time_ms].totalMilliseconds();

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -232,10 +232,6 @@ private:
         bool cleanup{false};
         bool vertical_lightweight_delete{false};
         bool vertical_ttl_delete{false};
-        /// When true, all source parts are fully expired (MergeType::TTLDrop).
-        /// The data pipeline is skipped entirely — no readers are opened,
-        /// no buffers allocated, and the result is an empty part.
-        bool ttl_drop_short_circuit{false};
         CompressionCodecPtr compression_codec{nullptr};
         /// T when `compression_codec` came from an explicit (non-`Default`) `RECOMPRESS` TTL. Adaptive codec selection must not override it.
         bool is_explicit_recompression{false};

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -3419,6 +3419,11 @@ private:
 
     bool isRowsMaxTTLExpired() const
     {
+        /// With no TTL stage in the pipeline, `new_data_part->ttl_infos` is still the source part's
+        /// copy, so it says nothing about this part's rows.
+        if (ctx->execute_ttl_type == ExecuteTTLType::NONE)
+            return false;
+
         const auto ttl = ctx->new_data_part->ttl_infos.table_ttl;
         return ttl.max && ttl.max <= ctx->time_of_mutation;
     }

--- a/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.sql
+++ b/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.sql
@@ -46,8 +46,8 @@ SELECT 'test1_check_cols', sum(c1), sum(c2), sum(c3), sum(c4) FROM t_ttl_vert_1;
 SELECT 'test1_parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't_ttl_vert_1' AND active;
 
 SYSTEM FLUSH LOGS part_log;
--- Exclude TTLDropMerge: a background TTLDrop merge may race with OPTIMIZE FINAL
--- and use Horizontal algorithm due to the TTLDrop short-circuit optimization.
+-- Exclude TTLDropMerge: a background TTLDrop merge may race with OPTIMIZE FINAL, and this test is
+-- about the algorithm of the forced merge.
 SELECT 'test1_algo', merge_algorithm FROM system.part_log
     WHERE database = currentDatabase() AND table = 't_ttl_vert_1' AND event_type = 'MergeParts'
     AND merge_reason != 'TTLDropMerge'

--- a/tests/queries/0_stateless/04009_projection_aggregate_empty_block_from_ttl.sql
+++ b/tests/queries/0_stateless/04009_projection_aggregate_empty_block_from_ttl.sql
@@ -5,8 +5,8 @@
 -- The projection must handle this gracefully instead of throwing a LOGICAL_ERROR.
 --
 -- Key conditions to reproduce:
--- 1. TTL with WHERE clause disables the `all_data_dropped` optimization in TTLTransform,
---    so the merge pipeline processes blocks normally instead of short-circuiting.
+-- 1. A WHERE-clause TTL is evaluated per row, so the merge pipeline processes blocks normally
+--    and hands the filtered result to the projection.
 -- 2. Parts inserted BEFORE ADD PROJECTION lack the projection, forcing it to be rebuilt
 --    (not merged) during OPTIMIZE, which calls calculateProjections on each block.
 -- 3. All rows are already expired, so TTLDeleteAlgorithm removes all rows,

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
@@ -15,7 +15,7 @@ TTLDropMerge	0	200
 50
 50
 -- Case 6: TTLDrop with a rows TTL and a column TTL
-TTLDropMerge	0	1
+TTLDropMerge	0	200
 0
 -- Case 7: TTLDrop with a rows TTL and a GROUP BY TTL
 TTLDropMerge	100	200

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
@@ -8,15 +8,15 @@ TTLDropMerge	0	200
 -- Case 3: TTLDrop with skip indexes
 TTLDropMerge	0	200
 0
--- Case 4: WHERE-clause TTL is not short-circuited
+-- Case 4: TTLDrop with a WHERE-clause TTL
 TTLDropMerge	0	200
 0
 -- Case 5: Table works after TTLDrop
 50
 50
--- Case 6: Rows TTL + column TTL is not short-circuited
+-- Case 6: TTLDrop with a rows TTL and a column TTL
 TTLDropMerge	0	1
 0
--- Case 7: Rows TTL + GROUP BY TTL is not short-circuited
+-- Case 7: TTLDrop with a rows TTL and a GROUP BY TTL
 TTLDropMerge	100	200
 100

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
@@ -1,12 +1,12 @@
 -- Case 1: Basic TTLDrop
-TTLDropMerge	0	0	1
+TTLDropMerge	0	200	1
 0
 -- Case 2: TTLDrop with projections
-TTLDropMerge	0	0
+TTLDropMerge	0	200
 0
 []
 -- Case 3: TTLDrop with skip indexes
-TTLDropMerge	0	0
+TTLDropMerge	0	200
 0
 -- Case 4: WHERE-clause TTL is not short-circuited
 TTLDropMerge	0	200

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
@@ -209,7 +209,7 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_idx;"
 # TTLPartDropMergeSelector assigns TTLDrop based on part_max_ttl even with
 # a WHERE clause, and the WHERE clause can only be answered per row.
 # -------------------------------------------------------------------
-echo "-- Case 4: WHERE-clause TTL is not short-circuited"
+echo "-- Case 4: TTLDrop with a WHERE-clause TTL"
 
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE t_ttl_where_no_shortcircuit
@@ -301,7 +301,7 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_then_insert;"
 # How many rows the sources pushed depends on the granule size, so assert only
 # that they were read at all.
 # -------------------------------------------------------------------
-echo "-- Case 6: Rows TTL + column TTL is not short-circuited"
+echo "-- Case 6: TTLDrop with a rows TTL and a column TTL"
 
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE t_ttl_col
@@ -352,7 +352,7 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_col;"
 # another TTLDrop merge. Filter by length(merged_from) > 1 to only
 # look at the merge that actually combined two source parts.
 # -------------------------------------------------------------------
-echo "-- Case 7: Rows TTL + GROUP BY TTL is not short-circuited"
+echo "-- Case 7: TTLDrop with a rows TTL and a GROUP BY TTL"
 
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE t_ttl_groupby

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
@@ -298,8 +298,6 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_then_insert;"
 
 # -------------------------------------------------------------------
 # Case 6: Rows TTL + column TTL
-# How many rows the sources pushed depends on the granule size, so assert only
-# that they were read at all.
 # -------------------------------------------------------------------
 echo "-- Case 6: TTLDrop with a rows TTL and a column TTL"
 
@@ -332,7 +330,7 @@ ${CLICKHOUSE_CLIENT} -q "
     SELECT
         merge_reason,
         rows,
-        read_rows > 0
+        read_rows
     FROM system.part_log
     WHERE
         database = currentDatabase()

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
@@ -7,14 +7,13 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# Test that TTLDrop merges do not open source parts or read any data.
-# This is important because TTLDrop merges know that all rows in all source
-# parts are expired, so the merge should produce an empty part without
-# allocating read buffers for source parts.
+# Test that a TTLDrop merge produces an empty part, over projections, skip indexes, a WHERE-clause
+# TTL, a column TTL and a GROUP BY TTL, and that its memory stays bounded. A TTLDrop merge is
+# assigned from the bounds stored in `ttl.txt`, so it evaluates the current TTL expression over the
+# rows before concluding that nothing survives, and therefore reads its source parts.
 #
-# We avoid OPTIMIZE TABLE FINAL because it always assigns MergeType::Regular,
-# which would bypass our TTLDrop short-circuit. Instead we rely on background
-# TTL merges (merge_with_ttl_timeout = 0) and wait for them to complete.
+# We avoid OPTIMIZE TABLE FINAL because it always assigns MergeType::Regular. Instead we rely on
+# background TTL merges (merge_with_ttl_timeout = 0) and wait for them to complete.
 
 # Helper: wait until the background TTL merge completes (at most 1 active part),
 # then flush logs and wait for the MergeParts entry to appear.
@@ -43,7 +42,7 @@ function wait_for_ttl_merge_and_flush_logs()
 }
 
 # -------------------------------------------------------------------
-# Case 1: Basic TTLDrop — no data should be read
+# Case 1: Basic TTLDrop
 # -------------------------------------------------------------------
 echo "-- Case 1: Basic TTLDrop"
 
@@ -206,10 +205,9 @@ ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_idx;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_idx;"
 
 # -------------------------------------------------------------------
-# Case 4: WHERE-clause TTL does NOT short-circuit
+# Case 4: WHERE-clause TTL
 # TTLPartDropMergeSelector assigns TTLDrop based on part_max_ttl even with
-# a WHERE clause. Our short-circuit detects the WHERE clause and falls
-# through to the normal pipeline, so data IS read.
+# a WHERE clause, and the WHERE clause can only be answered per row.
 # -------------------------------------------------------------------
 echo "-- Case 4: WHERE-clause TTL is not short-circuited"
 
@@ -237,8 +235,6 @@ ${CLICKHOUSE_CLIENT} -q "
 
 wait_for_ttl_merge_and_flush_logs "t_ttl_where_no_shortcircuit"
 
-# Data IS read because the short-circuit detected the WHERE clause and
-# fell through to the normal pipeline.
 ${CLICKHOUSE_CLIENT} -q "
     SELECT
         merge_reason,
@@ -301,11 +297,9 @@ ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_then_insert;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_then_insert;"
 
 # -------------------------------------------------------------------
-# Case 6: Rows TTL + column TTL — not short-circuited
-# hasOnlyRowsTTL is false when column TTL is present, so data IS read.
-# The rows TTL alone covers every row, so `TTLTransform` closes the read side
-# once the merge emits its first block. How many rows the sources pushed before
-# that depends on the granule size, so assert only that they were read at all.
+# Case 6: Rows TTL + column TTL
+# How many rows the sources pushed depends on the granule size, so assert only
+# that they were read at all.
 # -------------------------------------------------------------------
 echo "-- Case 6: Rows TTL + column TTL is not short-circuited"
 
@@ -352,8 +346,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_col;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_col;"
 
 # -------------------------------------------------------------------
-# Case 7: Rows TTL + GROUP BY TTL — not short-circuited
-# hasOnlyRowsTTL is false when GROUP BY TTL is present, so data IS read.
+# Case 7: Rows TTL + GROUP BY TTL
 # After the first merge, surviving rows still have expired TTL, so
 # TTLPartDropMergeSelector may re-select the single merged part for
 # another TTLDrop merge. Filter by length(merged_from) > 1 to only

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
@@ -13,10 +13,14 @@ Vertical
 -- MATERIALIZE TTL repairs a part instead of emptying it
 1	42
 1
+-- a mutation that runs no TTL stage does not empty the part
+1	42
 -- genuinely expired rows are still deleted
 0
 -- GROUP BY TTL is not permanently disabled
 2	30
 [1]
+-- GROUP BY TTL, in-range control: an expired rule does roll the key up
+1	20
 -- a patch part that un-expires rows is honoured
 1	1

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
@@ -1,6 +1,7 @@
 -- rows TTL, horizontal merge
 1	42
 1
+Horizontal
 -- rows TTL, in-range control: the same DDL with the default materialize_ttl_after_modify
 1	42
 -- rows TTL, vertical merge

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
@@ -9,7 +9,7 @@ Horizontal
 Vertical
 -- column TTL, wide part
 1	7777
--- column TTL, compact part
+-- column TTL, compact part: in-range control (the values are already read per row here)
 1	7777
 -- MATERIALIZE TTL repairs a part instead of emptying it
 1	42

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.reference
@@ -1,0 +1,22 @@
+-- rows TTL, horizontal merge
+1	42
+1
+-- rows TTL, in-range control: the same DDL with the default materialize_ttl_after_modify
+1	42
+-- rows TTL, vertical merge
+2	3
+Vertical
+-- column TTL, wide part
+1	7777
+-- column TTL, compact part
+1	7777
+-- MATERIALIZE TTL repairs a part instead of emptying it
+1	42
+1
+-- genuinely expired rows are still deleted
+0
+-- GROUP BY TTL is not permanently disabled
+2	30
+[1]
+-- a patch part that un-expires rows is honoured
+1	1

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
@@ -1,0 +1,156 @@
+-- A merge must decide what data survives from the current TTL expression evaluated over the rows,
+-- not from the bounds stored in `ttl.txt`. `materialize_ttl_after_modify = 0` leaves a part whose
+-- stored bounds are expired under the retired rule while the live rule keeps every row, which is
+-- the state an upgrade also produces when the expression's evaluation semantics change.
+
+DROP TABLE IF EXISTS t_ttl_rows;
+DROP TABLE IF EXISTS t_ttl_rows_materialized;
+DROP TABLE IF EXISTS t_ttl_vertical;
+DROP TABLE IF EXISTS t_ttl_column_wide;
+DROP TABLE IF EXISTS t_ttl_column_compact;
+DROP TABLE IF EXISTS t_ttl_materialize;
+DROP TABLE IF EXISTS t_ttl_still_deletes;
+DROP TABLE IF EXISTS t_ttl_group_by;
+DROP TABLE IF EXISTS t_ttl_patch_part;
+
+SELECT '-- rows TTL, horizontal merge';
+
+CREATE TABLE t_ttl_rows (ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY tuple()
+TTL ts + INTERVAL 1 SECOND SETTINGS min_bytes_for_wide_part = 0;
+SYSTEM STOP MERGES t_ttl_rows;
+INSERT INTO t_ttl_rows VALUES (now() - INTERVAL 1 DAY, 42);
+ALTER TABLE t_ttl_rows MODIFY TTL ts + INTERVAL 10 YEAR SETTINGS materialize_ttl_after_modify = 0;
+SYSTEM START MERGES t_ttl_rows;
+OPTIMIZE TABLE t_ttl_rows FINAL;
+SELECT count(), sum(v) FROM t_ttl_rows;
+-- The merge also rewrites the stored bounds, so the part is no longer a trap for the next merge.
+SELECT delete_ttl_info_min > now() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_ttl_rows' AND active;
+
+SELECT '-- rows TTL, in-range control: the same DDL with the default materialize_ttl_after_modify';
+
+-- The mutation this ALTER submits only runs while merges are started, so the part is protected with
+-- `STOP TTL MERGES` rather than `STOP MERGES`: otherwise whichever of the two runs first decides the
+-- result.
+CREATE TABLE t_ttl_rows_materialized (ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY tuple()
+TTL ts + INTERVAL 1 SECOND SETTINGS min_bytes_for_wide_part = 0;
+SYSTEM STOP TTL MERGES t_ttl_rows_materialized;
+INSERT INTO t_ttl_rows_materialized VALUES (now() - INTERVAL 1 DAY, 42);
+ALTER TABLE t_ttl_rows_materialized MODIFY TTL ts + INTERVAL 10 YEAR
+SETTINGS materialize_ttl_after_modify = 1, mutations_sync = 2;
+SYSTEM START TTL MERGES t_ttl_rows_materialized;
+OPTIMIZE TABLE t_ttl_rows_materialized FINAL;
+SELECT count(), sum(v) FROM t_ttl_rows_materialized;
+
+SELECT '-- rows TTL, vertical merge';
+
+CREATE TABLE t_ttl_vertical (ts DateTime, a UInt64, b String) ENGINE = MergeTree ORDER BY tuple()
+TTL ts + INTERVAL 1 SECOND
+-- Every one of these is a condition `chooseMergeAlgorithm` tests, and the runner randomizes them:
+-- a part below `min_bytes_for_full_part_storage` gets Packed storage, which is horizontal-only.
+SETTINGS min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0,
+         enable_vertical_merge_algorithm = 1, vertical_merge_optimize_ttl_delete = 1,
+         vertical_merge_algorithm_min_rows_to_activate = 0,
+         vertical_merge_algorithm_min_columns_to_activate = 1;
+SYSTEM STOP MERGES t_ttl_vertical;
+INSERT INTO t_ttl_vertical VALUES (now() - INTERVAL 1 DAY, 1, 'x');
+INSERT INTO t_ttl_vertical VALUES (now() - INTERVAL 1 DAY, 2, 'y');
+ALTER TABLE t_ttl_vertical MODIFY TTL ts + INTERVAL 10 YEAR SETTINGS materialize_ttl_after_modify = 0;
+SYSTEM START MERGES t_ttl_vertical;
+OPTIMIZE TABLE t_ttl_vertical FINAL;
+SELECT count(), sum(a) FROM t_ttl_vertical;
+-- Without this the case would silently be a second horizontal-merge test.
+SYSTEM FLUSH LOGS part_log;
+SELECT merge_algorithm FROM system.part_log
+WHERE database = currentDatabase() AND table = 't_ttl_vertical' AND event_type = 'MergeParts'
+  AND length(merged_from) > 1
+ORDER BY event_time DESC LIMIT 1;
+
+SELECT '-- column TTL, wide part';
+
+CREATE TABLE t_ttl_column_wide (ts DateTime, v UInt64 TTL ts + INTERVAL 1 SECOND)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part = 0;
+SYSTEM STOP MERGES t_ttl_column_wide;
+INSERT INTO t_ttl_column_wide VALUES (now() - INTERVAL 1 DAY, 7777);
+ALTER TABLE t_ttl_column_wide MODIFY COLUMN v UInt64 TTL ts + INTERVAL 10 YEAR
+SETTINGS materialize_ttl_after_modify = 0;
+SYSTEM START MERGES t_ttl_column_wide;
+OPTIMIZE TABLE t_ttl_column_wide FINAL;
+SELECT count(), sum(v) FROM t_ttl_column_wide;
+
+SELECT '-- column TTL, compact part';
+
+CREATE TABLE t_ttl_column_compact (ts DateTime, v UInt64 TTL ts + INTERVAL 1 SECOND)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part = 1000000000;
+SYSTEM STOP MERGES t_ttl_column_compact;
+INSERT INTO t_ttl_column_compact VALUES (now() - INTERVAL 1 DAY, 7777);
+ALTER TABLE t_ttl_column_compact MODIFY COLUMN v UInt64 TTL ts + INTERVAL 10 YEAR
+SETTINGS materialize_ttl_after_modify = 0;
+SYSTEM START MERGES t_ttl_column_compact;
+OPTIMIZE TABLE t_ttl_column_compact FINAL;
+SELECT count(), sum(v) FROM t_ttl_column_compact;
+
+SELECT '-- MATERIALIZE TTL repairs a part instead of emptying it';
+
+CREATE TABLE t_ttl_materialize (ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY tuple()
+TTL ts + INTERVAL 1 SECOND SETTINGS min_bytes_for_wide_part = 0;
+SYSTEM STOP MERGES t_ttl_materialize;
+INSERT INTO t_ttl_materialize VALUES (now() - INTERVAL 1 DAY, 42);
+ALTER TABLE t_ttl_materialize MODIFY TTL ts + INTERVAL 10 YEAR SETTINGS materialize_ttl_after_modify = 0;
+SYSTEM START MERGES t_ttl_materialize;
+ALTER TABLE t_ttl_materialize MATERIALIZE TTL SETTINGS mutations_sync = 2;
+SELECT count(), sum(v) FROM t_ttl_materialize;
+SELECT delete_ttl_info_min > now() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_ttl_materialize' AND active;
+
+SELECT '-- genuinely expired rows are still deleted';
+
+CREATE TABLE t_ttl_still_deletes (ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY tuple()
+TTL ts + INTERVAL 1 SECOND SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_ttl_still_deletes VALUES (now() - INTERVAL 1 DAY, 42);
+OPTIMIZE TABLE t_ttl_still_deletes FINAL;
+SELECT count() FROM t_ttl_still_deletes;
+
+SELECT '-- GROUP BY TTL is not permanently disabled';
+
+-- The map key of a GROUP BY rule is the formatted expression text, so changing the interval would
+-- create a fresh key and force a full recalculation. Patching the column the expression reads keeps
+-- the key and leaves the stored bounds expired while no row is.
+CREATE TABLE t_ttl_group_by (k UInt64, ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY k
+TTL ts + INTERVAL 1 SECOND GROUP BY k SET v = max(v)
+SETTINGS min_bytes_for_wide_part = 0, enable_block_number_column = 1, enable_block_offset_column = 1;
+SYSTEM STOP MERGES t_ttl_group_by;
+INSERT INTO t_ttl_group_by VALUES (1, now() - INTERVAL 1 DAY, 10), (1, now() - INTERVAL 1 DAY, 20);
+SET enable_lightweight_update = 1;
+UPDATE t_ttl_group_by SET ts = toDateTime('2099-01-01 00:00:00') WHERE 1;
+SYSTEM START MERGES t_ttl_group_by;
+OPTIMIZE TABLE t_ttl_group_by FINAL;
+SELECT count(), sum(v) FROM t_ttl_group_by;
+-- {0, 0} here would mean the rule was persisted as finished and the rollup can never run again.
+-- The patch part carries no GROUP BY record, so it is not one of the parts under test.
+SELECT arrayMap(x -> x > now(), group_by_ttl_info.min) FROM system.parts
+WHERE database = currentDatabase() AND table = 't_ttl_group_by' AND active
+  AND notEmpty(group_by_ttl_info.min);
+
+SELECT '-- a patch part that un-expires rows is honoured';
+
+CREATE TABLE t_ttl_patch_part (id UInt64, ts DateTime) ENGINE = MergeTree ORDER BY id
+TTL ts + INTERVAL 1 SECOND
+SETTINGS min_bytes_for_wide_part = 0, enable_block_number_column = 1, enable_block_offset_column = 1;
+SYSTEM STOP MERGES t_ttl_patch_part;
+INSERT INTO t_ttl_patch_part VALUES (1, now() - INTERVAL 1 DAY), (2, now() - INTERVAL 1 DAY), (3, now() - INTERVAL 1 DAY);
+UPDATE t_ttl_patch_part SET ts = toDateTime('2099-01-01 00:00:00') WHERE id = 1;
+SYSTEM START MERGES t_ttl_patch_part;
+OPTIMIZE TABLE t_ttl_patch_part FINAL;
+-- Rows 2 and 3 are genuinely expired and must still go.
+SELECT count(), min(id) FROM t_ttl_patch_part;
+
+DROP TABLE t_ttl_rows;
+DROP TABLE t_ttl_rows_materialized;
+DROP TABLE t_ttl_vertical;
+DROP TABLE t_ttl_column_wide;
+DROP TABLE t_ttl_column_compact;
+DROP TABLE t_ttl_materialize;
+DROP TABLE t_ttl_still_deletes;
+DROP TABLE t_ttl_group_by;
+DROP TABLE t_ttl_patch_part;

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
@@ -86,7 +86,7 @@ SYSTEM START MERGES t_ttl_column_wide;
 OPTIMIZE TABLE t_ttl_column_wide FINAL;
 SELECT count(), sum(v) FROM t_ttl_column_wide;
 
-SELECT '-- column TTL, compact part';
+SELECT '-- column TTL, compact part: in-range control (the values are already read per row here)';
 
 CREATE TABLE t_ttl_column_compact (ts DateTime, v UInt64 TTL ts + INTERVAL 1 SECOND)
 ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part = 1000000000;

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
@@ -18,7 +18,8 @@ DROP TABLE IF EXISTS t_ttl_patch_part;
 SELECT '-- rows TTL, horizontal merge';
 
 CREATE TABLE t_ttl_rows (ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY tuple()
-TTL ts + INTERVAL 1 SECOND SETTINGS min_bytes_for_wide_part = 0;
+TTL ts + INTERVAL 1 SECOND
+SETTINGS min_bytes_for_wide_part = 0, enable_vertical_merge_algorithm = 0;
 SYSTEM STOP MERGES t_ttl_rows;
 INSERT INTO t_ttl_rows VALUES (now() - INTERVAL 1 DAY, 42);
 ALTER TABLE t_ttl_rows MODIFY TTL ts + INTERVAL 10 YEAR SETTINGS materialize_ttl_after_modify = 0;
@@ -28,6 +29,11 @@ SELECT count(), sum(v) FROM t_ttl_rows;
 -- The merge also rewrites the stored bounds, so the part is no longer a trap for the next merge.
 SELECT delete_ttl_info_min > now() FROM system.parts
 WHERE database = currentDatabase() AND table = 't_ttl_rows' AND active;
+-- Without this the case would silently be a second vertical-merge test.
+SYSTEM FLUSH LOGS part_log;
+SELECT merge_algorithm FROM system.part_log
+WHERE database = currentDatabase() AND table = 't_ttl_rows' AND event_type = 'MergeParts'
+ORDER BY event_time DESC LIMIT 1;
 
 SELECT '-- rows TTL, in-range control: the same DDL with the default materialize_ttl_after_modify';
 

--- a/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
+++ b/tests/queries/0_stateless/05076_ttl_merge_reevaluates_rows.sql
@@ -9,8 +9,10 @@ DROP TABLE IF EXISTS t_ttl_vertical;
 DROP TABLE IF EXISTS t_ttl_column_wide;
 DROP TABLE IF EXISTS t_ttl_column_compact;
 DROP TABLE IF EXISTS t_ttl_materialize;
+DROP TABLE IF EXISTS t_ttl_mutation_no_stage;
 DROP TABLE IF EXISTS t_ttl_still_deletes;
 DROP TABLE IF EXISTS t_ttl_group_by;
+DROP TABLE IF EXISTS t_ttl_group_by_control;
 DROP TABLE IF EXISTS t_ttl_patch_part;
 
 SELECT '-- rows TTL, horizontal merge';
@@ -103,6 +105,24 @@ SELECT count(), sum(v) FROM t_ttl_materialize;
 SELECT delete_ttl_info_min > now() FROM system.parts
 WHERE database = currentDatabase() AND table = 't_ttl_materialize' AND active;
 
+SELECT '-- a mutation that runs no TTL stage does not empty the part';
+
+-- `ttl_only_drop_parts` lets a mutation drop a part whose rows are all expired, which is decided from
+-- the bounds the new part inherited from its source. A mutation whose commands need no reading stage
+-- never recomputes them, so the inherited bounds are the retired rule's. TTL merges stay stopped for
+-- the whole case, so emptying the part here can only come from the mutation.
+CREATE TABLE t_ttl_mutation_no_stage (ts DateTime, v UInt64, c UInt64)
+ENGINE = MergeTree ORDER BY tuple() TTL ts + INTERVAL 1 SECOND
+SETTINGS min_bytes_for_wide_part = 0, ttl_only_drop_parts = 1;
+-- `STOP MERGES` would also stop mutations and `mutations_sync = 2` would then wait forever.
+SYSTEM STOP TTL MERGES t_ttl_mutation_no_stage;
+INSERT INTO t_ttl_mutation_no_stage VALUES (now() - INTERVAL 1 DAY, 42, 1);
+ALTER TABLE t_ttl_mutation_no_stage MODIFY TTL ts + INTERVAL 10 YEAR
+SETTINGS materialize_ttl_after_modify = 0;
+-- `DROP COLUMN` is a file rename, so nothing is read and no TTL stage is built.
+ALTER TABLE t_ttl_mutation_no_stage DROP COLUMN c SETTINGS mutations_sync = 2;
+SELECT count(), sum(v) FROM t_ttl_mutation_no_stage;
+
 SELECT '-- genuinely expired rows are still deleted';
 
 CREATE TABLE t_ttl_still_deletes (ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY tuple()
@@ -132,6 +152,16 @@ SELECT arrayMap(x -> x > now(), group_by_ttl_info.min) FROM system.parts
 WHERE database = currentDatabase() AND table = 't_ttl_group_by' AND active
   AND notEmpty(group_by_ttl_info.min);
 
+SELECT '-- GROUP BY TTL, in-range control: an expired rule does roll the key up';
+
+-- Without this the case above cannot tell a preserved rule from a fixture that never rolls up.
+CREATE TABLE t_ttl_group_by_control (k UInt64, ts DateTime, v UInt64) ENGINE = MergeTree ORDER BY k
+TTL ts + INTERVAL 1 SECOND GROUP BY k SET v = max(v)
+SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_ttl_group_by_control VALUES (1, now() - INTERVAL 1 DAY, 10), (1, now() - INTERVAL 1 DAY, 20);
+OPTIMIZE TABLE t_ttl_group_by_control FINAL;
+SELECT count(), sum(v) FROM t_ttl_group_by_control;
+
 SELECT '-- a patch part that un-expires rows is honoured';
 
 CREATE TABLE t_ttl_patch_part (id UInt64, ts DateTime) ENGINE = MergeTree ORDER BY id
@@ -151,6 +181,8 @@ DROP TABLE t_ttl_vertical;
 DROP TABLE t_ttl_column_wide;
 DROP TABLE t_ttl_column_compact;
 DROP TABLE t_ttl_materialize;
+DROP TABLE t_ttl_mutation_no_stage;
 DROP TABLE t_ttl_still_deletes;
 DROP TABLE t_ttl_group_by;
+DROP TABLE t_ttl_group_by_control;
 DROP TABLE t_ttl_patch_part;

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
@@ -6,6 +6,10 @@
 1
 -- an expired part larger than the byte budget is still dropped
 0
+-- a TTLDrop merge applies a live patch part before deciding nothing survives
+100	1
+TTLDropMerge	1
+1
 -- a GROUP BY TTL whose rows survive stays selectable for a later rollup
 TTLDropMerge	2
 1	20

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
@@ -6,3 +6,6 @@
 1
 -- an expired part larger than the byte budget is still dropped
 0
+-- a GROUP BY TTL whose rows survive stays selectable for a later rollup
+2
+1	20

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
@@ -7,5 +7,11 @@
 -- an expired part larger than the byte budget is still dropped
 0
 -- a GROUP BY TTL whose rows survive stays selectable for a later rollup
-2
+TTLDropMerge	2
 1	20
+-- a rows TTL whose rows survive stays selectable for a later delete
+1	42
+0
+-- a column TTL whose values survive stays selectable for a later reset
+1	7777
+1	0

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
@@ -19,3 +19,6 @@ TTLDropMerge	2
 -- a column TTL whose values survive stays selectable for a later reset
 1	7777
 1	0
+-- a compact part's column TTL stays selectable for a later reset
+1	7777
+1	0

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
@@ -1,6 +1,7 @@
 -- a TTLDrop merge keeps rows the current expression does not expire
 100
 1
+1
 -- a TTLDrop range honours the byte budget
 1
 -- an expired part larger than the byte budget is still dropped

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.reference
@@ -1,0 +1,7 @@
+-- a TTLDrop merge keeps rows the current expression does not expire
+100
+1
+-- a TTLDrop range honours the byte budget
+1
+-- an expired part larger than the byte budget is still dropped
+0

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
@@ -134,6 +134,43 @@ wait_for_ttl_drop_merge "t_ttl_drop_oversized"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_oversized"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_oversized"
 
+echo "-- a TTLDrop merge applies a live patch part before deciding nothing survives"
+
+# The stored bounds are computed at write time and a lightweight UPDATE lives in a separate patch
+# part, so the part stays fully expired to the selector while no row is. A merge that decides the
+# output is empty without building the read pipeline never reads the patched values, and the acked
+# UPDATE's rows are dropped.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_drop_patch (id UInt64, ts DateTime)
+    ENGINE = MergeTree ORDER BY id
+    TTL ts + INTERVAL 1 SECOND
+    SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0,
+             enable_block_number_column = 1, enable_block_offset_column = 1,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
+
+    SYSTEM STOP MERGES t_ttl_drop_patch;
+    INSERT INTO t_ttl_drop_patch SELECT number, now() - INTERVAL 1 DAY FROM numbers(100);
+    SET enable_lightweight_update = 1;
+    UPDATE t_ttl_drop_patch SET ts = now() + INTERVAL 1 DAY WHERE 1;
+    SYSTEM START MERGES t_ttl_drop_patch;
+"
+
+wait_for_ttl_drop_merge "t_ttl_drop_patch"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), max(ts) > now() FROM t_ttl_drop_patch"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT merge_reason, read_rows > 0 FROM system.part_log
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_patch'
+      AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'
+    ORDER BY event_time DESC LIMIT 1"
+# A patch part is a part of its own, carries no TTL info, and is removed asynchronously once it has
+# been applied, so the data partition is named explicitly to keep this a single stable row.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT delete_ttl_info_min > now() FROM system.parts
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_patch' AND active
+      AND partition_id = 'all'"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_patch"
+
 echo "-- a GROUP BY TTL whose rows survive stays selectable for a later rollup"
 
 # A rule marked finished sets `part_min_ttl` to 0 and clears `has_any_non_finished_ttls`, so the

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
@@ -9,20 +9,40 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # current TTL expression over the rows before deciding that nothing survives. `OPTIMIZE ... FINAL`
 # always assigns `MergeType::Regular`, so these cases rely on background TTL merges.
 
-function wait_for_ttl_drop_merge()
+function wait_for_ttl_merge_matching()
 {
     local table=$1
+    local reason_pattern=$2
     for _ in $(seq 1 300); do
         ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS part_log"
         local count
         count=$(${CLICKHOUSE_CLIENT} -q "
             SELECT count() FROM system.part_log
             WHERE database = currentDatabase() AND table = '$table'
-              AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'")
+              AND event_type = 'MergeParts' AND merge_reason LIKE '$reason_pattern'")
         if [ "$count" -gt "0" ]; then
             return
         fi
         sleep 0.1
+    done
+}
+
+function wait_for_ttl_drop_merge()
+{
+    wait_for_ttl_merge_matching "$1" "TTLDropMerge"
+}
+
+function wait_for_row_count()
+{
+    local table=$1
+    local want=$2
+    for _ in $(seq 1 120); do
+        local count
+        count=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM $table")
+        if [ "$count" = "$want" ]; then
+            return
+        fi
+        sleep 0.5
     done
 }
 
@@ -76,7 +96,7 @@ ${CLICKHOUSE_CLIENT} -q "
 wait_for_ttl_drop_merge "t_ttl_drop_sized"
 
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT max(length(merged_from)) < 3 FROM system.part_log
+    SELECT max(length(merged_from)) = 1 FROM system.part_log
     WHERE database = currentDatabase() AND table = 't_ttl_drop_sized'
       AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_sized"
@@ -101,3 +121,47 @@ wait_for_ttl_drop_merge "t_ttl_drop_oversized"
 
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_oversized"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_oversized"
+
+echo "-- a GROUP BY TTL whose rows survive stays selectable for a later rollup"
+
+# A rule marked finished sets `part_min_ttl` to 0 and clears `has_any_non_finished_ttls`, so the
+# part is never selected for a TTL merge again. No system table exposes the flag, so it is observed
+# through that consequence: the rollup below can only run if the merge left the rule unfinished.
+#
+# The interval is part of the map key of a GROUP BY rule, so changing it would create a fresh key
+# and recalculate from scratch. Patching the column the expression reads keeps the key, which is
+# what leaves the stored bounds expired while no row is.
+#
+# `ts` lands 15 seconds ahead because the first merge has to run while no row is expired yet.
+#
+# The second merge has to be selector-driven. `OPTIMIZE ... FINAL` would reach the rows through
+# `MergeTreeDataPartTTLInfos::update`, which clears this flag for GROUP BY rules, so a forced merge
+# reports the same result whether or not the flag was set.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_group_by_stays (k UInt64, ts DateTime, v UInt64)
+    ENGINE = MergeTree ORDER BY k
+    TTL ts + INTERVAL 1 SECOND GROUP BY k SET v = max(v)
+    SETTINGS min_bytes_for_wide_part = 0, enable_block_number_column = 1,
+             enable_block_offset_column = 1, merge_with_ttl_timeout = 0;
+
+    SYSTEM STOP MERGES t_ttl_group_by_stays;
+    INSERT INTO t_ttl_group_by_stays VALUES (1, now() - INTERVAL 1 DAY, 10), (1, now() - INTERVAL 1 DAY, 20);
+    SET enable_lightweight_update = 1;
+    UPDATE t_ttl_group_by_stays SET ts = now() + INTERVAL 15 SECOND WHERE 1;
+    SYSTEM START MERGES t_ttl_group_by_stays;
+"
+
+wait_for_ttl_merge_matching "t_ttl_group_by_stays" "TTL%"
+
+# Both rows survived that merge, so the rollup below is a rule that was kept rather than a fixture
+# that never had rows left to roll up.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT rows FROM system.part_log
+    WHERE database = currentDatabase() AND table = 't_ttl_group_by_stays'
+      AND event_type = 'MergeParts' AND merge_reason LIKE 'TTL%'
+    ORDER BY event_time_microseconds LIMIT 1"
+
+wait_for_row_count "t_ttl_group_by_stays" 1
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_group_by_stays"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_group_by_stays"

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Tags: long
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A `TTLDrop` merge is assigned from the bounds stored in `ttl.txt`, so it must still evaluate the
+# current TTL expression over the rows before deciding that nothing survives. `OPTIMIZE ... FINAL`
+# always assigns `MergeType::Regular`, so these cases rely on background TTL merges.
+
+function wait_for_ttl_drop_merge()
+{
+    local table=$1
+    for _ in $(seq 1 300); do
+        ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS part_log"
+        local count
+        count=$(${CLICKHOUSE_CLIENT} -q "
+            SELECT count() FROM system.part_log
+            WHERE database = currentDatabase() AND table = '$table'
+              AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'")
+        if [ "$count" -gt "0" ]; then
+            return
+        fi
+        sleep 0.1
+    done
+}
+
+echo "-- a TTLDrop merge keeps rows the current expression does not expire"
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_drop_reeval (id UInt64, ts DateTime)
+    ENGINE = MergeTree ORDER BY id
+    TTL ts + INTERVAL 1 SECOND
+    SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0;
+
+    SYSTEM STOP MERGES t_ttl_drop_reeval;
+    INSERT INTO t_ttl_drop_reeval SELECT number, now() - INTERVAL 1 DAY FROM numbers(100);
+    ALTER TABLE t_ttl_drop_reeval MODIFY TTL ts + INTERVAL 10 YEAR SETTINGS materialize_ttl_after_modify = 0;
+    SYSTEM START MERGES t_ttl_drop_reeval;
+"
+
+wait_for_ttl_drop_merge "t_ttl_drop_reeval"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_reeval"
+# The merge has to open the source part to reach that verdict.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT read_rows > 0 FROM system.part_log
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_reeval'
+      AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'
+    ORDER BY event_time DESC LIMIT 1"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_reeval"
+
+echo "-- a TTLDrop range honours the byte budget"
+
+# Since the output is no longer known to be empty, the range is sized like any other merge. With a
+# budget below the combined size of the expired parts, no single range can cover all of them.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_drop_sized (id UInt64, payload String, ts DateTime)
+    ENGINE = MergeTree ORDER BY id
+    TTL ts + INTERVAL 1 SECOND
+    SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0,
+             max_bytes_to_merge_at_max_space_in_pool = 4096;
+
+    SYSTEM STOP MERGES t_ttl_drop_sized;
+    INSERT INTO t_ttl_drop_sized SELECT number, randomString(1000), now() - INTERVAL 1 DAY FROM numbers(20);
+    INSERT INTO t_ttl_drop_sized SELECT number + 100, randomString(1000), now() - INTERVAL 1 DAY FROM numbers(20);
+    INSERT INTO t_ttl_drop_sized SELECT number + 200, randomString(1000), now() - INTERVAL 1 DAY FROM numbers(20);
+    SYSTEM START MERGES t_ttl_drop_sized;
+"
+
+wait_for_ttl_drop_merge "t_ttl_drop_sized"
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT max(length(merged_from)) < 3 FROM system.part_log
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_sized'
+      AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_sized"
+
+echo "-- an expired part larger than the byte budget is still dropped"
+
+# Without the single-part retry a part above the budget is refused by every range, so expired data
+# on a full disk could never be freed.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_drop_oversized (id UInt64, payload String, ts DateTime)
+    ENGINE = MergeTree ORDER BY id
+    TTL ts + INTERVAL 1 SECOND
+    SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0,
+             max_bytes_to_merge_at_max_space_in_pool = 1024;
+
+    SYSTEM STOP MERGES t_ttl_drop_oversized;
+    INSERT INTO t_ttl_drop_oversized SELECT number, randomString(1000), now() - INTERVAL 1 DAY FROM numbers(50);
+    SYSTEM START MERGES t_ttl_drop_oversized;
+"
+
+wait_for_ttl_drop_merge "t_ttl_drop_oversized"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_drop_oversized"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_oversized"

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
@@ -17,7 +17,7 @@ function wait_for_ttl_merge_matching()
 {
     local table=$1
     local reason_pattern=$2
-    for _ in $(seq 1 300); do
+    for _ in $(seq 1 600); do
         ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS part_log"
         local count
         count=$(${CLICKHOUSE_CLIENT} -q "
@@ -40,7 +40,8 @@ function wait_for_query_result()
 {
     local query=$1
     local want=$2
-    for _ in $(seq 1 120); do
+    local iterations=${3:-120}
+    for _ in $(seq 1 "$iterations"); do
         local got
         got=$(${CLICKHOUSE_CLIENT} -q "$query")
         if [ "$got" = "$want" ]; then
@@ -52,7 +53,7 @@ function wait_for_query_result()
 
 function wait_for_row_count()
 {
-    wait_for_query_result "SELECT count() FROM $1" "$2"
+    wait_for_query_result "SELECT count() FROM $1" "$2" "$3"
 }
 
 echo "-- a TTLDrop merge keeps rows the current expression does not expire"
@@ -181,7 +182,8 @@ echo "-- a GROUP BY TTL whose rows survive stays selectable for a later rollup"
 # and recalculate from scratch. Patching the column the expression reads keeps the key, which is
 # what leaves the stored bounds expired while no row is.
 #
-# `ts` lands 15 seconds ahead because the first merge has to run while no row is expired yet.
+# `ts` lands far enough ahead that the first merge runs while no row is expired yet, even when the
+# background pools are saturated.
 #
 # The second merge has to be selector-driven. `OPTIMIZE ... FINAL` would reach the rows through
 # `MergeTreeDataPartTTLInfos::update`, which clears this flag for GROUP BY rules, so a forced merge
@@ -197,7 +199,7 @@ ${CLICKHOUSE_CLIENT} -q "
     SYSTEM STOP MERGES t_ttl_group_by_stays;
     INSERT INTO t_ttl_group_by_stays VALUES (1, now() - INTERVAL 1 DAY, 10), (1, now() - INTERVAL 1 DAY, 20);
     SET enable_lightweight_update = 1;
-    UPDATE t_ttl_group_by_stays SET ts = now() + INTERVAL 15 SECOND WHERE 1;
+    UPDATE t_ttl_group_by_stays SET ts = now() + INTERVAL 45 SECOND WHERE 1;
     SYSTEM START MERGES t_ttl_group_by_stays;
 "
 
@@ -211,7 +213,7 @@ ${CLICKHOUSE_CLIENT} -q "
       AND event_type = 'MergeParts' AND merge_reason LIKE 'TTL%'
     ORDER BY event_time_microseconds LIMIT 1"
 
-wait_for_row_count "t_ttl_group_by_stays" 1
+wait_for_row_count "t_ttl_group_by_stays" 1 240
 
 ${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_group_by_stays"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_group_by_stays"
@@ -223,7 +225,8 @@ echo "-- a rows TTL whose rows survive stays selectable for a later delete"
 #
 # `MergeTreeDataPartTTLInfos::update` rebuilds only GROUP BY entries as unfinished, so for a rows or
 # a column TTL a forced merge cannot clear the flag and the poisoning merge may be `OPTIMIZE FINAL`.
-# The live rule lands 10 seconds ahead, which is both after that merge and before the wait below.
+# The live rule lands far enough ahead to outlast that merge on a loaded arm, and near enough to
+# expire inside the wait below.
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE t_ttl_rows_stays_selectable (ts DateTime, v UInt64)
     ENGINE = MergeTree ORDER BY tuple()
@@ -233,7 +236,7 @@ ${CLICKHOUSE_CLIENT} -q "
 
     SYSTEM STOP MERGES t_ttl_rows_stays_selectable;
     INSERT INTO t_ttl_rows_stays_selectable VALUES (now() - INTERVAL 1 DAY, 42);
-    ALTER TABLE t_ttl_rows_stays_selectable MODIFY TTL ts + INTERVAL 1 DAY + INTERVAL 10 SECOND
+    ALTER TABLE t_ttl_rows_stays_selectable MODIFY TTL ts + INTERVAL 1 DAY + INTERVAL 30 SECOND
     SETTINGS materialize_ttl_after_modify = 0;
     SYSTEM START MERGES t_ttl_rows_stays_selectable;
     OPTIMIZE TABLE t_ttl_rows_stays_selectable FINAL;
@@ -259,7 +262,7 @@ ${CLICKHOUSE_CLIENT} -q "
     SYSTEM STOP MERGES t_ttl_column_stays_selectable;
     INSERT INTO t_ttl_column_stays_selectable VALUES (now() - INTERVAL 1 DAY, 7777);
     ALTER TABLE t_ttl_column_stays_selectable
-    MODIFY COLUMN v UInt64 TTL ts + INTERVAL 1 DAY + INTERVAL 10 SECOND
+    MODIFY COLUMN v UInt64 TTL ts + INTERVAL 1 DAY + INTERVAL 30 SECOND
     SETTINGS materialize_ttl_after_modify = 0;
     SYSTEM START MERGES t_ttl_column_stays_selectable;
     OPTIMIZE TABLE t_ttl_column_stays_selectable FINAL;
@@ -271,3 +274,30 @@ wait_for_query_result "SELECT sum(v) FROM t_ttl_column_stays_selectable" 0
 
 ${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_column_stays_selectable"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_column_stays_selectable"
+
+echo "-- a compact part's column TTL stays selectable for a later reset"
+
+# The same rule on a compact part, where the stored bounds never stand in for the values, so the
+# surviving value is not what separates the two states here: the reset below is, and it can only
+# happen if the merge left the rule unfinished.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_column_stays_selectable_compact (ts DateTime, v UInt64 TTL ts + INTERVAL 1 SECOND)
+    ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 1000000000, merge_with_ttl_timeout = 0,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
+
+    SYSTEM STOP MERGES t_ttl_column_stays_selectable_compact;
+    INSERT INTO t_ttl_column_stays_selectable_compact VALUES (now() - INTERVAL 1 DAY, 7777);
+    ALTER TABLE t_ttl_column_stays_selectable_compact
+    MODIFY COLUMN v UInt64 TTL ts + INTERVAL 1 DAY + INTERVAL 30 SECOND
+    SETTINGS materialize_ttl_after_modify = 0;
+    SYSTEM START MERGES t_ttl_column_stays_selectable_compact;
+    OPTIMIZE TABLE t_ttl_column_stays_selectable_compact FINAL;
+"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_column_stays_selectable_compact"
+
+wait_for_query_result "SELECT sum(v) FROM t_ttl_column_stays_selectable_compact" 0
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_column_stays_selectable_compact"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_column_stays_selectable_compact"

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
@@ -8,6 +8,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # A `TTLDrop` merge is assigned from the bounds stored in `ttl.txt`, so it must still evaluate the
 # current TTL expression over the rows before deciding that nothing survives. `OPTIMIZE ... FINAL`
 # always assigns `MergeType::Regular`, so these cases rely on background TTL merges.
+#
+# The merge-selecting task backs off to `max_merge_selecting_sleep_ms`, 60 seconds by default, once it
+# finds nothing to assign, so a selection attempt can be further away than the waits below allow.
+# Every table pins that cadence, which bounds each wait by the pinned value instead.
 
 function wait_for_ttl_merge_matching()
 {
@@ -32,18 +36,23 @@ function wait_for_ttl_drop_merge()
     wait_for_ttl_merge_matching "$1" "TTLDropMerge"
 }
 
-function wait_for_row_count()
+function wait_for_query_result()
 {
-    local table=$1
+    local query=$1
     local want=$2
     for _ in $(seq 1 120); do
-        local count
-        count=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM $table")
-        if [ "$count" = "$want" ]; then
+        local got
+        got=$(${CLICKHOUSE_CLIENT} -q "$query")
+        if [ "$got" = "$want" ]; then
             return
         fi
         sleep 0.5
     done
+}
+
+function wait_for_row_count()
+{
+    wait_for_query_result "SELECT count() FROM $1" "$2"
 }
 
 echo "-- a TTLDrop merge keeps rows the current expression does not expire"
@@ -52,7 +61,8 @@ ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE t_ttl_drop_reeval (id UInt64, ts DateTime)
     ENGINE = MergeTree ORDER BY id
     TTL ts + INTERVAL 1 SECOND
-    SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0;
+    SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
 
     SYSTEM STOP MERGES t_ttl_drop_reeval;
     INSERT INTO t_ttl_drop_reeval SELECT number, now() - INTERVAL 1 DAY FROM numbers(100);
@@ -84,7 +94,8 @@ ${CLICKHOUSE_CLIENT} -q "
     ENGINE = MergeTree ORDER BY id
     TTL ts + INTERVAL 1 SECOND
     SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0,
-             max_bytes_to_merge_at_max_space_in_pool = 4096;
+             max_bytes_to_merge_at_max_space_in_pool = 4096,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
 
     SYSTEM STOP MERGES t_ttl_drop_sized;
     INSERT INTO t_ttl_drop_sized SELECT number, randomString(1000), now() - INTERVAL 1 DAY FROM numbers(20);
@@ -110,7 +121,8 @@ ${CLICKHOUSE_CLIENT} -q "
     ENGINE = MergeTree ORDER BY id
     TTL ts + INTERVAL 1 SECOND
     SETTINGS ttl_only_drop_parts = 1, merge_with_ttl_timeout = 0, min_bytes_for_wide_part = 0,
-             max_bytes_to_merge_at_max_space_in_pool = 1024;
+             max_bytes_to_merge_at_max_space_in_pool = 1024,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
 
     SYSTEM STOP MERGES t_ttl_drop_oversized;
     INSERT INTO t_ttl_drop_oversized SELECT number, randomString(1000), now() - INTERVAL 1 DAY FROM numbers(50);
@@ -142,7 +154,8 @@ ${CLICKHOUSE_CLIENT} -q "
     ENGINE = MergeTree ORDER BY k
     TTL ts + INTERVAL 1 SECOND GROUP BY k SET v = max(v)
     SETTINGS min_bytes_for_wide_part = 0, enable_block_number_column = 1,
-             enable_block_offset_column = 1, merge_with_ttl_timeout = 0;
+             enable_block_offset_column = 1, merge_with_ttl_timeout = 0,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
 
     SYSTEM STOP MERGES t_ttl_group_by_stays;
     INSERT INTO t_ttl_group_by_stays VALUES (1, now() - INTERVAL 1 DAY, 10), (1, now() - INTERVAL 1 DAY, 20);
@@ -156,7 +169,7 @@ wait_for_ttl_merge_matching "t_ttl_group_by_stays" "TTL%"
 # Both rows survived that merge, so the rollup below is a rule that was kept rather than a fixture
 # that never had rows left to roll up.
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT rows FROM system.part_log
+    SELECT merge_reason, rows FROM system.part_log
     WHERE database = currentDatabase() AND table = 't_ttl_group_by_stays'
       AND event_type = 'MergeParts' AND merge_reason LIKE 'TTL%'
     ORDER BY event_time_microseconds LIMIT 1"
@@ -165,3 +178,59 @@ wait_for_row_count "t_ttl_group_by_stays" 1
 
 ${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_group_by_stays"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_group_by_stays"
+
+echo "-- a rows TTL whose rows survive stays selectable for a later delete"
+
+# Observed the same way as the GROUP BY case above, through the consequence of the flag rather than
+# the flag itself.
+#
+# `MergeTreeDataPartTTLInfos::update` rebuilds only GROUP BY entries as unfinished, so for a rows or
+# a column TTL a forced merge cannot clear the flag and the poisoning merge may be `OPTIMIZE FINAL`.
+# The live rule lands 10 seconds ahead, which is both after that merge and before the wait below.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_rows_stays_selectable (ts DateTime, v UInt64)
+    ENGINE = MergeTree ORDER BY tuple()
+    TTL ts + INTERVAL 1 SECOND
+    SETTINGS min_bytes_for_wide_part = 0, merge_with_ttl_timeout = 0,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
+
+    SYSTEM STOP MERGES t_ttl_rows_stays_selectable;
+    INSERT INTO t_ttl_rows_stays_selectable VALUES (now() - INTERVAL 1 DAY, 42);
+    ALTER TABLE t_ttl_rows_stays_selectable MODIFY TTL ts + INTERVAL 1 DAY + INTERVAL 10 SECOND
+    SETTINGS materialize_ttl_after_modify = 0;
+    SYSTEM START MERGES t_ttl_rows_stays_selectable;
+    OPTIMIZE TABLE t_ttl_rows_stays_selectable FINAL;
+"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_rows_stays_selectable"
+
+wait_for_row_count "t_ttl_rows_stays_selectable" 0
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_ttl_rows_stays_selectable"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_rows_stays_selectable"
+
+echo "-- a column TTL whose values survive stays selectable for a later reset"
+
+# Same shape for `TTLColumnAlgorithm`: the reset of `v` below can only happen if the merge left the
+# rule unfinished. `count()` is read alongside it because an empty table also sums to zero.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_column_stays_selectable (ts DateTime, v UInt64 TTL ts + INTERVAL 1 SECOND)
+    ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS min_bytes_for_wide_part = 0, merge_with_ttl_timeout = 0,
+             merge_selecting_sleep_ms = 100, max_merge_selecting_sleep_ms = 500;
+
+    SYSTEM STOP MERGES t_ttl_column_stays_selectable;
+    INSERT INTO t_ttl_column_stays_selectable VALUES (now() - INTERVAL 1 DAY, 7777);
+    ALTER TABLE t_ttl_column_stays_selectable
+    MODIFY COLUMN v UInt64 TTL ts + INTERVAL 1 DAY + INTERVAL 10 SECOND
+    SETTINGS materialize_ttl_after_modify = 0;
+    SYSTEM START MERGES t_ttl_column_stays_selectable;
+    OPTIMIZE TABLE t_ttl_column_stays_selectable FINAL;
+"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_column_stays_selectable"
+
+wait_for_query_result "SELECT sum(v) FROM t_ttl_column_stays_selectable" 0
+
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(v) FROM t_ttl_column_stays_selectable"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_column_stays_selectable"

--- a/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
+++ b/tests/queries/0_stateless/05077_ttl_drop_merge_reevaluates_rows.sh
@@ -49,6 +49,10 @@ ${CLICKHOUSE_CLIENT} -q "
     WHERE database = currentDatabase() AND table = 't_ttl_drop_reeval'
       AND event_type = 'MergeParts' AND merge_reason = 'TTLDropMerge'
     ORDER BY event_time DESC LIMIT 1"
+# The merge also rewrites the stored bounds, so the part is no longer a trap for the next merge.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT delete_ttl_info_min > now() FROM system.parts
+    WHERE database = currentDatabase() AND table = 't_ttl_drop_reeval' AND active"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_reeval"
 
 echo "-- a TTLDrop range honours the byte budget"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117990
Closes: https://github.com/ClickHouse/ClickHouse/issues/116678

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix silent data loss in `MergeTree` TTL merges: a merge could drop a whole part, or clear a wide part's column, from the TTL bounds stored in `ttl.txt` instead of the current TTL expression. A part written before the `DateTime` overflow fix in TTL analysis, or left by `MODIFY TTL` with `materialize_ttl_after_modify = 0`, lost rows or column values on the next merge. In a mixed-version cluster this is complete only after all replicas are upgraded: an unfixed replica that wins the merge race still writes the empty part, and the others fetch it.

### Description

`ttl.txt` holds a *past* evaluation of the TTL expression. Five decisions trusted its stored `max` and skipped row-level evaluation: the whole-part drop in `TTLTransform`, `TTLDeleteFilterTransform` for vertical merges, the whole-column reset in `TTLColumnAlgorithm` for wide parts, the pipeline-less `TTLDrop` path in `MergeTask`, and the expired-part drop in `MutateTask` when a mutation runs no TTL stage. Where the stored value disagreed, the merge removed data the table's TTL says to keep, permanently.

Reachable without an upgrade: `ALTER TABLE ... MODIFY TTL <longer> SETTINGS materialize_ttl_after_modify = 0` leaves bounds expired under the retired rule and the next merge deletes the rows; the default keeps them.

Persisted bounds are now a scheduling hint only: any decision that removes rows, resets column values or marks a TTL finished is derived from the current expression over the rows, so this does not trade data loss for retention. A `TTLDrop` range is sized by the normal merge constraints, with a single-part retry so an over-sized expired part is still dropped.

A `TTLDrop` merge now reads its sources, reverting the no-read guarantee added in `04df856e14c065e`. On 90 all-expired wide parts of a 300-path `JSON` column, `peak_memory_usage` goes 2.79 -> 136.75 MiB, against 196.22 MiB for an ordinary merge of those parts: the range is now bounded by `max_size_bytes` and `max_size_rows`, unlike master.

Not fixed here: a stored `min` wrongly in the future still stops a part being examined, `estimateNeededDiskSpace` still excludes expired sources, a `TTLDrop` on a `prefer_not_to_merge` volume can rewrite rather than empty the part, and with `apply_patches_on_merge = 0` a TTL merge evaluates unpatched rows, as master already does for a partially expired part.

#63383 keeps and refines this shortcut, overlapping five files; #116175 fixes the same `TTLAggregationAlgorithm` flag differently and adds another such shortcut. My open #113385 and #108550 touch code this removes.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118209&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118209](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118209+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

