### PR TITLE
Make `\d <table>` of the interactive client describe the table

### DIFF
--- a/docs/concepts/features/interfaces/client.mdx
+++ b/docs/concepts/features/interfaces/client.mdx
@@ -215,10 +215,13 @@ For more information, see the section [External data for query processing](/refe
 
 You can use the following aliases from within the REPL:
 
-- `\l` - SHOW DATABASES
-- `\d` - SHOW TABLES
-- `\c <DATABASE>` - USE DATABASE
+- `\l` - `SHOW DATABASES`
+- `\d` - `SHOW TABLES`
+- `\d <TABLE>` - `DESCRIBE TABLE <TABLE>`
+- `\c <DATABASE>` - `USE <DATABASE>`
 - `.` - repeat the last query
+
+An argument of `\d` that continues the `SHOW TABLES` query instead of naming a table - as in `\d FROM system` or `\d LIKE 'hits%'` - keeps the listing. A table whose name is spelled as one of these clauses has to be quoted: `` \d `format` ``.
 
 ### Keyboard shortcuts {#keyboard_shortcuts}
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -100,6 +100,8 @@
 #include <Storages/SelectQueryInfo.h>
 #include <TableFunctions/ITableFunction.h>
 
+#include <algorithm>
+#include <array>
 #include <filesystem>
 #include <iostream>
 #include <limits>
@@ -230,6 +232,29 @@ void cleanupTempFile(const DB::ASTPtr & parsed_query, const String & tmp_file)
                 fs::remove(tmp_file);
         }
     }
+}
+
+/// Whether the argument of the interactive `\d` command is the name of a table, as in `\d hits`,
+/// rather than a continuation of the `SHOW TABLES` query that a bare `\d` expands to, as in
+/// `\d FROM system` or `\d NOT LIKE 'hits%'`. A table named after one of these clauses has to be
+/// quoted, which is also what tells it apart from the clause.
+bool isTableNameArgument(std::string_view argument)
+{
+    static constexpr auto show_tables_clauses = std::to_array<std::string_view>(
+        {"FROM", "IN", "NOT", "LIKE", "ILIKE", "WHERE", "LIMIT", "INTO", "FORMAT", "SETTINGS", "PARALLEL"});
+
+    while (!argument.empty() && isWhitespaceASCII(argument.front()))
+        argument.remove_prefix(1);
+
+    /// An unquoted name begins an identifier, a quoted one starts with a backtick or a double
+    /// quote. Anything else is not a name: no argument at all, or the `;` of a bare command.
+    if (argument.empty()
+        || !(isValidIdentifierBegin(argument.front()) || argument.front() == '`' || argument.front() == '"'))
+        return false;
+
+    const std::string_view first_word(argument.begin(), std::ranges::find_if(argument, isWhitespaceASCII));
+
+    return std::ranges::none_of(show_tables_clauses, [&](std::string_view clause) { return boost::iequals(first_word, clause); });
 }
 
 void performAtomicRename(const DB::ASTPtr & parsed_query, const String & out_file)
@@ -4881,11 +4906,22 @@ void ClientBase::runInteractive()
     /// Enable bracketed-paste-mode so that we are able to paste multiline queries as a whole.
     lr->enableBracketedPaste();
 
-    static const std::initializer_list<std::pair<String, String>> backslash_aliases =
+    /// The `psql`-style commands. `\d` follows `psql` in expanding to a listing of the tables when
+    /// it is used without an argument and to a description of a table when a table name is given.
+    struct BackslashAlias
+    {
+        std::string_view command;
+        std::string_view query;
+        /// The query to use when the argument is the name of a table; empty if the command has no
+        /// such form and the argument always continues `query`.
+        std::string_view query_for_table;
+    };
+
+    static const std::initializer_list<BackslashAlias> backslash_aliases =
         {
-            { "\\l", "SHOW DATABASES" },
-            { "\\d", "SHOW TABLES" },
-            { "\\c", "USE" },
+            { "\\l", "SHOW DATABASES", {} },
+            { "\\d", "SHOW TABLES", "DESCRIBE TABLE" },
+            { "\\c", "USE", {} },
         };
 
     static const std::initializer_list<String> repeat_last_input_aliases =
@@ -4931,18 +4967,20 @@ void ClientBase::runInteractive()
             has_vertical_output_suffix = true;
         }
 
-        for (const auto & [alias, command] : backslash_aliases)
+        for (const auto & [command, query, query_for_table] : backslash_aliases)
         {
-            auto it = std::search(input.begin(), input.end(), alias.begin(), alias.end());
+            auto it = std::search(input.begin(), input.end(), command.begin(), command.end());
             if (it != input.end() && std::all_of(input.begin(), it, isWhitespaceASCII))
             {
-                it += alias.size();
-                if (it == input.end() || isWhitespaceASCII(*it))
+                it += command.size();
+                if (it == input.end() || isWhitespaceASCII(*it) || *it == ';')
                 {
-                    String new_input = command;
-                    // append the rest of input to the command
+                    const std::string_view argument(it, input.end());
+
+                    String new_input{!query_for_table.empty() && isTableNameArgument(argument) ? query_for_table : query};
+                    // append the rest of input to the query
                     // for parameters support, e.g. \c db_name -> USE db_name
-                    new_input.append(it, input.end());
+                    new_input.append(argument);
                     input = std::move(new_input);
                     break;
                 }

--- a/tests/queries/0_stateless/05098_client_psql_describe_table.expect
+++ b/tests/queries/0_stateless/05098_client_psql_describe_table.expect
@@ -1,0 +1,104 @@
+#!/usr/bin/expect -f
+
+# The `psql`-style `\d` of the interactive client expands to a listing of the tables when it is used
+# without an argument, and to a description of a table when a table name is given - which is how
+# `\d` behaves in `psql`, and used to be a syntax error here (issue #118180).
+# An argument that continues the listing query instead - `\d FROM system`, `\d LIKE 'on%'` - is
+# still a listing.
+# In interactive mode the client echoes the query it is about to run, so what each `\d` expanded to
+# is asserted directly, and the output of the query proves it ran.
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+set history_file $CLICKHOUSE_TMP/$basename.history
+
+log_user 0
+set timeout 60
+match_max 100000
+expect_after {
+    -i $any_spawn_id eof     { exp_continue }
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+# `replxx` treats a `\r` that arrives in the same read as the characters before it as a newline
+# inside one input instead of as a submission - on a loaded machine the whole `send` is waiting in
+# the terminal by the time the client reads it - and the next input would then be appended to this
+# one. Every input is therefore typed first, awaited in its echo, which is the proof that the line
+# editor has consumed it, and only then submitted with a `\r` of its own. Awaiting the echo also
+# separates the input from the output: what is asserted afterwards is the answer of the client.
+proc type_and_submit {text} {
+    send -- $text
+    expect -ex $text
+    send -- "\r"
+}
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file"
+expect ":) "
+
+type_and_submit {CREATE TABLE d_command (col_alpha UInt64, col_beta String) ENGINE = Memory}
+expect ":) "
+
+# ─── A bare `\d` lists the tables, with and without the `;` of a ClickHouse user ───
+type_and_submit {\d}
+expect -ex "SHOW TABLES"
+expect "d_command"
+expect ":) "
+
+type_and_submit {\d;}
+expect -ex "SHOW TABLES"
+expect "d_command"
+expect ":) "
+
+# ─── `\d <table>` describes that table ───
+type_and_submit {\d d_command}
+expect -ex "DESCRIBE TABLE d_command"
+expect "col_alpha"
+expect "UInt64"
+expect ":) "
+
+type_and_submit {\d d_command;}
+expect -ex "DESCRIBE TABLE d_command"
+expect "col_beta"
+expect ":) "
+
+# A name that has to be quoted - because it is spelled as one of the clauses of the listing query -
+# is a table name all the same.
+type_and_submit {CREATE TABLE `format` (col_gamma UInt64) ENGINE = Memory}
+expect ":) "
+type_and_submit {\d `format`}
+expect "col_gamma"
+expect ":) "
+
+# The table is described by the server, so a missing one is reported as such instead of being a
+# syntax error in a listing query.
+type_and_submit {\d no_such_table_05098}
+expect -ex "(UNKNOWN_TABLE)"
+expect ":) "
+
+# ─── An argument that continues the listing query keeps the listing ───
+type_and_submit {\d FROM system LIKE 'on%'}
+expect -ex "SHOW TABLES FROM system LIKE 'on%'"
+expect "one"
+expect ":) "
+
+# ─── The other `psql`-style commands are unaffected ───
+type_and_submit {\l}
+expect -ex "SHOW DATABASES"
+expect "system"
+expect ":) "
+
+type_and_submit {\c system}
+expect -ex "USE system"
+expect ":) "
+type_and_submit {SELECT currentDatabase()}
+expect "system"
+expect ":) "
+
+send -- "\4"
+expect eof


### PR DESCRIPTION
The `psql`-style `\d` of the interactive client is a textual alias of `SHOW TABLES`, so `\d hits` became `SHOW TABLES hits`, which is a syntax error. In `psql` a bare `\d` lists the relations and `\d <name>` describes one, and that is what it does here now: given a table name it expands to `DESCRIBE TABLE`, while a bare `\d` still lists the tables.

An argument that continues the listing query instead - `\d FROM system`, `\d LIKE 'hits%'` - keeps the listing, as it does today. A table whose name is spelled as one of the clauses that `SHOW TABLES` accepts (`FROM`, `IN`, `NOT`, `LIKE`, `ILIKE`, `WHERE`, `LIMIT`, `INTO`, `FORMAT`, `SETTINGS`, `PARALLEL`) has to be quoted, which is also what tells it apart from the clause.

The alias can now be followed by a `;` as well, so `\d;` and `\l;` are no longer syntax errors.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118180

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `psql`-style `\d` of the interactive client now describes a table when a table name is given (`\d hits`), like it does in `psql`; without an argument it still lists the tables.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118281&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118281](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118281+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
