### PR TITLE
docs: prototype a workload-to-service selection guide

### DIFF
--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -15,6 +15,9 @@ New to ClickHouse? Pick a starting point below.
   <Card title="Use cases" icon="chart-line" href="/get-started/use-cases/overview">
     See how ClickHouse powers real-time analytics, observability, data warehousing, and agentic analytics.
   </Card>
+  <Card title="Choose a service" icon="list-check" href="/get-started/use-cases/choosing-a-service">
+    Map analytical results, transactional state, observability, and local analysis to the right starting point.
+  </Card>
   <Card title="Deployment modes" icon="diagram-project" href="/get-started/about/deployment-modes">
     Compare ClickHouse Cloud, self-managed, and embedded deployment options.
   </Card>

--- a/docs/get-started/navigation.json
+++ b/docs/get-started/navigation.json
@@ -66,6 +66,7 @@
           "group": "Use cases",
           "pages": [
             "get-started/use-cases/overview",
+            "get-started/use-cases/choosing-a-service",
             "get-started/use-cases/real-time-analytics",
             "get-started/use-cases/observability",
             "get-started/use-cases/data-warehousing",

--- a/docs/get-started/use-cases/choosing-a-service.mdx
+++ b/docs/get-started/use-cases/choosing-a-service.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Choose a service for your workload'
+sidebarTitle: 'Choose a service'
+description: 'Map analytical queries, transactional application state, observability, and local analysis to ClickHouse Cloud, ClickHouse Managed Postgres, ClickStack, or chDB.'
+keywords: ['database selection', 'analytical database', 'transactional database', 'managed postgres', 'report history']
+doc_type: 'guide'
+---
+
+Start with the queries and correctness requirements your application needs to support. A large row count alone does not determine the database, and an application that generates reports can contain both analytical and transactional workloads.
+
+ClickHouse Cloud runs the ClickHouse analytical database engine. ClickHouse Managed Postgres runs PostgreSQL. They are separate database services with different SQL behavior; choosing one does not require deploying the other.
+
+## Map the workload to a starting point {#workload-map}
+
+| What your application needs | Start by evaluating | What to check before choosing |
+| --- | --- | --- |
+| Aggregations, filtering, and comparisons across large event or result histories | [ClickHouse Cloud](/products/cloud/getting-started/intro) | Representative queries, ingestion batches, data freshness, concurrent queries, and the design of updates or retries |
+| Transactional application state, such as orders, inventory reservations, or jobs whose state transitions require transactions and constraints | [ClickHouse Managed Postgres](/products/managed-postgres/overview) | Transaction boundaries, constraints, indexes, connection management, and the service's supported features and availability |
+| Transactional application state plus analytical queries that need an independent serving system | [Managed Postgres with ClickHouse integration](/products/managed-postgres/clickhouse-integration) | Which tables need replication, acceptable replication lag, schema changes, and the cost and operation of two services |
+| A managed experience for searching and investigating application logs, metrics, and traces | [Managed ClickStack](/clickstack/getting-started/managed) | Instrumentation, telemetry ingestion, retention, and the observability workflows your team needs |
+| Analysis of files or in-memory data inside a local application or notebook | [chDB](/chdb/index) | Local resources and whether you need a separately hosted, shared database service |
+
+Check the linked product documentation for current availability, regions, and limitations. ClickHouse Managed Postgres is currently in public beta; see its [quickstart](/products/managed-postgres/quickstart).
+
+For a self-managed ClickHouse server or other local options, see [deployment modes](/get-started/about/deployment-modes).
+
+## Example: report results and run history {#report-results-and-history}
+
+Suppose an application processes uploaded files, produces reports, and needs to retain queryable results and a history of runs. Before choosing a database, distinguish the result rows from the run records:
+
+- **Results:** Are queries retrieving a few rows for one report, or aggregating across many reports, datasets, and time ranges? Which table is expected to reach hundreds of millions of rows?
+- **Run records:** Is one immutable record written when a run completes, or does the application need to coordinate live job ownership and status transitions?
+- **Correctness:** Must several records change in one transaction? Must the database enforce uniqueness or prevent two workers from claiming the same job?
+- **Freshness:** How soon must a successful write be visible, and can queries tolerate an incomplete or delayed analytical copy?
+
+### Completed runs and analytical results {#completed-runs}
+
+ClickHouse Cloud is a candidate when the dominant workload is analysis across result rows and run records can be appended on completion. A small metadata table does not by itself require a second database.
+
+Design and test how readers distinguish a complete run from a partially ingested one. Define stable run identifiers, retry behavior, and how duplicate result rows are handled. Separate inserts into a results table and a run-history table must not be treated as a single cross-table transaction.
+
+If you store multiple versions of a run record, define how queries select the current version. [ReplacingMergeTree](/reference/engines/table-engines/mergetree-family/replacingmergetree) supports query-time deduplication with `FINAL`; correctness must not depend on background merges having already happened. The [update reference](/reference/statements/update) describes another update mechanism and its limitations. Neither pattern should be assumed to provide PostgreSQL-style transactional guarantees.
+
+### Transactional job state {#transactional-job-state}
+
+Evaluate ClickHouse Managed Postgres when the run table is also a transactional work queue or system of record: for example, a worker must claim a job atomically while other workers compete for it, or several application records must change together with constraints enforced.
+
+Postgres can also serve reporting queries. Add an analytical service when representative query performance, concurrency, or isolation requirements justify it, rather than assuming that every reporting application needs two databases.
+
+### Transactions and analytics together {#transactions-and-analytics}
+
+When both workloads justify separate services, keep transactional state in Postgres and replicate the required tables to ClickHouse using [ClickPipes](/products/managed-postgres/clickhouse-integration). Account for replication lag and continue to use the transactional source for decisions that require current application state. Replication does not make a Postgres write and a ClickHouse read part of one transaction.
+
+The [pg_clickhouse extension](/products/managed-postgres/extensions/pg_clickhouse/introduction) can provide access to ClickHouse through Postgres. A shared query entry point does not turn the two services into one database engine or remove the need to account for data freshness.
+
+## Check fit before provisioning {#check-fit}
+
+Write down a small set of representative queries and test them against realistic data volumes. Include narrow lookups as well as cross-history aggregates, your expected concurrent load, and the correctness cases that matter to your application. Report the schema, query shapes, hardware or service size, and ingestion behavior alongside any benchmark result.
+
+For a managed deployment, also check:
+
+- Region, networking, access control, and recovery requirements.
+- Expected active time, stored data, backups, and transfer charges in the [ClickHouse Cloud billing guide](/products/cloud/reference/billing/billing-overview) or [Managed Postgres pricing guide](/products/managed-postgres/pricing).
+- Whether an intermittent analytical workload can tolerate the connection delay associated with [automatic idling](/products/cloud/features/autoscaling/idling).
+- The team's responsibility for schema design, application retries, query tuning, and cost controls, even when the service manages the infrastructure.
+
+Once you have selected ClickHouse Cloud, use the [ClickHouse CLI](/products/cloud/features/cli) to create and manage resources from a terminal. For the other starting points, follow the product guides linked in the workload map.

--- a/docs/get-started/use-cases/choosing-a-service.mdx
+++ b/docs/get-started/use-cases/choosing-a-service.mdx
@@ -1,22 +1,22 @@
 ---
 title: 'Choose a service for your workload'
 sidebarTitle: 'Choose a service'
-description: 'Map analytical queries, transactional application state, observability, and local analysis to ClickHouse Cloud, ClickHouse Managed Postgres, ClickStack, or chDB.'
+description: 'Choose ClickHouse or Postgres services within ClickHouse Cloud for analytics or transactions, Managed ClickStack for observability, or chDB for local analysis.'
 keywords: ['database selection', 'analytical database', 'transactional database', 'managed postgres', 'report history']
 doc_type: 'guide'
 ---
 
 Start with the queries and correctness requirements your application needs to support. A large row count alone does not determine the database, and an application that generates reports can contain both analytical and transactional workloads.
 
-ClickHouse Cloud runs the ClickHouse analytical database engine. ClickHouse Managed Postgres runs PostgreSQL. They are separate database services with different SQL behavior; choosing one does not require deploying the other.
+ClickHouse Cloud is the platform for managed services, including ClickHouse for analytics and ClickHouse Managed Postgres for transactional workloads. These services run different database engines — ClickHouse and PostgreSQL — with different SQL behavior. You can use either service independently or combine them within ClickHouse Cloud.
 
 ## Map the workload to a starting point {#workload-map}
 
 | What your application needs | Start by evaluating | What to check before choosing |
 | --- | --- | --- |
-| Aggregations, filtering, and comparisons across large event or result histories | [ClickHouse Cloud](/products/cloud/getting-started/intro) | Representative queries, ingestion batches, data freshness, concurrent queries, and the design of updates or retries |
-| Transactional application state, such as orders, inventory reservations, or jobs whose state transitions require transactions and constraints | [ClickHouse Managed Postgres](/products/managed-postgres/overview) | Transaction boundaries, constraints, indexes, connection management, and the service's supported features and availability |
-| Transactional application state plus analytical queries that need an independent serving system | [Managed Postgres with ClickHouse integration](/products/managed-postgres/clickhouse-integration) | Which tables need replication, acceptable replication lag, schema changes, and the cost and operation of two services |
+| Aggregations, filtering, and comparisons across large event or result histories | [ClickHouse service in ClickHouse Cloud](/products/cloud/getting-started/intro) | Representative queries, ingestion batches, data freshness, concurrent queries, and the design of updates or retries |
+| Transactional application state, such as orders, inventory reservations, or jobs whose state transitions require transactions and constraints | [ClickHouse Managed Postgres in ClickHouse Cloud](/products/managed-postgres/overview) | Transaction boundaries, constraints, indexes, connection management, and the service's supported features and availability |
+| Transactional application state plus analytical queries that need an independent serving system | [Postgres and ClickHouse services in ClickHouse Cloud](/products/managed-postgres/clickhouse-integration) | Which tables need replication, acceptable replication lag, schema changes, and the cost and operation of two services |
 | A managed experience for searching and investigating application logs, metrics, and traces | [Managed ClickStack](/clickstack/getting-started/managed) | Instrumentation, telemetry ingestion, retention, and the observability workflows your team needs |
 | Analysis of files or in-memory data inside a local application or notebook | [chDB](/chdb/index) | Local resources and whether you need a separately hosted, shared database service |
 
@@ -35,7 +35,7 @@ Suppose an application processes uploaded files, produces reports, and needs to 
 
 ### Completed runs and analytical results {#completed-runs}
 
-ClickHouse Cloud is a candidate when the dominant workload is analysis across result rows and run records can be appended on completion. A small metadata table does not by itself require a second database.
+A ClickHouse service in ClickHouse Cloud is a candidate when the dominant workload is analysis across result rows and run records can be appended on completion. A small metadata table does not by itself require a second database.
 
 Design and test how readers distinguish a complete run from a partially ingested one. Define stable run identifiers, retry behavior, and how duplicate result rows are handled. Separate inserts into a results table and a run-history table must not be treated as a single cross-table transaction.
 
@@ -64,4 +64,4 @@ For a managed deployment, also check:
 - Whether an intermittent analytical workload can tolerate the connection delay associated with [automatic idling](/products/cloud/features/autoscaling/idling).
 - The team's responsibility for schema design, application retries, query tuning, and cost controls, even when the service manages the infrastructure.
 
-Once you have selected ClickHouse Cloud, use the [ClickHouse CLI](/products/cloud/features/cli) to create and manage resources from a terminal. For the other starting points, follow the product guides linked in the workload map.
+For ClickHouse or Postgres services in ClickHouse Cloud, use the [ClickHouse CLI](/products/cloud/features/cli) to create and manage resources from a terminal. For Managed ClickStack and chDB, follow the product guides linked in the workload map.

--- a/docs/get-started/use-cases/overview.mdx
+++ b/docs/get-started/use-cases/overview.mdx
@@ -11,6 +11,8 @@ ClickHouse is suitable for use as both a **primary data store** and as an **anal
 
 Its columnar architecture, vectorized processing, and cloud-native design make it uniquely suited for analytical workloads that require both speed and scale.
 
+If you are choosing a database for an application, start with [Choose a service for your workload](/get-started/use-cases/choosing-a-service). It maps analytical results, transactional state, observability, and local analysis to the relevant services and explains when a mixed workload needs more than one database.
+
 | Use case | TLDR |
 |----------|------|
 | [Real-time analytics](/get-started/use-cases/real-time-analytics) | Sub-second queries on billions of rows as data arrives. Ideal for customer-facing dashboards, live leaderboards, and any product feature that reads from a continuously updating event stream. |


### PR DESCRIPTION
### Summary

Prototype a workload-to-service guide under **Get started → Use cases**.
The page maps analytical results, transactional application state, mixed workloads,
observability, and local analysis to the relevant ClickHouse products, and links
to the existing product references. A landing-page card and overview link make
the guide discoverable without knowing a product name first.

### Why

An application's name (for example, a report builder) and projected row count
do not identify its database requirements. Readers need to distinguish large
analytical result tables from transactional job state before selecting an engine.
ClickHouse Cloud is the overall platform, containing both ClickHouse analytical
services and ClickHouse Managed Postgres services. These use different database
engines within the same platform and can be used independently or together.

The report-history example makes that boundary concrete: completed-run inserts
can be evaluated separately from atomic worker claims and constrained state
transitions. It also explains why versioned rows, CDC, and a shared query entry
point do not imply cross-table or cross-service transactions.

### Review requested

- Is **Get started → Use cases** the right cross-product entry point?
- Is the workload map balanced and are the service boundaries clear?
- Are the metadata/transaction and replication-freshness caveats sufficient?

This is a documentation prototype, not a benchmark, exhaustive product selector,
or claim that a content change has demonstrated improved selection. It adds no
new product guarantees, prices, performance thresholds, or provisioning code.
Managed Postgres's current beta qualification is retained.

### Validation

- Repository navigation-completeness check passed.
- Repository snippet-import/image-reference check passed.
- Changed-page internal targets and unique heading anchors checked locally.
- Markdown/MDX parsing checked locally (Mintlify heading-anchor syntax normalized).
- `git diff --check` passed.
- Full Mintlify site build remains for CI; no production publication performed.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118243&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118243](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118243+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.965` (included in `26.9` and later)
<!-- ch-version-info:end -->