### PR TITLE
Pin the tests that measure what plan-based parallel replicas does not do yet

### DIFF
--- a/tests/queries/0_stateless/03215_analyzer_replace_with_dummy_tables.sql
+++ b/tests/queries/0_stateless/03215_analyzer_replace_with_dummy_tables.sql
@@ -13,4 +13,7 @@ FROM
         )
     FROM t
 )
-SETTINGS allow_experimental_parallel_reading_from_replicas = 1, cluster_for_parallel_replicas='not_exists', max_parallel_replicas = 2, enable_analyzer = 1, parallel_replicas_for_non_replicated_merge_tree = 1; -- { serverError CLUSTER_DOESNT_EXIST }
+-- `parallel_replicas_plan_based = 0`: the plan-based implementation does not distribute a plan that
+-- builds an `IN` set, so it never resolves `cluster_for_parallel_replicas` and the query succeeds
+-- instead of failing. See https://github.com/ClickHouse/ClickHouse/issues/118264.
+SETTINGS allow_experimental_parallel_reading_from_replicas = 1, cluster_for_parallel_replicas='not_exists', max_parallel_replicas = 2, enable_analyzer = 1, parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_plan_based = 0; -- { serverError CLUSTER_DOESNT_EXIST }

--- a/tests/queries/0_stateless/03394_pr_insert_select.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select.sql
@@ -1,5 +1,10 @@
 SET enable_analyzer=1; -- parallel distributed insert select for replicated tables works only with analyzer
 SET parallel_distributed_insert_select=2;
+-- Pinned to the query-based implementation: with `parallel_replicas_plan_based` the insert is not
+-- distributed at all, because the probe in `isSuitableForInsertSelectWithParallelReplicas` looks
+-- for the query-based reading step in the unoptimized plan. The data stays correct, only the
+-- insert stops being distributed. See https://github.com/ClickHouse/ClickHouse/issues/118276.
+SET parallel_replicas_plan_based = 0;
 
 DROP TABLE IF EXISTS t_mt_source;
 DROP TABLE IF EXISTS t_rmt_target SYNC;

--- a/tests/queries/0_stateless/03394_pr_insert_select_local_pipeline.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select_local_pipeline.sql
@@ -1,5 +1,10 @@
 SET enable_analyzer=1; -- parallel distributed insert select for replicated tables works only with analyzer
 SET parallel_distributed_insert_select=2;
+-- Pinned to the query-based implementation: with `parallel_replicas_plan_based` the insert is not
+-- distributed at all, because the probe in `isSuitableForInsertSelectWithParallelReplicas` looks
+-- for the query-based reading step in the unoptimized plan. The data stays correct, only the
+-- insert stops being distributed. See https://github.com/ClickHouse/ClickHouse/issues/118276.
+SET parallel_replicas_plan_based = 0;
 
 DROP TABLE IF EXISTS t_mt_source;
 DROP TABLE IF EXISTS t_rmt_target SYNC;

--- a/tests/queries/0_stateless/03394_pr_insert_select_threads.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select_threads.sql
@@ -2,6 +2,10 @@
 
 SET enable_analyzer=1; -- parallel distributed insert select for replicated tables works only with analyzer
 SET parallel_distributed_insert_select=2;
+-- Pinned to the query-based implementation: with `parallel_replicas_plan_based` the insert is not
+-- distributed at all, so the per-replica rows this test measures are never produced. See
+-- https://github.com/ClickHouse/ClickHouse/issues/118276.
+SET parallel_replicas_plan_based = 0;
 
 DROP TABLE IF EXISTS t_mt_source;
 DROP TABLE IF EXISTS t_rmt_target SYNC;

--- a/tests/queries/0_stateless/03403_parallel_blocks_marshalling_for_distributed.sql
+++ b/tests/queries/0_stateless/03403_parallel_blocks_marshalling_for_distributed.sql
@@ -12,6 +12,10 @@ FROM numbers_mt(1000000);
 SET automatic_parallel_replicas_mode = 0;
 SET enable_parallel_replicas = 1, parallel_replicas_local_plan = 1, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = 1;
 SET prefer_localhost_replica = 1, enable_analyzer = 1;
+-- Pinned to the query-based implementation: plan-based parallel replicas does not insert
+-- `BlocksMarshalling` steps, and names the merging step `MergingAggregated (merge)`. See
+-- https://github.com/ClickHouse/ClickHouse/issues/118274.
+SET parallel_replicas_plan_based = 0;
 
 SELECT replaceRegexpAll(explain, 'ReadFromRemoteParallelReplicas.*', 'ReadFromRemoteParallelReplicas')
 FROM (

--- a/tests/queries/0_stateless/03560_parallel_replicas_memory_bound_merging_projection.reference
+++ b/tests/queries/0_stateless/03560_parallel_replicas_memory_bound_merging_projection.reference
@@ -1,6 +1,6 @@
 -- { echoOn } --
 set optimize_aggregation_in_order = 0;
-SELECT trimLeft(*) FROM (explain select sum(b) from pr_t group by a order by a limit 5 offset 500) WHERE explain LIKE '%ReadFromMergeTree%';
+SELECT trimLeft(*) FROM (explain select sum(b) from pr_t group by a order by a limit 5 offset 500 settings parallel_replicas_plan_based = 0) WHERE explain LIKE '%ReadFromMergeTree%';
 ReadFromMergeTree (p_agg)
 set optimize_aggregation_in_order = 1;
 explain pipeline select sum(b) from pr_t group by a order by a limit 5 offset 500 settings parallel_replicas_plan_based = 0;

--- a/tests/queries/0_stateless/03560_parallel_replicas_memory_bound_merging_projection.sql
+++ b/tests/queries/0_stateless/03560_parallel_replicas_memory_bound_merging_projection.sql
@@ -1,9 +1,10 @@
 -- Tags: no-random-merge-tree-settings
 -- no-random-merge-tree-settings: to fix pipeline structure
 
--- The `explain pipeline` below is pinned to the query-based implementation of parallel replicas:
--- the plan-based one builds a differently shaped pipeline. The plan and result checks around it
--- are not pinned and run on the default implementation.
+-- The two explains below are pinned to the query-based implementation of parallel replicas: the
+-- plan-based one builds a differently shaped pipeline, and it embeds the shipped fragment in the
+-- step description, whose lines then match the `ReadFromMergeTree` filter as extra rows. The
+-- result check is not pinned and runs on the default implementation.
 
 SET explain_query_plan_default = 'legacy';
 drop table if exists pr_t;
@@ -26,7 +27,7 @@ set max_estimated_execution_time = 0;
 
 -- { echoOn } --
 set optimize_aggregation_in_order = 0;
-SELECT trimLeft(*) FROM (explain select sum(b) from pr_t group by a order by a limit 5 offset 500) WHERE explain LIKE '%ReadFromMergeTree%';
+SELECT trimLeft(*) FROM (explain select sum(b) from pr_t group by a order by a limit 5 offset 500 settings parallel_replicas_plan_based = 0) WHERE explain LIKE '%ReadFromMergeTree%';
 set optimize_aggregation_in_order = 1;
 explain pipeline select sum(b) from pr_t group by a order by a limit 5 offset 500 settings parallel_replicas_plan_based = 0;
 select sum(b) from pr_t group by a order by a limit 5 offset 500;

--- a/tests/queries/0_stateless/03634_autopr_input_bytes_estimation_compact.sql
+++ b/tests/queries/0_stateless/03634_autopr_input_bytes_estimation_compact.sql
@@ -9,6 +9,10 @@ set max_threads=4, max_block_size=8192;
 
 -- For runs with the old analyzer
 SET enable_analyzer=1;
+-- Pinned to the query-based implementation: for a plain read the plan-based fragment is the reading
+-- step itself, so automatic parallel replicas cannot estimate what the replicas would send and
+-- collects no statistics. See https://github.com/ClickHouse/ClickHouse/issues/118265.
+SET parallel_replicas_plan_based = 0;
 
 -- Reading of aggregation states from disk will affect `ReadCompressedBytes`
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;

--- a/tests/queries/0_stateless/03707_autopr_unsupported_cases.sql
+++ b/tests/queries/0_stateless/03707_autopr_unsupported_cases.sql
@@ -29,8 +29,11 @@ FROM numbers_mt(1e5);
 
 -- The plan of the outer aggregation has no counterpart in the single-node plan:
 -- "Cannot find step with matching hash in single-node plan".
+-- Pinned to the query-based implementation: the plan-based one does find a counterpart here (the
+-- fragment root is the inner aggregation, which the single-node plan also has) and collects
+-- statistics, so this case documents a query-based limitation only.
 SELECT AVG(transfer) FROM (SELECT number, SUM(number) AS transfer FROM t GROUP BY number) FORMAT Null
-SETTINGS log_comment='unsupported_aggregation_over_aggregation';
+SETTINGS log_comment='unsupported_aggregation_over_aggregation', parallel_replicas_plan_based=0;
 
 -- "Unsupported steps: Union".
 SELECT * FROM t UNION ALL SELECT * FROM t FORMAT Null

--- a/tests/queries/0_stateless/04052_distributed_index_analysis_in_subquery_no_quadratic.sh
+++ b/tests/queries/0_stateless/04052_distributed_index_analysis_in_subquery_no_quadratic.sh
@@ -45,6 +45,9 @@ $CLICKHOUSE_CLIENT --query_id $query_id -q "
     SET use_query_condition_cache = 0;
     SET distributed_index_analysis_for_non_shared_merge_tree = 1;
     SET enable_parallel_replicas = 1;
+    -- Pinned to the query-based implementation: the plan-based one runs the greater(key, ...)
+    -- index analysis twice, see https://github.com/ClickHouse/ClickHouse/issues/118275.
+    SET parallel_replicas_plan_based = 0;
     SET distributed_index_analysis = 1;
     SET distributed_index_analysis_only_on_coordinator = 1;
     SET cluster_for_parallel_replicas = 'test_cluster_one_shard_two_replicas';

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
@@ -45,10 +45,15 @@ SET
 -- `optimizeJoinLogicalImpl` exits early without converting the `JoinStepLogical`s, and
 -- `optimizeJoinLegacy` is a no-op on them, so the user-written order `(a JOIN b) JOIN c` reaches
 -- `ReadFromMergeTree` unchanged and the traversal is `a, b, c`.
+-- Pinned to the query-based implementation: the plan-based one embeds the shipped fragment in the
+-- step description, and its `ReadFromMergeTree` line matches the filter as an extra row, so the
+-- traversal reads `c, b, a, c`. `description = 0` is not an option here - the table name this
+-- asserts on *is* the description.
 SELECT extract(explain, '(pr_dp_a|pr_dp_b|pr_dp_c)')
 FROM (
   EXPLAIN PLAN
   SELECT count() FROM pr_dp_a AS a JOIN pr_dp_b AS b ON a.x = b.x JOIN pr_dp_c AS c ON b.x = c.x
+  SETTINGS parallel_replicas_plan_based = 0
 )
 WHERE explain LIKE '%ReadFromMergeTree%';
 

--- a/tests/queries/0_stateless/04341_autopr_mode1_apply_join.sql
+++ b/tests/queries/0_stateless/04341_autopr_mode1_apply_join.sql
@@ -51,6 +51,11 @@ SET query_plan_join_swap_table='false';
 SET query_plan_optimize_join_order_randomize=0, enable_join_runtime_filters=1, join_runtime_filter_min_probe_rows=1000;
 -- For runs with the old analyzer
 SET enable_analyzer=1;
+-- Pinned to the query-based implementation: with join runtime filters the plan-based local branch
+-- carries an extra pass-through `Expression`, so the node hashes of the two plans differ and no
+-- statistics are collected for the INNER and RIGHT joins. See
+-- https://github.com/ClickHouse/ClickHouse/issues/118265.
+SET parallel_replicas_plan_based = 0;
 -- Small blocks so enough are fed to the statistics collector.
 SET max_threads=4, max_block_size=128;
 -- Don't let the min-bytes gate or remote-read task sizing disable parallel replicas for this data.

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
@@ -53,14 +53,18 @@ SETTINGS parallel_replicas_local_plan = 0;
 -- (canUseLocalPlanForParallelReplicas returns false otherwise), so without the pin a
 -- randomized old-analyzer run would silently route the local-plan query through the
 -- remote path and leave that half of the regression uncovered.
+-- Both plan checks are pinned to the query-based implementation: they match the step by name, and
+-- the plan-based one also embeds the shipped fragment in the step description, so its
+-- `ReadFromMergeTree` line matches as an extra row and the remote-plan check cannot read 0. The
+-- result checks above are not pinned and run on the default implementation.
 SELECT '-- local plan reads initiator locally';
 SELECT countIf(explain ILIKE '%ReadFromMergeTree%') > 0 AND countIf(explain ILIKE '%ReadFromRemoteParallelReplicas%') > 0
-FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 1)
+FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 1, parallel_replicas_plan_based = 0)
 SETTINGS enable_analyzer = 1;
 
 SELECT '-- remote plan reads all replicas remotely';
 SELECT countIf(explain ILIKE '%ReadFromMergeTree%') = 0 AND countIf(explain ILIKE '%ReadFromRemoteParallelReplicas%') > 0
-FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 0)
+FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 0, parallel_replicas_plan_based = 0)
 SETTINGS enable_analyzer = 1;
 
 DROP TABLE t_04371;

--- a/tests/queries/0_stateless/04647_no_blocks_marshalling_for_local_shard_plan.sh
+++ b/tests/queries/0_stateless/04647_no_blocks_marshalling_for_local_shard_plan.sh
@@ -30,7 +30,10 @@ MARSHALLING_ON="enable_parallel_blocks_marshalling = 1, prefer_localhost_replica
 MARSHALLING_OFF="enable_parallel_blocks_marshalling = 0, prefer_localhost_replica = 1"
 # Mode 2 throws instead of silently falling back to plain local execution, so an unavailable
 # cluster fails the test instead of making the parallel replicas cases assert nothing.
-PARALLEL_REPLICAS="automatic_parallel_replicas_mode = 0, enable_parallel_replicas = 2, parallel_replicas_local_plan = 1, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = 1, prefer_localhost_replica = 1"
+# Pinned to the query-based implementation: plan-based parallel replicas does not insert
+# `BlocksMarshalling` steps at all, so these counts would be 0. See
+# https://github.com/ClickHouse/ClickHouse/issues/118274.
+PARALLEL_REPLICAS="automatic_parallel_replicas_mode = 0, enable_parallel_replicas = 2, parallel_replicas_local_plan = 1, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = 1, prefer_localhost_replica = 1, parallel_replicas_plan_based = 0"
 
 $INITIAL_CLIENT -q "
     CREATE TABLE tab (x UInt64, y UInt64, z UInt64) ENGINE = MergeTree ORDER BY x;

--- a/tests/queries/0_stateless/04838_autopr_input_bytes_estimation_compact_codec.sql
+++ b/tests/queries/0_stateless/04838_autopr_input_bytes_estimation_compact_codec.sql
@@ -14,6 +14,10 @@ SET enable_parallel_replicas=1, automatic_parallel_replicas_mode=2, parallel_rep
 SET max_threads=4, max_block_size=8192;
 
 SET enable_analyzer=1;
+-- Pinned to the query-based implementation: for a plain read the plan-based fragment is the reading
+-- step itself, so automatic parallel replicas cannot estimate what the replicas would send and
+-- collects no statistics. See https://github.com/ClickHouse/ClickHouse/issues/118265.
+SET parallel_replicas_plan_based = 0;
 
 DROP TABLE IF EXISTS t_default_codec;
 DROP TABLE IF EXISTS t_column_codec;

--- a/tests/queries/0_stateless/05043_autopr_set_source_leaf_steps.sql
+++ b/tests/queries/0_stateless/05043_autopr_set_source_leaf_steps.sql
@@ -21,6 +21,11 @@ SET enable_parallel_replicas = 1, automatic_parallel_replicas_mode = 1, parallel
     parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3,
     cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
 SET enable_analyzer = 1;
+-- Pinned to the query-based implementation: the plan-based one does not distribute a plan that
+-- builds an `IN` set (`planHasSubquerySet`), so there is no parallel-replicas step to instrument
+-- and the query stops being a candidate. See
+-- https://github.com/ClickHouse/ClickHouse/issues/118264.
+SET parallel_replicas_plan_based = 0;
 
 -- The `IN` is on a column outside the primary key, so the set is not there to be turned into a key
 -- condition - it is only ever a filter, which is the shape that leaves the set source plan otherwise


### PR DESCRIPTION
Sixteen stateless test files, each pinning `parallel_replicas_plan_based = 0` on the specific assertion that cannot hold for the plan-based implementation, with a comment and a tracking issue. This is the last batch standing between CI and running with the setting on (https://github.com/ClickHouse/ClickHouse/pull/112351); the gaps themselves are left for later.

| Gap | Tests | Issue |
|---|---|---|
| `BlocksMarshalling` steps are not inserted, so blocks from the replicas are not marshalled in parallel | `04647_no_blocks_marshalling_for_local_shard_plan`, `03403_parallel_blocks_marshalling_for_distributed` | #118274 |
| `parallel_distributed_insert_select = 2` stops distributing the insert | `03394_pr_insert_select`, `03394_pr_insert_select_local_pipeline`, `03394_pr_insert_select_threads` | #118276 |
| A plan that builds an `IN` set is not distributed at all — **provisional, see note below** | `05043_autopr_set_source_leaf_steps`, `03215_analyzer_replace_with_dummy_tables` | #118264 |
| Some plan shapes do not hash-match, so automatic parallel replicas collects no statistics | `03634_autopr_input_bytes_estimation_compact`, `04838_autopr_input_bytes_estimation_compact_codec`, `04341_autopr_mode1_apply_join`, and one case of `03707_autopr_unsupported_cases` in the other direction | #118265 |
| Distributed index analysis runs one of its queries twice | `04052_distributed_index_analysis_in_subquery_no_quadratic` | #118275 |
| The shipped fragment is embedded in the step description, so its lines match a filtered `EXPLAIN` as extra rows | `03560_parallel_replicas_memory_bound_merging_projection`, `04277_parallel_replicas_join_dp_reorder`, `04371_implicit_bool_filter_projection_parallel_replicas` | - |

**The two `IN` set pins are provisional.** https://github.com/ClickHouse/ClickHouse/pull/114086 ships the subquery plan with the fragment and replaces the blanket bail-out on `DelayedCreatingSetsStep` with a precise check, which removes the reason those two are pinned. They are included here only so CI on #112351 is not red while both changes are in flight, and #114086 should drop them (together with the already-merged pin in `04836_merge_table_parallel_replicas_duplicate_announcement`). I am happy to remove them from this PR instead if #114086 lands first. Issue #118264 has been narrowed to the remaining same-table `UNION` case.

Two notes on individual cases:

- `03707_autopr_unsupported_cases` is pinned in the *opposite* direction. It lists `unsupported_aggregation_over_aggregation` as a shape automatic parallel replicas cannot match, and the plan-based implementation does match it and collects statistics, so that one case documents a query-based limitation only.
- `03394_pr_insert_select_threads` is tagged `long`, so the Fast test never ran it and the CI report never showed it. It fails for the same reason as the other two and is pinned with them.

Pins are on individual queries or settings clauses rather than whole files wherever the surrounding correctness checks can keep running on the default implementation.

Verified locally against a debug server with `parallel_replicas_plan_based` defaulting to `1`: all sixteen pass.

Related: https://github.com/ClickHouse/ClickHouse/pull/112351

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
