### PR TITLE
Never delete an existing `Distributed` spool file during batch recovery

### DIFF
--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -201,31 +201,14 @@ bool DistributedAsyncInsertBatch::recoverBatch()
         }
     }
 
-    /// A quarantined file proves that every preceding file was already processed,
-    /// because split batches handle files in order. File names are not reused after
-    /// restart because initialization scans the broken directory too. Finalize any
-    /// acknowledged predecessors left behind by an abnormal shutdown.
-    size_t processed_files = 0;
-    for (size_t i = 0; i != files.size(); ++i)
-    {
-        const auto broken_file = fs::path(parent.broken_path) / fs::path(files[i]).filename();
-        if (fs::exists(broken_file))
-            processed_files = i + 1;
-    }
-
-    if (processed_files)
-    {
-        auto dir_sync_guard = parent.getDirectorySyncGuard(parent.relative_path);
-        for (size_t i = 0; i != processed_files; ++i)
-        {
-            if (fs::exists(files[i]))
-                parent.markAsSend(files[i]);
-        }
-        files.erase(files.begin(), files.begin() + processed_files);
-    }
-
     /// Files are removed in order, so a missing prefix was already processed
     /// before an abnormal shutdown. Keep the surviving suffix in its persisted order.
+    ///
+    /// A quarantined twin in the broken directory does not prove that the files listed
+    /// before it were sent: older servers skipped files that failed with a transient
+    /// error and went on with the next one, so a batch written by such a server can
+    /// hold an unsent file in front of a quarantined one. Never finalize a file that
+    /// still exists here. Resending it may duplicate rows, deleting it loses them.
     auto first_existing_file = files.begin();
     while (first_existing_file != files.end() && !fs::exists(*first_existing_file))
     {

--- a/tests/integration/test_distributed_directory_monitor_split_batch_on_failure/test.py
+++ b/tests/integration/test_distributed_directory_monitor_split_batch_on_failure/test.py
@@ -218,7 +218,7 @@ def test_transient_error_after_sent_file_keeps_only_unsent_files(started_cluster
     assert int(node1.query("select sum(uniq_values) from dist_data")) == 3
 
 
-def test_recovery_skips_sent_prefix_before_broken_file(started_cluster):
+def test_recovery_resends_existing_file_before_broken_file(started_cluster):
     create_tables(
         background_insert_batch=1, background_insert_split_batch_on_failure=1
     )
@@ -237,12 +237,9 @@ def test_recovery_skips_sent_prefix_before_broken_file(started_cluster):
     assert len(files) == 3
     file_indices = [file.rsplit("/", 1)[-1][:-4] for file in files]
 
-    # Simulate an acknowledged first file followed by a quarantined second file,
-    # with the stale batch metadata left by an abnormal shutdown.
-    node1.query(
-        "insert into dist values (1, 1)",
-        settings={"distributed_foreground_insert": 1},
-    )
+    # A server without ordered split retries skipped `A` after a transient error, went
+    # on to quarantine `B`, and died before rewriting the batch metadata. `A` was never
+    # acknowledged by the remote shard, so recovery must resend it rather than delete it.
     node1.exec_in_container(["mv", files[1], f"{queue_path}/broken/"])
     node1.exec_in_container(
         [
@@ -253,15 +250,13 @@ def test_recovery_skips_sent_prefix_before_broken_file(started_cluster):
     )
 
     node1.query("system flush distributed dist")
-    # Only the direct insert and `C` may reach the sink. Every insert block produces
-    # its own row in `data`, so a resent `A` would add a third row (or, if it was
-    # squashed together with `C`, raise `uniq_values` of that row to 2).
-    sink_state = node1.query("select count(), sum(uniq_values) from dist_data")
-    assert sink_state.split() == ["2", "2"]
-    # `A` must be finalized locally rather than retried, and the queue directory must
-    # drain. (`system.distribution_queue` is not consulted here: `B` was quarantined
-    # by this test with an out-of-band `mv`, so the in-memory file counter still
-    # accounts for it.)
+    # Every insert block produces its own row in `data` with the number of distinct
+    # values it carried, so the sum counts delivered files whether or not `A` and `C`
+    # were squashed into one block. Both must arrive; only quarantined `B` is lost.
+    assert int(node1.query("select sum(uniq_values) from dist_data")) == 2
+    # The queue directory must drain. (`system.distribution_queue` is not consulted
+    # here: `B` was quarantined by this test with an out-of-band `mv`, so the in-memory
+    # file counter still accounts for it.)
     remaining_files = node1.exec_in_container(
         ["bash", "-c", f"ls -1 {queue_path}/*.bin 2>/dev/null || true"]
     ).strip()


### PR DESCRIPTION
After https://github.com/ClickHouse/ClickHouse/pull/117034, `DistributedAsyncInsertBatch::recoverBatch` treated a same-named twin in the `broken/` directory as proof that every file listed before it in `current_batch.txt` had already been acknowledged, and finalized those files with `markAsSend`, deleting them. That inference only holds for servers that already have ordered split retries. The previous `sendSeparateFiles` skipped a file after a transient error such as `TOO_MANY_PARTS` and continued with the next one, so a server being upgraded from any earlier release can leave an unsent file in front of a quarantined one. Recovery on the new binary then deleted rows that never reached any shard, silently.

This change removes the inference. A still existing file listed before a quarantined twin is kept: the missing quarantined member already makes `recoverBatch` return `false`, the stale batch file is dropped, and the surviving files are resent through the normal queue. Duplicates are possible in this edge case, data loss is not.

The recovery integration test now models the pre-upgrade on-disk state and asserts that the unsent predecessor is delivered.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118153
Related: https://github.com/ClickHouse/ClickHouse/pull/117034
Related: https://github.com/ClickHouse/ClickHouse/pull/118138
Related: https://github.com/ClickHouse/ClickHouse/pull/118141

### Changelog category (leave one):
- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix silent data loss on upgrade in `Distributed` background inserts with `background_insert_split_batch_on_failure`: batch recovery no longer deletes a spool file that was never sent when a later file of the same batch was quarantined into `broken/` by a previous server version.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118211&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118211](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118211+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
