### PR TITLE
Docs: Clarify transactions and guide OLTP users to ClickHouse Managed Postgres

### DIFF
--- a/docs/concepts/features/operations/insert/transactions.mdx
+++ b/docs/concepts/features/operations/insert/transactions.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Page describing transactional (ACID) support in ClickHouse'
+description: 'Understand ClickHouse insert guarantees and experimental transactions, and when to use managed Postgres for transactional workloads.'
 slug: /guides/developer/transactional
 title: 'Transactional (ACID) support'
 doc_type: 'guide'
@@ -7,6 +7,18 @@ doc_type: 'guide'
 
 import { ExperimentalBadge } from "/snippets/components/ExperimentalBadge/ExperimentalBadge.jsx";
 import { CloudNotSupportedBadge } from "/snippets/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx";
+
+This page describes transaction guarantees in the ClickHouse analytical database, including insert guarantees and experimental support for transactions across multiple statements.
+
+<Tip>
+**Looking for a database for transactional workloads (OLTP)?**
+
+For applications that need frequent reads and writes to individual records, and transactions across multiple statements—for example, creating an order and updating inventory together—consider [Postgres managed by ClickHouse](/products/managed-postgres/overview).
+
+Use Postgres as your application's system of record, and add ClickHouse for analytics by replicating committed changes with ClickPipes. [Learn how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics).
+</Tip>
+
+If you're checking the atomicity, isolation, or durability of inserts into ClickHouse, continue with the cases below.
 
 ## Case 1: INSERT into one partition, of one table, of the MergeTree* family {#case-1-insert-into-one-partition-of-one-table-of-the-mergetree-family}
 
@@ -54,6 +66,8 @@ Same as Case 1 above, with this detail:
 <CloudNotSupportedBadge/>
 
 In addition to the functionality described at the top of this document, ClickHouse has experimental support for transactions, commits, and rollback functionality.
+
+For application workloads that need transactions across multiple statements, consider [Postgres managed by ClickHouse](/products/managed-postgres/overview#transactions-and-analytics).
 
 ### Requirements {#requirements}
 

--- a/docs/concepts/features/operations/insert/transactions.mdx
+++ b/docs/concepts/features/operations/insert/transactions.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Understand ClickHouse insert guarantees and experimental transactions, and when to use managed Postgres for transactional workloads.'
+description: 'Understand ClickHouse insert guarantees and experimental transactions, and when to use ClickHouse Managed Postgres for transactional workloads.'
 slug: /guides/developer/transactional
 title: 'Transactional (ACID) support'
 doc_type: 'guide'
@@ -13,7 +13,7 @@ This page describes transaction guarantees in the ClickHouse analytical database
 <Tip>
 **Looking for a database for transactional workloads (OLTP)?**
 
-For applications that need frequent reads and writes to individual records, and transactions across multiple statements—for example, creating an order and updating inventory together—consider [Postgres managed by ClickHouse](/products/managed-postgres/overview).
+For applications that need frequent reads and writes to individual records, and transactions across multiple statements—for example, creating an order and updating inventory together—consider [ClickHouse Managed Postgres](/products/managed-postgres/overview).
 
 Use Postgres as your application's system of record, and add ClickHouse for analytics by replicating committed changes with ClickPipes. [Learn how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics).
 </Tip>
@@ -67,7 +67,7 @@ Same as Case 1 above, with this detail:
 
 In addition to the functionality described at the top of this document, ClickHouse has experimental support for transactions, commits, and rollback functionality.
 
-For application workloads that need transactions across multiple statements, consider [Postgres managed by ClickHouse](/products/managed-postgres/overview#transactions-and-analytics).
+For application workloads that need transactions across multiple statements, consider [ClickHouse Managed Postgres](/products/managed-postgres/overview#transactions-and-analytics).
 
 ### Requirements {#requirements}
 

--- a/docs/concepts/features/operations/insert/transactions.mdx
+++ b/docs/concepts/features/operations/insert/transactions.mdx
@@ -13,9 +13,7 @@ This page describes transaction guarantees in the ClickHouse analytical database
 <Tip>
 **Looking for a database for transactional workloads (OLTP)?**
 
-For applications that need frequent reads and writes to individual records, and transactions across multiple statements—for example, creating an order and updating inventory together—consider [ClickHouse Managed Postgres](/products/managed-postgres/overview).
-
-Use Postgres as your application's system of record, and add ClickHouse for analytics by replicating committed changes with ClickPipes. [Learn how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics).
+For applications that need frequent reads and writes to individual records, use [ClickHouse Managed Postgres](/products/managed-postgres/overview) as your application's system of record, and add ClickHouse for analytics by replicating committed changes with ClickPipes. [Learn how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics).
 </Tip>
 
 If you're checking the atomicity, isolation, or durability of inserts into ClickHouse, continue with the cases below.
@@ -67,7 +65,7 @@ Same as Case 1 above, with this detail:
 
 In addition to the functionality described at the top of this document, ClickHouse has experimental support for transactions, commits, and rollback functionality.
 
-For application workloads that need transactions across multiple statements, consider [ClickHouse Managed Postgres](/products/managed-postgres/overview#transactions-and-analytics).
+For application workloads, consider [ClickHouse Managed Postgres](/products/managed-postgres/overview#transactions-and-analytics).
 
 ### Requirements {#requirements}
 

--- a/docs/get-started/migrate/postgres/overview.mdx
+++ b/docs/get-started/migrate/postgres/overview.mdx
@@ -7,7 +7,7 @@ sidebarTitle: 'Overview'
 doc_type: 'guide'
 ---
 
-## Why use ClickHouse over Postgres? {#why-use-clickhouse-over-postgres}
+## Why use ClickHouse for Postgres analytics? {#why-use-clickhouse-over-postgres}
 
 TLDR: Because ClickHouse is designed for fast analytics, specifically `GROUP BY` queries, as an OLAP database whereas Postgres is an OLTP database designed for transactional workloads.
 
@@ -18,6 +18,14 @@ OLAP, or online analytical processing databases, are designed to meet those need
 See [here](/get-started/migrate/postgres/appendix#postgres-vs-clickhouse-equivalent-and-different-concepts) for a more in-depth comparison of ClickHouse and PostgreSQL.
 
 To see the potential performance differences between ClickHouse and Postgres on analytical queries, see [Rewriting PostgreSQL Queries in ClickHouse](/get-started/migrate/postgres/migration-guide/migration-guide-part2).
+
+<Tip>
+**Keep Postgres for transactions and add ClickHouse for analytics**
+
+You can move analytical queries to ClickHouse while keeping Postgres as your application's transactional system of record. Replicate committed changes to ClickHouse with CDC, and continue to run application transactions in Postgres.
+
+You can use your existing Postgres deployment or [Postgres managed by ClickHouse](/products/managed-postgres/overview). See [how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics) for the architecture and replication guarantees.
+</Tip>
 
 ## Migration strategies {#migration-strategies}
 

--- a/docs/get-started/migrate/postgres/overview.mdx
+++ b/docs/get-started/migrate/postgres/overview.mdx
@@ -24,7 +24,7 @@ To see the potential performance differences between ClickHouse and Postgres on 
 
 You can move analytical queries to ClickHouse while keeping Postgres as your application's transactional system of record. Replicate committed changes to ClickHouse with CDC, and continue to run application transactions in Postgres.
 
-You can use your existing Postgres deployment or [Postgres managed by ClickHouse](/products/managed-postgres/overview). See [how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics) for the architecture and replication guarantees.
+You can use your existing Postgres deployment or [ClickHouse Managed Postgres](/products/managed-postgres/overview). See [how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics) for the architecture and replication guarantees.
 </Tip>
 
 ## Migration strategies {#migration-strategies}

--- a/docs/guides/clickhouse/data-modelling/stored-procedures-and-prepared-statements.mdx
+++ b/docs/guides/clickhouse/data-modelling/stored-procedures-and-prepared-statements.mdx
@@ -560,7 +560,7 @@ print(f"Status: {status}, Loyalty Points: {points}")
 <Tip>
 **When to use each approach:**
 
-- **OLTP workloads** (orders, payments, user accounts) → Use MySQL or PostgreSQL for application transactions and stored procedures. [Postgres managed by ClickHouse](/products/managed-postgres/overview) is available in ClickHouse Cloud.
+- **OLTP workloads** (orders, payments, user accounts) → Use MySQL or PostgreSQL for application transactions and stored procedures. [ClickHouse Managed Postgres](/products/managed-postgres/overview) is available in ClickHouse Cloud.
 - **Analytics workloads** (reporting, aggregations, time-series) → Use ClickHouse with application orchestration
 - **Hybrid architecture** → Keep application transactions in Postgres and replicate committed changes to ClickHouse for analytics. See [how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics) and the [integration quickstart](/products/managed-postgres/quickstart#part-2).
 </Tip>

--- a/docs/guides/clickhouse/data-modelling/stored-procedures-and-prepared-statements.mdx
+++ b/docs/guides/clickhouse/data-modelling/stored-procedures-and-prepared-statements.mdx
@@ -560,9 +560,9 @@ print(f"Status: {status}, Loyalty Points: {points}")
 <Tip>
 **When to use each approach:**
 
-- **OLTP workloads** (orders, payments, user accounts) → Use MySQL/PostgreSQL with stored procedures
+- **OLTP workloads** (orders, payments, user accounts) → Use MySQL or PostgreSQL for application transactions and stored procedures. [Postgres managed by ClickHouse](/products/managed-postgres/overview) is available in ClickHouse Cloud.
 - **Analytics workloads** (reporting, aggregations, time-series) → Use ClickHouse with application orchestration
-- **Hybrid architecture** → Use both! Stream transactional data from OLTP to ClickHouse for analytics
+- **Hybrid architecture** → Keep application transactions in Postgres and replicate committed changes to ClickHouse for analytics. See [how Postgres and ClickHouse work together](/products/managed-postgres/overview#transactions-and-analytics) and the [integration quickstart](/products/managed-postgres/quickstart#part-2).
 </Tip>
 
 #### Using workflow orchestration tools {#using-workflow-orchestration-tools}

--- a/docs/products/managed-postgres/overview.mdx
+++ b/docs/products/managed-postgres/overview.mdx
@@ -33,7 +33,7 @@ flowchart LR
 
 Replication is asynchronous, so analytical results can lag behind committed Postgres changes. The two databases have separate transaction boundaries: CDC and `pg_clickhouse` do not provide a shared transaction across Postgres and ClickHouse. Reads that require the latest committed application state should use Postgres.
 
-You can start with Postgres alone and add ClickHouse when you need it. Follow the [managed Postgres quickstart](/products/managed-postgres/quickstart) to try both services, or go directly to [adding analytics](/products/managed-postgres/quickstart#part-2) if you already have a Postgres service.
+You can start with Postgres alone and add ClickHouse when you need it. Follow the [ClickHouse Managed Postgres quickstart](/products/managed-postgres/quickstart) to try both services, or go directly to [adding analytics](/products/managed-postgres/quickstart#part-2) if you already have a Postgres service.
 
 ## NVMe-powered performance {#nvme-performance}
 

--- a/docs/products/managed-postgres/overview.mdx
+++ b/docs/products/managed-postgres/overview.mdx
@@ -7,7 +7,6 @@ doc_type: 'guide'
 ---
 
 import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
-import { Image } from "/snippets/components/Image.jsx";
 
 <BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.overview-beta" />
 
@@ -15,8 +14,26 @@ ClickHouse Managed Postgres is an enterprise-grade managed Postgres service buil
 
 Built in partnership with [Ubicloud](https://www.ubicloud.com/), whose founding team has a track record of delivering world-class Postgres at Citus Data, Heroku, and Microsoft, ClickHouse Managed Postgres solves the performance challenges that fast-growing applications commonly face: slower ingestion and updates, slow vacuums, increased tail latency, and WAL spikes caused by limited disk IOPS.
 
-{/* TODO: Architecture diagram showing Postgres + ClickHouse integration
-    Path: /images/cloud/managed-postgres/architecture-overview.png */}
+## Postgres for transactions, ClickHouse for analytics {#transactions-and-analytics}
+
+Use Postgres for transactional application workloads (OLTP), such as creating orders, updating inventory, and managing user accounts. Postgres is your system of record: related changes can commit or roll back together in a transaction.
+
+When your application also needs analytics over large datasets, add a ClickHouse service and connect the two with ClickPipes:
+
+```mermaid
+flowchart LR
+    Application -->|Reads and writes| Postgres
+    Postgres -->|Committed changes via ClickPipes| ClickHouse
+    Analytics -->|Queries| ClickHouse
+```
+
+1. Your application reads and writes operational data in Postgres, using transactions to group related changes.
+2. [Configure ClickPipes](/products/managed-postgres/clickhouse-integration) to copy selected tables to ClickHouse and continuously replicate committed inserts, updates, and deletes using change data capture (CDC).
+3. Run analytical queries in ClickHouse. You can connect to ClickHouse directly or query its tables from Postgres through the [`pg_clickhouse`](/products/managed-postgres/extensions/pg_clickhouse/introduction) extension.
+
+Replication is asynchronous, so analytical results can lag behind committed Postgres changes. The two databases have separate transaction boundaries: CDC and `pg_clickhouse` do not provide a shared transaction across Postgres and ClickHouse. Reads that require the latest committed application state should use Postgres.
+
+You can start with Postgres alone and add ClickHouse when you need it. Follow the [managed Postgres quickstart](/products/managed-postgres/quickstart) to try both services, or go directly to [adding analytics](/products/managed-postgres/quickstart#part-2) if you already have a Postgres service.
 
 ## NVMe-powered performance {#nvme-performance}
 


### PR DESCRIPTION
Readers evaluating ClickHouse for transactional application workloads can land on insert guarantees or experimental transaction documentation without a clear route to ClickHouse Managed Postgres. Add conditional workload guidance to both sections, and link the stored-procedure and Postgres migration guides to the same architecture explanation.

Add a Postgres + ClickHouse architecture section to the ClickHouse Managed Postgres overview, including a diagram, setup links, and the distinction between Postgres transactions and asynchronous CDC into ClickHouse. Explain that CDC and `pg_clickhouse` do not provide a shared transaction across both databases.

Validation: English documentation internal links and heading anchors; scoped Mintlify configuration, MDX, and import validation for the four edited pages; `git diff --check`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Clarify the distinction between ClickHouse transaction guarantees and OLTP workloads, and document how to combine ClickHouse Managed Postgres for application transactions with ClickHouse for analytics.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118238&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118238](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118238+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1200` (included in `26.9` and later)
<!-- ch-version-info:end -->