### PR TITLE
Perf: optimize repeated index runs in ColumnSparse::index()

### DIFF
--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -506,6 +506,31 @@ ColumnPtr ColumnSparse::indexImpl(const PaddedPODArray<Type> & indexes, size_t l
     auto res_values = values->cloneEmpty();
     res_values->insertDefault();
 
+    auto insert_run = [&](size_t value_index, size_t output_start, size_t length)
+    {
+        if (value_index == 0)
+            return;
+
+        if (length == 1)
+        {
+            res_values->insertFrom(*values, value_index);
+            res_offsets_data.push_back(output_start);
+            return;
+        }
+
+        res_values->insertManyFrom(*values, value_index, length);
+        for (size_t i = 0; i < length; ++i)
+            res_offsets_data.push_back(output_start + i);
+    };
+
+    auto get_run_end = [&](size_t start)
+    {
+        size_t end = start + 1;
+        while (end < limit && indexes[end] == indexes[start])
+            ++end;
+        return end;
+    };
+
     /// If we need to permute full column, or if limit is large enough,
     /// it's better to save indexes of values in O(size)
     /// and avoid binary search for obtaining every index.
@@ -520,26 +545,20 @@ ColumnPtr ColumnSparse::indexImpl(const PaddedPODArray<Type> & indexes, size_t l
         for (size_t i = 0; i < _size; ++i, ++offset_it)
             values_index[i] = offset_it.getValueIndex();
 
-        for (size_t i = 0; i < limit; ++i)
+        for (size_t i = 0; i < limit;)
         {
-            size_t index = values_index[indexes[i]];
-            if (index != 0)
-            {
-                res_values->insertFrom(*values, index);
-                res_offsets_data.push_back(i);
-            }
+            size_t run_end = get_run_end(i);
+            insert_run(values_index[indexes[i]], i, run_end - i);
+            i = run_end;
         }
     }
     else
     {
-        for (size_t i = 0; i < limit; ++i)
+        for (size_t i = 0; i < limit;)
         {
-            size_t index = getValueIndex(indexes[i]);
-            if (index != 0)
-            {
-                res_values->insertFrom(*values, index);
-                res_offsets_data.push_back(i);
-            }
+            size_t run_end = get_run_end(i);
+            insert_run(getValueIndex(indexes[i]), i, run_end - i);
+            i = run_end;
         }
     }
 

--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -525,8 +525,9 @@ ColumnPtr ColumnSparse::indexImpl(const PaddedPODArray<Type> & indexes, size_t l
 
     auto get_run_end = [&](size_t start)
     {
+        const auto index = indexes[start];
         size_t end = start + 1;
-        while (end < limit && indexes[end] == indexes[start])
+        while (end < limit && indexes[end] == index)
             ++end;
         return end;
     };

--- a/src/Columns/tests/gtest_column_sparse.cpp
+++ b/src/Columns/tests/gtest_column_sparse.cpp
@@ -329,4 +329,49 @@ TEST(ColumnSparse, GetPermutation)
     }
 }
 
+TEST(ColumnSparse, Index)
+{
+    auto values = ColumnUInt64::create();
+    auto offsets = ColumnUInt64::create();
+    auto full = ColumnUInt64::create();
+
+    values->insertValue(0);
+    values->insertValue(10);
+    values->insertValue(20);
+    values->insertValue(30);
+
+    offsets->insertValue(1);
+    offsets->insertValue(4);
+    offsets->insertValue(6);
+
+    full->insertValue(0);
+    full->insertValue(10);
+    full->insertValue(0);
+    full->insertValue(0);
+    full->insertValue(20);
+    full->insertValue(0);
+    full->insertValue(30);
+    full->insertValue(0);
+
+    auto sparse = ColumnSparse::create(std::move(values), std::move(offsets), full->size());
+
+    auto test_case = [&](std::initializer_list<UInt64> index_values, size_t limit)
+    {
+        auto indexes = ColumnUInt64::create();
+        for (UInt64 index : index_values)
+            indexes->insertValue(index);
+
+        auto sparse_result = sparse->index(*indexes, limit);
+        auto full_result = full->index(*indexes, limit);
+
+        ASSERT_TRUE(checkEquals(*sparse_result->convertToFullColumnIfSparse(), *full_result));
+    };
+
+    /// Exercise the binary-search path with repeated default and non-default rows.
+    test_case({4, 4, 2, 2, 0}, 5);
+
+    /// Exercise the linear path with repeated and unique rows.
+    test_case({4, 4, 4, 1, 0, 6, 6, 2}, 8);
+}
+
 #undef DUMP_COLUMN

--- a/src/Columns/tests/gtest_column_sparse.cpp
+++ b/src/Columns/tests/gtest_column_sparse.cpp
@@ -370,6 +370,9 @@ TEST(ColumnSparse, Index)
     /// Exercise the binary-search path with repeated default and non-default rows.
     test_case({4, 4, 2, 2, 0}, 5);
 
+    /// Check that a run continuing past the requested limit is truncated.
+    test_case({4, 4, 4, 1, 0}, 3);
+
     /// Exercise the linear path with repeated and unique rows.
     test_case({4, 4, 4, 1, 0, 6, 6, 2}, 8);
 }

--- a/tests/performance/sparse_column_index_runs.xml
+++ b/tests/performance/sparse_column_index_runs.xml
@@ -39,7 +39,7 @@
 
     <!-- Keep the output size roughly constant while changing the length of each repeated index run. -->
     <query>
-        SELECT u64, payload
+        SELECT materialize(u64), materialize(payload)
         FROM (SELECT u64, payload FROM sparse_column_index_runs_{run_length})
         ARRAY JOIN range({run_length}) AS element
         FORMAT Null

--- a/tests/performance/sparse_column_index_runs.xml
+++ b/tests/performance/sparse_column_index_runs.xml
@@ -1,0 +1,50 @@
+<test>
+    <substitutions>
+        <substitution>
+            <name>run_length</name>
+            <values>
+                <value>1</value>
+                <value>2</value>
+                <value>4</value>
+                <value>8</value>
+                <value>16</value>
+                <value>64</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE sparse_column_index_runs_{run_length}
+        (
+            id UInt64,
+            u64 UInt64,
+            payload String
+        )
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS ratio_of_defaults_for_sparse_serialization = 0.8
+    </create_query>
+
+    <fill_query>
+        INSERT INTO sparse_column_index_runs_{run_length}
+        SELECT
+            number,
+            number % 20 = 0 ? number : 0,
+            number % 20 = 0 ? repeat(toString(number), 64) : ''
+        FROM numbers(intDiv(1000000, {run_length}))
+    </fill_query>
+
+    <!-- Keep the output size roughly constant while changing the length of each repeated index run. -->
+    <query>
+        SELECT u64, payload
+        FROM (SELECT u64, payload FROM sparse_column_index_runs_{run_length})
+        ARRAY JOIN range({run_length}) AS element
+        FORMAT Null
+        SETTINGS enable_lazy_columns_replication = 1
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS sparse_column_index_runs_{run_length}</drop_query>
+</test>

--- a/tests/performance/sparse_column_index_runs.xml
+++ b/tests/performance/sparse_column_index_runs.xml
@@ -34,12 +34,12 @@
             number,
             number % 20 = 0 ? number : 0,
             number % 20 = 0 ? repeat(toString(number), 64) : ''
-        FROM numbers(intDiv(1000000, {run_length}))
+        FROM numbers(intDiv(10000000, {run_length}))
     </fill_query>
 
     <!-- Keep the output size roughly constant while changing the length of each repeated index run. -->
     <query>
-        SELECT materialize(u64), materialize(payload)
+        SELECT sum(u64), min(payload)
         FROM (SELECT u64, payload FROM sparse_column_index_runs_{run_length})
         ARRAY JOIN range({run_length}) AS element
         FORMAT Null


### PR DESCRIPTION
### Changelog category

- Performance Improvement

### Changelog entry

Speeds up materialization of lazily replicated sparse columns when consecutive output rows refer to the same source row.

### What does this PR do?

- Detects consecutive equal indexes in `ColumnSparse::index()`.
- Looks up the Sparse value once per run.
- Uses nested `insertManyFrom()` for runs longer than one row.
- Keeps the existing `insertFrom()` path for single-row runs.
- Adds unit coverage for repeated indexes, default rows, both lookup strategies, and a run truncated by `limit`.
- Adds CI performance coverage for run lengths 1, 2, 4, 8, 16, and 64 with both `UInt64` and `String` columns.

### Why?

`ColumnReplicated` stores repeated rows as an index array. Lazy replication can produce runs such as `[7, 7, 7, 7]`.

Before this change, `ColumnSparse::index()` handled every output row separately. A repeated run therefore repeated the same Sparse lookup and nested insertion work. The new path batches only the nested value copy. Sparse offsets are still written for every non-default output row, so the output order and representation stay the same.

### Scope and correctness

- Run length 1 keeps the scalar insertion path.
- Default rows still do not add entries to the Sparse values column.
- Both the linear and binary-search lookup paths use the same run handling.
- Runs that extend past `limit` stop at the requested output size.
- Join planning and join result semantics are unchanged.

### Testing

- Added `ColumnSparse.Index` unit coverage.
- Added `tests/performance/sparse_column_index_runs.xml`.
- The performance test keeps about 1M output rows per run length. Run length 1 is the all-unique control.
- The queries explicitly call `materialize(...)` after `ARRAY JOIN`, so `FORMAT Null` still exercises the Sparse indexing path.
- `git diff --check` passes.
- CI will run the unit and performance checks.

### Related work

- #117460 optimizes a separate HashJoin output gather path. This PR only changes the generic Sparse indexing path.
- #109424 materializes sparse sort-key columns during sorting. It does not touch this indexing path.
- #115159 tracks a broader lazy materialization effort for ARRAY JOIN.
- #117321 adds bulk insertion for nested Array values, which can also be used when Sparse wraps an Array.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118237&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118237](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118237+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.931` (included in `26.9` and later)
<!-- ch-version-info:end -->