### PR TITLE
Fix `IPv6` and `UInt128` conversion on big-endian

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -1691,10 +1691,17 @@ static void NO_SANITIZE_UNDEFINED convertFromUInt128toIPv6(ColVecToData & vec_to
         std::is_same_v<DataTypeUInt128::FieldType, DataTypeIPv6::FieldType::UnderlyingType>,
         "IPv6 and UInt128 types must be same");
 
+    /// No need to swap bytes on big-endian platforms because `IPv6` holds its bytes in network
+    /// byte order.
     for (size_t i = 0; i < input_rows_count; i++)
     {
-        vec_to[i].toUnderType().items[1] = std::byteswap(vec_from[i].items[0]);
-        vec_to[i].toUnderType().items[0] = std::byteswap(vec_from[i].items[1]);
+        if constexpr (std::endian::native == std::endian::little)
+        {
+            vec_to[i].toUnderType().items[1] = std::byteswap(vec_from[i].items[0]);
+            vec_to[i].toUnderType().items[0] = std::byteswap(vec_from[i].items[1]);
+        }
+        else
+            vec_to[i].toUnderType() = vec_from[i];
     }
 }
 
@@ -1705,10 +1712,17 @@ static void NO_SANITIZE_UNDEFINED convertFromIPv6ToUInt128(ColVecToData & vec_to
         std::is_same_v<DataTypeUInt128::FieldType, DataTypeIPv6::FieldType::UnderlyingType>,
         "UInt128 and IPv6 types must be same");
 
+    /// No need to swap bytes on big-endian platforms because `IPv6` holds its bytes in network
+    /// byte order.
     for (size_t i = 0; i < input_rows_count; i++)
     {
-        vec_to[i].items[1] = std::byteswap(vec_from[i].toUnderType().items[0]);
-        vec_to[i].items[0] = std::byteswap(vec_from[i].toUnderType().items[1]);
+        if constexpr (std::endian::native == std::endian::little)
+        {
+            vec_to[i].items[1] = std::byteswap(vec_from[i].toUnderType().items[0]);
+            vec_to[i].items[0] = std::byteswap(vec_from[i].toUnderType().items[1]);
+        }
+        else
+            vec_to[i] = vec_from[i].toUnderType();
     }
 }
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118164

Fixes a bug where `toIPv6` of a `UInt128` returns the address with its bytes in the wrong
order on big-endian platforms. `bitAnd` and `bitOr` of an `IPv6` with a `UInt128` are wrong
in the same way, because they cast their `IPv6` argument through the same conversion. Every
release since v25.4.1 is affected.

Reproducer:
```sql
SELECT toIPv6(toUInt128(1));
```
Expected result on s390x:

`::1`

Actual result on s390x:

`100::`

Cause:

`convertFromUInt128toIPv6` and `convertFromIPv6ToUInt128` reverse all 16 bytes of the value.
`IPv6` holds the address in network byte order, which is what a little-endian platform
reaches by that reversal and what a big-endian platform already has, so there the same code
reverses a value that is already correct.

Side effects:

Little-endian platforms: none

Big-endian platforms: this changes a conversion and not a stored format, so no file becomes unreadable and no read fails. Rows whose `IPv6` addresses were produced from a `UInt128` before this change hold the wrong address, and keep holding it: `toIPv6(toUInt128(1))` stored `100::` where it should have stored `::1`. A query for `ip = toIPv6(toUInt128(1))` will no longer find such a row because the expression now gives `::1`. Those rows have to be inserted again.

No new test: nothing is skipped on little-endian, so no test can observe the difference
there, and CI builds `Build (s390x)` with `-DENABLE_TESTS=0` and never runs the binary.

Tested on a real IBM z16 instead. The four `02935_ipv6_*` tests that fail there pass after this change, and `02935_ipv6_to_and_from_uint128`, which passes either way because a round trip reverses the bytes twice, still passes.

We are considering ClickHouse as the backend database for one of our mainframe products. We
have access to real z hardware, and we intend to keep reporting and fixing big-endian
related problems.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `toIPv6` of a `UInt128` on big-endian platforms (s390x), where the address comes out
with its bytes in the wrong order. `bitAnd` and `bitOr` of an `IPv6` with a `UInt128` are
fixed in the same way.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118273&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118273](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118273+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
