### PR TITLE
Find the perf reference build from git on a local run

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1315,10 +1315,20 @@ def find_master_build(commits, build_type):
     return None
 
 
+def local_master_track_commits(local_master_commits_to_check_for_build):
+    """Master shas below the merge base for a local run, which has no `master_track_commits_sha` kv data."""
+    return Shell.get_output(
+        f"git log --first-parent --format=%H -n {local_master_commits_to_check_for_build} "
+        "$(git merge-base HEAD origin/master)"
+    ).split()
+
+
 def find_prev_build(info, build_type):
-    return find_master_build(
-        info.get_kv_data("master_track_commits_sha") or [], build_type
-    )
+    commits = info.get_kv_data("master_track_commits_sha") or []
+    if not commits and info.is_local_run:
+        # for a local run let's check 50 commits
+        commits = local_master_track_commits(50)
+    return find_master_build(commits, build_type)
 
 
 def find_base_release_build(info, build_type):

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1334,9 +1334,24 @@ def local_master_track_commits(local_master_commits_to_check_for_build):
             "skipping local master-track commits"
         )
         return []
+    # merge-base may sit off master's first-parent chain (branch cut from a merge's 2nd parent); anchor on the newest master-first-parent commit at/below it.
+    anchor = merge_base
+    if not Shell.check(
+        f"git rev-list --first-parent -n 1000 {master_ref} | grep -q ^{merge_base}"
+    ):
+        anchor = Shell.get_output(
+            f"git rev-list --first-parent -n 1000 {master_ref} | "
+            f"while read c; do git merge-base --is-ancestor $c {merge_base} && echo $c && break; done"
+        ).strip()
+    if not anchor:
+        print(
+            "WARNING: no master-side ancestor below the merge-base; "
+            "skipping local master-track commits"
+        )
+        return []
     commits = Shell.get_output(
         f"git log --first-parent --format=%H -n {local_master_commits_to_check_for_build} "
-        f"{merge_base}"
+        f"{anchor}"
     ).split()
     # Drop first commit on the branch
     head = Shell.get_output("git rev-parse HEAD").strip()

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1317,16 +1317,22 @@ def find_master_build(commits, build_type):
 
 def local_master_track_commits(local_master_commits_to_check_for_build):
     """Master shas below the merge base for a local run, which has no `master_track_commits_sha` kv data."""
-    # resolving 'master' via upstream or origin as a fallback; added 'main' just in case
+    # Prefer an explicit upstream master ref, then fall back to origin.
     master_ref = next(
         (
             ref
             for ref in ("upstream/master", "upstream/main", "origin/master", "origin/main")
             if Shell.check(f"git rev-parse --verify --quiet {ref} > /dev/null")
         ),
-        "origin/master",
+        None,
     )
-    # resolving merge-base up front and fail loud (return []) instead of silently walking HEAD.
+    if master_ref is None:
+        print(
+            "WARNING: no upstream/origin master ref found; "
+            "skipping local master-track commits"
+        )
+        return []
+    # Resolve merge-base first so failures cannot make git log walk HEAD.
     merge_base = Shell.get_output(f"git merge-base HEAD {master_ref}").strip()
     if not merge_base:
         print(
@@ -1334,15 +1340,12 @@ def local_master_track_commits(local_master_commits_to_check_for_build):
             "skipping local master-track commits"
         )
         return []
-    # merge-base may sit off master's first-parent chain (branch cut from a merge's 2nd parent); anchor on the newest master-first-parent commit at/below it.
-    anchor = merge_base
-    if not Shell.check(
-        f"git rev-list --first-parent -n 1000 {master_ref} | grep -q ^{merge_base}"
-    ):
-        anchor = Shell.get_output(
-            f"git rev-list --first-parent -n 1000 {master_ref} | "
-            f"while read c; do git merge-base --is-ancestor $c {merge_base} && echo $c && break; done"
-        ).strip()
+    # Anchor on the newest master first-parent commit reachable from the merge-base.
+    # `above` is the oldest newer commit; its first parent is the anchor.
+    above = Shell.get_output(
+        f"git rev-list --first-parent {master_ref} ^{merge_base} | tail -1"
+    ).strip()
+    anchor = Shell.get_output(f"git rev-parse {above}^").strip() if above else merge_base
     if not anchor:
         print(
             "WARNING: no master-side ancestor below the merge-base; "
@@ -1353,7 +1356,7 @@ def local_master_track_commits(local_master_commits_to_check_for_build):
         f"git log --first-parent --format=%H -n {local_master_commits_to_check_for_build} "
         f"{anchor}"
     ).split()
-    # Drop first commit on the branch
+    # Drop HEAD to avoid comparing a build with itself.
     head = Shell.get_output("git rev-parse HEAD").strip()
     if commits and commits[0] == head:
         commits.pop(0)

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1317,10 +1317,32 @@ def find_master_build(commits, build_type):
 
 def local_master_track_commits(local_master_commits_to_check_for_build):
     """Master shas below the merge base for a local run, which has no `master_track_commits_sha` kv data."""
-    return Shell.get_output(
+    # resolving 'master' via upstream or origin as a fallback; added 'main' just in case
+    master_ref = next(
+        (
+            ref
+            for ref in ("upstream/master", "upstream/main", "origin/master", "origin/main")
+            if Shell.check(f"git rev-parse --verify --quiet {ref} > /dev/null")
+        ),
+        "origin/master",
+    )
+    # resolving merge-base up front and fail loud (return []) instead of silently walking HEAD.
+    merge_base = Shell.get_output(f"git merge-base HEAD {master_ref}").strip()
+    if not merge_base:
+        print(
+            "WARNING: could not resolve merge-base with upstream master; "
+            "skipping local master-track commits"
+        )
+        return []
+    commits = Shell.get_output(
         f"git log --first-parent --format=%H -n {local_master_commits_to_check_for_build} "
-        "$(git merge-base HEAD origin/master)"
+        f"{merge_base}"
     ).split()
+    # Drop first commit on the branch
+    head = Shell.get_output("git rev-parse HEAD").strip()
+    if commits and commits[0] == head:
+        commits.pop(0)
+    return commits
 
 
 def find_prev_build(info, build_type):

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1363,12 +1363,33 @@ def local_master_track_commits(local_master_commits_to_check_for_build):
     return commits
 
 
+LATEST_MASTER_BUILD_PREFIX = (
+    "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/"
+)
+LOCAL_REFERENCE_FALLBACK_WARNING = (
+    "No ancestor baseline build found. Comparing against the latest available master build. "
+    "Results may include changes merged into master since this branch diverged."
+)
+
+
 def find_prev_build(info, build_type):
     commits = info.get_kv_data("master_track_commits_sha") or []
     if not commits and info.is_local_run:
         # for a local run let's check 50 commits
         commits = local_master_track_commits(50)
-    return find_master_build(commits, build_type)
+    link = find_master_build(commits, build_type)
+    if link or not info.is_local_run:
+        return link
+
+    # `build_master_head_hook` publishes these release binaries even when the
+    # master tip has no build yet. No local history or GitHub credentials are needed.
+    arch = {"build_arm_release": "aarch64", "build_amd_release": "amd64"}[build_type]
+    link = f"{LATEST_MASTER_BUILD_PREFIX}{arch}/clickhouse"
+    if Shell.check(f"curl --connect-timeout 5 --max-time 15 -sfI {link} > /dev/null"):
+        print(f"WARNING: {LOCAL_REFERENCE_FALLBACK_WARNING} Reference: {link}")
+        return link
+    print(f"WARNING: latest master reference build is also unavailable: {link}")
+    return None
 
 
 def find_base_release_build(info, build_type):
@@ -1863,6 +1884,12 @@ def main():
     else:
         Utils.raise_with_error("Unknown processor architecture")
 
+    reference_warning = (
+        LOCAL_REFERENCE_FALLBACK_WARNING
+        if info.is_local_run and link_for_ref_ch.startswith(LATEST_MASTER_BUILD_PREFIX)
+        else ""
+    )
+
     if compare_against_release:
         print("It's a comparison against latest release baseline")
         print(
@@ -1909,6 +1936,14 @@ def main():
 
     res = True
     results = []
+    if reference_warning:
+        results.append(
+            Result(
+                name="Reference baseline",
+                status=Result.Status.OK,
+                info=f"{reference_warning} Reference: {link_for_ref_ch}",
+            )
+        )
 
     # Fix the check start time once, for the whole job: the system log export,
     # `compare.sh` and the report uploads must all stamp the same run identity,
@@ -1963,10 +1998,19 @@ def main():
     reference_sha = ""
     if res and JobStages.INSTALL_CLICKHOUSE_REFERENCE in stages:
         print("Install Reference")
-        if not Path(f"{perf_left}/.done").is_file():
+        reference_source = Path(f"{perf_left}/reference-source.txt")
+        # The latest-master URL is mutable: refresh it when entering the install
+        # stage. Also invalidate a cached binary when the selected baseline changes.
+        if (
+            reference_warning
+            or not Path(f"{perf_left}/.done").is_file()
+            or not reference_source.is_file()
+            or reference_source.read_text() != link_for_ref_ch
+        ):
             commands = [
                 f"mkdir -p {perf_left_config}",
-                f"wget -nv -P {perf_left}/ {link_for_ref_ch}",
+                f"wget -nv -O {perf_left}/clickhouse.download {link_for_ref_ch}",
+                f"mv {perf_left}/clickhouse.download {perf_left}/clickhouse",
                 f"chmod +x {perf_left}/clickhouse",
                 f"cp -r ./tests/performance {perf_left}/",
                 f"ln -sf {perf_left}/clickhouse {perf_left}/clickhouse-local",
@@ -1979,11 +2023,14 @@ def main():
                     name="Install Reference ClickHouse", command=commands
                 )
             )
+            res = results[-1].is_ok()
+            if res:
+                reference_source.write_text(link_for_ref_ch)
+                Shell.check(f"touch {perf_left}/.done")
+        if res:
             reference_sha = Shell.get_output(
                 f"{perf_left}/clickhouse -q \"SELECT value FROM system.build_options WHERE name='GIT_HASH'\""
             )
-            res = results[-1].is_ok()
-            Shell.check(f"touch {perf_left}/.done")
 
     if res and not info.is_local_run:
 
@@ -2241,6 +2288,15 @@ def main():
         )
 
         Shell.check(f"{perf_left}/clickhouse --version  > {perf_wd}/left-commit.txt")
+        if reference_warning:
+            # Read the actual binary's identity, including when resuming at `report`.
+            reference_sha = Shell.get_output(
+                f"{perf_left}/clickhouse -q \"SELECT value FROM system.build_options WHERE name='GIT_HASH'\""
+            )
+            with open(f"{perf_wd}/left-commit.txt", "a", encoding="utf-8") as reference:
+                reference.write(
+                    f"\nWARNING: {reference_warning}\nReference commit: {reference_sha}\n"
+                )
         Shell.check(f"git log -1 HEAD > {perf_wd}/right-commit.txt")
         os.environ["CLICKHOUSE_PERFORMANCE_COMPARISON_CHECK_NAME_PREFIX"] = (
             Utils.normalize_string(info.job_name)


### PR DESCRIPTION
**Problem**

When the performance job runs (either in CI or manually) it needs a reference master build to validate against. In CI this is set by the `store_data` workflow hook, which records the first-parent master chain in the `master_track_commits_sha` kv data that `find_prev_build` walks. For manual runs it's not available (a local run has no kv data at all), and such runs fail before the first stage with `AssertionError: reference clickhouse build has not been found`.

**Fix**

To improve that, the solution is to check the last N (hardcoded default 50) master commits down from the branch point (the merge base of `HEAD` and `origin/master`), and to pick the latest available build as the reference to validate against. The branch point rather than the master tip is used because a local checkout, unlike a PR CI checkout, is not merged onto current master, so a reference taken from the tip would also measure everything merged into master since the branch was created.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118266&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118266](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118266+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.984` (included in `26.9` and later)
<!-- ch-version-info:end -->