### PR TITLE
Docs: add ADQM Notebook to third-party visual interfaces

### DIFF
--- a/docs/integrations/connectors/tools/gui.mdx
+++ b/docs/integrations/connectors/tools/gui.mdx
@@ -498,6 +498,26 @@ Features:
 
 ## Commercial {#commercial}
 
+<Accordion title="ADQM Notebook">
+
+[ADQM Notebook](https://docs.arenadata.io/en/ADQM/current/notebook.html) is a notebook-style SQL workspace included in the Enterprise edition of [Arenadata QuickMarts (ADQM)](https://docs.arenadata.io/en/ADQM/current/introduction/intro.html), the column-oriented DBMS built on ClickHouse by Arenadata. It extends the built-in ClickHouse web interface with multi-cell notebooks, interactive results, query plan analysis, and a cluster-wide schema browser, and is available out of the box at `/notebook` on the HTTP port (`8123`) of an ADQM host, next to `/play`, or through Chproxy.
+
+Features:
+
+- SQL and Markdown cells, up to five statements per cell, and memory, time, and thread limits per notebook or cell.
+- SQL editor with syntax highlighting, autocompletion, `{{variable}}` substitution, and `Beautify SQL`.
+- Results as a sortable, searchable grid with per-column NULL share, unique count, and value range.
+- Line, area, and bar charts; downloads as CSV, TSV, JSON, JSONLines, or Parquet.
+- Estimated and actual query plans, `EXPLAIN PIPELINE` and logical views, and findings with suggested fixes.
+- Query statistics from `system.query_log` with a per-node breakdown; run history for the last five runs.
+- Databases panel for the local host or the whole cluster with column statistics and ready-made queries.
+- Dependency graph of tables, views, materialized views, dictionaries, and projections.
+- Live view of running queries with a `KILL` button.
+- Access through Chproxy as a single entry point to the cluster, with queries balanced across all hosts.
+- Auto-save, JSON export and import, notebook storage on the ClickHouse server, and sharing by link.
+
+</Accordion>
+
 <Accordion title="ProbeDeck">
 
 [ProbeDeck](https://probedeck.app) is an iOS and iPadOS client for monitoring and querying ClickHouse.


### PR DESCRIPTION
Adds ADQM Notebook to the Commercial section of the "Visual Interfaces from Third-party Developers" page (`docs/integrations/connectors/tools/gui.mdx`).

ADQM Notebook is a notebook-style SQL web interface included in the Enterprise edition of Arenadata QuickMarts (ADQM), the column-oriented DBMS built on ClickHouse by Arenadata. It extends the built-in ClickHouse web interface (`/notebook` next to `/play` on the HTTP port) with SQL and Markdown cells, results as grids, charts, and downloads, estimated and actual query plans with fix recommendations, a database browser with column statistics and a dependency graph, live processes, and notebooks stored on the ClickHouse server.

The entry follows the format of the surrounding accordions, describes only functionality documented by the vendor, and links to the English-language documentation: https://docs.arenadata.io/en/ADQM/current/notebook.html

One file changed; no navigation or redirect changes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ADQM Notebook to the list of third-party visual interfaces.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118241&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118241](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118241+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1009` (included in `26.9` and later)
<!-- ch-version-info:end -->