### PR TITLE
Count packed skip-index archive index loads, and assert 04653 on that counter

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -512,7 +512,7 @@
     M(LoadedPrimaryIndexFiles, "Number of primary index files loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexRows, "Number of rows of primary key loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexBytes, "Number of rows of primary key loaded.", ValueType::Bytes) \
-    M(PackedSkipIndicesArchiveIndexLoads, "Number of reads of the index of a part's packed skip-indices archive. A part storage reads it at most once, lazily, on the first access to a skip index stored inside the archive; an index seeded from another part storage is not counted.", ValueType::Number) \
+    M(PackedSkipIndicesArchiveIndexLoads, "Number of attempted reads of the index of a part's packed skip-indices archive. The read is lazy and memoized per part storage, so it normally happens once; a probe that finds the archive relocated is not memoized, and concurrent first accesses can each read. An index seeded from another part storage is not counted.", ValueType::Number) \
     \
     M(Merge, "Number of launched background merges.", ValueType::Number) \
     M(MergeSourceParts, "Number of source parts scheduled for merges.", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -512,6 +512,7 @@
     M(LoadedPrimaryIndexFiles, "Number of primary index files loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexRows, "Number of rows of primary key loaded.", ValueType::Number) \
     M(LoadedPrimaryIndexBytes, "Number of rows of primary key loaded.", ValueType::Bytes) \
+    M(PackedSkipIndicesArchiveIndexLoads, "Number of reads of the index of a part's packed skip-indices archive. A part storage reads it at most once, lazily, on the first access to a skip index stored inside the archive; an index seeded from another part storage is not counted.", ValueType::Number) \
     \
     M(Merge, "Number of launched background merges.", ValueType::Number) \
     M(MergeSourceParts, "Number of source parts scheduled for merges.", ValueType::Number) \

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -25,10 +25,16 @@
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
+#include <Common/ProfileEvents.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 
 #include <fmt/ranges.h>
+
+namespace ProfileEvents
+{
+    extern const Event PackedSkipIndicesArchiveIndexLoads;
+}
 
 namespace DB
 {
@@ -1218,6 +1224,8 @@ std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskBase::getSkipIndic
         Expect404ResponseScope scope;
         try
         {
+            /// Counts attempts: the catch below does not cache a miss, so a re-probe counts again.
+            ProfileEvents::increment(ProfileEvents::PackedSkipIndicesArchiveIndexLoads);
             skip_indices_packed_reader = std::make_shared<PackedFilesReader>(disk, packed_path, ReadSettings{});
         }
         catch (const Exception &)

--- a/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskPacked.cpp
@@ -14,7 +14,13 @@
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
+#include <Common/ProfileEvents.h>
 #include <Common/logger_useful.h>
+
+namespace ProfileEvents
+{
+    extern const Event PackedSkipIndicesArchiveIndexLoads;
+}
 
 namespace DB
 {
@@ -687,6 +693,8 @@ std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskPacked::getSkipInd
         const String data_path = getRelativeDataPath();
         try
         {
+            /// Counts attempts: the catch below does not cache a miss, so a re-probe counts again.
+            ProfileEvents::increment(ProfileEvents::PackedSkipIndicesArchiveIndexLoads);
             auto inner_archive_buf = reader->readFile(
                 volume->getDisk(), data_path, String(SKIP_INDICES_PACKED_FILENAME), getReadSettings(), std::nullopt);
             auto inner_index = PackedFilesReader::readIndex(*inner_archive_buf);

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
@@ -1,15 +1,15 @@
 packed	1	Packed
-accounted	1
+accounted	1	1
+full_storage	1	Full
+full_indices	1	1
+sizes_index_equal	1	1	1
+sizes_column_equal	1	1	1
+rows_intact	2000
 rows	1
 untouched	1
 cold_no_archive_load	1
 warm_one_archive_load	1
-full_storage	1	Full
-full_indices	1	1
 full_rows	1
 full_untouched	1
 full_one_archive_load	1
 full_no_archive_zero_load	1
-sizes_index_equal	1	1	1
-sizes_column_equal	1	1	1
-rows_intact	2000

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
@@ -2,8 +2,8 @@ packed	1	Packed
 accounted	1
 rows	1
 untouched	1
-fewer_file_open	1
-fewer_pool_read	1
+cold_no_archive_load	1
+warm_one_archive_load	1
 sizes_index_equal	1	1	1
 sizes_column_equal	1	1	1
 rows_intact	2000

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.reference
@@ -4,6 +4,12 @@ rows	1
 untouched	1
 cold_no_archive_load	1
 warm_one_archive_load	1
+full_storage	1	Full
+full_indices	1	1
+full_rows	1
+full_untouched	1
+full_one_archive_load	1
+full_no_archive_zero_load	1
 sizes_index_equal	1	1	1
 sizes_column_equal	1	1	1
 rows_intact	2000

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
@@ -12,17 +12,10 @@
 -- `ThreadPoolImpl::scheduleImpl`): a pool that cannot schedule throws `CANNOT_SCHEDULE_TASK`, not a
 -- memory-tracker exception, so `LockMemoryExceptionInThread` does not suppress it and it escapes.
 --
--- The commit must therefore read nothing. The oracle is the `MutatePart` row of `system.part_log`:
--- `ProfileEventsScope` in `MutatePlainMergeTreeTask::executeStep` covers `transaction.commit`, and
--- `write_part_log` runs after it on the same thread. An object-storage disk is used not because the
--- scheduling happens there, but because it makes the extra access deterministically measurable as
--- read volume: on it the read runs synchronously (`AsynchronousBoundedReadBuffer::readSync` ->
--- `ThreadPoolRemoteFSReader::execute`), so the test observes the access, not the scheduling.
---
--- The cold arm is compared against a warm control rather than against an absolute count: with
--- `columns_and_secondary_indices_sizes_lazy_calculation = 0` the part is warmed when it is loaded,
--- so that arm always contains exactly one archive read and never needs another one in the commit.
--- Absolute counts would depend on the fixture, the control makes the assertion self-normalizing.
+-- The commit must therefore read nothing. `PackedSkipIndicesArchiveIndexLoads` counts that read, and
+-- is read per table from the `MutatePart` row of `system.part_log`: `ProfileEventsScope` in
+-- `MutatePlainMergeTreeTask::executeStep` covers `transaction.commit`, and `write_part_log` runs after
+-- it on the same thread, so the counters it collects are the mutation's own.
 
 DROP TABLE IF EXISTS packed_commit_cold SYNC;
 DROP TABLE IF EXISTS packed_commit_warm SYNC;
@@ -99,34 +92,16 @@ SELECT 'untouched',
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
--- The warm control computes the sizes when it loads the cloned part, so its `MutatePart` row always
--- contains that one archive read. The cold arm must contain strictly fewer file opens, because
--- after the fix it does not read the archive at all: not when loading (the sizes stay lazy) and not
--- in the commit (the aggregates are dropped instead of updated). Before the fix it read in the
--- commit, so it opened the same number of files as the control.
---
--- Strictly fewer, not "no more than": the unfixed build reads exactly as much as the control, so a
--- "no more than" assertion would hold on both builds and the test would prove nothing.
---
--- `FileOpen` is the counter because it does not depend on which reader implementation serves the
--- read, so the assertion survives `local_filesystem_read_method` and `remote_filesystem_read_method`
--- randomization.
-SELECT 'fewer_file_open',
-    maxIf(ProfileEvents['FileOpen'], table = 'packed_commit_cold')
-   < maxIf(ProfileEvents['FileOpen'], table = 'packed_commit_warm')
+-- The commit must not load the skip-indices archive index at all, so the cold arm's count is 0. The
+-- warm control computes the sizes when it loads the cloned part, and a part storage loads that index
+-- at most once, so its count is exactly 1.
+SELECT 'cold_no_archive_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_cold') = 0
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
--- The same statement in bytes moved through `ThreadPoolRemoteFSReader::execute`, which as noted above
--- runs synchronously on the mutation thread here, so the `MutatePart` counter scope collects it.
---
--- It is a second read-volume signal beside `FileOpen`, not the scheduling observable: on the
--- scheduled path the same increment happens on a pool worker under its own thread group, which the
--- part-log snapshot cannot collect. The claim that the read is handed to a pool, and so can raise
--- `CANNOT_SCHEDULE_TASK`, is carried by the fix's rationale and by the boundary probe instead.
-SELECT 'fewer_pool_read',
-    maxIf(ProfileEvents['ThreadpoolReaderReadBytes'], table = 'packed_commit_cold')
-   < maxIf(ProfileEvents['ThreadpoolReaderReadBytes'], table = 'packed_commit_warm')
+SELECT 'warm_one_archive_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_warm') = 1
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
@@ -3,14 +3,18 @@
 -- tests/config/install.sh, which clears EXPORT_S3_STORAGE_POLICIES, so the s3 policies are not
 -- installed there at all.
 
+-- The object-storage policy is kept because that is the configuration the aborting read was observed
+-- in; the counter itself is disk-independent.
+
 -- `MergeTreeData::Transaction::commit` updates the table's per-column and per-secondary-index size
 -- aggregates inside a `NOEXCEPT_SCOPE` whose catch-all terminates the server. For a part whose sizes
 -- are not computed yet, that update called the size getters, which lazily read the part storage, and
--- on packed storage that read resolves the skip-index archive index. Under the default
--- `local_filesystem_read_method = 'pread_threadpool'` it is submitted to a thread pool, which is where
--- the reproduced abort came from (`AsynchronousReadBufferFromFileDescriptor::asyncReadInto` ->
--- `ThreadPoolImpl::scheduleImpl`): a pool that cannot schedule throws `CANNOT_SCHEDULE_TASK`, not a
--- memory-tracker exception, so `LockMemoryExceptionInThread` does not suppress it and it escapes.
+-- when the skip indices are bundled into a packed archive that read resolves the archive's index.
+-- Under the default `local_filesystem_read_method = 'pread_threadpool'` it is submitted to a thread
+-- pool, which is where the reproduced abort came from
+-- (`AsynchronousReadBufferFromFileDescriptor::asyncReadInto` -> `ThreadPoolImpl::scheduleImpl`): a
+-- pool that cannot schedule throws `CANNOT_SCHEDULE_TASK`, not a memory-tracker exception, so
+-- `LockMemoryExceptionInThread` does not suppress it and it escapes.
 --
 -- The commit must therefore read nothing. `PackedSkipIndicesArchiveIndexLoads` counts that read, and
 -- is read per table from the `MutatePart` row of `system.part_log`: `ProfileEventsScope` in
@@ -19,6 +23,8 @@
 
 DROP TABLE IF EXISTS packed_commit_cold SYNC;
 DROP TABLE IF EXISTS packed_commit_warm SYNC;
+DROP TABLE IF EXISTS full_commit_archive SYNC;
+DROP TABLE IF EXISTS full_commit_no_archive SYNC;
 
 -- Cold arm: the mutation's cloned part arrives with its sizes not yet computed.
 CREATE TABLE packed_commit_cold
@@ -55,10 +61,47 @@ SETTINGS storage_policy = 's3_no_fake_transaction',
          min_bytes_for_full_part_storage = 1000000000,
          columns_and_secondary_indices_sizes_lazy_calculation = 0;
 
+-- `Full` part storage keeps the packed skip-indices archive as a standalone file, which a different
+-- reader opens, so it is covered by its own arm. The second table writes the same two indices with
+-- packing disabled, so a 0 there means "no archive to load" rather than "no indices".
+CREATE TABLE full_commit_archive
+(
+    s String,
+    a String,
+    b String,
+    INDEX m_a a TYPE minmax GRANULARITY 1,
+    INDEX m_b b TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY s
+SETTINGS storage_policy = 's3_no_fake_transaction',
+         min_bytes_for_wide_part = 0,
+         packed_skip_index_max_bytes = '1M',
+         index_granularity = 1024,
+         min_bytes_for_full_part_storage = 0,
+         columns_and_secondary_indices_sizes_lazy_calculation = 0;
+
+CREATE TABLE full_commit_no_archive
+(
+    s String,
+    a String,
+    b String,
+    INDEX m_a a TYPE minmax GRANULARITY 1,
+    INDEX m_b b TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY s
+SETTINGS storage_policy = 's3_no_fake_transaction',
+         min_bytes_for_wide_part = 0,
+         packed_skip_index_max_bytes = 0,
+         index_granularity = 1024,
+         min_bytes_for_full_part_storage = 0,
+         columns_and_secondary_indices_sizes_lazy_calculation = 0;
+
 -- String columns on purpose: `loadRowsCount` computes on-disk sizes for numeric columns in debug and
 -- sanitizer builds, which would warm the cloned part and hide the read.
 INSERT INTO packed_commit_cold SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
 INSERT INTO packed_commit_warm SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
+INSERT INTO full_commit_archive SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
+INSERT INTO full_commit_no_archive SELECT toString(number), toString(number * 7), toString(number * 11) FROM numbers(2000);
 
 -- Both parts must be `Packed`, otherwise there is no archive to read and the test is vacuous.
 SELECT 'packed', countDistinct(part_storage_type) = 1, any(part_storage_type)
@@ -93,8 +136,8 @@ FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
 
 -- The commit must not load the skip-indices archive index at all, so the cold arm's count is 0. The
--- warm control computes the sizes when it loads the cloned part, and a part storage loads that index
--- at most once, so its count is exactly 1.
+-- warm control computes the sizes when it loads the cloned part, and that load is single-threaded and
+-- memoized, so its count is exactly 1.
 SELECT 'cold_no_archive_load',
     maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_cold') = 0
 FROM system.part_log
@@ -104,6 +147,45 @@ SELECT 'warm_one_archive_load',
     maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_warm') = 1
 FROM system.part_log
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'full_storage', countDistinct(part_storage_type) = 1, any(part_storage_type)
+FROM system.parts
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND active;
+
+SELECT 'full_indices', count() = 2, min(idx_bytes > 0)
+FROM
+(
+    SELECT sum(secondary_indices_compressed_bytes) AS idx_bytes
+    FROM system.parts
+    WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND active
+    GROUP BY table
+);
+
+ALTER TABLE full_commit_archive UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
+ALTER TABLE full_commit_no_archive UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
+
+SYSTEM FLUSH LOGS part_log;
+
+SELECT 'full_rows', count() = 2
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
+
+-- Both rows have to exist, otherwise `maxIf` over an empty set would satisfy the `= 0` row below.
+SELECT 'full_untouched',
+    minIf(ProfileEvents['MutationUntouchedParts'], table = 'full_commit_archive') > 0
+  AND minIf(ProfileEvents['MutationUntouchedParts'], table = 'full_commit_no_archive') > 0
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'full_one_archive_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'full_commit_archive') = 1
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'full_no_archive_zero_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'full_commit_no_archive') = 0
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
 
 -- The aggregates must stay correct: dropping them and rebuilding on the next read has to give the
 -- same answer the incremental update gave. The warm control is that answer, because it never takes
@@ -176,3 +258,5 @@ SELECT 'rows_intact', count() FROM packed_commit_cold;
 
 DROP TABLE packed_commit_cold SYNC;
 DROP TABLE packed_commit_warm SYNC;
+DROP TABLE full_commit_archive SYNC;
+DROP TABLE full_commit_no_archive SYNC;

--- a/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
+++ b/tests/queries/0_stateless/04653_packed_part_size_accounting_no_read_in_commit.sql
@@ -108,45 +108,17 @@ SELECT 'packed', countDistinct(part_storage_type) = 1, any(part_storage_type)
 FROM system.parts
 WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND active;
 
--- Reading a size sets the table level flag, which is what makes the commit update the aggregates at
--- all.
-SELECT 'accounted', sum(data_compressed_bytes) > 0
-FROM system.data_skipping_indices
-WHERE database = currentDatabase() AND table LIKE 'packed_commit_%';
-
--- A predicate matching no rows takes the untouched-part shortcut, which clones the part and keeps
--- its block range, so the source part is covered and both accounting paths run in the commit.
--- `untouched` below asserts that shortcut was taken.
-ALTER TABLE packed_commit_cold UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
-ALTER TABLE packed_commit_warm UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
-
-SYSTEM FLUSH LOGS part_log;
-
-SELECT 'rows', count() = 2
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
-
--- `MutationUntouchedParts` is read per table from the `MutatePart` row rather than from
--- `system.events`, whose counters are process-wide and lifetime-cumulative, so a concurrent test
--- taking the same shortcut would satisfy the assertion for us and it would fail open.
-SELECT 'untouched',
-    minIf(ProfileEvents['MutationUntouchedParts'], table = 'packed_commit_cold') > 0
-  AND minIf(ProfileEvents['MutationUntouchedParts'], table = 'packed_commit_warm') > 0
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
-
--- The commit must not load the skip-indices archive index at all, so the cold arm's count is 0. The
--- warm control computes the sizes when it loads the cloned part, and that load is single-threaded and
--- memoized, so its count is exactly 1.
-SELECT 'cold_no_archive_load',
-    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_cold') = 0
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
-
-SELECT 'warm_one_archive_load',
-    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_warm') = 1
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+-- Reading a size computes it, which sets that table's flag, and the flag is what makes the commit
+-- update the aggregates at all. Asserted per table, because an aggregate over both tables would also
+-- be satisfied with one of them left unarmed.
+SELECT 'accounted', count() = 2, min(idx_bytes > 0)
+FROM
+(
+    SELECT sum(data_compressed_bytes) AS idx_bytes
+    FROM system.data_skipping_indices
+    WHERE database = currentDatabase() AND table LIKE 'packed_commit_%'
+    GROUP BY table
+);
 
 SELECT 'full_storage', countDistinct(part_storage_type) = 1, any(part_storage_type)
 FROM system.parts
@@ -161,31 +133,13 @@ FROM
     GROUP BY table
 );
 
+-- A predicate matching no rows takes the untouched-part shortcut, which clones the part and keeps
+-- its block range, so the source part is covered and both accounting paths run in the commit.
+-- `untouched` further below asserts that shortcut was taken.
+ALTER TABLE packed_commit_cold UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
+ALTER TABLE packed_commit_warm UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
 ALTER TABLE full_commit_archive UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
 ALTER TABLE full_commit_no_archive UPDATE a = concat(a, 'x') WHERE s = 'no_such_key' SETTINGS mutations_sync = 2;
-
-SYSTEM FLUSH LOGS part_log;
-
-SELECT 'full_rows', count() = 2
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
-
--- Both rows have to exist, otherwise `maxIf` over an empty set would satisfy the `= 0` row below.
-SELECT 'full_untouched',
-    minIf(ProfileEvents['MutationUntouchedParts'], table = 'full_commit_archive') > 0
-  AND minIf(ProfileEvents['MutationUntouchedParts'], table = 'full_commit_no_archive') > 0
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
-
-SELECT 'full_one_archive_load',
-    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'full_commit_archive') = 1
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
-
-SELECT 'full_no_archive_zero_load',
-    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'full_commit_no_archive') = 0
-FROM system.part_log
-WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
 
 -- The aggregates must stay correct: dropping them and rebuilding on the next read has to give the
 -- same answer the incremental update gave. The warm control is that answer, because it never takes
@@ -256,7 +210,60 @@ FROM
 
 SELECT 'rows_intact', count() FROM packed_commit_cold;
 
+-- The tables are dropped before the part log is read, because a synchronous mutation is reported done
+-- as soon as its result part becomes visible, which is before the mutation task writes its
+-- `MutatePart` row: a flush issued right after the ALTER can miss that row. Dropping a table waits for
+-- that table's background tasks, so afterwards every row is queued and one flush observes all of them.
 DROP TABLE packed_commit_cold SYNC;
 DROP TABLE packed_commit_warm SYNC;
 DROP TABLE full_commit_archive SYNC;
 DROP TABLE full_commit_no_archive SYNC;
+
+SYSTEM FLUSH LOGS part_log;
+
+SELECT 'rows', count() = 2
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+-- `MutationUntouchedParts` is read per table from the `MutatePart` row rather than from
+-- `system.events`, whose counters are process-wide and lifetime-cumulative, so a concurrent test
+-- taking the same shortcut would satisfy the assertion for us and it would fail open.
+SELECT 'untouched',
+    minIf(ProfileEvents['MutationUntouchedParts'], table = 'packed_commit_cold') > 0
+  AND minIf(ProfileEvents['MutationUntouchedParts'], table = 'packed_commit_warm') > 0
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+-- The commit must not load the skip-indices archive index at all, so the cold arm's count is 0. The
+-- warm control computes the sizes when it loads the cloned part, and that load is single-threaded and
+-- memoized, so its count is exactly 1.
+SELECT 'cold_no_archive_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_cold') = 0
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'warm_one_archive_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'packed_commit_warm') = 1
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'packed_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'full_rows', count() = 2
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
+
+-- Both rows have to exist, otherwise `maxIf` over an empty set would satisfy the `= 0` row below.
+SELECT 'full_untouched',
+    minIf(ProfileEvents['MutationUntouchedParts'], table = 'full_commit_archive') > 0
+  AND minIf(ProfileEvents['MutationUntouchedParts'], table = 'full_commit_no_archive') > 0
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'full_one_archive_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'full_commit_archive') = 1
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';
+
+SELECT 'full_no_archive_zero_load',
+    maxIf(ProfileEvents['PackedSkipIndicesArchiveIndexLoads'], table = 'full_commit_no_archive') = 0
+FROM system.part_log
+WHERE database = currentDatabase() AND table LIKE 'full_commit_%' AND event_type = 'MutatePart';


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112691


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added the `PackedSkipIndicesArchiveIndexLoads` ProfileEvent, which counts attempted reads of the index of a part's packed skip-indices archive.


### Description

`04653_packed_part_size_accounting_no_read_in_commit` (added by #112691) reddens unrelated PRs: 7 failures against 20774 passes, always the same two rows.

Both rows compared incidental I/O aggregates whose whole margin between the arms is **one** `disk->readFile`: the warm control resolves the archive index once while computing the cloned part's sizes at load, and the cold arm keeps them lazy, so the oracle was `baseline < baseline + 1` and any one-unit perturbation flipped both. CIDB re-ran both failures 124 and 121 times with identical settings, 0 reproductions, so no `no-random-*` clamp applies.

This adds `PackedSkipIndicesArchiveIndexLoads`, incremented once per attempted archive-index load at both sites performing one (`DataPartStorageOnDiskPacked::getSkipIndicesPackedReader` and the `DataPartStorageOnDiskBase` one used on `Full` storage), and rewrites the two rows as absolute counts: 0 cold, exactly 1 for the control. Two further arms cover the second site: one load with the archive bundled, zero without. Seeding paths install an index without reading it and do not count, which makes 0 meaningful.

The part log is read only after the tables are dropped, because `mutations_sync` does not imply the `MutatePart` row is queued: a mutation is reported done once its result part is visible, while dropping a table waits for its background tasks. A delay injected between the two reproduced the `amd_debug` flaky-check failure byte for byte. The size precondition is asserted per table.

Validation: counts 0/1 and 1/0, identical 3/3; reverting the #112691 guards reddens the cold row alone; deleting the base-class increment reddens the `Full` row alone; a lazy warm arm reads 0, so the control can fail; 200/200 randomized runs green.

It does not claim the rate drops to zero: no mechanism able to move both old counters was found. But a residual occurrence now names its side: `cold != 0` is a real extra read, `warm != 1` an unarmed fixture.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118234&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118234](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118234+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

