### PR TITLE
Make 05054_embedded_rocksdb_explicit_dir_file_grant stress-restart safe

### DIFF
--- a/tests/queries/0_stateless/05054_embedded_rocksdb_explicit_dir_file_grant.sh
+++ b/tests/queries/0_stateless/05054_embedded_rocksdb_explicit_dir_file_grant.sh
@@ -150,9 +150,11 @@ out=$(${CLICKHOUSE_CLIENT} --user "${USER}" -q "RESTORE TABLE ${POC}.restore_src
 rc=$?
 if [ "$rc" -eq 0 ] && created restore_src; then echo "restore-allowed"; else echo "restore-FAILED (unexpected): rc=$rc $out"; fi
 
-${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${POC} SYNC"
+# `IF EXISTS` is not used on either drop: it reports success for a merely detached object, whose
+# metadata still names these directories. Their output is discarded because any stderr fails the test.
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${POC} SYNC" 2>/dev/null
 poc_rc=$?
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${VICTIM} SYNC SETTINGS ignore_drop_queries_probability = 0"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${VICTIM} SYNC SETTINGS ignore_drop_queries_probability = 0" 2>/dev/null
 victim_rc=$?
 ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
 
@@ -165,8 +167,8 @@ if [ "$victim_rc" -eq 0 ] && [ "$probe_rc" -eq 0 ] && [ "$victim_left" != "0" ];
 fi
 
 # Dropping such a table closes its handle but leaves the directory, so remove the three this test made,
-# once both drops above have reported success: a stored definition whose `rocksdb_dir` is gone cannot
-# be attached.
+# once the drops above have reported success and the victim is really gone: a `read_only` definition
+# whose `rocksdb_dir` is gone cannot be attached, and a writable one silently comes back empty.
 if [ -n "${CLICKHOUSE_USER_FILES}" ] && [ "$poc_rc" -eq 0 ] && [ "$victim_rc" -eq 0 ] \
    && [ "$probe_rc" -eq 0 ] && [ "$victim_left" = "0" ]; then
     rm -rf "${CLICKHOUSE_USER_FILES:?}/${SECRET_DIR}" "${CLICKHOUSE_USER_FILES:?}/${RW_DIR}" \

--- a/tests/queries/0_stateless/05054_embedded_rocksdb_explicit_dir_file_grant.sh
+++ b/tests/queries/0_stateless/05054_embedded_rocksdb_explicit_dir_file_grant.sh
@@ -138,7 +138,10 @@ ${CLICKHOUSE_CLIENT} -q "GRANT READ ON FILE TO ${USER}"
 ${CLICKHOUSE_CLIENT} -q "GRANT READ ON DISK TO ${USER}"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${POC}.restore_src (k String, v String) ENGINE = EmbeddedRocksDB(0, '${RESTORE_DIR}') PRIMARY KEY k"
 ${CLICKHOUSE_CLIENT} -q "BACKUP TABLE ${POC}.restore_src TO ${BACKUP} FORMAT Null"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE ${POC}.restore_src SYNC"
+# A top-level `DROP TABLE` of a table that stores data on disk is ignored with the probability the
+# stress runner puts in `ignore_drop_queries_probability`, and still reports success. Pin it to 0
+# wherever this test relies on a drop having happened: the `RESTORE` below needs the name free.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${POC}.restore_src SYNC SETTINGS ignore_drop_queries_probability = 0"
 ${CLICKHOUSE_CLIENT} --user "${USER}" -q "RESTORE TABLE ${POC}.restore_src FROM ${BACKUP} FORMAT Null" 2>&1 \
     | denied_write && echo "restore-denied" || echo "NOT DENIED"
 created restore_src && echo "CREATED ANYWAY (unexpected)" || echo "not-created"
@@ -148,11 +151,15 @@ rc=$?
 if [ "$rc" -eq 0 ] && created restore_src; then echo "restore-allowed"; else echo "restore-FAILED (unexpected): rc=$rc $out"; fi
 
 ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${POC} SYNC"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${VICTIM} SYNC"
+poc_rc=$?
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${VICTIM} SYNC SETTINGS ignore_drop_queries_probability = 0"
+victim_rc=$?
 ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
 
-# Dropping such a table closes its handle but leaves the directory, so remove the three this test made.
-if [ -n "${CLICKHOUSE_USER_FILES}" ]; then
+# Dropping such a table closes its handle but leaves the directory, so remove the three this test made,
+# once both drops above have reported success: a stored definition whose `rocksdb_dir` is gone cannot
+# be attached, and a table that fails to attach aborts metadata loading, so the server cannot start.
+if [ -n "${CLICKHOUSE_USER_FILES}" ] && [ "$poc_rc" -eq 0 ] && [ "$victim_rc" -eq 0 ]; then
     rm -rf "${CLICKHOUSE_USER_FILES:?}/${SECRET_DIR}" "${CLICKHOUSE_USER_FILES:?}/${RW_DIR}" \
         "${CLICKHOUSE_USER_FILES:?}/${RESTORE_DIR}" "${CLICKHOUSE_USER_FILES:?}/${MISSING_DIR}"
 fi

--- a/tests/queries/0_stateless/05054_embedded_rocksdb_explicit_dir_file_grant.sh
+++ b/tests/queries/0_stateless/05054_embedded_rocksdb_explicit_dir_file_grant.sh
@@ -156,10 +156,19 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${VICTIM} SYNC SETTINGS ignore_dro
 victim_rc=$?
 ${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
 
+# A drop that reports success and leaves the table behind is the silent skip above, not a lost race,
+# so it is reported rather than trusted. A failed probe is not read as absence: the directories stay.
+victim_left=$(${CLICKHOUSE_CLIENT} -q "EXISTS TABLE ${VICTIM}")
+probe_rc=$?
+if [ "$victim_rc" -eq 0 ] && [ "$probe_rc" -eq 0 ] && [ "$victim_left" != "0" ]; then
+    echo "victim-survived-a-successful-drop (unexpected)"
+fi
+
 # Dropping such a table closes its handle but leaves the directory, so remove the three this test made,
 # once both drops above have reported success: a stored definition whose `rocksdb_dir` is gone cannot
-# be attached, and a table that fails to attach aborts metadata loading, so the server cannot start.
-if [ -n "${CLICKHOUSE_USER_FILES}" ] && [ "$poc_rc" -eq 0 ] && [ "$victim_rc" -eq 0 ]; then
+# be attached.
+if [ -n "${CLICKHOUSE_USER_FILES}" ] && [ "$poc_rc" -eq 0 ] && [ "$victim_rc" -eq 0 ] \
+   && [ "$probe_rc" -eq 0 ] && [ "$victim_left" = "0" ]; then
     rm -rf "${CLICKHOUSE_USER_FILES:?}/${SECRET_DIR}" "${CLICKHOUSE_USER_FILES:?}/${RW_DIR}" \
         "${CLICKHOUSE_USER_FILES:?}/${RESTORE_DIR}" "${CLICKHOUSE_USER_FILES:?}/${MISSING_DIR}"
 fi


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117665


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Stress test (*)` loses the whole job: the post-stress restart cannot attach `<db>_poc_<pid>.leak` (`Code: 555 ... /CURRENT: No such file or directory`). 8 rows in 3 days: 2 unrelated PRs, 6 release-branch runs, all after the reland.

Dropping an `EmbeddedRocksDB` table with an explicit `rocksdb_dir` closes the handle but leaves the directory, so this test removes its own. `stress.py` SIGTERMs a random `clickhouse-client` whose pattern misses the test script, so the script outlives its dead client and still runs the `rm -rf`; `prepare_for_hung_check` then only detaches databases, so `leak.sql` reaches the final restart, where `FORCE_ATTACH` skips `fs::create_directories` and `OpenForReadOnly` fails on the missing directory.

The `rm -rf` runs only if both teardown drops reported success and a probe confirms the victim is gone: nothing is removed while a stored definition still names it. Two things make a zero status mean the drop happened: the top-level `DROP TABLE`s pin `ignore_drop_queries_probability = 0`, because `Stress test` injects `0.2` and `InterpreterDropQuery` then skips a disk-backed table's drop, reporting success; and neither teardown drop says `IF EXISTS`, which reports success for a merely detached object. Their stderr is discarded: any stderr fails a test. `DROP DATABASE` needs no pin, the skip being disabled inside one. The `RESTORE` pin also removes a latent per-run failure.

Teardown extracted verbatim: unfixed, the directories go and the restart fails; fixed, they stay and it starts, `leak` readable. Measured with the client killed and with the databases detached. Removing either pin reds a mutant, as does dropping the redirect. 41 randomized runs, 20 under the injected client option: green, nothing left behind.

Not fixed here: at `FORCE_ATTACH` a `read_only` table whose directory has vanished still cannot attach, and with `async_load_databases = false` that aborts startup, though the level's contract is to ignore errors. Pre-existing, reachable via `truncate()` alone.

<details>
<summary>CIDB breadth query and result</summary>

```sql
SELECT check_name, if(pull_request_number = 0, head_ref, 'unrelated PR') AS ref,
       count() AS n, max(check_start_time) AS last
FROM default.checks
WHERE check_start_time > now() - INTERVAL 3 DAY
  AND test_context_raw LIKE '%05054_embedded_rocksdb_explicit_dir_file_grant%'
  AND test_context_raw LIKE '%Failed to open rocksdb path%'
GROUP BY check_name, ref ORDER BY last
```

```
┌─check_name─────────────────┬─ref──────────┬─n─┬────────────────last─┐
│ Stress test (amd_msan)     │ unrelated PR │ 1 │ 2026-09-04 17:35:33 │
│ Stress test (amd_tsan)     │ unrelated PR │ 1 │ 2026-09-04 20:40:33 │
│ Stress test (arm_asan, s3) │ 26.3         │ 2 │ 2026-09-04 21:26:50 │
│ Stress test (arm_asan)     │ 26.3         │ 1 │ 2026-09-04 21:26:50 │
│ Stress test (amd_debug)    │ 26.3         │ 1 │ 2026-09-04 21:33:53 │
│ Stress test (amd_msan)     │ 26.3         │ 2 │ 2026-09-04 21:33:56 │
└────────────────────────────┴──────────────┴───┴─────────────────────┘
```

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=26.3&sha=0d1d84363d80aab0cb154b6d670bd50f7ec5a528&name_0=ReleaseBranchCI&name_1=Stress%20test%20%28amd_debug%29

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=26.3&sha=3e4f263a8de732250e07b36e12a90d5607d17110&name_0=ReleaseBranchCI&name_1=Stress%20test%20%28arm_asan%2C%20s3%29

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118220&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118220](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118220+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.802` (included in `26.9` and later)
- Backported to: `26.8.3.62`, `26.7.7.52`, `26.6.5.79`, `26.3.33.18`
<!-- ch-version-info:end -->