### PR TITLE
Remove redundant const

### DIFF
--- a/src/Interpreters/HashJoin/JoinFeatures.h
+++ b/src/Interpreters/HashJoin/JoinFeatures.h
@@ -38,9 +38,6 @@ struct JoinFeatures
     static constexpr bool need_flags = MapGetter<KIND, STRICTNESS, mapsKindOf<Map>()>::flagged;
 
     static constexpr bool is_maps_all = std::is_same_v<std::decay_t<Map>, HashJoin::MapsAll>;
-
-    /// Whether the map stores no right row at all, so nothing of the right side can be read from it.
-    static constexpr bool is_maps_set = std::is_same_v<std::decay_t<Map>, HashJoin::MapsSet>;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Following up https://github.com/ClickHouse/ClickHouse/pull/115301#discussion_r3934394133

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118271&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118271](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118271+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.800` (included in `26.9` and later)
<!-- ch-version-info:end -->