### PR TITLE
A NULL key value is not a definite match of a negated comparison

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -5699,6 +5699,93 @@ static void tupleRangeToBoundingBox(const Range & tuple_range, Float64 & x_min, 
     }
 }
 
+namespace
+{
+
+/// Whether the analysed range of a key column may hold a NULL value. A NULL key value is analysed as
+/// the `+inf` stand-in of the `NULLS LAST` order, so every range that reaches `+inf` may hold one.
+bool rangeOfKeyColumnMayHoldNull(const Range & key_range, const DataTypes & key_types, size_t key_position)
+{
+    return key_range.right.isPositiveInfinity() && key_position < key_types.size() && key_types[key_position]
+        && isNullableOrLowCardinalityNullable(key_types[key_position]);
+}
+
+/// Whether the atom answers NULL - and hence "not true" to `WHERE` - for a NULL argument, instead of
+/// answering true or false as `IS NULL` and `IS NOT NULL` do.
+bool atomIsNullForNullArgument(KeyCondition::RPNElement::Function function)
+{
+    switch (function)
+    {
+        case KeyCondition::RPNElement::FUNCTION_IN_RANGE:
+        case KeyCondition::RPNElement::FUNCTION_NOT_IN_RANGE:
+        case KeyCondition::RPNElement::FUNCTION_IN_SET:
+        case KeyCondition::RPNElement::FUNCTION_NOT_IN_SET:
+        case KeyCondition::RPNElement::FUNCTION_ARGS_IN_HYPERRECTANGLE:
+        case KeyCondition::RPNElement::FUNCTION_POINT_IN_POLYGON:
+            return true;
+        case KeyCondition::RPNElement::FUNCTION_IS_NULL:
+        case KeyCondition::RPNElement::FUNCTION_IS_NOT_NULL:
+        case KeyCondition::RPNElement::FUNCTION_UNKNOWN:
+        case KeyCondition::RPNElement::FUNCTION_NOT:
+        case KeyCondition::RPNElement::FUNCTION_AND:
+        case KeyCondition::RPNElement::FUNCTION_OR:
+        case KeyCondition::RPNElement::ALWAYS_FALSE:
+        case KeyCondition::RPNElement::ALWAYS_TRUE:
+            return false;
+    }
+}
+
+}
+
+/// `WHERE` rejects a row whose comparison is NULL, so a NULL key value satisfies neither a comparison
+/// nor its negation. The two-valued range algebra of `checkInHyperrectangle` cannot express that: "no
+/// NULL row lies inside the range" turns, under negation, into "every row lies outside it", which
+/// reports a granule of NULLs as wholly matching a negated comparison - and the exact-count
+/// optimization then counts the very rows the `WHERE` throws away. So the exactness of the whole
+/// analysis is gone as soon as one such atom reads a `Nullable` key column whose range may hold a
+/// NULL. `IS NULL` and `IS NOT NULL` are excluded: they answer true or false for a NULL as well, so
+/// the algebra describes them exactly. Only `can_be_false` is affected; `can_be_true`, and with it
+/// every pruning decision, is left alone.
+bool KeyCondition::mayReadNullKeyValue(const Hyperrectangle & hyperrectangle, const DataTypes & key_types) const
+{
+    for (const auto & element : rpn)
+    {
+        if (!atomIsNullForNullArgument(element.function))
+            continue;
+
+        for (size_t key_column : element.key_columns)
+            if (key_column < hyperrectangle.size() && rangeOfKeyColumnMayHoldNull(hyperrectangle[key_column], key_types, key_column))
+                return true;
+    }
+
+    return false;
+}
+
+/// The same over the sparse representation of the primary index, where a key column is addressed by
+/// its position among the columns the index resolves.
+bool KeyCondition::mayReadNullKeyValue(
+    const std::vector<int> & key_col_to_sparse_pos, const Hyperrectangle & sparse_hyperrectangle, const DataTypes & sparse_key_types) const
+{
+    for (const auto & element : rpn)
+    {
+        if (!atomIsNullForNullArgument(element.function))
+            continue;
+
+        for (size_t key_column : element.key_columns)
+        {
+            if (key_column >= key_col_to_sparse_pos.size() || key_col_to_sparse_pos[key_column] == -1)
+                continue;
+
+            const size_t sparse_pos = static_cast<size_t>(key_col_to_sparse_pos[key_column]);
+            if (sparse_pos < sparse_hyperrectangle.size()
+                && rangeOfKeyColumnMayHoldNull(sparse_hyperrectangle[sparse_pos], sparse_key_types, sparse_pos))
+                return true;
+        }
+    }
+
+    return false;
+}
+
 BoolMask KeyCondition::checkInHyperrectangle(
     const Hyperrectangle & hyperrectangle,
     const DataTypes & data_types,
@@ -6131,6 +6218,9 @@ BoolMask KeyCondition::checkInHyperrectangle(
 
     if (rpn_stack.size() != 1)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected stack size in KeyCondition::checkInHyperrectangle");
+
+    if (unlikely(!rpn_stack[0].can_be_false && mayReadNullKeyValue(hyperrectangle, data_types)))
+        rpn_stack[0].can_be_false = true;
 
     return rpn_stack[0];
 }
@@ -6619,6 +6709,9 @@ BoolMask KeyCondition::checkInHyperrectangle(
 
     if (rpn_stack.size() != 1)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected stack size in KeyCondition::checkInHyperrectangle");
+
+    if (unlikely(!rpn_stack[0].can_be_false && mayReadNullKeyValue(key_col_to_sparse_pos, sparse_hyperrectangle, sparse_data_types)))
+        rpn_stack[0].can_be_false = true;
 
     return rpn_stack[0];
 }

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -495,6 +495,15 @@ public:
         bool date_time_overflow_behavior_ignore_);
 
 private:
+    /// Whether any atom reads a `Nullable` key column whose analysed range may hold a NULL value.
+    /// A NULL satisfies neither a comparison nor its negation, which the two-valued range algebra of
+    /// `checkInHyperrectangle` cannot express, so it costs the analysis its `can_be_false` claim.
+    bool mayReadNullKeyValue(const Hyperrectangle & hyperrectangle, const DataTypes & key_types) const;
+    bool mayReadNullKeyValue(
+        const std::vector<int> & key_col_to_sparse_pos,
+        const Hyperrectangle & sparse_hyperrectangle,
+        const DataTypes & sparse_key_types) const;
+
     /// Information used when building a KeyCondition out of ActionsDAG.
     struct BuildInfo
     {

--- a/tests/queries/0_stateless/05083_nullable_key_exact_count.reference
+++ b/tests/queries/0_stateless/05083_nullable_key_exact_count.reference
@@ -1,0 +1,22 @@
+the rows a negated equality really returns
+s	s
+count of the same condition
+1
+1
+and of a negated set
+1
+1
+and of a negated pattern
+1
+1
+a key of mostly NULLs
+11
+11
+4
+12
+a nullable key without NULLs
+15
+15
+the exact count of a non-nullable key
+1
+16

--- a/tests/queries/0_stateless/05083_nullable_key_exact_count.sql
+++ b/tests/queries/0_stateless/05083_nullable_key_exact_count.sql
@@ -1,0 +1,68 @@
+-- Tags: no-parallel-replicas, no-replicated-database
+-- no-parallel-replicas: the EXPLAIN assertion below requires the exact-count projection to
+--   short-circuit on the initiator, which is suppressed when reading from remote replicas.
+-- no-replicated-database: EXPLAIN output differs for a replicated database.
+
+-- `SELECT count()` answered from the implicit exact-count projection reads a granule's key range
+-- instead of its rows. A NULL key value is analysed as the `+inf` stand-in of the `NULLS LAST` order,
+-- and a comparison is NULL - so `WHERE` rejects the row - for such a key, which the two-valued range
+-- algebra cannot express: a granule of NULLs looked like a definite match of a negated comparison, so
+-- `count()` counted rows that the same query without the projection, and `SELECT *`, do not return.
+
+SET optimize_use_projections = 1, optimize_use_implicit_projections = 1;
+
+DROP TABLE IF EXISTS t_nullable_key;
+CREATE TABLE t_nullable_key (id Nullable(String), s Nullable(String)) ENGINE = MergeTree ORDER BY (id, s)
+SETTINGS allow_nullable_key = 1, index_granularity = 1;
+INSERT INTO t_nullable_key VALUES ('s', 's'), (NULL, 's1'), (NULL, NULL);
+
+SELECT 'the rows a negated equality really returns';
+SELECT id, s FROM t_nullable_key WHERE id != '';
+
+SELECT 'count of the same condition';
+SELECT count() FROM t_nullable_key WHERE id != '';
+SELECT count() FROM t_nullable_key WHERE id != '' SETTINGS optimize_use_implicit_projections = 0;
+
+SELECT 'and of a negated set';
+SELECT count() FROM t_nullable_key WHERE id NOT IN ('');
+SELECT count() FROM t_nullable_key WHERE id NOT IN ('') SETTINGS optimize_use_implicit_projections = 0;
+
+SELECT 'and of a negated pattern';
+SELECT count() FROM t_nullable_key WHERE id NOT LIKE 'z%';
+SELECT count() FROM t_nullable_key WHERE id NOT LIKE 'z%' SETTINGS optimize_use_implicit_projections = 0;
+
+-- More NULLs than values, so a count that trusts the key range is off by more than one row.
+DROP TABLE IF EXISTS t_nullable_key_wide;
+CREATE TABLE t_nullable_key_wide (id Nullable(UInt32)) ENGINE = MergeTree ORDER BY id
+SETTINGS allow_nullable_key = 1, index_granularity = 2;
+INSERT INTO t_nullable_key_wide SELECT if(number % 4 = 0, NULL, number) FROM numbers(16);
+
+SELECT 'a key of mostly NULLs';
+SELECT count() FROM t_nullable_key_wide WHERE id != 1;
+SELECT count() FROM t_nullable_key_wide WHERE id != 1 SETTINGS optimize_use_implicit_projections = 0;
+SELECT count() FROM t_nullable_key_wide WHERE id IS NULL;
+SELECT count() FROM t_nullable_key_wide WHERE id IS NOT NULL;
+
+-- A key that holds no NULL, so no row is rejected by three-valued logic.
+DROP TABLE IF EXISTS t_nullable_key_without_nulls;
+CREATE TABLE t_nullable_key_without_nulls (id Nullable(UInt32)) ENGINE = MergeTree ORDER BY id
+SETTINGS allow_nullable_key = 1, index_granularity = 2;
+INSERT INTO t_nullable_key_without_nulls SELECT number FROM numbers(16);
+
+SELECT 'a nullable key without NULLs';
+SELECT count() FROM t_nullable_key_without_nulls WHERE id != 1;
+SELECT count() FROM t_nullable_key_without_nulls WHERE id != 1 SETTINGS optimize_use_implicit_projections = 0;
+
+-- The exact-count projection is still used where NULL cannot be involved.
+DROP TABLE IF EXISTS t_key;
+CREATE TABLE t_key (id UInt32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_key SELECT number FROM numbers(16);
+
+SELECT 'the exact count of a non-nullable key';
+SELECT count() > 0 FROM (EXPLAIN SELECT count() FROM t_key WHERE id != 100) WHERE explain ILIKE '%_exact_count_projection%';
+SELECT count() FROM t_key WHERE id != 100;
+
+DROP TABLE t_key;
+DROP TABLE t_nullable_key_without_nulls;
+DROP TABLE t_nullable_key_wide;
+DROP TABLE t_nullable_key;


### PR DESCRIPTION
`SELECT count()` answered from the implicit exact-count projection reads a granule's key range instead of its rows. A NULL key value is analysed as the `+inf` stand-in of the `NULLS LAST` order, and a comparison against a NULL is NULL - so `WHERE` rejects the row - which the two-valued range algebra of `KeyCondition::checkInHyperrectangle` cannot express: "no NULL row lies inside the range" turns, under negation, into "every row lies outside it". A granule of NULLs therefore looked like a definite match of `id != ''`, `id NOT IN ('')` or `id NOT LIKE 'z%'`, and `count()` counted rows that `SELECT *` under the same `WHERE` does not return - at default settings, on a `Nullable` primary key:

```sql
CREATE TABLE t (id Nullable(String), s Nullable(String)) ENGINE = MergeTree ORDER BY (id, s)
SETTINGS allow_nullable_key = 1;
INSERT INTO t VALUES ('s', 's'), (NULL, 's1'), (NULL, NULL);

SELECT * FROM t WHERE id != '';        -- one row
SELECT count() FROM t WHERE id != '';  -- 3 before, 1 now
```

The whole analysis now gives up its `can_be_false` claim as soon as an atom that answers NULL for a NULL argument reads a `Nullable` key column whose range reaches the NULL stand-in. `IS NULL` and `IS NOT NULL` are excluded: they answer true or false for a NULL as well, so the algebra describes them exactly, and the exact count that `04318_sparse_pk_index_analysis_last_mark_null` pins keeps working. `can_be_true`, and with it every pruning decision, is untouched.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112641
Related: https://github.com/ClickHouse/ClickHouse/issues/112242
Related: https://github.com/ClickHouse/ClickHouse/pull/115152

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `SELECT count()` returning too many rows for a negated comparison (`!=`, `NOT IN`, `NOT LIKE`) over a `Nullable` primary key column: the exact-count optimization counted the NULL-key rows that the `WHERE` condition rejects.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118214&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118214](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118214+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.45`, `26.7.7.41`, `26.6.5.67`, `26.3.33.27`
<!-- ch-version-info:end -->