### PR TITLE
Take the apt mirror verdict from the step's own index warning

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -284,20 +284,33 @@ APT_MIRROR_ERRORS = [
     "Unable to fetch some archives",
     # `apt-get update` could not refresh the package lists
     "Some index files failed to download",
-    # `apt-get update` treats a suite whose `InRelease` the mirror withheld as a
-    # warning (`W: Failed to fetch ... 503`, `W: Some index files failed to
-    # download`) and carries on with whatever suites it did get, so it exits 0 and
-    # the `E:` lands on the `apt-get install` that follows: with `jammy`,
-    # `jammy-updates` and `jammy-security` gone, nothing is left to provide the
-    # packages, or only a candidate whose dependencies live in a missing suite. On
-    # the pristine base image these Dockerfiles start from, a package Ubuntu ships
-    # that has no candidate or unmet dependencies can only mean the index apt
-    # resolved against is a partial one, i.e. the mirror. Measured on 2026-09-05,
-    # when every arm64 keeper image build on the fleet reded this way and no build
-    # ever reached Canonical.
+]
+
+# `apt-get update` does not fail when a mirror withholds a suite's `InRelease`: it
+# warns (`W: Failed to fetch ... 503`, then `W: Some index files failed to download`),
+# carries on with whatever suites it did get and exits 0. So the `RUN` chain reaches
+# `apt-get install`, which dies resolving the packages against a partial index, and it
+# is that resolution error - naming no mirror, no URL and no `Failed to fetch` - that
+# buildx fences. `APT_MIRROR_ERRORS` matches none of it, which is why not one of the
+# 26 arm64 image builds that reded across the fleet inside the 00:00 UTC hour of
+# 2026-09-05 rebuilt against Canonical.
+#
+# Which of the three shapes apt reports depends only on what the missing suites were
+# providing, so all three have to be here: `wget` and `tzdata` came out as `Unable to
+# locate package`, `busybox`, `ca-certificates` and `locales` as `has no installation
+# candidate` because the pristine base image's `/var/lib/dpkg/status` still names them,
+# and a `wget` whose `libpsl5` had gone as `held broken packages`.
+APT_RESOLUTION_ERRORS = [
+    "Unable to locate package",
     "has no installation candidate",
     "Unable to correct problems, you have held broken packages",
 ]
+# On its own a resolution error is also what a misspelled package name in one of these
+# Dockerfiles produces, and that must keep failing on the first attempt. What separates
+# the two is the `apt-get update` in the very same step: against a healthy mirror it
+# refreshes every suite silently, so this warning is the mirror's own signature and not
+# an inference from the base image's contents.
+APT_INDEX_WARNING = "Some index files failed to download"
 
 
 # `--progress=plain` prints the whole build, so a signature found anywhere in the
@@ -370,6 +383,45 @@ def is_apt_mirror_failure(info: str) -> bool:
         and APT_ERROR_SEVERITY in line
         and any(error in line for error in APT_MIRROR_ERRORS)
         for line in terminal_build_failure(info).splitlines()
+    )
+
+
+def terminal_step_prefix(info: str) -> str:
+    """`--progress=plain` line prefix (`#8 `) of the step the build stopped on.
+
+    buildx tags every output line with the step it came from and announces the failure
+    as `#8 ERROR: process ... did not complete successfully`, which is the only place
+    the fenced block's step number is stated. Empty when that line is absent, so
+    callers fail closed.
+    """
+    prefix = ""
+    for line in info.splitlines():
+        if line.startswith("#") and line.partition(" ")[2].startswith(
+            BUILDX_ERROR_PREFIX
+        ):
+            prefix = line.partition(" ")[0] + " "
+    return prefix
+
+
+def is_apt_index_failure(info: str) -> bool:
+    """Did the step that stopped the build resolve packages against a partial index?
+
+    Both halves have to come from that one step: apt's `E:` resolution error inside the
+    terminal fenced block, and the warning that the step's own index refresh came back
+    incomplete, which apt prints far enough above the fence that only the step's
+    `#N ` prefix ties the two together.
+    """
+    if not any(
+        not line.startswith(BUILDX_STEP_HEADER_PREFIX)
+        and APT_ERROR_SEVERITY in line
+        and any(error in line for error in APT_RESOLUTION_ERRORS)
+        for line in terminal_build_failure(info).splitlines()
+    ):
+        return False
+    prefix = terminal_step_prefix(info)
+    return bool(prefix) and any(
+        line.startswith(prefix) and APT_INDEX_WARNING in line
+        for line in info.splitlines()
     )
 
 
@@ -447,7 +499,11 @@ def should_try_next_mirror(info: str) -> bool:
     has to reach the next mirror too - it is only reached once the build is failing
     anyway, and `buildx_timeout` keeps the extra attempt inside the job's own cap.
     """
-    return is_apt_mirror_failure(info) or is_buildx_timeout(info)
+    return (
+        is_apt_mirror_failure(info)
+        or is_apt_index_failure(info)
+        or is_buildx_timeout(info)
+    )
 
 
 def buildx_args(


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118213
Related: https://github.com/ClickHouse/ClickHouse/pull/115726
Related: https://github.com/ClickHouse/ClickHouse/pull/118023

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/118213, which added two apt resolution signatures to `APT_MIRROR_ERRORS` so the mirror fallback fires when the in-region mirror serves a partial index. They were justified by what the base image contains: on a pristine `ubuntu:22.04`, a package Ubuntu ships that has no installation candidate or unmet dependencies can only be resolving against a partial index. That inference holds, but it misses the third shape apt produces.

Which of the three apt picks depends only on what the missing suites were providing: `busybox`, `ca-certificates` and `locales` come out as `has no installation candidate` because `/var/lib/dpkg/status` still names them, a `wget` whose `libpsl5` has gone comes out as `Unable to correct problems, you have held broken packages`, and `wget` and `tzdata`, with nothing left to refer to them, come out as the shape that was missing: `Unable to locate package`. Two of the ten image builds that reded on 2026-09-05 after 05:00 UTC were that third shape, so they still did not reach Canonical.

`Unable to locate package` cannot simply be added to the list. Unlike the other two, it is also exactly what a misspelled package name in one of these Dockerfiles produces, so listing it would cost the fail-fast property that the narrowed retry allowlist of https://github.com/ClickHouse/ClickHouse/pull/108969 exists to keep.

There is no need to infer any of this. `apt-get update` says so itself, in the very same step: `W: Some index files failed to download`, printed once it has warned about each suite the mirror withheld. Against a healthy mirror it refreshes every suite silently, so that line is the mirror's own signature, and a genuine packaging error, whose `apt-get update` was clean, carries none of it. `is_apt_index_failure` requires both halves, and both from the step the build stopped on: the resolution error inside the terminal fenced block, and the warning among the same step's `#N `-prefixed output above it, which is the only thing tying the two together once buildx has fenced the tail. All three shapes then move behind that evidence, so this widens the coverage and narrows the licence at the same time.

Verified with a throwaway test against the real logs of all twelve failed builds from CIDB: master says yes for ten of them and this branch for all twelve. Eight negative cases still say no: a misspelled package in each of the three shapes, an index warning belonging to an earlier successful step, the signature only in the fenced step header, a truncated log with no terminal block, a non-apt failure, and a recovered warning followed by a genuine `dpkg` error in the same step.

No related open issue found. Example failure (`Docker server image` on master, both arm64 legs): https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=dab9efce85ab16d6811013d2e2d03ad8245f398f&name_0=MasterCI&name_1=Docker%20server%20image

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118263&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118263](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118263+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.799` (included in `26.9` and later)
<!-- ch-version-info:end -->