### PR TITLE
Name the rewritten `IN` subquery's column after the subquery, not at random

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -1855,7 +1855,15 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                 /// query "SELECT * FROM numbers(3)" returns column `number` which will collide with outer column `number`
                 auto subquery_node = std::move(in_second_argument);
 
-                String unique_column_name = "__subquery_column_" + toString(UUIDHelpers::generateV4());
+                /// Name the column after the subquery it projects rather than at random: two
+                /// identical `IN` expressions have to stay identical through the rewrite, or the
+                /// analyzer rejects a query that repeats one of them under a single alias with
+                /// `MULTIPLE_EXPRESSIONS_FOR_ALIAS` - a query it accepts without the rewrite. The
+                /// name only has to differ from the names of the outer scope, which the prefix
+                /// already takes care of.
+                const auto subquery_hash = subquery_node->getTreeHash(/*compare_options=*/ {.compare_aliases = false});
+                String unique_column_name
+                    = fmt::format("__subquery_column_{}_{}", subquery_hash.low64, subquery_hash.high64);
 
                 /// Re-resolve subquery columns setting the unique alias
                 auto subquery_projection_columns = subquery_node->as<QueryNode>()->getProjectionColumns();

--- a/tests/queries/0_stateless/05091_rewrite_in_to_join_repeated_alias.reference
+++ b/tests/queries/0_stateless/05091_rewrite_in_to_join_repeated_alias.reference
@@ -1,0 +1,12 @@
+the same aliased IN twice in the projection
+0	0
+1	1
+and nested in a condition
+22
+in a WHERE next to itself
+1
+two different subqueries under different aliases
+0	0
+1	0
+0	1
+a repeated alias over different expressions

--- a/tests/queries/0_stateless/05091_rewrite_in_to_join_repeated_alias.sql
+++ b/tests/queries/0_stateless/05091_rewrite_in_to_join_repeated_alias.sql
@@ -1,0 +1,24 @@
+-- The `IN (subquery)` to join rewrite renames the subquery's projection to a name of its own, so that
+-- it cannot collide with the outer scope. Drawing that name at random made two identical `IN`
+-- expressions differ after the rewrite, and the analyzer - which accepts an alias repeated over
+-- identical expressions - rejected such a query with `MULTIPLE_EXPRESSIONS_FOR_ALIAS`.
+
+SET rewrite_in_to_join = 1;
+SET allow_experimental_correlated_subqueries = 1;
+
+SELECT 'the same aliased IN twice in the projection';
+SELECT dummy IN (SELECT 1) AS ie, dummy IN (SELECT 1) AS ie FROM system.one;
+SELECT dummy NOT IN (SELECT 1) AS ie, dummy NOT IN (SELECT 1) AS ie FROM system.one;
+
+SELECT 'and nested in a condition';
+SELECT if(1 = 1, if(dummy IN (SELECT 1) AS ie, 11, 22), if(dummy IN (SELECT 1) AS ie, 11, 22)) FROM system.one;
+
+SELECT 'in a WHERE next to itself';
+SELECT number FROM numbers(3) WHERE (number IN (SELECT 1) AS ie) OR (number IN (SELECT 1) AS ie) ORDER BY number;
+
+SELECT 'two different subqueries under different aliases';
+SELECT number IN (SELECT 1) AS one, number IN (SELECT 2) AS two FROM numbers(3) ORDER BY number;
+
+-- An alias really used for two different expressions is still rejected.
+SELECT 'a repeated alias over different expressions';
+SELECT dummy IN (SELECT 1) AS ie, dummy IN (SELECT 2) AS ie FROM system.one; -- { serverError MULTIPLE_EXPRESSIONS_FOR_ALIAS }


### PR DESCRIPTION
The `IN (subquery)` to join rewrite renames the subquery's projection so that the name cannot collide with the outer scope. The name was a fresh UUID per occurrence, which made two identical `IN` expressions differ after the rewrite, and the analyzer - which accepts one alias repeated over identical expressions - rejected a query it accepts without the rewrite:

```sql
SET rewrite_in_to_join = 1;
SELECT dummy IN (SELECT 1) AS ie, dummy IN (SELECT 1) AS ie FROM system.one;
-- Code: 179. DB::Exception: Multiple expressions
--   exists(...`__subquery_column_43d1dae1-...`...) and
--   exists(...`__subquery_column_4f7030f4-...`...) for alias ie. (MULTIPLE_EXPRESSIONS_FOR_ALIAS)
```

The name now comes from the tree hash of the subquery it projects, so equal subqueries get equal names. The prefix keeps it out of the way of the outer scope's names, which is all the rename is for, and an alias genuinely used for two different expressions is still rejected (the test pins that).

Closes: https://github.com/ClickHouse/ClickHouse/issues/113418
Related: https://github.com/ClickHouse/ClickHouse/issues/112129

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `MULTIPLE_EXPRESSIONS_FOR_ALIAS` under `rewrite_in_to_join` for a query that repeats one identical aliased `IN (subquery)` expression more than once.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118292&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118292](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118292+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
