### PR TITLE
docs: clarify lightweight UPDATE visibility versus materialization

### DIFF
--- a/src/Parsers/ParserUpdateQuery.cpp
+++ b/src/Parsers/ParserUpdateQuery.cpp
@@ -147,16 +147,19 @@ UPDATE hits SET Title = 'Updated Title' WHERE EventDate = today();
 UPDATE wikistat SET hits = hits + 1, time = now() WHERE path = 'ClickHouse';
 ```
 
-## Lightweight updates do not update data immediately {#lightweight-update-does-not-update-data-immediately}
+## Lightweight updates are immediately visible in queries {#lightweight-update-does-not-update-data-immediately}
 
-Lightweight `UPDATE` is implemented using **patch parts** - a special kind of data part that contains only the updated columns and rows.
-A lightweight `UPDATE` creates patch parts but does not immediately modify the original data physically in storage.
-The process of updating is similar to a `INSERT ... SELECT ...` query but the `UPDATE` query waits until the patch part creation is completed before returning.
+Lightweight `UPDATE` makes updated values immediately visible in `SELECT` queries by applying **patch parts**. Queries do not need to wait for a merge to read the updated values.
+Patch parts are a special kind of data part that contains only the updated columns and rows. Creating them does not immediately modify the original data physically in storage.
+The update process is similar to an `INSERT ... SELECT ...` query, and the `UPDATE` query waits until patch part creation is completed before returning.
 
-The updated values are:
-- **Immediately visible** in `SELECT` queries through patches application
-- **Physically materialized** only during subsequent merges and mutations
-- **Automatically cleaned up** once all active parts have the patches materialized
+Query visibility and physical materialization are separate:
+
+- **Query visibility:** `SELECT` queries apply patches to read the updated values before those patches are materialized into the original data parts.
+- **Physical materialization:** subsequent merges and mutations incorporate the updated values into the data parts.
+- **Cleanup:** patch parts are automatically removed once all active parts have the patches materialized.
+
+For the consistency of concurrent updates, see [Concurrent operations](#concurrent-operations).
 
 ## Lightweight updates requirements {#lightweight-update-requirements}
 


### PR DESCRIPTION
### Summary

Clarify the lightweight `UPDATE` reference by distinguishing query visibility from physical materialization:

- Replace the heading that says updates do not update data immediately with one that states their immediate visibility to queries.
- Explain that `SELECT` applies patch parts without waiting for a merge, while merges and mutations later materialize the values into the data parts.
- Make clear that cleanup removes patch parts, not the updated values, and link to the existing concurrent-operation caveats.

The old heading can be read as an eventual-visibility guarantee even though the existing text immediately below it says that updated values are visible to `SELECT`. This is a documentation clarification, not a change to update behavior or a claim of general-purpose transactional semantics.

### Implementation

The page is autogenerated, so this changes the statement registration documentation in `src/Parsers/ParserUpdateQuery.cpp`, not the generated MDX. The documentation autogeneration workflow will regenerate the page. The existing heading anchor is preserved, along with beta status, requirements, concurrent-update settings, and performance limitations.

### Validation

- `git diff --check` passes.
- Verified that the diff is confined to the intended documentation section; the surrounding C++ and the generated page are unchanged.
- Verified all existing anchors, beta status, requirements, and concurrency/performance caveats are preserved.
- Parsed the statement documentation string with `@mdx-js/mdx` plus frontmatter/GFM plugins, normalizing Mintlify heading anchors for the parser.
- Compared the wording with the [current UPDATE reference](https://clickhouse.com/docs/reference/statements/update).
- No runtime code changed. Full server build and documentation autogeneration were not run locally.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118244&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118244](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118244+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
