### PR TITLE
Do not list a subcolumn that a column of the same name shadows

### DIFF
--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -663,7 +663,24 @@ NamesAndTypesList ColumnsDescription::getNested(const String & column_name) cons
     return nested;
 }
 
-void ColumnsDescription::addSubcolumnsToList(NamesAndTypesList & source_list) const
+static GetColumnsOptions::Kind defaultKindToGetKind(ColumnDefaultKind kind)
+{
+    switch (kind)
+    {
+        case ColumnDefaultKind::Default:
+            return GetColumnsOptions::Ordinary;
+        case ColumnDefaultKind::Materialized:
+            return GetColumnsOptions::Materialized;
+        case ColumnDefaultKind::Alias:
+            return GetColumnsOptions::Aliases;
+        case ColumnDefaultKind::Ephemeral:
+            return GetColumnsOptions::Ephemeral;
+    }
+
+    return GetColumnsOptions::None;
+}
+
+void ColumnsDescription::addSubcolumnsToList(NamesAndTypesList & source_list, const GetColumnsOptions & options) const
 {
     NamesAndTypesList subcolumns_list;
     for (const auto & col : source_list)
@@ -675,8 +692,20 @@ void ColumnsDescription::addSubcolumnsToList(NamesAndTypesList & source_list) co
             continue;
 
         auto range = subcolumns.get<1>().equal_range(col.name);
-        if (range.first != range.second)
-            subcolumns_list.insert(subcolumns_list.end(), range.first, range.second);
+        for (auto subcolumn_it = range.first; subcolumn_it != range.second; ++subcolumn_it)
+        {
+            /// A column may be named like a subcolumn of another column (see the note in
+            /// `addSubcolumns`). `tryGetColumn` answers such a name with the column, so the shadowed
+            /// subcolumn is unreachable and must not be listed next to the column: a block that holds
+            /// both under one name is rejected as soon as their types differ, which made every read of
+            /// the table fail after an `ALTER TABLE ... MODIFY COLUMN` of the shadowing column.
+            auto shadowing_column = columns.get<1>().find(subcolumn_it->name);
+            if (shadowing_column != columns.get<1>().end()
+                && (defaultKindToGetKind(shadowing_column->default_desc.kind) & options.kind))
+                continue;
+
+            subcolumns_list.push_back(*subcolumn_it);
+        }
     }
 
     source_list.splice(source_list.end(), std::move(subcolumns_list));
@@ -754,7 +783,7 @@ NamesAndTypesList ColumnsDescription::get(const GetColumnsOptions & options) con
     }
 
     if (options.with_subcolumns)
-        addSubcolumnsToList(res);
+        addSubcolumnsToList(res, options);
 
     auto cached = std::make_shared<const NamesAndTypesList>(std::move(res));
     {
@@ -779,23 +808,6 @@ bool ColumnsDescription::hasNested(const String & column_name) const
 {
     auto range = getNameRange(columns, column_name);
     return range.first != range.second && range.first->name.length() > column_name.length();
-}
-
-static GetColumnsOptions::Kind defaultKindToGetKind(ColumnDefaultKind kind)
-{
-    switch (kind)
-    {
-        case ColumnDefaultKind::Default:
-            return GetColumnsOptions::Ordinary;
-        case ColumnDefaultKind::Materialized:
-            return GetColumnsOptions::Materialized;
-        case ColumnDefaultKind::Alias:
-            return GetColumnsOptions::Aliases;
-        case ColumnDefaultKind::Ephemeral:
-            return GetColumnsOptions::Ephemeral;
-    }
-
-    return GetColumnsOptions::None;
 }
 
 bool ColumnsDescription::hasSubcolumn(GetColumnsOptions::Kind kind, const String & column_name) const

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -288,7 +288,7 @@ private:
     SubcolumnsContainter subcolumns;
 
     void modifyColumnOrder(const String & column_name, const String & after_column, bool first);
-    void addSubcolumnsToList(NamesAndTypesList & source_list) const;
+    void addSubcolumnsToList(NamesAndTypesList & source_list, const GetColumnsOptions & options) const;
 
     void addSubcolumns(const String & name_in_storage, const DataTypePtr & type_in_storage);
     void removeSubcolumns(const String & name_in_storage);

--- a/tests/queries/0_stateless/05086_column_shadowing_array_size_subcolumn.reference
+++ b/tests/queries/0_stateless/05086_column_shadowing_array_size_subcolumn.reference
@@ -1,0 +1,16 @@
+count of parts of both types
+20
+20
+the name answers with the column, not with the size subcolumn
+0	0	[0,0]
+1	1	[1,1]
+19	9	[9]
+18	8	[8]
+the array itself is still readable
+30
+and the column keeps its own values after the type change
+90
+the alias over a map subcolumn
+1	['x']
+2	['y','z']
+3

--- a/tests/queries/0_stateless/05086_column_shadowing_array_size_subcolumn.sql
+++ b/tests/queries/0_stateless/05086_column_shadowing_array_size_subcolumn.sql
@@ -1,0 +1,44 @@
+-- A column may be named like a subcolumn of another column, and a name lookup answers with the
+-- column. Listing both under that one name was harmless only while their types matched: after
+-- `ALTER TABLE ... MODIFY COLUMN` of the shadowing column, building a block of all columns and
+-- subcolumns hit two different structures under the name `a.size0` and every read of the table
+-- failed with `AMBIGUOUS_COLUMN_NAME`.
+
+DROP TABLE IF EXISTS t_shadowed_size0;
+CREATE TABLE t_shadowed_size0 (id UInt64, `a.size0` UInt64, a Array(UInt64)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_shadowed_size0 SELECT number, number, [number, number] FROM numbers(10);
+ALTER TABLE t_shadowed_size0 MODIFY COLUMN `a.size0` Nullable(UInt64);
+INSERT INTO t_shadowed_size0 SELECT number + 10, number, [number] FROM numbers(10);
+
+SELECT 'count of parts of both types';
+SELECT count() FROM t_shadowed_size0 WHERE id >= 0;
+SELECT count() FROM t_shadowed_size0;
+
+SELECT 'the name answers with the column, not with the size subcolumn';
+SELECT id, `a.size0`, a FROM t_shadowed_size0 ORDER BY id LIMIT 2;
+SELECT id, `a.size0`, a FROM t_shadowed_size0 ORDER BY id DESC LIMIT 2;
+
+SELECT 'the array itself is still readable';
+SELECT sum(length(a)) FROM t_shadowed_size0;
+
+SELECT 'and the column keeps its own values after the type change';
+SELECT sum(assumeNotNull(`a.size0`)) FROM t_shadowed_size0;
+
+DROP TABLE t_shadowed_size0;
+
+-- The same shape with an `ALIAS` shadowing a `Map` subcolumn: there the subcolumn is the physical
+-- one and the alias is not, so a physical read still finds the subcolumn.
+DROP TABLE IF EXISTS t_shadowed_map_keys;
+CREATE TABLE t_shadowed_map_keys
+(
+    id UInt64,
+    m Map(String, UInt64),
+    `m.keys` Array(String) ALIAS mapKeys(m)
+) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_shadowed_map_keys VALUES (1, map('x', 1)), (2, map('y', 2, 'z', 3));
+
+SELECT 'the alias over a map subcolumn';
+SELECT id, `m.keys` FROM t_shadowed_map_keys ORDER BY id;
+SELECT sum(length(m.keys)) FROM t_shadowed_map_keys;
+
+DROP TABLE t_shadowed_map_keys;


### PR DESCRIPTION
A column may be named like a subcolumn of another column - the documented example is an `ALIAS attribute.values` next to a `Map` column `attribute` - and a name lookup answers with the column, so the shadowed subcolumn is unreachable by that name. Listing both of them under that one name was harmless only while their types matched:

```sql
CREATE TABLE t (id UInt64, `a.size0` UInt64, a Array(UInt64)) ENGINE = MergeTree ORDER BY id;
INSERT INTO t SELECT number, number, [number, number] FROM numbers(10);
ALTER TABLE t MODIFY COLUMN `a.size0` Nullable(UInt64);
INSERT INTO t SELECT number + 10, number, [number] FROM numbers(10);

SELECT count() FROM t WHERE id >= 0;
-- Code: 352. DB::Exception: Block structure mismatch ... a.size0 Nullable(UInt64) ...
--   a.size0 UInt64 UInt64(size = 0). (AMBIGUOUS_COLUMN_NAME)
```

Building a block of all columns and subcolumns hit two different structures under `a.size0`, so every read of the table - including a `SELECT count()` that touches neither column - failed, which left the data inaccessible through SQL.

`addSubcolumnsToList` now leaves out a subcolumn whose name belongs to a column the requested kind already contains, mirroring the precedence of `tryGetColumn`. The kind matters: an `ALIAS` does not shadow the subcolumn in a list of physical columns, where the subcolumn is the one that can be read.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113420
Related: https://github.com/ClickHouse/ClickHouse/pull/92453
Related: https://github.com/ClickHouse/ClickHouse/issues/87375

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `AMBIGUOUS_COLUMN_NAME` on every read of a table that has a column named like a subcolumn of another column (for example `a.size0` next to an `Array` column `a`) after `ALTER TABLE ... MODIFY COLUMN` changed that column's type.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118228&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118228](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118228+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
