### PR TITLE
Do not fail a detached docker exec on its exit code in the integration harness

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2743,6 +2743,11 @@ class ClickHouseCluster:
             exec_id = self.docker_client.api.exec_create(container_id, cmd, **kwargs)
             output = self.docker_client.api.exec_start(exec_id, detach=detach)
 
+            if detach:
+                # A detached exec is left running, so docker reports `ExitCode: None` for it; a
+                # value here would only mean it happened to finish first, which was not waited for.
+                return exec_id if get_exec_id else output
+
             exit_code = self.docker_client.api.exec_inspect(exec_id)["ExitCode"]
             if exit_code:
                 container_info = self.docker_client.api.inspect_container(container_id)
@@ -2762,10 +2767,8 @@ class ClickHouseCluster:
                     logging.debug(message)
                 else:
                     raise Exception(message)
-            if not detach:
-                assert not get_exec_id
-                return output.decode()
-            return exec_id if get_exec_id else output
+            assert not get_exec_id
+            return output.decode()
 
     def copy_file_to_container(self, container_id, local_path, dest_path):
         with open(local_path, "rb") as fdata:

--- a/tests/integration/test_cluster_waiters/test_exec_in_container_detach.py
+++ b/tests/integration/test_cluster_waiters/test_exec_in_container_detach.py
@@ -25,13 +25,14 @@ FUNC_NAME = "exec_in_container"
 
 EXEC_ID = {"Id": "exec-1234"}
 EXIT_CODE = 36
+SENTINEL_OUTPUT = b"detached-output\n"
 
 
 def _function_ast():
     """Extract ClickHouseCluster.exec_in_container, scoped to its class.
 
-    ClickHouseInstance defines a forwarder of the same name, so a bare walk of the module
-    can return that instead and every arm below would then exercise a stub.
+    ClickHouseInstance defines a forwarder of the same name, so the extraction is scoped and
+    asserted unique: an unscoped match would silently hand the arms below the wrong function.
     """
     with open(CLUSTER_PY, encoding="utf-8") as f:
         module = ast.parse(f.read())
@@ -112,6 +113,17 @@ def test_a_detached_exec_is_not_failed_by_its_exit_code():
     )
     assert raised is None, raised
     assert returned is EXEC_ID
+    assert counts["inspects"] == 0
+
+
+def test_a_detached_exec_returns_its_output_without_inspecting():
+    """The other half of the guarded return: a detached caller that did not ask for the exec
+    id gets the output object back, and the exit code is still not fetched."""
+    raised, returned, counts = _run(
+        EXIT_CODE, output=SENTINEL_OUTPUT, detach=True, use_cli=False
+    )
+    assert raised is None, raised
+    assert returned is SENTINEL_OUTPUT
     assert counts["inspects"] == 0
 
 

--- a/tests/integration/test_cluster_waiters/test_exec_in_container_detach.py
+++ b/tests/integration/test_cluster_waiters/test_exec_in_container_detach.py
@@ -1,0 +1,133 @@
+"""Pins that ClickHouseCluster.exec_in_container does not consult the exit code of an
+exec it was asked to detach from.
+
+Docker reports `ExitCode: None` for an exec that is still running and a real integer once
+it has finished, so inspecting a detached exec returns whichever of the two the inspection
+happened to race into. A server that exits quickly - as one started with a config it
+rejects does - therefore made the harness raise out of the start call instead of letting
+the caller observe the outcome it was waiting for.
+
+The function under test is loaded out of helpers/cluster.py by AST extraction and executed
+against stubs, so these assertions track the shipped source rather than a copy of it, and
+they are deterministic: no Docker, no container and no ClickHouseCluster instance.
+"""
+
+import ast
+import os
+import types
+from typing import Any, Sequence
+
+CLUSTER_PY = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "helpers", "cluster.py")
+)
+CLASS_NAME = "ClickHouseCluster"
+FUNC_NAME = "exec_in_container"
+
+EXEC_ID = {"Id": "exec-1234"}
+EXIT_CODE = 36
+
+
+def _function_ast():
+    """Extract ClickHouseCluster.exec_in_container, scoped to its class.
+
+    ClickHouseInstance defines a forwarder of the same name, so a bare walk of the module
+    can return that instead and every arm below would then exercise a stub.
+    """
+    with open(CLUSTER_PY, encoding="utf-8") as f:
+        module = ast.parse(f.read())
+    classes = [
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == CLASS_NAME
+    ]
+    assert len(classes) == 1, f"{CLASS_NAME} not found exactly once in {CLUSTER_PY}"
+    functions = [
+        node
+        for node in classes[0].body
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC_NAME
+    ]
+    assert (
+        len(functions) == 1
+    ), f"{CLASS_NAME}.{FUNC_NAME} not found exactly once in {CLUSTER_PY}"
+    return functions[0]
+
+
+def _run(exit_code, output=b"", **kwargs):
+    """Execute the shipped function against stubs and report what it did."""
+    counts = {"inspects": 0}
+
+    def exec_create(container_id, cmd, **_):
+        return EXEC_ID
+
+    def exec_start(exec_id, detach=False):
+        return output
+
+    def exec_inspect(exec_id):
+        counts["inspects"] += 1
+        return {"ExitCode": exit_code}
+
+    # inspect_container and inspect_image are reached only on the failing path, and without
+    # them it would die of an AttributeError before the raise the arms below assert on.
+    api = types.SimpleNamespace(
+        exec_create=exec_create,
+        exec_start=exec_start,
+        exec_inspect=exec_inspect,
+        inspect_container=lambda container_id: {"Image": "image-1"},
+        inspect_image=lambda image_id: {},
+    )
+    cluster = types.SimpleNamespace(docker_client=types.SimpleNamespace(api=api))
+
+    # `Any` and `Sequence` are the annotations of the shipped signature, evaluated when the
+    # def executes because cluster.py does not postpone them.
+    namespace = {
+        "Any": Any,
+        "Sequence": Sequence,
+        "logging": types.SimpleNamespace(debug=lambda *a, **k: None),
+        "pprint": types.SimpleNamespace(pprint=lambda *a, **k: None),
+    }
+    exec(  # pylint:disable=exec-used
+        compile(
+            ast.Module(body=[_function_ast()], type_ignores=[]), CLUSTER_PY, "exec"
+        ),
+        namespace,
+    )
+
+    raised = None
+    returned = None
+    try:
+        returned = namespace[FUNC_NAME](
+            cluster, "container-1", ["bash", "-c", f"exit {EXIT_CODE}"], **kwargs
+        )
+    except Exception as ex:  # pylint:disable=broad-except
+        # Broad: the function raises a bare Exception, and the arms assert its message.
+        raised = str(ex)
+    return raised, returned, counts
+
+
+def test_a_detached_exec_is_not_failed_by_its_exit_code():
+    """The arm that pins the fix: a detached exec that has already exited nonzero is
+    returned to the caller, and its exit code is not even fetched."""
+    raised, returned, counts = _run(
+        EXIT_CODE, detach=True, use_cli=False, get_exec_id=True
+    )
+    assert raised is None, raised
+    assert returned is EXEC_ID
+    assert counts["inspects"] == 0
+
+
+def test_a_waited_exec_still_fails_on_a_nonzero_exit_code():
+    """Control: the caller that did wait still gets the failure, so the fix cannot have
+    disabled the check for everyone."""
+    raised, returned, counts = _run(EXIT_CODE, detach=False, use_cli=False)
+    assert raised is not None
+    assert f"Return code {EXIT_CODE}" in raised, raised
+    assert returned is None
+    assert counts["inspects"] == 1
+
+
+def test_a_waited_exec_returns_its_output():
+    """Control: the waited path still decodes and returns the output it captured."""
+    raised, returned, counts = _run(0, output=b"ok\n", detach=False, use_cli=False)
+    assert raised is None, raised
+    assert returned == "ok\n"
+    assert counts["inspects"] == 1


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117895

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Integration tests no longer fail a server start that was deliberately not waited for.


### Description

`ClickHouseCluster.exec_in_container`'s docker-API branch inspected the exec's exit code
unconditionally, including for `detach=True`. Docker reports `ExitCode: None` while an exec runs and
a real integer once it has finished, so the check passed only while the process was alive. A server
started with a config it rejects exits in about 160 ms, so the inspection landed after it and the
harness raised before the caller could observe the failure it awaited.

Seen on `Integration tests (arm_binary, distributed plan, 1/4)`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117895&sha=9ce0986bd047e67f2a8e88e4f7ddb04016700bcc&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29)),
where `test_keeper_feature_flags` asserts a start failure and got `... Return code 36. Output:` -
empty, because `exec_start(detach=True)` returns no output. `exec_inspect` ran 286 ms after
`exec_start` there, while the healthy restart four seconds earlier inspected after 1 ms and saw
`None`.

Return early on `detach`, before the inspection: this removes a check rather than adding a guard.
`run_and_check`'s detach branch already implements that invariant, and `test_refreshable_mv` relies
on it, polling this field guarded by `if exit_code is not None`. Gating on `exit_code is not None`
here would not fix it, since the observed value is 36, not `None`. The detached return value itself
is unchanged.

`use_cli=False` is the only way into this branch, and the two pre-existing sites passing it with
`detach=True` own their outcome: `start_clickhouse` via `wait_start` /
`wait_start_failed` / its terminal raise, and `test_keeper_snapshot_rotation_race` by polling pids.
No failure goes undetected, only its exit code in the harness message. 20
`expected_to_fail=True` call sites ride on the first.

The four new arms execute the shipped function against stubs, so they are deterministic; two are
controls, pinning that a waited exec still fails on a nonzero code and still decodes its output.
Also verified against a real container.

This addresses one of at least four distinct failure signatures `test_keeper_feature_flags` has
shown over 90 days, not a blanket de-flake.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118231&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118231](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118231+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.821` (included in `26.9` and later)
<!-- ch-version-info:end -->