### PR TITLE
Require agents to run the style check locally before pushing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -154,8 +154,6 @@ When writing C++ code, always use Allman-style braces (opening brace on a new li
 
 Run the style check locally before you push, and never hand over a change that you have not style-checked. It is the cheapest CI job to reproduce and by far the most common reason an otherwise finished pull request comes back red, which costs a full CI round-trip to learn something a local command answers in a second.
 
-The job runs the same tools the style-check image installs, so take the prerequisites from there rather than guessing: `ci/docker/style-test/requirements.txt` for the Python ones (`ruff`, `yamllint`, ...) and the `apt-get install` list in `ci/docker/style-test/Dockerfile` for the system ones (`libxml2-utils`, which provides `xmllint`, plus `ripgrep`). A missing tool is reported as a failure of its sub-check, not as a skip, so an incomplete environment looks like a broken change.
-
 ```bash
 pip install -r ci/docker/style-test/requirements.txt
 sudo apt-get install libxml2-utils ripgrep

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -156,17 +156,8 @@ Run the style check locally before you push, and never hand over a change that y
 
 ```bash
 mkdir -p ci/tmp  # praktika keeps its local state here, the job fails without it
-
-# A single sub-check - run the ones matching what you changed
-PYTHONPATH=./ci:. python3 ci/jobs/check_style.py --test ruff
-
-# The whole job
 PYTHONPATH=./ci:. python3 ci/jobs/check_style.py
 ```
-
-`--test` takes a case-insensitive substring, so `--test yaml` runs `yamllint`. The sub-check names are `whitespace_check`, `yamllint`, `xmllint`, `functional_tests_check`, `server_data_manipulation_in_stateless_tests`, `test_numbers_check`, `symlinks`, `catch_all`, `compose_images_from_dockerhub`, `clickhouse_spelling`, `settings_changes_history`, `cpp`, `various`, `embedded_doc_snippets` and `ruff`. Python changes need `ruff`, C++ changes need `cpp`, and `catch_all`, `various` and `whitespace_check` are cheap and cover cross-cutting rules. Some sub-checks shell out to tools that may not be installed (`shellcheck`, `clang-format`, `typos`, `yamllint`, `actionlint`); a sub-check that genuinely cannot run locally is the only case where CI is the first thing to see the problem.
-
-Two things worth knowing about the Python checks. `ruff` does not count `# type:` comments as usage, so a `typing` import referenced only from a type comment is reported as an unused import (F401) - write a real annotation, `x: Dict[str, int] = {}`, instead. And `black` is configured in `pyproject.toml` but is not enforced by any CI job, so running it is optional and a `black` diff is not a style-check failure.
 
 Never use sleep in C++ code to fix race conditions - this is stupid and not acceptable!
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -152,6 +152,22 @@ When adding a new test, use `./tests/queries/0_stateless/add-test <name>` for `.
 
 When writing C++ code, always use Allman-style braces (opening brace on a new line). This is enforced by the style check in CI.
 
+Run the style check locally before you push, and never hand over a change that you have not style-checked. It is the cheapest CI job to reproduce and by far the most common reason an otherwise finished pull request comes back red, which costs a full CI round-trip to learn something a local command answers in a second.
+
+```bash
+mkdir -p ci/tmp  # praktika keeps its local state here, the job fails without it
+
+# A single sub-check - run the ones matching what you changed
+PYTHONPATH=./ci:. python3 ci/jobs/check_style.py --test ruff
+
+# The whole job
+PYTHONPATH=./ci:. python3 ci/jobs/check_style.py
+```
+
+`--test` takes a case-insensitive substring, so `--test yaml` runs `yamllint`. The sub-check names are `whitespace_check`, `yamllint`, `xmllint`, `functional_tests_check`, `server_data_manipulation_in_stateless_tests`, `test_numbers_check`, `symlinks`, `catch_all`, `compose_images_from_dockerhub`, `clickhouse_spelling`, `settings_changes_history`, `cpp`, `various`, `embedded_doc_snippets` and `ruff`. Python changes need `ruff`, C++ changes need `cpp`, and `catch_all`, `various` and `whitespace_check` are cheap and cover cross-cutting rules. Some sub-checks shell out to tools that may not be installed (`shellcheck`, `clang-format`, `typos`, `yamllint`, `actionlint`); a sub-check that genuinely cannot run locally is the only case where CI is the first thing to see the problem.
+
+Two things worth knowing about the Python checks. `ruff` does not count `# type:` comments as usage, so a `typing` import referenced only from a type comment is reported as an unused import (F401) - write a real annotation, `x: Dict[str, int] = {}`, instead. And `black` is configured in `pyproject.toml` but is not enforced by any CI job, so running it is optional and a `black` diff is not a style-check failure.
+
 Never use sleep in C++ code to fix race conditions - this is stupid and not acceptable!
 
 Avoid fallback paths. When an operation fails, prefer letting the error propagate over silently substituting a default value or alternate behavior. Fallbacks hide bugs and make incidents harder to diagnose. If a fallback is genuinely needed, follow the fail-close principle: never perform a destructive, expensive, or otherwise consequential action on the fallback path. Skip the operation and surface the error instead — for example, when label-attribution data is unavailable, do not assume "human-added" and create backports anyway; let the run fail and retry once the data is available.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -154,12 +154,15 @@ When writing C++ code, always use Allman-style braces (opening brace on a new li
 
 Run the style check locally before you push, and never hand over a change that you have not style-checked. It is the cheapest CI job to reproduce and by far the most common reason an otherwise finished pull request comes back red, which costs a full CI round-trip to learn something a local command answers in a second.
 
+The job runs the same tools the style-check image installs, so take the prerequisites from there rather than guessing: `ci/docker/style-test/requirements.txt` for the Python ones (`ruff`, `yamllint`, ...) and the `apt-get install` list in `ci/docker/style-test/Dockerfile` for the system ones (`libxml2-utils`, which provides `xmllint`, plus `ripgrep`). A missing tool is reported as a failure of its sub-check, not as a skip, so an incomplete environment looks like a broken change.
+
 ```bash
+pip install -r ci/docker/style-test/requirements.txt
+sudo apt-get install libxml2-utils ripgrep
+
 mkdir -p ci/tmp  # praktika keeps its local state here, the job fails without it
 PYTHONPATH=./ci:. python3 ci/jobs/check_style.py
 ```
-
-On a clean tree this still exits 1 with three failures that are about the environment and not about your change: `yamllint` and `xmllint` need tools that are usually not installed, and `settings_changes_history` reads a changed-files list that only a CI run records. Treat any other failure as yours.
 
 Never use sleep in C++ code to fix race conditions - this is stupid and not acceptable!
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -159,6 +159,8 @@ mkdir -p ci/tmp  # praktika keeps its local state here, the job fails without it
 PYTHONPATH=./ci:. python3 ci/jobs/check_style.py
 ```
 
+On a clean tree this still exits 1 with three failures that are about the environment and not about your change: `yamllint` and `xmllint` need tools that are usually not installed, and `settings_changes_history` reads a changed-files list that only a CI run records. Treat any other failure as yours.
+
 Never use sleep in C++ code to fix race conditions - this is stupid and not acceptable!
 
 Avoid fallback paths. When an operation fails, prefer letting the error propagate over silently substituting a default value or alternate behavior. Fallbacks hide bugs and make incidents harder to diagnose. If a fallback is genuinely needed, follow the fail-close principle: never perform a destructive, expensive, or otherwise consequential action on the fallback path. Skip the operation and surface the error instead — for example, when label-attribution data is unavailable, do not assume "human-added" and create backports anyway; let the run fail and retry once the data is available.


### PR DESCRIPTION
The style check is the cheapest CI job to reproduce locally and the most common reason an otherwise finished pull request comes back red. Waiting for CI to report it costs a full round-trip to learn something a local command answers in a second, and an agent has no reason to spend that. This makes running it locally a requirement rather than a habit, and records how to run it, which is currently not written down anywhere.

```bash
pip install -r ci/docker/style-test/requirements.txt
sudo apt-get install libxml2-utils ripgrep

mkdir -p ci/tmp
PYTHONPATH=./ci:. python3 ci/jobs/check_style.py
```

Each line is there because the job fails without it:

- `ci/jobs/check_style.py` imports `praktika`, so without `PYTHONPATH=./ci:.` it dies with `ModuleNotFoundError: No module named 'praktika'`.
- It writes its environment into `ci/tmp`, so without that directory it dies with `FileNotFoundError: [Errno 2] No such file or directory: './ci/tmp/environment.json'`.
- A tool a sub-check shells out to being absent is reported as a *failure* of that sub-check, not a skip, so an incomplete environment is indistinguishable from a broken change. On a machine without `yamllint` and `xmllint` the job exits 1 with `Failures: 3/15` on a clean tree; installing `yamllint` alone takes it to 2/15. The two install lines are the style-check image's own dependency files, so they cannot drift from what CI runs.

`.claude/CLAUDE.md` is the file `AGENTS.md` symlinks to, so a single edit reaches both.

Verified by following the instruction on its own change.

Related: https://github.com/ClickHouse/ClickHouse/pull/118235

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118239&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118239](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118239+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.798` (included in `26.9` and later)
<!-- ch-version-info:end -->