### PR TITLE
Rebuild against Canonical when the in-region apt mirror serves a partial index

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -284,6 +284,19 @@ APT_MIRROR_ERRORS = [
     "Unable to fetch some archives",
     # `apt-get update` could not refresh the package lists
     "Some index files failed to download",
+    # `apt-get update` treats a suite whose `InRelease` the mirror withheld as a
+    # warning (`W: Failed to fetch ... 503`, `W: Some index files failed to
+    # download`) and carries on with whatever suites it did get, so it exits 0 and
+    # the `E:` lands on the `apt-get install` that follows: with `jammy`,
+    # `jammy-updates` and `jammy-security` gone, nothing is left to provide the
+    # packages, or only a candidate whose dependencies live in a missing suite. On
+    # the pristine base image these Dockerfiles start from, a package Ubuntu ships
+    # that has no candidate or unmet dependencies can only mean the index apt
+    # resolved against is a partial one, i.e. the mirror. Measured on 2026-09-05,
+    # when every arm64 keeper image build on the fleet reded this way and no build
+    # ever reached Canonical.
+    "has no installation candidate",
+    "Unable to correct problems, you have held broken packages",
 ]
 
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115726
Related: https://github.com/ClickHouse/ClickHouse/pull/117960

The `Docker keeper image` job reded on every arm64 build across the fleet on 2026-09-05 (10 of 10 PRs at 00:00 UTC, again at 04:00 UTC) and on an amd64 build on 2026-09-04, and none of them rebuilt against Canonical although the apt mirror fallback from https://github.com/ClickHouse/ClickHouse/pull/115726 is in place.

The in-region mirror answered `503` for the `jammy`, `jammy-updates` and `jammy-security` `InRelease` files. `apt-get update` treats that as a warning (`W: Failed to fetch ...`, `W: Some index files failed to download`) and carries on with the one suite it did get, so it exits 0 and the `E:` lands on the `apt-get install` that follows, as `E: Package 'ca-certificates' has no installation candidate` or `E: Unable to correct problems, you have held broken packages` (`wget : Depends: libpsl5 ... but it is not installable`). `is_apt_mirror_failure` did not know either shape, so `should_try_next_mirror` said no and the job failed on the first mirror.

This adds the two signatures to `APT_MIRROR_ERRORS`. The two guards from the original fallback stay in force: only apt `E:` lines inside the terminal buildx failure block count, so a recovered `apt-get update` warning, a step header naming apt, or a truncated log without the fenced shape still does not trigger a rebuild. On the pristine base image these Dockerfiles start from, a package Ubuntu ships that has no candidate or unmet dependencies can only mean the index apt resolved against is a partial one.

Verified with a throwaway test against the real logs of two failed builds from CIDB: master's classifier says no for both, the patched one says yes, and the negative cases (recovered warnings with a later `wget` failure, signature only in the step header, `E:` in an earlier successful step, no terminal block) still say no.

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117960&sha=e523443dea969b125df53bdba9f23e04c37cc19b&name_0=PR&name_1=Docker%20keeper%20image

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118213&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118213](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118213+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.47`
<!-- ch-version-info:end -->