### PR TITLE
Fix flaky test_settings_connection_wait_timeout by waiting until the pool connection is held

### DIFF
--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -1,5 +1,4 @@
 import os
-import threading
 import time
 from contextlib import contextmanager
 
@@ -10,6 +9,7 @@ import pytest
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import mysql_pass
+from helpers.test_tools import assert_eq_with_retry
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -423,6 +423,9 @@ def test_settings_connection_wait_timeout(started_cluster):
     table_name = "test_settings_connection_wait_timeout"
     node1.query(f"DROP TABLE IF EXISTS {table_name}")
     wait_timeout = 2
+    # The holder query below reads one row per block and sleeps a second on each block, so this
+    # row count is how many seconds it keeps the pool's single connection checked out.
+    holder_rows = 60
 
     conn = get_mysql_conn(started_cluster, cluster.mysql8_ip)
     drop_mysql_table(conn, table_name)
@@ -443,42 +446,41 @@ def test_settings_connection_wait_timeout(started_cluster):
     )
 
     node1.query(
-        "INSERT INTO {} (id, name) SELECT number, concat('name_', toString(number)) from numbers(10) ".format(
-            table_name
+        "INSERT INTO {} (id, name) SELECT number, concat('name_', toString(number)) from numbers({}) ".format(
+            table_name, holder_rows
         )
     )
 
-    worker_started_event = threading.Event()
-
-    def worker():
-        worker_started_event.set()
-        node1.query(
-            "SELECT 1, sleepEachRow(1) FROM {} SETTINGS max_threads=1".format(
-                table_name
-            )
+    holder_query_id = f"{table_name}_holder"
+    holder = node1.get_query_request(
+        f"SELECT 1, sleepEachRow(1) FROM {table_name} SETTINGS max_threads=1, max_block_size=1",
+        query_id=holder_query_id,
+    )
+    try:
+        # A non-zero `read_rows` means the MySQL source has already returned a row, so it has taken
+        # the pool's single connection and keeps it for the rest of the read.
+        assert_eq_with_retry(
+            node1,
+            f"SELECT read_rows > 0 FROM system.processes WHERE query_id = '{holder_query_id}'",
+            "1",
+            retry_count=60,
         )
 
-    worker_thread = threading.Thread(target=worker)
-    worker_thread.start()
+        started = time.time()
+        with pytest.raises(
+            QueryRuntimeException,
+            match=r"Exception: mysqlxx::Pool is full \(connection_wait_timeout is exceeded\)",
+        ):
+            node1.query(f"SELECT 2 FROM {table_name} SETTINGS max_threads=1")
+        ended = time.time()
+        assert (ended - started) >= wait_timeout
+    finally:
+        node1.query(f"KILL QUERY WHERE query_id = '{holder_query_id}' SYNC")
+        _, holder_error = holder.get_answer_and_error()
 
-    # ensure that first query started in worker_thread
-    assert worker_started_event.wait(10)
-    time.sleep(1)
-
-    started = time.time()
-    with pytest.raises(
-        QueryRuntimeException,
-        match=r"Exception: mysqlxx::Pool is full \(connection_wait_timeout is exceeded\)",
-    ):
-        node1.query(
-            "SELECT 2, sleepEachRow(1) FROM {} SETTINGS max_threads=1".format(
-                table_name
-            )
-        )
-    ended = time.time()
-    assert (ended - started) >= wait_timeout
-
-    worker_thread.join()
+    # Cancelled rather than finished: the holder still owned the connection while the query above
+    # was waiting for it.
+    assert "Query was cancelled" in holder_error
 
     drop_mysql_table(conn, table_name)
     conn.close()


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make `test_storage_mysql::test_settings_connection_wait_timeout` synchronise on an observable server-side fact instead of a fixed sleep.

### Description

The test's stated synchronisation does not exist. `worker_started_event.set()` is the first statement of `worker()`, before `node1.query(...)` is sent, so the `wait(10)` returns immediately and the comment `# ensure that first query started in worker_thread` is false. The only real ordering margin is the following `time.sleep(1)`, against two independent `clickhouse client` start-ups. When the holder's client is the slower one, the waiter takes the pool's single connection, the *holder* gets `Pool is full` inside a thread that cannot re-raise it, and the test fails as `DID NOT RAISE`.

Injecting that skew reproduces the CI signature deterministically: `time.sleep(3)` after the `set()` fails 3/3 with `Failed: DID NOT RAISE`, the holder's stack ending in `mysqlxx::Pool::get` from `MySQLWithFailoverSource::onStart`. The product is correct and unchanged: `Pool::get` tests the deadline before its sleep, so the wait is never short.

The fix waits on a server-side fact: the holder runs with an explicit `query_id`, and the test proceeds only once that query has `read_rows > 0` in `system.processes`, which cannot happen before the MySQL source took the pool entry. The holder then reads one row per second for 60 rows, so the requirement becomes "the waiter starts within 57 s" instead of "within 1 s". `KILL QUERY ... SYNC` in a `finally` ends it, and the holder's error is asserted to be the cancellation.

Assertions are unchanged: same `pytest.raises`, same `match`, same `>= wait_timeout`. No tag, no skip, no weakened bound. This is the only coverage of `connection_wait_timeout` on the table-engine path, so the timing dependency is removed rather than widened.

With the same skew the fixed test passes; 30/30 green, whole module green, runtime 10.5 s to 3.6 s. Mutating `Pool::get` so the deadline no longer throws makes the fixed test fail, so its oracle stays armed.

Observed failure: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117968&sha=67771a2c1c0a1a316de9dd714d200735d2e3cdf4&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%203%2F6%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118294&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118294](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118294+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.812` (included in `26.9` and later)
<!-- ch-version-info:end -->