### PR TITLE
Do not invert an ordered comparison that can see a `NaN` in the CNF form

### DIFF
--- a/src/Analyzer/Passes/CNF.cpp
+++ b/src/Analyzer/Passes/CNF.cpp
@@ -12,6 +12,8 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/logical.h>
 
+#include <DataTypes/IDataType.h>
+
 #include <Common/checkStackSize.h>
 
 namespace DB
@@ -286,11 +288,60 @@ private:
     }
 };
 
+/// Whether the type, or a type nested in it, can hold a `NaN`.
+bool typeCanHoldNaN(const IDataType & type)
+{
+    if (WhichDataType(type).isFloat())
+        return true;
+
+    bool result = false;
+    type.forEachChild([&](const IDataType & child) { result = result || WhichDataType(child).isFloat(); });
+    return result;
+}
+
+/// Whether an argument of a comparison can be a `NaN`. A literal is judged by its value, anything
+/// else by its type.
+bool argumentCanBeNaN(const QueryTreeNodePtr & argument)
+{
+    if (const auto * constant = argument->as<ConstantNode>())
+    {
+        const auto & value = constant->getValue();
+        /// A `Tuple` or `Array` constant can still hide a `NaN` in an element, so only a plain
+        /// floating point literal is decided by its value here.
+        if (value.getType() == Field::Types::Float64)
+            return value.isNaN();
+    }
+
+    const auto & type = argument->getResultType();
+    return type && typeCanHoldNaN(*type);
+}
+
+/// `NaN` fails every ordered comparison, so for a `NaN` argument `NOT (x < c)` is true while
+/// `x >= c` is false: the two are complementary over a totally ordered domain only. Inverting such a
+/// comparison would silently drop the `NaN` rows from the result.
+bool inversionKeepsComparisonSemantics(const FunctionNode & function_node)
+{
+    static const std::unordered_set<std::string_view> ordered_comparisons
+        = {"less", "lessOrEquals", "greater", "greaterOrEquals"};
+
+    if (!ordered_comparisons.contains(function_node.getFunctionName()))
+        return true;
+
+    for (const auto & argument : function_node.getArguments())
+        if (argumentCanBeNaN(argument))
+            return false;
+
+    return true;
+}
+
 std::optional<CNFAtomicFormula> tryInvertFunction(
     const CNFAtomicFormula & atom, const ContextPtr & context, const std::unordered_map<std::string, std::string> & inverse_relations)
 {
     auto * function_node = atom.node_with_hash.node->as<FunctionNode>();
     if (!function_node)
+        return std::nullopt;
+
+    if (!inversionKeepsComparisonSemantics(*function_node))
         return std::nullopt;
 
     if (auto it = inverse_relations.find(function_node->getFunctionName()); it != inverse_relations.end())

--- a/src/Interpreters/TreeCNFConverter.cpp
+++ b/src/Interpreters/TreeCNFConverter.cpp
@@ -302,12 +302,17 @@ static void pushPullNotInAtom(CNFQueryAtomicFormula & atom, const std::unordered
     }
 }
 
+/// The ordered comparisons are missing from the two maps below on purpose. `NaN` fails every ordered
+/// comparison, so for a `NaN` argument `NOT (x < c)` is true while `x >= c` is false: `less` and
+/// `greaterOrEquals` (and `greater` and `lessOrEquals`) are complementary over a totally ordered
+/// domain only, and inverting one into the other silently drops the `NaN` rows. This stage runs on the
+/// AST, where the type of an argument is not known, so it cannot tell a floating point comparison from
+/// an integer one and leaves every ordered comparison alone. The analyzer, which has the types, keeps
+/// inverting the comparisons that cannot see a `NaN` - see `Analyzer::CNF::pushNotIntoFunction`.
 static void pullNotOut(CNFQueryAtomicFormula & atom)
 {
     static const std::unordered_map<std::string, std::string> inverse_relations = {
         {"notEquals", "equals"},
-        {"greaterOrEquals", "less"},
-        {"greater", "lessOrEquals"},
         {"notIn", "in"},
         {"notLike", "like"},
         {"notEmpty", "empty"},
@@ -323,14 +328,10 @@ void pushNotIn(CNFQueryAtomicFormula & atom)
 
     static const std::unordered_map<std::string, std::string> inverse_relations = {
         {"equals", "notEquals"},
-        {"less", "greaterOrEquals"},
-        {"lessOrEquals", "greater"},
         {"in", "notIn"},
         {"like", "notLike"},
         {"empty", "notEmpty"},
         {"notEquals", "equals"},
-        {"greaterOrEquals", "less"},
-        {"greater", "lessOrEquals"},
         {"notIn", "in"},
         {"notLike", "like"},
         {"notEmpty", "empty"},

--- a/tests/queries/0_stateless/05084_cnf_nan_ordered_comparison.reference
+++ b/tests/queries/0_stateless/05084_cnf_nan_ordered_comparison.reference
@@ -1,0 +1,26 @@
+not less
+2
+2
+2
+not greater
+2
+2
+2
+not less or equals
+2
+2
+not greater or equals
+2
+2
+not equals
+2
+2
+not in
+1
+1
+the integer comparison is still inverted
+1
+2
+2
+the float comparison is not
+0

--- a/tests/queries/0_stateless/05084_cnf_nan_ordered_comparison.sql
+++ b/tests/queries/0_stateless/05084_cnf_nan_ordered_comparison.sql
@@ -1,0 +1,46 @@
+-- `NaN` fails every ordered comparison, so `NOT (x < c)` is true for a `NaN` while `x >= c` is false.
+-- The CNF converter inverted one into the other, which silently dropped the `NaN` rows.
+
+DROP TABLE IF EXISTS t_cnf_nan;
+CREATE TABLE t_cnf_nan (x Float64, i Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_cnf_nan VALUES (nan, 1), (1, 2), (100, 3);
+
+SELECT 'not less';
+SELECT count() FROM t_cnf_nan WHERE NOT (x < 65.5) SETTINGS convert_query_to_cnf = 0;
+SELECT count() FROM t_cnf_nan WHERE NOT (x < 65.5) SETTINGS convert_query_to_cnf = 1;
+SELECT count() FROM t_cnf_nan WHERE NOT (x < 65.5) SETTINGS convert_query_to_cnf = 1, enable_analyzer = 0;
+
+SELECT 'not greater';
+SELECT count() FROM t_cnf_nan WHERE NOT (x > 65.5) SETTINGS convert_query_to_cnf = 0;
+SELECT count() FROM t_cnf_nan WHERE NOT (x > 65.5) SETTINGS convert_query_to_cnf = 1;
+SELECT count() FROM t_cnf_nan WHERE NOT (x > 65.5) SETTINGS convert_query_to_cnf = 1, enable_analyzer = 0;
+
+SELECT 'not less or equals';
+SELECT count() FROM t_cnf_nan WHERE NOT (x <= 65.5) SETTINGS convert_query_to_cnf = 0;
+SELECT count() FROM t_cnf_nan WHERE NOT (x <= 65.5) SETTINGS convert_query_to_cnf = 1;
+
+SELECT 'not greater or equals';
+SELECT count() FROM t_cnf_nan WHERE NOT (x >= 65.5) SETTINGS convert_query_to_cnf = 0;
+SELECT count() FROM t_cnf_nan WHERE NOT (x >= 65.5) SETTINGS convert_query_to_cnf = 1;
+
+-- The equality operators are complementary for a `NaN` as well, so they keep being inverted.
+SELECT 'not equals';
+SELECT count() FROM t_cnf_nan WHERE NOT (x = 1) SETTINGS convert_query_to_cnf = 0;
+SELECT count() FROM t_cnf_nan WHERE NOT (x = 1) SETTINGS convert_query_to_cnf = 1;
+SELECT 'not in';
+SELECT count() FROM t_cnf_nan WHERE NOT (x IN (1, 100)) SETTINGS convert_query_to_cnf = 0;
+SELECT count() FROM t_cnf_nan WHERE NOT (x IN (1, 100)) SETTINGS convert_query_to_cnf = 1;
+
+-- An integer column cannot hold a `NaN`, so its comparison is still inverted into the CNF form.
+SELECT 'the integer comparison is still inverted';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT count() FROM t_cnf_nan WHERE NOT (i < 2) SETTINGS convert_query_to_cnf = 1)
+WHERE explain LIKE '%function_name: greaterOrEquals%';
+SELECT count() FROM t_cnf_nan WHERE NOT (i < 2) SETTINGS convert_query_to_cnf = 1;
+SELECT count() FROM t_cnf_nan WHERE NOT (i < 2) SETTINGS convert_query_to_cnf = 0;
+
+-- A float comparison is not, even though the constant itself is not a `NaN`.
+SELECT 'the float comparison is not';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT count() FROM t_cnf_nan WHERE NOT (x < 65.5) SETTINGS convert_query_to_cnf = 1)
+WHERE explain LIKE '%function_name: greaterOrEquals%';
+
+DROP TABLE t_cnf_nan;


### PR DESCRIPTION
`convert_query_to_cnf = 1` rewrote `NOT (x < c)` into `x >= c` and `NOT (x > c)` into `x <= c`. `NaN` fails every ordered comparison, so `NOT (nan < c)` is true while `nan >= c` is false: the two operators are complementary over a totally ordered domain only, and the rewrite silently dropped every `NaN` row from the result.

```sql
CREATE TABLE t_nan (x Float64) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t_nan VALUES (nan), (1), (100);

SELECT count() FROM t_nan WHERE NOT (x < 65.5);                                   -- 2
SELECT count() FROM t_nan WHERE NOT (x < 65.5) SETTINGS convert_query_to_cnf = 1; -- 1 before, 2 now
```

The analyzer knows the argument types, so it keeps inverting a comparison that cannot see a `NaN`: an argument that is a floating point column - or holds one inside an `Array`, `Tuple`, `Map`, `Nullable` or `LowCardinality` - declines the inversion, and a floating point literal declines it only when it really is a `NaN`. The legacy AST stage in `TreeCNFConverter` has no types, so it cannot tell a floating point comparison from an integer one and now leaves every ordered comparison alone; the equality, `IN`, `LIKE` and `empty` operators keep being inverted there, since those answer false, not NULL, for a `NaN`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112036
Related: https://github.com/ClickHouse/ClickHouse/issues/111939

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `convert_query_to_cnf = 1` silently dropping rows with a `NaN` in a floating point column: the conversion rewrote `NOT (x < c)` into `x >= c`, which is not an equivalent condition for `NaN`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118216&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118216](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118216+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.306` (included in `26.10` and later)
<!-- ch-version-info:end -->