### PR TITLE
Docs: add ADQM Control to third-party visual interfaces

### DIFF
--- a/docs/integrations/connectors/tools/gui.mdx
+++ b/docs/integrations/connectors/tools/gui.mdx
@@ -656,3 +656,20 @@ Features:
 - Connection options: HTTP/HTTPS, SSH tunnel for private clusters behind a firewall, optional read-only mode for safe production browsing.
 - Works with ClickHouse Cloud and self-hosted.
 </Accordion>
+
+<Accordion title="ADQM Control">
+
+[ADQM Control](https://docs.arenadata.io/en/ADQMCONTROL/current/concept/overview.html) (Arenadata QuickMarts Control) is an observability platform for ClickHouse clusters deployed as [Arenadata QuickMarts (ADQM)](https://docs.arenadata.io/en/ADQM/current/introduction/intro.html), the column-oriented DBMS built on ClickHouse by Arenadata. It combines host metrics from Prometheus with data about hosts, tables, and queries collected from the cluster to show how tables grow, how queries behave, and where hosts are under pressure, across one or many ADQM clusters. ADQM Control is deployed as a separate cluster with [Arenadata Cluster Manager (ADCM)](https://github.com/arenadata/adcm) and stores collected data in PostgreSQL.
+
+Features:
+
+- Heat map of host states for the selected ADQM cluster.
+- Related alerts grouped into incidents by time, with adjustable sensitivity.
+- Table size, rows, and request counts over time, with skew and imbalance metrics across hosts.
+- Per-column compressed and uncompressed size, compression savings, and codec, with graphs.
+- Complete query history with status, exception codes, duration, memory, and rows and bytes read and written.
+- Query filters by text, table, user, host, duration, status, and exception-code presets.
+- Query graphs by duration, user, and kind; per-host load graphs with anomaly detection.
+- Threshold alerts on host resources that explain the problem and recommend a fix.
+
+</Accordion>


### PR DESCRIPTION
Adds ADQM Control to the Commercial section of the "Visual Interfaces from Third-party Developers" page (`docs/integrations/connectors/tools/gui.mdx`).

ADQM Control is an observability platform with a web interface for ClickHouse clusters deployed as Arenadata QuickMarts (ADQM), the column-oriented DBMS built on ClickHouse by Arenadata. It combines host metrics from Prometheus with data about hosts, tables, and queries collected from the cluster, and provides a host heat map, threshold and availability alerts grouped into incidents, table and column-level size and compression tracking with cross-host skew metrics, and query analytics with per-host anomaly detection.

The entry follows the format of the surrounding accordions, describes only functionality documented by the vendor, and links to the English-language documentation: https://docs.arenadata.io/en/ADQMCONTROL/current/concept/overview.html

One file changed; no navigation or redirect changes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ADQM Control to the list of third-party visual interfaces.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118240&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118240](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118240+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1010` (included in `26.9` and later)
<!-- ch-version-info:end -->