### PR TITLE
Fix backports stranded by a merged cherry-pick, and stop re-cloning per CherryPick tick

### DIFF
--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -16,7 +16,7 @@ on: # yamllint disable-line rule:truthy
     # Every 20 minutes. Offset from round values (e.g. */20 -> :00/:20/:40),
     # which are popular and get their launches delayed by GitHub.
     #
-    # A tick that fires while the loop below is running is not wasted work: it is
+    # A tick that fires while the Python loop is running is not wasted work: it is
     # the successor that starts as soon as the loop exits, and it is what restarts
     # the loop within 20 minutes if a run dies early.
     - cron: '9,29,49 * * * *'
@@ -50,80 +50,8 @@ jobs:
       - name: Debug Info
         uses: ./.github/actions/debug
       - name: Cherry pick
-        run: |
-          cd "$GITHUB_WORKSPACE/tests/ci"
-
-          # Checking the repository out dominates this job: the runner is
-          # ephemeral, so `actions/checkout` re-fetches the whole history on every
-          # run. Measured at 1052 s of `git fetch` against 7 min of actual work,
-          # which is also why the job took longer than its own 20-minute cron and
-          # the cadence was really the run time.
-          #
-          # Iterate inside one job instead of paying that per tick. The clone is
-          # amortised over the window, ~9% of the job instead of ~70%, and every
-          # iteration after the first re-fetches into a warm repository in about a
-          # second. PERIOD_SECONDS keeps the cadence the cron already asks for;
-          # now that the clone is not in the way it could be lowered.
-          LOOP_SECONDS=$((170 * 60))
-          PERIOD_SECONDS=$((20 * 60))
-          MAX_CONSECUTIVE_FAILURES=3
-
-          deadline=$(( $(date +%s) + LOOP_SECONDS ))
-          iteration=0
-          failures=0
-          consecutive=0
-
-          while :; do
-            iteration=$(( iteration + 1 ))
-            started=$(date +%s)
-
-            echo "::group::Iteration ${iteration}"
-            if python3 cherry_pick.py; then
-              consecutive=0
-            else
-              failures=$(( failures + 1 ))
-              consecutive=$(( consecutive + 1 ))
-              # cherry_pick.py reports the error itself through CIBuddy. Keep the
-              # loop going so one transient failure does not cost the rest of the
-              # window, and fail the job at the end.
-              echo "::error::cherry_pick.py failed on iteration ${iteration}"
-            fi
-            echo "::endgroup::"
-
-            # `clear_repo` in git_helper puts HEAD back, but the local branches a
-            # run creates are left behind, and a stale `backport/<release>/<PR>`
-            # makes the next iteration's `git pull --ff-only` fail once its remote
-            # counterpart has moved. Return to the state a fresh checkout gives.
-            git -C "$GITHUB_WORKSPACE" checkout -f master
-            git -C "$GITHUB_WORKSPACE" for-each-ref --format='%(refname:lstrip=2)' refs/heads \
-            | while read -r branch; do
-                if [ "${branch}" != "master" ]; then
-                  git -C "$GITHUB_WORKSPACE" branch -D "${branch}"
-                fi
-              done
-
-            if [ "${consecutive}" -ge "${MAX_CONSECUTIVE_FAILURES}" ]; then
-              # Something is broken rather than flaky. Give up the window and let
-              # the next run start from a clean checkout.
-              echo "::error::${consecutive} consecutive failures, ending the loop"
-              break
-            fi
-
-            now=$(date +%s)
-            if [ "${now}" -ge "${deadline}" ]; then
-              break
-            fi
-            remaining=$(( PERIOD_SECONDS - (now - started) ))
-            if [ "${remaining}" -gt 0 ]; then
-              sleep "${remaining}"
-            fi
-          done
-
-          echo "Ran ${iteration} iteration(s), ${failures} failed" \
-            | tee -a "$GITHUB_STEP_SUMMARY"
-          if [ "${failures}" -gt 0 ]; then
-            exit 1
-          fi
+        working-directory: tests/ci
+        run: python3 cherry_pick.py --loop
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -6,19 +6,28 @@ env:
 
 concurrency:
   group: cherry-pick
-  # Never run two cherry-pick jobs at the same time: a new scheduled run waits
-  # for the in-progress one to finish instead of cancelling it.
+  # Never cancel the run that is already looping. GitHub keeps exactly one newer
+  # run pending, so it takes over the moment this one exits, and it cancels any
+  # pending run older than that: the in-progress loop is never interrupted and no
+  # more than one successor is ever waiting.
   cancel-in-progress: false
 on: # yamllint disable-line rule:truthy
   schedule:
     # Every 20 minutes. Offset from round values (e.g. */20 -> :00/:20/:40),
     # which are popular and get their launches delayed by GitHub.
+    #
+    # A tick that fires while the loop below is running is not wasted work: it is
+    # the successor that starts as soon as the loop exits, and it is what restarts
+    # the loop within 20 minutes if a run dies early.
     - cron: '9,29,49 * * * *'
   workflow_dispatch:
 
 jobs:
   CherryPick:
     runs-on: [self-hosted, style-checker-aarch64]
+    # The loop stops on its own well before this; the timeout only bounds a
+    # single hung iteration.
+    timeout-minutes: 200
     steps:
       - name: Set envs
         # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#multiline-strings
@@ -43,7 +52,78 @@ jobs:
       - name: Cherry pick
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"
-          python3 cherry_pick.py
+
+          # Checking the repository out dominates this job: the runner is
+          # ephemeral, so `actions/checkout` re-fetches the whole history on every
+          # run. Measured at 1052 s of `git fetch` against 7 min of actual work,
+          # which is also why the job took longer than its own 20-minute cron and
+          # the cadence was really the run time.
+          #
+          # Iterate inside one job instead of paying that per tick. The clone is
+          # amortised over the window, ~9% of the job instead of ~70%, and every
+          # iteration after the first re-fetches into a warm repository in about a
+          # second. PERIOD_SECONDS keeps the cadence the cron already asks for;
+          # now that the clone is not in the way it could be lowered.
+          LOOP_SECONDS=$((170 * 60))
+          PERIOD_SECONDS=$((20 * 60))
+          MAX_CONSECUTIVE_FAILURES=3
+
+          deadline=$(( $(date +%s) + LOOP_SECONDS ))
+          iteration=0
+          failures=0
+          consecutive=0
+
+          while :; do
+            iteration=$(( iteration + 1 ))
+            started=$(date +%s)
+
+            echo "::group::Iteration ${iteration}"
+            if python3 cherry_pick.py; then
+              consecutive=0
+            else
+              failures=$(( failures + 1 ))
+              consecutive=$(( consecutive + 1 ))
+              # cherry_pick.py reports the error itself through CIBuddy. Keep the
+              # loop going so one transient failure does not cost the rest of the
+              # window, and fail the job at the end.
+              echo "::error::cherry_pick.py failed on iteration ${iteration}"
+            fi
+            echo "::endgroup::"
+
+            # `clear_repo` in git_helper puts HEAD back, but the local branches a
+            # run creates are left behind, and a stale `backport/<release>/<PR>`
+            # makes the next iteration's `git pull --ff-only` fail once its remote
+            # counterpart has moved. Return to the state a fresh checkout gives.
+            git -C "$GITHUB_WORKSPACE" checkout -f master
+            git -C "$GITHUB_WORKSPACE" for-each-ref --format='%(refname:lstrip=2)' refs/heads \
+            | while read -r branch; do
+                if [ "${branch}" != "master" ]; then
+                  git -C "$GITHUB_WORKSPACE" branch -D "${branch}"
+                fi
+              done
+
+            if [ "${consecutive}" -ge "${MAX_CONSECUTIVE_FAILURES}" ]; then
+              # Something is broken rather than flaky. Give up the window and let
+              # the next run start from a clean checkout.
+              echo "::error::${consecutive} consecutive failures, ending the loop"
+              break
+            fi
+
+            now=$(date +%s)
+            if [ "${now}" -ge "${deadline}" ]; then
+              break
+            fi
+            remaining=$(( PERIOD_SECONDS - (now - started) ))
+            if [ "${remaining}" -gt 0 ]; then
+              sleep "${remaining}"
+            fi
+          done
+
+          echo "Ran ${iteration} iteration(s), ${failures} failed" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "${failures}" -gt 0 ]; then
+            exit 1
+          fi
       - name: Cleanup
         if: always()
         run: |

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -37,6 +37,7 @@ https://github.com/ClickHouse/internal-knowledge-base/issues/452
 import argparse
 import logging
 import os
+import shlex
 import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -1533,17 +1534,38 @@ def parse_args():
         action="store_true",
         help="add debug logging for git_helper and github_helper",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--loop", action="store_true", help="repeat within one checkout"
+    )
+    parser.add_argument(
+        "--loop-duration",
+        type=int,
+        default=170 * 60,
+        help="stop starting iterations after this many seconds",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=20 * 60,
+        help="seconds between iteration starts",
+    )
+    parser.add_argument(
+        "--max-consecutive-failures",
+        type=int,
+        default=3,
+        help="stop the loop after this many consecutive failures",
+    )
+    args = parser.parse_args()
+    for option in ("loop_duration", "interval", "max_consecutive_failures"):
+        if getattr(args, option) <= 0:
+            parser.error(f"--{option.replace('_', '-')} must be positive")
+    return args
 
 
-def main():
+def run_once(args):
     temp_path = Path(TEMP_PATH)
     temp_path.mkdir(parents=True, exist_ok=True)
 
-    args = parse_args()
-    if args.debug_helpers:
-        logging.getLogger("github_helper").setLevel(logging.DEBUG)
-        logging.getLogger("git_helper").setLevel(logging.DEBUG)
     token = args.token or get_best_robot_token()
 
     gh = GitHub(token)
@@ -1577,24 +1599,104 @@ def main():
         )
 
 
+def check_git_version() -> None:
+    version = git_runner("git --version").split()[2]
+    if tuple(int(part) for part in version.split(".")[:2]) < (2, 38):
+        raise BackportException(
+            f"Git 2.38 or newer is required for cherry-pick retries; found {version}. "
+            "Upgrade the runner image before running backport automation."
+        )
+
+
+def local_branches() -> set:
+    return set(
+        git_runner(
+            "git for-each-ref --format='%(refname:short)' refs/heads"
+        ).splitlines()
+    )
+
+
+def restore_checkout(initial_sha: str, initial_branches: set) -> None:
+    # Keep the selected code for every iteration, including manual branch runs.
+    git_runner(f"{GIT_PREFIX} checkout --detach -f {initial_sha}")
+    for branch in sorted(local_branches() - initial_branches):
+        if branch.startswith(("backport/", "cherrypick/")):
+            logging.info("Deleting temporary local branch %s", branch)
+            git_runner(f"git branch -D -- {shlex.quote(branch)}")
+
+
+def run_loop(args) -> None:
+    initial_sha = git_runner("git rev-parse HEAD")
+    initial_branches = local_branches()
+    deadline = time.monotonic() + args.loop_duration
+    iterations = 0
+    failures = 0
+    consecutive_failures = 0
+    last_error = None  # type: Optional[Exception]
+
+    while True:
+        started = time.monotonic()
+        if args.loop and started >= deadline:
+            break
+        iterations += 1
+        logging.info("Starting backport iteration %s at %s", iterations, initial_sha)
+        try:
+            # Recreate clients and refresh credentials and repository state each pass.
+            run_once(args)
+        except Exception as e:
+            failures += 1
+            consecutive_failures += 1
+            last_error = e
+            logging.exception("Backport iteration %s failed", iterations)
+            recover_git_state()
+            if IS_CI and not args.dry_run:
+                CIBuddy().post_job_error(
+                    f"The backport process finished with errors: {e}",
+                    with_instance_info=True,
+                    with_wf_link=True,
+                    critical=True,
+                )
+        else:
+            consecutive_failures = 0
+        finally:
+            # Failure to restore a usable checkout aborts the loop as well.
+            restore_checkout(initial_sha, initial_branches)
+
+        if not args.loop or consecutive_failures >= args.max_consecutive_failures:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        delay = min(max(0, args.interval - (time.monotonic() - started)), remaining)
+        if delay > 0:
+            time.sleep(delay)
+
+    summary = f"Ran {iterations} iteration(s), {failures} failed"
+    logging.info(summary)
+    if IS_CI and os.getenv("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as output:
+            output.write(summary + "\n")
+    if failures:
+        raise BackportException(summary) from last_error
+
+
+def main():
+    args = parse_args()
+    if args.debug_helpers:
+        logging.getLogger("github_helper").setLevel(logging.DEBUG)
+        logging.getLogger("git_helper").setLevel(logging.DEBUG)
+    # Check prerequisites before fetching credentials or making API mutations.
+    check_git_version()
+    if is_shallow():
+        raise BackportException("Backport automation requires a complete Git checkout")
+    with stash():
+        if os.getenv("ROBOT_CLICKHOUSE_SSH_KEY", ""):
+            with SSHKey("ROBOT_CLICKHOUSE_SSH_KEY"):
+                run_loop(args)
+        else:
+            run_loop(args)
+
+
 if __name__ == "__main__":
     logging.getLogger().setLevel(level=logging.INFO)
-
-    assert not is_shallow()
-    try:
-        with stash():
-            if os.getenv("ROBOT_CLICKHOUSE_SSH_KEY", ""):
-                with SSHKey("ROBOT_CLICKHOUSE_SSH_KEY"):
-                    main()
-            else:
-                main()
-
-    except Exception as e:
-        if IS_CI:
-            ci_buddy = CIBuddy()
-            ci_buddy.post_job_error(
-                f"The backport process finished with errors: {e}",
-                with_instance_info=True,
-                with_wf_link=True,
-                critical=True,
-            )
+    main()

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -1566,7 +1566,7 @@ def run_once(args):
     temp_path = Path(TEMP_PATH)
     temp_path.mkdir(parents=True, exist_ok=True)
 
-    token = args.token or get_best_robot_token()
+    token = args.token or get_best_robot_token(refresh=True)
 
     gh = GitHub(token)
     temp_path = Path(TEMP_PATH)

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -341,7 +341,9 @@ close it.
         """
         # Pin the release used for both the resolved tree and its final parent.
         # A retry can refresh the remote ref while the local release stays stale.
-        release_head = git_runner(f"git rev-parse {base or f'{self.REMOTE}/{self.name}'}")
+        release_head = git_runner(
+            f"git rev-parse {base or f'{self.REMOTE}/{self.name}'}"
+        )
         git_runner(f"{GIT_PREFIX} checkout -f {release_head}")
         # Create or reset backport branch
         git_runner(f"{GIT_PREFIX} checkout -B {self.backport_branch}")
@@ -543,61 +545,35 @@ close it.
             )
             return False
 
-        # A merge conflict can only land in a file the PR itself touches, so if
-        # nothing arrived on the release branch in those paths since the last
-        # attempt, the merge cannot come out differently. Two tree diffs answer
-        # that in milliseconds, where the retry below costs ~20 s of working-tree
-        # churn per PR: with tens of conflicting cherry-picks open and a release
-        # branch that moves several times a day, this is what keeps the retry from
-        # running on every pass for every one of them.
-        #
-        # `--no-renames` on the release-side diff so a rename shows up as both the
-        # old and the new path, which can only make this less eager to skip. `-z`
-        # because plain `--name-only` does not quote spaces.
-        pr_paths = set(
-            git_runner(
-                "git diff --name-only -z --no-renames "
-                f"{self.pr.merge_commit_sha}^1 {self.pr.merge_commit_sha}"
-            ).split("\0")
+        # Rebuild the empty merge and resolve entirely in the object database.
+        # Literal path intersections miss renames between master and the release;
+        # `merge-tree` uses the real merge machinery without rewriting the checkout.
+        release_tree = git_runner(f"git rev-parse {release_head}^{{tree}}")
+        refreshed_base = git_runner(
+            f"{GIT_PREFIX} commit-tree {release_tree} "
+            f"-p {release_head} -p {first_parent} -F -",
+            input=f"Refresh cherry-pick base for #{self.pr.number} on {self.name}",
         )
-        release_paths = set(
-            git_runner(
-                f"git diff --name-only -z --no-renames {base_parents[0]} {release_head}"
-            ).split("\0")
-        )
-        overlap = {path for path in pr_paths & release_paths if path}
-        if pr_paths and not overlap:
+        try:
+            result = git_runner(
+                f"{GIT_PREFIX} -c merge.renameLimit=999999 merge-tree "
+                f"--write-tree --name-only -z --no-messages {head} {refreshed_base}"
+            )
+        except CalledProcessError as e:
+            # Exit status 1 means conflicts; other failures must abort the retry.
+            if e.returncode != 1:
+                raise
             logging.info(
-                "Retry of cherry-pick PR #%s skipped: %s moved to %s but touched "
-                "none of the %s path(s) of #%s",
+                "Cherry-pick PR #%s still conflicts against %s at %s on: %s",
                 self.cherrypick_pr.number,
                 self.name,
                 release_head,
-                len(pr_paths),
-                self.pr.number,
+                ", ".join(path for path in e.output.split("\0")[1:] if path),
             )
             return False
+        resolved_tree = result.split("\0", maxsplit=1)[0]
 
-        logging.info(
-            "%s moved from %s to %s since cherry-pick PR #%s was created and "
-            "touched %s of the original PR's paths, re-trying the merge",
-            self.name,
-            base_parents[0],
-            release_head,
-            self.cherrypick_pr.number,
-            len(overlap),
-        )
-        self._prepare_backport_branch(remote_release)
-        if not self._try_merge_backport_into_cherrypick():
-            logging.info(
-                "Cherry-pick PR #%s still conflicts against %s at %s",
-                self.cherrypick_pr.number,
-                self.name,
-                release_head,
-            )
-            return False
-
-        if self._cherrypick_is_empty():
+        if resolved_tree == release_tree:
             # The prerequisite that landed was the change itself, applied by
             # some other route. Same conclusion as in `create_cherrypick`, and
             # the PR has nothing left to do.
@@ -630,6 +606,11 @@ close it.
             )
             return False
 
+        resolved_head = git_runner(
+            f"{GIT_PREFIX} commit-tree {resolved_tree} "
+            f"-p {head} -p {refreshed_base} -F -",
+            input=f"Retry cherry-pick #{self.pr.number} against {self.name}",
+        )
         # Protect the exact refs inspected above, including against a human push
         # during the merge. Publish both refs together or leave both untouched.
         git_runner(
@@ -637,8 +618,8 @@ close it.
             f"--force-with-lease=refs/heads/{self.cherrypick_branch}:{head} "
             f"--force-with-lease=refs/heads/{self.backport_branch}:{base} "
             f"{self.REMOTE} "
-            f"{self.cherrypick_branch}:refs/heads/{self.cherrypick_branch} "
-            f"{self.backport_branch}:refs/heads/{self.backport_branch}"
+            f"{resolved_head}:refs/heads/{self.cherrypick_branch} "
+            f"{refreshed_base}:refs/heads/{self.backport_branch}"
         )
         self.cherrypick_pr.create_issue_comment(
             f"The `{self.name}` branch moved since this cherry-pick was created "
@@ -671,8 +652,18 @@ close it.
         # Checkout the backport branch from the remote and make all changes to
         # apply like they are only one cherry-pick commit on top of release
         logging.info("Creating backport for PR #%s", self.pr.number)
-        git_runner(f"{GIT_PREFIX} checkout -f {self.backport_branch}")
-        git_runner(f"{GIT_PREFIX} pull --ff-only {self.REMOTE} {self.backport_branch}")
+        git_runner(
+            f"{GIT_PREFIX} fetch {self.REMOTE} "
+            f"+refs/heads/{self.backport_branch}:"
+            f"refs/remotes/{self.REMOTE}/{self.backport_branch}"
+        )
+        backport_head = git_runner(
+            f"git rev-parse {self.REMOTE}/{self.backport_branch}"
+        )
+        # A retry may have replaced the remote base in this same iteration.
+        git_runner(
+            f"{GIT_PREFIX} checkout -f -B {self.backport_branch} {backport_head}"
+        )
         merge_base = git_runner(
             f"{GIT_PREFIX} merge-base "
             f"{self.REMOTE}/{self.name} {self.backport_branch}"
@@ -681,10 +672,11 @@ close it.
         title = f"Backport #{self.pr.number} to {self.name}: {self.pr.title}"
         git_runner(f"{GIT_PREFIX} commit --allow-empty -F -", input=title)
 
-        # Push with force, create the backport PR, label and assign it
+        # Do not overwrite a resolution pushed after the fetch above.
         git_runner(
-            f"{GIT_PREFIX} push -f {self.REMOTE} "
-            f"{self.backport_branch}:{self.backport_branch}"
+            f"{GIT_PREFIX} push "
+            f"--force-with-lease=refs/heads/{self.backport_branch}:{backport_head} "
+            f"{self.REMOTE} {self.backport_branch}:refs/heads/{self.backport_branch}"
         )
         self._finalize_backport_pr(title)
 
@@ -703,8 +695,7 @@ close it.
         resolved_tree = git_runner(f"git rev-parse {self.cherrypick_branch}^{{tree}}")
         title = f"Backport #{self.pr.number} to {self.name}: {self.pr.title}"
         commit = git_runner(
-            f"{GIT_PREFIX} commit-tree {resolved_tree} "
-            f"-p {release_head} -F -",
+            f"{GIT_PREFIX} commit-tree {resolved_tree} " f"-p {release_head} -F -",
             input=title,
         )
         git_runner(f"{GIT_PREFIX} branch -f {self.backport_branch} {commit}")

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -1080,7 +1080,7 @@ class BackportPRs:
         cherry-pick was merged.
         """
         # branch -> (release branch, original PR number)
-        branches = {}  # type: Dict[str, Tuple[str, int]]
+        branches: Dict[str, Tuple[str, int]] = {}
         for release in self.release_branches:
             refs = git_runner(
                 "git for-each-ref --format='%(refname:short)' "
@@ -1121,7 +1121,7 @@ class BackportPRs:
             [ReleaseBranch.cp_branch(*branches[branch]) for branch in stranded],
         )
         # original PR number -> release branches it is stranded on
-        to_recover = {}  # type: Dict[int, List[str]]
+        to_recover: Dict[int, List[str]] = {}
         for branch in stranded:
             release, number = branches[branch]
             states = [

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -500,7 +500,8 @@ close it.
         # generates, i.e. a release branch commit merged with the original PR's
         # first parent. Anything else was hand-edited.
         first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
-        base_parents = git_runner(f"git rev-parse {remote_backport}^@").split()
+        base = git_runner(f"git rev-parse {remote_backport}")
+        base_parents = git_runner(f"git rev-parse {base}^@").split()
         if len(base_parents) != 2 or base_parents[1] != first_parent:
             logging.info(
                 "Retry of cherry-pick PR #%s skipped: its base %s is not a "
@@ -508,6 +509,14 @@ close it.
                 self.cherrypick_pr.number,
                 remote_backport,
                 first_parent,
+            )
+            return False
+        if git_runner(f"git rev-parse {base}^{{tree}}") != git_runner(
+            f"git rev-parse {base_parents[0]}^{{tree}}"
+        ):
+            logging.info(
+                "Retry of cherry-pick PR #%s skipped: its base tree was edited",
+                self.cherrypick_pr.number,
             )
             return False
         if not Shell.check(
@@ -621,8 +630,16 @@ close it.
             )
             return False
 
-        for branch in (self.cherrypick_branch, self.backport_branch):
-            git_runner(f"{GIT_PREFIX} push -f {self.REMOTE} {branch}:{branch}")
+        # Protect the exact refs inspected above, including against a human push
+        # during the merge. Publish both refs together or leave both untouched.
+        git_runner(
+            f"{GIT_PREFIX} push --atomic "
+            f"--force-with-lease=refs/heads/{self.cherrypick_branch}:{head} "
+            f"--force-with-lease=refs/heads/{self.backport_branch}:{base} "
+            f"{self.REMOTE} "
+            f"{self.cherrypick_branch}:refs/heads/{self.cherrypick_branch} "
+            f"{self.backport_branch}:refs/heads/{self.backport_branch}"
+        )
         self.cherrypick_pr.create_issue_comment(
             f"The `{self.name}` branch moved since this cherry-pick was created "
             f"(now at {release_head[:12]}). Re-tried the merge against it and it "

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -23,6 +23,12 @@ A plan:
 Cherry-pick stage:
     - From time to time the cherry-pick fails, if it was done manually. In the
     case we check if it's even needed, and mark the release as done somehow.
+    - A cherry-pick PR that conflicts is retried on every run against the
+    current release branch (`ReleaseBranch._retry_cherrypick`). Conflicts are
+    very often caused by a prerequisite backport that has not landed yet, and
+    both branches of the cherry-pick PR are frozen at the moment the conflict
+    was found, so once the prerequisite arrives the PR heals itself instead of
+    waiting for someone to close it and let the bot start over.
 
 The cross-repo synchronization is described in the KB article:
 https://github.com/ClickHouse/internal-knowledge-base/issues/452
@@ -31,6 +37,7 @@ https://github.com/ClickHouse/internal-knowledge-base/issues/452
 import argparse
 import logging
 import os
+import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -119,6 +126,14 @@ Otherwise, if you do not want to backport them, then just close this pull-reques
 
 The check results does not matter at this step - you can safely ignore them.
 
+### Before you resolve anything
+
+Conflicts are often caused by a prerequisite change that has not been backported \
+yet, rather than by a real divergence. The bot re-tries this cherry-pick against \
+the release branch on every run, so if that is the case here it will merge itself \
+as soon as the prerequisite lands, and you will see a comment saying so. Manual \
+resolution is only needed while the conflict persists.
+
 ### Troubleshooting
 
 #### If the conflicts were resolved in a wrong way
@@ -140,6 +155,11 @@ close it.
 """
     PR_SOURCE_DESCRIPTION = ""
     REMOTE = ""
+    # GitHub recomputes a PR's `mergeable` asynchronously after a push and
+    # reports None meanwhile. `_retry_cherrypick` waits this long for it so the
+    # same run can finish the healed cherry-pick instead of the next one.
+    MERGEABLE_POLL_ATTEMPTS = 3
+    MERGEABLE_POLL_SECONDS = 5
 
     @property
     def pr_source(self) -> str:
@@ -240,7 +260,7 @@ close it.
         return prs
 
     def process(  # pylint: disable=too-many-return-statements
-        self, dry_run: bool
+        self, dry_run: bool, retried: bool = False
     ) -> None:
         if self.backported:
             return
@@ -289,6 +309,15 @@ close it.
             self.cherrypick_pr.number,
             self.pr.number,
         )
+        if not retried and self._retry_cherrypick(dry_run):
+            # The branches were rebuilt against the current release branch and
+            # the merge is clean now, so re-enter to take the ordinary merge and
+            # `create_backport` path above. `retried` bounds this to one extra
+            # pass, for the case where GitHub has not recomputed `mergeable` yet.
+            return self.process(dry_run, retried=True)
+        if self.backported:
+            # The retry found the release branch already carries the changes
+            return
         # Assign to engineer if not already assigned (only for PRs with conflicts)
         if not self.cherrypick_pr.assignees:
             if dry_run:
@@ -301,10 +330,17 @@ close it.
                 self.cherrypick_pr.update()
         self.ping_cherry_pick_assignees(dry_run)
 
-    def create_cherrypick(self):
-        # First, create backport branch:
-        # Checkout release branch with discarding every change
-        git_runner(f"{GIT_PREFIX} checkout -f {self.name}")
+    def _prepare_backport_branch(self, base: str = "") -> None:
+        """
+        Reset `backport_branch` to `base` (the release branch by default) plus an
+        empty merge of the original PR's first parent.
+
+        The `-s ours` merge applies nothing; it only makes that first parent an
+        ancestor, so that merging the PR's merge commit into this branch reduces
+        to a cherry-pick of the PR's own diff.
+        """
+        # Checkout the base with discarding every change
+        git_runner(f"{GIT_PREFIX} checkout -f {base or self.name}")
         # Create or reset backport branch
         git_runner(f"{GIT_PREFIX} checkout -B {self.backport_branch}")
         # Merge all changes from PR's the first parent commit w/o applying anything
@@ -312,33 +348,39 @@ close it.
         first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
         git_runner(f"{GIT_PREFIX} merge -s ours --no-edit {first_parent}")
 
-        # Second step, create cherrypick branch
+    def _try_merge_backport_into_cherrypick(self) -> bool:
+        """
+        Reset `cherrypick_branch` to the PR's merge commit, merge
+        `backport_branch` into it and report whether it applied cleanly.
+
+        The rename limit is raised so git does not silently disable rename
+        detection on large diffs (files renamed between the release branch and
+        master would otherwise show up as spurious conflicts).
+
+        Clean: `cherrypick_branch` now holds the fully resolved tree. Conflict:
+        `merge --abort` restores `cherrypick_branch` to the PR's merge commit.
+        """
         git_runner(
             f"{GIT_PREFIX} checkout --no-track -B "
             f"{self.cherrypick_branch} {self.pr.merge_commit_sha}"
         )
-
-        # Merge backport_branch into cherrypick_branch locally to find out
-        # whether the cherry-pick applies cleanly. The rename limit is raised
-        # so git does not silently disable rename detection on large diffs
-        # (files renamed between the release branch and master would otherwise
-        # show up as spurious conflicts).
-        #
-        # - No conflicts: cherrypick_branch now holds the fully resolved tree,
-        #   so the backport PR can be created directly from it and the
-        #   intermediate cherry-pick PR is skipped (see
-        #   create_backport_from_resolved_tree).
-        # - Conflicts: `merge --abort` restores cherrypick_branch to
-        #   pr.merge_commit_sha and we fall back to opening a cherry-pick PR
-        #   for manual resolution by the assigned engineer.
-        merged_cleanly = False
         try:
             git_runner(
                 f"{GIT_PREFIX} -c merge.renameLimit=999999 "
                 f"merge --no-ff --no-edit {self.backport_branch}"
             )
-            merged_cleanly = True
+            return True
         except CalledProcessError:
+            # Read the unmerged paths before aborting: they name what a human
+            # would have to resolve, and they are the input for spotting a
+            # missing prerequisite backport
+            logging.info(
+                "Cherry-pick of #%s to %s conflicts on: %s",
+                self.pr.number,
+                self.name,
+                ", ".join(git_runner("git diff --name-only --diff-filter=U").split())
+                or "unknown paths",
+            )
             try:
                 git_runner(f"{GIT_PREFIX} merge --abort")
             except CalledProcessError:
@@ -348,18 +390,27 @@ close it.
                 # git command in this checkout. Clean it up so subsequent
                 # PRs in the same run are not poisoned.
                 recover_git_state()
+            return False
 
-        if merged_cleanly:
-            # If the merge produced no tree change vs backport_branch, the PR
-            # is effectively already backported to the release branch - either
-            # "Already up to date" (no merge commit at all) or an empty merge
-            # commit whose resolution collapsed onto backport_branch's tree
-            # (e.g. the PR was manually applied with equivalent content). In
-            # either case, skip creating an empty PR.
-            if not git_runner(
-                f"{GIT_PREFIX} diff --name-only "
-                f"{self.backport_branch} {self.cherrypick_branch}"
-            ):
+    def _cherrypick_is_empty(self) -> bool:
+        """
+        Whether the resolved cherry-pick changes nothing versus the backport
+        branch, meaning the release branch already carries these changes: either
+        "Already up to date" (no merge commit at all) or an empty merge commit
+        whose resolution collapsed onto the backport branch's tree (e.g. the PR
+        was applied by hand with equivalent content).
+        """
+        return not git_runner(
+            f"{GIT_PREFIX} diff --name-only "
+            f"{self.backport_branch} {self.cherrypick_branch}"
+        )
+
+    def create_cherrypick(self):
+        self._prepare_backport_branch()
+
+        if self._try_merge_backport_into_cherrypick():
+            # Nothing to open a PR for
+            if self._cherrypick_is_empty():
                 logging.info(
                     "Release branch %s already contain changes from %s",
                     self.name,
@@ -396,6 +447,168 @@ close it.
         # Do not assign yet - will assign only if there are conflicts
         # update cherrypick PR to get the state for PR.mergable
         self.cherrypick_pr.update()
+
+    def _retry_cherrypick(self, dry_run: bool) -> bool:
+        """
+        Re-try a conflicting cherry-pick against the current release branch, and
+        report whether it now applies cleanly.
+
+        Both branches of a cherry-pick PR are frozen at the moment the conflict
+        was found: the base is the release branch head from back then. A conflict
+        is very often caused by a prerequisite backport that had not landed yet,
+        and when it does land the base still lacks it, so GitHub keeps reporting
+        `CONFLICTING` indefinitely. Recovering meant a human closing the PR,
+        deleting its branch and unlabelling the original just to make the bot
+        start over.
+
+        Rebuild both branches against the current release branch head instead. If
+        the merge is clean now, force-push them so the PR becomes mergeable and
+        the caller's existing merge and `create_backport` path takes over.
+        """
+        assert self.cherrypick_pr is not None
+        remote_release = f"{self.REMOTE}/{self.name}"
+        remote_backport = f"{self.REMOTE}/{self.backport_branch}"
+        remote_cherrypick = f"{self.REMOTE}/{self.cherrypick_branch}"
+        # Forced refspecs: the bot force-pushes both of these branches, so a
+        # non-forced fetch can leave stale remote-tracking refs behind
+        git_runner(
+            f"{GIT_PREFIX} fetch {self.REMOTE} "
+            + " ".join(
+                f"+refs/heads/{branch}:refs/remotes/{self.REMOTE}/{branch}"
+                for branch in (self.name, self.backport_branch, self.cherrypick_branch)
+            )
+        )
+
+        # The retry force-pushes the cherry-pick branch, so it must never
+        # overwrite a partial resolution somebody is working on. An untouched
+        # head is the only condition strictly required for that.
+        head = git_runner(f"git rev-parse {remote_cherrypick}")
+        if head != self.pr.merge_commit_sha:
+            logging.info(
+                "Retry of cherry-pick PR #%s skipped: its head is %s, not the "
+                "original merge commit %s, so it was resolved by hand",
+                self.cherrypick_pr.number,
+                head,
+                self.pr.merge_commit_sha,
+            )
+            return False
+
+        # Belt and braces: the base must still be the merge commit this script
+        # generates, i.e. a release branch commit merged with the original PR's
+        # first parent. Anything else was hand-edited.
+        first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
+        base_parents = git_runner(f"git rev-parse {remote_backport}^@").split()
+        if len(base_parents) != 2 or base_parents[1] != first_parent:
+            logging.info(
+                "Retry of cherry-pick PR #%s skipped: its base %s is not a "
+                "generated merge of the release branch with %s",
+                self.cherrypick_pr.number,
+                remote_backport,
+                first_parent,
+            )
+            return False
+        if not Shell.check(
+            f"git merge-base --is-ancestor {base_parents[0]} {remote_release}",
+            verbose=True,
+        ):
+            logging.info(
+                "Retry of cherry-pick PR #%s skipped: its base is not built on %s",
+                self.cherrypick_pr.number,
+                self.name,
+            )
+            return False
+
+        # Nothing new to merge against, so the outcome cannot have changed. This
+        # is the common case and it costs no merge attempt and no API call.
+        release_head = git_runner(f"git rev-parse {remote_release}")
+        if release_head == base_parents[0]:
+            logging.info(
+                "Retry of cherry-pick PR #%s skipped: %s is unchanged at %s since "
+                "the conflict was found",
+                self.cherrypick_pr.number,
+                self.name,
+                release_head,
+            )
+            return False
+
+        logging.info(
+            "%s moved from %s to %s since cherry-pick PR #%s was created, "
+            "re-trying the merge",
+            self.name,
+            base_parents[0],
+            release_head,
+            self.cherrypick_pr.number,
+        )
+        self._prepare_backport_branch(remote_release)
+        if not self._try_merge_backport_into_cherrypick():
+            logging.info(
+                "Cherry-pick PR #%s still conflicts against %s at %s",
+                self.cherrypick_pr.number,
+                self.name,
+                release_head,
+            )
+            return False
+
+        if self._cherrypick_is_empty():
+            # The prerequisite that landed was the change itself, applied by
+            # some other route. Same conclusion as in `create_cherrypick`, and
+            # the PR has nothing left to do.
+            logging.info(
+                "Release branch %s already contain changes from %s",
+                self.name,
+                self.pr.number,
+            )
+            self._backported = True
+            if dry_run:
+                logging.info(
+                    "DRY RUN: would close cherry-pick PR #%s, %s already has the "
+                    "changes",
+                    self.cherrypick_pr.number,
+                    self.name,
+                )
+                return False
+            self.cherrypick_pr.create_issue_comment(
+                f"`{self.name}` already contains these changes, closing."
+            )
+            self.cherrypick_pr.edit(state="closed")
+            return False
+
+        if dry_run:
+            logging.info(
+                "DRY RUN: would refresh the branches of cherry-pick PR #%s "
+                "against %s and let the bot merge it",
+                self.cherrypick_pr.number,
+                release_head,
+            )
+            return False
+
+        for branch in (self.cherrypick_branch, self.backport_branch):
+            git_runner(f"{GIT_PREFIX} push -f {self.REMOTE} {branch}:{branch}")
+        self.cherrypick_pr.create_issue_comment(
+            f"The `{self.name}` branch moved since this cherry-pick was created "
+            f"(now at {release_head[:12]}). Re-tried the merge against it and it "
+            "applies cleanly, so the bot is proceeding without manual resolution."
+        )
+        logging.info(
+            "Cherry-pick PR #%s merges cleanly now, branches pushed",
+            self.cherrypick_pr.number,
+        )
+
+        # GitHub recomputes `mergeable` asynchronously and reports None while it
+        # does. Give it a few chances so this run can finish the job; if it is
+        # still None, the next run merges the PR instead.
+        for attempt in range(1, self.MERGEABLE_POLL_ATTEMPTS + 1):
+            self.cherrypick_pr.update()
+            if self.cherrypick_pr.mergeable is not None:
+                break
+            logging.info(
+                "GitHub has not recomputed `mergeable` for #%s yet (attempt %s/%s)",
+                self.cherrypick_pr.number,
+                attempt,
+                self.MERGEABLE_POLL_ATTEMPTS,
+            )
+            time.sleep(self.MERGEABLE_POLL_SECONDS)
+        return True
 
     def create_backport(self):
         assert self.cherrypick_pr is not None

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -34,7 +34,7 @@ import os
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from github.GithubException import GithubException
 
@@ -54,8 +54,14 @@ from env_helper import (
     TEMP_PATH,
 )
 from get_robot_token import get_best_robot_token
-from git_helper import GIT_PREFIX, git_runner, is_shallow, stash
-from github_helper import GitHub, PullRequest, PullRequests, Repository
+from git_helper import GIT_PREFIX, git_runner, is_shallow, removeprefix, stash
+from github_helper import (
+    GitHub,
+    PullRequest,
+    PullRequestInfo,
+    PullRequests,
+    Repository,
+)
 from pr_info import Labels
 from report import GITHUB_JOB_URL
 from s3_helper import S3Helper
@@ -666,6 +672,10 @@ class BackportPRs:
         self.release_branches: List[str] = []
         self.labels_to_backport: List[str] = []
         self.prs_for_backport = []  # type: PullRequests
+        # Original PRs that `reconcile_backport_branches` found stranded. They are
+        # unreachable through `receive_prs_for_backport`, so they are processed in
+        # addition to its search result.
+        self.prs_to_reprocess = []  # type: PullRequests
         self.error = None  # type: Optional[Exception]
 
     @property
@@ -783,8 +793,212 @@ class BackportPRs:
             "\n ".join([pr.html_url for pr in self.prs_for_backport]),
         )
 
+    def backport_branch_carries_changes(self, release: str, branch: str) -> bool:
+        """
+        Whether a backport branch has anything to open a backport PR for.
+
+        A freshly created backport branch is the release tip plus a
+        `merge -s ours` of the original PR's first parent, so it holds the
+        release branch's tree unchanged until a cherry-pick is merged into it.
+        The comparison is against the merge base -- the same commit
+        `create_backport` squashes onto -- and not against the release tip, so
+        the answer does not flip as the release branch moves on.
+        """
+        merge_base = git_runner(
+            f"git merge-base {self.remote}/{release} {self.remote}/{branch}"
+        )
+        return bool(
+            git_runner(f"git diff --name-only {merge_base} {self.remote}/{branch}")
+        )
+
+    def reconcile_backport_branches(self) -> None:
+        """
+        Recover backports whose work is finished but which have no backport PR.
+
+        A backport PR is only ever created while processing the ORIGINAL PR, and
+        the original is dropped from `receive_prs_for_backport` for good once it
+        carries `pr-backports-created`. A cherry-pick PR merged after that label
+        was set therefore leaves its resolution stranded on the `backport/*`
+        branch with nothing pointing at it. `check_open_prs` is the only existing
+        recovery path and it looks exclusively at cherry-pick PRs that are open at
+        the moment a run starts, so a reopen and a merge that both fall between
+        two runs are lost with no trace.
+
+        Every backport reaches a release branch through a
+        `backport/<release>/<PR>` branch, which makes the set of those branches a
+        complete work list. Anything that carries changes and has no backport PR
+        is unstuck here, independently of when, how fast or by whom the
+        cherry-pick was merged.
+        """
+        # branch -> (release branch, original PR number)
+        branches = {}  # type: Dict[str, Tuple[str, int]]
+        for release in self.release_branches:
+            refs = git_runner(
+                "git for-each-ref --format='%(refname:short)' "
+                f"'refs/remotes/{self.remote}/backport/{release}/*'"
+            ).split("\n")
+            for ref in refs:
+                branch = removeprefix(ref, f"{self.remote}/")
+                number = branch.rsplit("/", maxsplit=1)[-1]
+                if not number.isdigit():
+                    # Not an automation branch, e.g. `backport/release/26.2/wip`
+                    continue
+                branches[branch] = (release, int(number))
+
+        if not branches:
+            return
+
+        # One GraphQL request per 50 branches, instead of a REST request each
+        backport_prs = self.gh.get_pull_states_by_head_refs(
+            self._repo_name, sorted(branches)
+        )
+        stranded = [branch for branch in sorted(branches) if not backport_prs[branch]]
+        logging.info(
+            "Reconciliation: %s backport branches for active releases, "
+            "%s without a backport PR",
+            len(branches),
+            len(stranded),
+        )
+        if not stranded:
+            return
+
+        # A stranded branch is only actionable when the cherry-pick work on it is
+        # done: an open cherry-pick PR is still waiting for a human, and a closed
+        # one is a decision not to backport. A branch with no cherry-pick PR at
+        # all was pushed by the conflict-free path, which means `create_pull` did
+        # not run or did not survive.
+        cherrypick_prs = self.gh.get_pull_states_by_head_refs(
+            self._repo_name,
+            [ReleaseBranch.cp_branch(*branches[branch]) for branch in stranded],
+        )
+        # original PR number -> release branches it is stranded on
+        to_recover = {}  # type: Dict[int, List[str]]
+        for branch in stranded:
+            release, number = branches[branch]
+            states = [
+                state
+                for _, state in cherrypick_prs[ReleaseBranch.cp_branch(release, number)]
+            ]
+            if states and "MERGED" not in states:
+                continue
+            try:
+                carries_changes = self.backport_branch_carries_changes(release, branch)
+            except CalledProcessError as e:
+                # This is a safety net for the normal path that runs after it, so
+                # one unreadable branch must not stop the rest of the run
+                logging.error("Cannot inspect the branch %s: %s", branch, e)
+                self.error = e
+                continue
+            if not carries_changes:
+                # Nothing was applied to the branch yet, so there is no backport
+                # to open a PR for. Creating one would produce an empty PR.
+                continue
+            logging.warning(
+                "Backport branch %s carries changes but has no backport PR", branch
+            )
+            to_recover.setdefault(number, []).append(release)
+
+        if not to_recover:
+            return
+
+        general_backport_labels = {
+            Labels.MUST_BACKPORT,
+            Labels.MUST_BACKPORT_FORCE,
+        } | Labels.AUTO_BACKPORT
+        infos = self.gh.get_pulls_lightweight_by_numbers(
+            self._repo_name, sorted(to_recover)
+        )
+        for number, releases in sorted(to_recover.items()):
+            try:
+                self._recover_stranded_pr(
+                    number, releases, infos.get(number), general_backport_labels
+                )
+            except Exception as e:
+                logging.error("Cannot recover the PR #%s: %s", number, e)
+                self.error = e
+
+    def _recover_stranded_pr(
+        self,
+        number: int,
+        releases: List[str],
+        info: Optional[PullRequestInfo],
+        general_backport_labels: Iterable[str],
+    ) -> None:
+        """Put one stranded original PR back into the backport process."""
+        if info is None:
+            logging.error("Cannot fetch the original PR #%s, skipping", number)
+            return
+        if not info.merged:
+            # `create_cherrypick` needs the merge commit. A backport branch for an
+            # unmerged PR was not created by this automation.
+            logging.info("PR #%s is not merged, skipping", number)
+            return
+
+        # The labels may have been removed deliberately since the branch was
+        # created. Recreating a backport nobody asked for would be worse than
+        # leaving the branch alone, so re-check the targets. Unlike in
+        # `process_pr`, the labels are not guaranteed by the search here, so the
+        # no-label case has to be excluded before `select_backport_branches`
+        # asserts on it.
+        labels = set(info.label_names)
+        if not labels & set(general_backport_labels) and not any(
+            label_version(label) is not None for label in labels
+        ):
+            logging.info(
+                "PR #%s carries no backport label anymore, leaving the branch(es) alone",
+                number,
+            )
+            return
+        targets = select_backport_branches(
+            info.label_names,
+            self.release_branches,
+            general_backport_labels=set(general_backport_labels),
+            force_backport_label=Labels.MUST_BACKPORT_FORCE,
+        )
+        stale = [release for release in releases if release not in targets]
+        if stale:
+            logging.info(
+                "PR #%s no longer targets %s, leaving the branch(es) alone",
+                number,
+                ", ".join(stale),
+            )
+        wanted = [release for release in releases if release in targets]
+        if not wanted:
+            return
+
+        logging.info(
+            "PR #%s is stranded on %s, putting it back into the process",
+            number,
+            ", ".join(wanted),
+        )
+        if self.dry_run:
+            logging.info("DRY RUN: would reprocess PR #%s", number)
+            return
+
+        # Not `get_pull_cached`: the label set must be current, and it is about to
+        # be edited
+        pr = self.repo.get_pull(number)
+        if Labels.PR_BACKPORTS_CREATED in [label.name for label in pr.labels]:
+            # Dropping the label also makes the normal search pick the PR up on
+            # the next run, so the recovery is retried if this run dies before the
+            # backport PR is created
+            pr.remove_from_labels(Labels.PR_BACKPORTS_CREATED)
+            logging.info(
+                "Removed label %s from PR #%s", Labels.PR_BACKPORTS_CREATED, number
+            )
+        self.prs_to_reprocess.append(pr)
+
     def process_backports(self):
-        for pr in self.prs_for_backport:
+        prs = list(self.prs_for_backport)
+        numbers = {pr.number for pr in prs}
+        for pr in self.prs_to_reprocess:
+            # The search may already return a stranded PR, e.g. when its label was
+            # dropped by an earlier run
+            if pr.number not in numbers:
+                prs.append(pr)
+                numbers.add(pr.number)
+
+        for pr in prs:
             try:
                 self.process_pr(pr)
             except Exception as e:
@@ -1086,6 +1300,9 @@ def main():
     bpp.gh.cache_path = temp_path / "gh_cache"
     bpp.receive_release_prs()
     bpp.update_local_release_branches()
+    # Before the search, so a recovered PR is processed in this very run: it is
+    # invisible to `receive_prs_for_backport` until GitHub reindexes the label
+    bpp.reconcile_backport_branches()
     bpp.receive_prs_for_backport()
     bpp.process_backports()
     gh_cache.upload()

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -330,7 +330,7 @@ close it.
                 self.cherrypick_pr.update()
         self.ping_cherry_pick_assignees(dry_run)
 
-    def _prepare_backport_branch(self, base: str = "") -> None:
+    def _prepare_backport_branch(self, base: str = "") -> str:
         """
         Reset `backport_branch` to `base` (the release branch by default) plus an
         empty merge of the original PR's first parent.
@@ -339,14 +339,17 @@ close it.
         ancestor, so that merging the PR's merge commit into this branch reduces
         to a cherry-pick of the PR's own diff.
         """
-        # Checkout the base with discarding every change
-        git_runner(f"{GIT_PREFIX} checkout -f {base or self.name}")
+        # Pin the release used for both the resolved tree and its final parent.
+        # A retry can refresh the remote ref while the local release stays stale.
+        release_head = git_runner(f"git rev-parse {base or f'{self.REMOTE}/{self.name}'}")
+        git_runner(f"{GIT_PREFIX} checkout -f {release_head}")
         # Create or reset backport branch
         git_runner(f"{GIT_PREFIX} checkout -B {self.backport_branch}")
         # Merge all changes from PR's the first parent commit w/o applying anything
         # It will allow to create a merge commit like it would be a cherry-pick
         first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
         git_runner(f"{GIT_PREFIX} merge -s ours --no-edit {first_parent}")
+        return release_head
 
     def _try_merge_backport_into_cherrypick(self) -> bool:
         """
@@ -406,7 +409,7 @@ close it.
         )
 
     def create_cherrypick(self):
-        self._prepare_backport_branch()
+        release_head = self._prepare_backport_branch()
 
         if self._try_merge_backport_into_cherrypick():
             # Nothing to open a PR for
@@ -421,7 +424,7 @@ close it.
             # A clean cherry-pick needs no manual conflict resolution, so the
             # intermediate cherry-pick PR carries no value. Create the backport
             # PR directly from the already resolved tree and skip it entirely.
-            self.create_backport_from_resolved_tree()
+            self.create_backport_from_resolved_tree(release_head)
             return
 
         # There are conflicts: cherrypick_branch stays at pr.merge_commit_sha
@@ -668,7 +671,7 @@ close it.
         )
         self._finalize_backport_pr(title)
 
-    def create_backport_from_resolved_tree(self):
+    def create_backport_from_resolved_tree(self, release_head: str):
         # Fast path for a conflict-free cherry-pick: the merge done in
         # create_cherrypick already produced the fully resolved tree in
         # cherrypick_branch. Materialize it as a single commit on top of the
@@ -684,7 +687,7 @@ close it.
         title = f"Backport #{self.pr.number} to {self.name}: {self.pr.title}"
         commit = git_runner(
             f"{GIT_PREFIX} commit-tree {resolved_tree} "
-            f"-p {self.REMOTE}/{self.name} -F -",
+            f"-p {release_head} -F -",
             input=title,
         )
         git_runner(f"{GIT_PREFIX} branch -f {self.backport_branch} {commit}")

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -531,13 +531,49 @@ close it.
             )
             return False
 
+        # A merge conflict can only land in a file the PR itself touches, so if
+        # nothing arrived on the release branch in those paths since the last
+        # attempt, the merge cannot come out differently. Two tree diffs answer
+        # that in milliseconds, where the retry below costs ~20 s of working-tree
+        # churn per PR: with tens of conflicting cherry-picks open and a release
+        # branch that moves several times a day, this is what keeps the retry from
+        # running on every pass for every one of them.
+        #
+        # `--no-renames` on the release-side diff so a rename shows up as both the
+        # old and the new path, which can only make this less eager to skip. `-z`
+        # because plain `--name-only` does not quote spaces.
+        pr_paths = set(
+            git_runner(
+                "git diff --name-only -z --no-renames "
+                f"{self.pr.merge_commit_sha}^1 {self.pr.merge_commit_sha}"
+            ).split("\0")
+        )
+        release_paths = set(
+            git_runner(
+                f"git diff --name-only -z --no-renames {base_parents[0]} {release_head}"
+            ).split("\0")
+        )
+        overlap = {path for path in pr_paths & release_paths if path}
+        if pr_paths and not overlap:
+            logging.info(
+                "Retry of cherry-pick PR #%s skipped: %s moved to %s but touched "
+                "none of the %s path(s) of #%s",
+                self.cherrypick_pr.number,
+                self.name,
+                release_head,
+                len(pr_paths),
+                self.pr.number,
+            )
+            return False
+
         logging.info(
-            "%s moved from %s to %s since cherry-pick PR #%s was created, "
-            "re-trying the merge",
+            "%s moved from %s to %s since cherry-pick PR #%s was created and "
+            "touched %s of the original PR's paths, re-trying the merge",
             self.name,
             base_parents[0],
             release_head,
             self.cherrypick_pr.number,
+            len(overlap),
         )
         self._prepare_backport_branch(remote_release)
         if not self._try_merge_backport_into_cherrypick():

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -1110,7 +1110,8 @@ class BackportPRs:
 
         # One GraphQL request per 50 branches, instead of a REST request each
         backport_prs = self.gh.get_pull_states_by_head_refs(
-            self._repo_name, sorted(branches)
+            self._repo_name,
+            {branch: branches[branch][0] for branch in sorted(branches)},
         )
         stranded = [branch for branch in sorted(branches) if not backport_prs[branch]]
         logging.info(
@@ -1129,7 +1130,7 @@ class BackportPRs:
         # not run or did not survive.
         cherrypick_prs = self.gh.get_pull_states_by_head_refs(
             self._repo_name,
-            [ReleaseBranch.cp_branch(*branches[branch]) for branch in stranded],
+            {ReleaseBranch.cp_branch(*branches[branch]): branch for branch in stranded},
         )
         # original PR number -> release branches it is stranded on
         to_recover: Dict[int, List[str]] = {}

--- a/tests/ci/get_robot_token.py
+++ b/tests/ci/get_robot_token.py
@@ -26,9 +26,7 @@ def get_parameter_from_ssm(
 ) -> str:
     if not client:
         client = boto3.client("ssm", region_name="us-east-1")
-    return client.get_parameter(  # type:ignore
-        Name=name, WithDecryption=decrypt
-    )[
+    return client.get_parameter(Name=name, WithDecryption=decrypt)[  # type: ignore
         "Parameter"
     ]["Value"]
 
@@ -60,9 +58,11 @@ def get_parameters_from_ssm(
 ROBOT_TOKEN = None  # type: Optional[Token]
 
 
-def get_best_robot_token(tokens_path: str = "/github-tokens") -> str:
+def get_best_robot_token(
+    tokens_path: str = "/github-tokens", *, refresh: bool = False
+) -> str:
     global ROBOT_TOKEN  # pylint:disable=global-statement
-    if ROBOT_TOKEN is not None:
+    if ROBOT_TOKEN is not None and not refresh:
         return ROBOT_TOKEN.value
     client = boto3.client("ssm", region_name="us-east-1")
     tokens = {

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Helper for GitHub API requests"""
+
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
@@ -237,7 +238,9 @@ class GitHub(github.Github):
             closing_issue_numbers=closing_issue_numbers,
         )
 
-    def _graphql(self, query: str, variables: dict) -> dict:
+    def _graphql(
+        self, query: str, variables: dict, *, allow_partial: bool = True
+    ) -> dict:
         # pylint: disable=protected-access
         requester = self._Github__requester  # type: ignore
         url = f"{requester.base_url}/graphql"
@@ -253,9 +256,10 @@ class GitHub(github.Github):
                 # that field plus a NOT_FOUND error, while the other aliases
                 # resolve. Use whatever `data` resolved; only raise when nothing
                 # came back at all (malformed query, auth failure, ...).
+                # Callers making recovery decisions require `allow_partial=False`.
                 payload = data.get("data")
                 errors = data.get("errors")
-                if payload is None:
+                if payload is None or (errors and not allow_partial):
                     raise GithubException(
                         200, errors or "GraphQL query returned no data", None
                     )
@@ -418,14 +422,12 @@ class GitHub(github.Github):
                 f"  repository(owner:$owner, name:$name) {{ {aliases} }}"
                 "}"
             )
-            repository = (
-                self._graphql(gql, {"owner": owner, "name": name})["repository"] or {}
-            )
+            repository = self._graphql(
+                gql, {"owner": owner, "name": name}, allow_partial=False
+            )["repository"]
             for i, head in enumerate(batch):
-                node = repository.get(f"b{i}") or {}
-                result[head] = [
-                    (pr["number"], pr["state"]) for pr in (node.get("nodes") or [])
-                ]
+                node = repository[f"b{i}"]
+                result[head] = [(pr["number"], pr["state"]) for pr in node["nodes"]]
         return result
 
     def sleep_on_rate_limit(self) -> None:

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -389,6 +389,45 @@ class GitHub(github.Github):
                 result[head] = oid
         return result
 
+    def get_pull_states_by_head_refs(
+        self, repo_name: str, head_refs: List[str]
+    ) -> Dict[str, List[Tuple[int, str]]]:
+        """For each head branch name, return `(number, state)` of every PR opened
+        from it, batching many head refs per GraphQL request.
+
+        `state` is GitHub's `PullRequestState`: `OPEN`, `CLOSED` or `MERGED`.
+        This is the general form of `get_backport_merge_commits`, which answers
+        only "was a PR from this branch merged", and it replaces one REST
+        `get_pulls(head=...)` request per branch.
+
+        A branch with no PR at all maps to an empty list, so every requested ref
+        is present in the result and callers need no `.get` with a default.
+        """
+        owner, name = repo_name.split("/")
+        result: Dict[str, List[Tuple[int, str]]] = {ref: [] for ref in head_refs}
+        batch_size = 50
+        for start in range(0, len(head_refs), batch_size):
+            batch = head_refs[start : start + batch_size]
+            aliases = " ".join(
+                f'b{i}: pullRequests(headRefName: "{head}", first: 10) '
+                "{ nodes { number state } }"
+                for i, head in enumerate(batch)
+            )
+            gql = (
+                "query($owner:String!, $name:String!) {"
+                f"  repository(owner:$owner, name:$name) {{ {aliases} }}"
+                "}"
+            )
+            repository = (
+                self._graphql(gql, {"owner": owner, "name": name})["repository"] or {}
+            )
+            for i, head in enumerate(batch):
+                node = repository.get(f"b{i}") or {}
+                result[head] = [
+                    (pr["number"], pr["state"]) for pr in (node.get("nodes") or [])
+                ]
+        return result
+
     def sleep_on_rate_limit(self) -> None:
         for limit, data in self.get_rate_limit().raw_data.items():
             if data["remaining"] == 0:

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -394,40 +394,72 @@ class GitHub(github.Github):
         return result
 
     def get_pull_states_by_head_refs(
-        self, repo_name: str, head_refs: List[str]
+        self, repo_name: str, head_refs: Dict[str, str]
     ) -> Dict[str, List[Tuple[int, str]]]:
-        """For each head branch name, return `(number, state)` of every PR opened
-        from it, batching many head refs per GraphQL request.
+        """Return `(number, state)` for PRs from this repository's head refs.
 
-        `state` is GitHub's `PullRequestState`: `OPEN`, `CLOSED` or `MERGED`.
-        This is the general form of `get_backport_merge_commits`, which answers
-        only "was a PR from this branch merged", and it replaces one REST
-        `get_pulls(head=...)` request per branch.
-
-        A branch with no PR at all maps to an empty list, so every requested ref
-        is present in the result and callers need no `.get` with a default.
+        `head_refs` maps each head branch to its expected base branch. Fork PRs
+        are excluded, and every connection is fully paginated. A successful empty
+        connection maps to an empty list; incomplete responses raise.
         """
         owner, name = repo_name.split("/")
         result: Dict[str, List[Tuple[int, str]]] = {ref: [] for ref in head_refs}
+        pending: Dict[str, Optional[str]] = {ref: None for ref in head_refs}
         batch_size = 50
-        for start in range(0, len(head_refs), batch_size):
-            batch = head_refs[start : start + batch_size]
-            aliases = " ".join(
-                f'b{i}: pullRequests(headRefName: "{head}", first: 10) '
-                "{ nodes { number state } }"
-                for i, head in enumerate(batch)
-            )
-            gql = (
-                "query($owner:String!, $name:String!) {"
-                f"  repository(owner:$owner, name:$name) {{ {aliases} }}"
-                "}"
-            )
-            repository = self._graphql(
-                gql, {"owner": owner, "name": name}, allow_partial=False
-            )["repository"]
+        while pending:
+            batch = list(pending)[:batch_size]
+            parameters = ["$owner:String!", "$name:String!"]
+            variables: Dict[str, Optional[str]] = {"owner": owner, "name": name}
+            aliases = []
             for i, head in enumerate(batch):
-                node = repository[f"b{i}"]
-                result[head] = [(pr["number"], pr["state"]) for pr in node["nodes"]]
+                parameters.extend(
+                    [f"$head{i}:String!", f"$base{i}:String!", f"$after{i}:String"]
+                )
+                variables.update(
+                    {
+                        f"head{i}": head,
+                        f"base{i}": head_refs[head],
+                        f"after{i}": pending[head],
+                    }
+                )
+                aliases.append(
+                    f"b{i}: pullRequests(headRefName:$head{i}, baseRefName:$base{i}, "
+                    f"first:100, after:$after{i}) {{ "
+                    "nodes { number state headRepository { id } } "
+                    "pageInfo { hasNextPage endCursor } }"
+                )
+            gql = (
+                f"query({', '.join(parameters)}) {{ "
+                "repository(owner:$owner, name:$name) { id "
+                + " ".join(aliases)
+                + " } }"
+            )
+            repository = self._graphql(gql, variables, allow_partial=False)[
+                "repository"
+            ]
+            for i, head in enumerate(batch):
+                connection = repository[f"b{i}"]
+                for pr in connection["nodes"]:
+                    # A deleted fork has no head repository and cannot own one
+                    # of the automation refs being reconciled here.
+                    head_repository = pr["headRepository"]
+                    if (
+                        head_repository is not None
+                        and head_repository["id"] == repository["id"]
+                    ):
+                        result[head].append((pr["number"], pr["state"]))
+                page = connection["pageInfo"]
+                if page["hasNextPage"]:
+                    cursor = page["endCursor"]
+                    if not cursor or cursor == pending[head]:
+                        raise GithubException(
+                            200,
+                            f"PR lookup pagination did not advance for {head}",
+                            None,
+                        )
+                    pending[head] = cursor
+                else:
+                    del pending[head]
         return result
 
     def sleep_on_rate_limit(self) -> None:


### PR DESCRIPTION
Recover stranded backports, reuse the checkout across scheduled passes, and retry untouched conflicting cherry-picks when their release branch gains the missing prerequisites.

A merged cherry-pick can leave changes on a `backport/*` branch after the original PR has received `pr-backports-created`, so the ordinary search never revisits it. `BackportPRs.reconcile_backport_branches` checks those branches for completed cherry-picks without a backport PR and returns the original PR to processing. It rechecks the requested release labels and respects open or closed cherry-picks. Batched lookups require the exact head repository and base branch, follow all pages, and reject null or partial API responses instead of treating them as absent PRs.

`cherry_pick.py --loop` runs passes on a 20-minute cadence within a 170-minute window, amortizing the full checkout across passes. The workflow invokes Python directly. Python refreshes clients and credentials each pass, restores the originally selected commit, and removes only automation branches created during this run. It checks a monotonic deadline before starting each pass and caps sleeps at that deadline. Three consecutive failures end the loop, and any failed pass makes the job fail even if a later pass succeeds. Single-run invocation remains the default. A pass already running at the deadline is allowed to finish, subject to the workflow's overall timeout.

`ReleaseBranch._retry_cherrypick` uses `git merge-tree --write-tree` to resolve against the current release snapshot without changing the checkout or index, including renamed files. It requires an untouched cherry-pick head and generated base, then updates both remote refs atomically with leases against the exact inspected SHAs. Concurrent edits reject the push. Persistent conflicts remain for manual resolution, other Git failures propagate, and already-applied changes close the empty cherry-pick. A changed head, including an earlier successful retry, remains for humans to handle if it conflicts again.

Backport preparation pins one release SHA for both its resolved tree and final commit parent. Finalization fetches the current backport branch and protects its squash push with an explicit lease.

Git 2.38 or newer is required and checked before credentials or API mutations. Existing Ubuntu 22.04 runners have Git 2.34.1, as confirmed in this [CherryPick run](https://github.com/ClickHouse/ClickHouse/actions/runs/34016741650); live execution requires the separate runner-image upgrade to be deployed. Selecting this branch for a manual workflow run still operates on real repository backports.

Validation: 34 focused throwaway checks passed, covering local bare remotes, stale and moving refs, concurrent updates, atomic rejection, renamed files, healing and finalization, persistent conflicts, already-applied changes, dry runs, strict lookup errors, repository/base filtering and pagination, loop timing, failure exits, checkout/stash preservation, and token cache refresh. One check uses read-only live GitHub queries. Black and Ruff passed; Pylint has no new diagnostics relative to the original PR head.

Related: https://github.com/ClickHouse/clickhouse-private/pull/72922

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Recover stranded backports and improve cherry-pick retry and scheduling reliability.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118235&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118235](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118235+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.927` (included in `26.9` and later)
<!-- ch-version-info:end -->