### PR TITLE
Run one group of Keeper clusters at a time in test_keeper_snapshot_chunked_transfer

### DIFF
--- a/tests/integration/helpers/keeper_snapshot_utils.py
+++ b/tests/integration/helpers/keeper_snapshot_utils.py
@@ -215,12 +215,19 @@ def phase_instances(phase_clusters, phase=None):
 def _wait_serving_requests(cluster, node, timeout):
     import helpers.keeper_utils as keeper_utils
     # A server started a moment ago has not necessarily bound its Keeper port yet, and
-    # wait_until_connected lets the refused connect propagate. Complete readiness is not
+    # wait_until_connected lets the refused connect propagate. A server whose cluster has no
+    # leader yet answers "not serving requests" instead of refusing, so that wait gets the
+    # remaining budget too and both paths end at one deadline. Complete readiness is not
     # probed because that probe is a client read, which a pinned old image can drop.
     deadline = time.time() + timeout
     while True:
         try:
-            keeper_utils.wait_until_connected(cluster, node, wait_complete_readiness=False)
+            keeper_utils.wait_until_connected(
+                cluster,
+                node,
+                timeout=max(deadline - time.time(), 0.0),
+                wait_complete_readiness=False,
+            )
             return
         except OSError:
             if time.time() >= deadline:

--- a/tests/integration/helpers/keeper_snapshot_utils.py
+++ b/tests/integration/helpers/keeper_snapshot_utils.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import os
 import re
 import time
@@ -199,3 +200,111 @@ def assert_obj_ids(node_lagging, snapshot_log_idx, expected, after_time):
     assert set(all_ids) == set(expected), f"Expected obj_ids={set(expected)}, got: {sorted(set(all_ids))}"
     assert duplicates <= max_allowed, \
         f"Too many duplicate chunks: {duplicates} (max {max_allowed}), obj_ids={all_ids}"
+
+
+def phase_instances(phase_clusters, phase=None):
+    """Instances of one phase of a phase table, or of all of them when phase is None.
+
+    A phase table maps a phase name to the list of independent Keeper clusters that
+    phase exercises: {"small": [[node1, node2, node3], [node7, node8, node9]], ...}.
+    """
+    phases = phase_clusters.values() if phase is None else [phase_clusters[phase]]
+    return [node for clusters in phases for cluster_nodes in clusters for node in cluster_nodes]
+
+
+def _wait_serving_requests(cluster, node, timeout):
+    import helpers.keeper_utils as keeper_utils
+    # A server started a moment ago has not necessarily bound its Keeper port yet, and
+    # wait_until_connected lets the refused connect propagate. Complete readiness is not
+    # probed because that probe is a client read, which a pinned old image can drop.
+    deadline = time.time() + timeout
+    while True:
+        try:
+            keeper_utils.wait_until_connected(cluster, node, wait_complete_readiness=False)
+            return
+        except OSError:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.5)
+
+
+def _wait_first_node_is_leader(cluster, nodes, timeout):
+    import helpers.keeper_utils as keeper_utils
+    # generate_keeper_configs gives the first server of a cluster the top priority and starts
+    # every other one as a follower, and no test kills the first server. Leadership has to be
+    # back on the first server before a test runs, or killing a lagging node can remove the
+    # leader instead, and the re-election that follows drops the writes then in flight.
+    deadline = time.time() + timeout
+    last_request = None
+    while True:
+        try:
+            if keeper_utils.is_leader(cluster, nodes[0]):
+                return
+            if last_request is None or time.time() - last_request > 5:
+                keeper_utils.send_4lw_cmd(cluster, nodes[0], cmd="rqld")
+                last_request = time.time()
+        except OSError:
+            pass
+        if time.time() >= deadline:
+            raise Exception(
+                f"{nodes[0].name} did not become the Keeper leader within {timeout}s"
+            )
+        time.sleep(0.5)
+
+
+def use_keeper_phase(cluster, phase_clusters, phase, start_timeout=180, always_running=()):
+    """Leave exactly the Keeper clusters of `phase` serving and led by their first server,
+    and every other instance of the phase table stopped.
+
+    Only one phase is ever under test, while an idle sanitizer server costs about as
+    much resident memory as a busy one, so the rest stay stopped instead of resident.
+
+    Instances in `always_running` are never stopped or started, only asserted to be up.
+    """
+    wanted = {node.name for node in phase_instances(phase_clusters, phase)}
+    pinned = {node.name for node in always_running}
+
+    # Converge from live process state rather than from a remembered phase: a test that
+    # fails between its own stop_clickhouse() and start_clickhouse() leaves a node of
+    # the current phase down, and the next test in that phase needs it back.
+    to_start = []
+    for node in phase_instances(phase_clusters):
+        if node.name in pinned:
+            continue
+        running = node.get_process_pid("clickhouse") is not None
+        if node.name not in wanted:
+            if running:
+                node.stop_clickhouse()
+        elif not running:
+            to_start.append(node)
+
+    # A Keeper server brought up on its own stalls for keeper_server.startup_timeout
+    # waiting for a quorum only its peers can form, and start_clickhouse waits for the
+    # server to answer queries, so the servers of a phase have to come up together.
+    if to_start:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(to_start)) as pool:
+            futures = [pool.submit(node.start_clickhouse, start_timeout) for node in to_start]
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+
+    for cluster_nodes in phase_clusters[phase]:
+        for node in cluster_nodes:
+            _wait_serving_requests(cluster, node, start_timeout)
+        _wait_first_node_is_leader(cluster, cluster_nodes, start_timeout)
+
+    for node in phase_instances(phase_clusters):
+        running = node.get_process_pid("clickhouse") is not None
+        expected = node.name in wanted or node.name in pinned
+        assert running == expected, (
+            f"{node.name} is {'running' if running else 'stopped'} but Keeper phase "
+            f"'{phase}' requires it to be {'running' if expected else 'stopped'}"
+        )
+
+
+def start_keeper_phase_only(cluster, phase_clusters, phase, always_running=()):
+    """Stop every server outside `phase` right after cluster.start() brought them all up."""
+    keep = {node.name for node in phase_instances(phase_clusters, phase)}
+    keep |= {node.name for node in always_running}
+    for node in phase_instances(phase_clusters):
+        if node.name not in keep:
+            node.stop_clickhouse()

--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -17,6 +17,8 @@ from helpers.keeper_snapshot_utils import (
     get_received_snapshot_info,
     assert_receiving_snapshot_logged,
     assert_obj_ids,
+    start_keeper_phase_only,
+    use_keeper_phase,
 )
 
 
@@ -73,10 +75,29 @@ compat_s3_2 = cluster.add_instance("compat_s3_2", main_configs=["configs/enable_
 compat_s3_3 = cluster.add_instance("compat_s3_3", main_configs=["configs/enable_keeper_compat_s3_3.xml", "configs/text_log.xml"], user_configs=[_small_buf_cfg], stay_alive=True, with_minio=True, with_remote_database_disk=False)
 
 
+# A test exercises exactly one of these groups of independent Keeper clusters, so only
+# one group is kept running at a time (use_keeper_phase); the first group listed stays
+# running after cluster.start().
+KEEPER_PHASES = {
+    "small": [[node1, node2, node3], [node7, node8, node9]],
+    "large": [[node4, node5, node6], [node10, node11, node12]],
+    "compat": [[compat1, compat2, compat3], [compat_s3_1, compat_s3_2, compat_s3_3]],
+}
+
+# The servers running a pinned release stay up for the whole module. A release Keeper aborts
+# at startup on a snapshot written by the newer server it is clustered with ("Unsupported
+# snapshot version", "Manual intervention is necessary for recovery"), so restarting one is
+# not recoverable. They are also the cheap servers here, being the only non-sanitizer builds.
+PINNED_RELEASE_INSTANCES = [compat1, compat2, compat_s3_1, compat_s3_2]
+
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
+        start_keeper_phase_only(
+            cluster, KEEPER_PHASES, next(iter(KEEPER_PHASES)), PINNED_RELEASE_INSTANCES
+        )
         yield cluster
     finally:
         cluster.shutdown()
@@ -89,6 +110,13 @@ CHUNK_SIZE = 4096  # matches snapshot_transfer_chunk_size in small-chunk configs
 # took ~95 s in CI, so the wait must be generous: start_clickhouse returns as soon as the
 # server is ready, so a large upper bound costs nothing on fast runs.
 RESTART_TIMEOUT_SECONDS = 180
+
+
+def use_phase(phase):
+    use_keeper_phase(
+        cluster, KEEPER_PHASES, phase, RESTART_TIMEOUT_SECONDS, PINNED_RELEASE_INSTANCES
+    )
+
 
 CHUNKED_TRANSFER_PARAMS = [
     pytest.param({"leader": node1, "middle": node2, "lagging": node3, "disk_type": "local"}, id="local_disk"),
@@ -118,6 +146,7 @@ def get_coordination_setting(node, name):
 
 @pytest.mark.parametrize("nodes", CHUNKED_TRANSFER_PARAMS)
 def test_recover_from_snapshot_with_chunked_transfer(started_cluster, nodes):
+    use_phase("small")
     node_leader = nodes["leader"]
     node_middle = nodes["middle"]
     node_lagging = nodes["lagging"]
@@ -171,6 +200,7 @@ def test_recover_from_snapshot_with_chunked_transfer(started_cluster, nodes):
 @pytest.mark.parametrize("nodes", CHUNKED_TRANSFER_PARAMS)
 def test_recover_after_interrupted_transfer(started_cluster, nodes):
     """A `tmp_snapshot_X.bin` left by an interrupted transfer must not block recovery."""
+    use_phase("small")
     node_leader = nodes["leader"]
     node_lagging = nodes["lagging"]
     is_remote = nodes["disk_type"] == "remote"
@@ -290,40 +320,10 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
     cleanup_test_tree(cluster, node_leader, prefix)
 
 
-@pytest.mark.parametrize("nodes", LARGE_CHUNK_PARAMS)
-def test_recover_with_chunk_size_larger_than_snapshot(started_cluster, nodes):
-    """When chunk_size > snapshot size the whole snapshot is one NuRaft object (obj_id=0)."""
-    node_leader = nodes["leader"]
-    node_lagging = nodes["lagging"]
-    prefix = "/test_large_chunk_transfer"
-
-    cleanup_test_tree(cluster, node_leader, prefix)
-
-    kill_time = get_kill_timestamp(node_lagging)
-    node_lagging.stop_clickhouse(kill=True)
-
-    leader_zk = keeper_utils.get_fake_zk(cluster, node_leader.name)
-    fill_test_tree(leader_zk, prefix)
-
-    node_lagging.start_clickhouse(RESTART_TIMEOUT_SECONDS)
-    keeper_utils.wait_until_connected(cluster, node_lagging)
-    received = get_received_snapshot_info(node_lagging, kill_time)
-
-    leader_zk = keeper_utils.get_fake_zk(cluster, node_leader.name)
-    lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)
-    verify_test_tree(leader_zk, lagging_zk, prefix)
-    cleanup_test_tree(cluster, node_leader, prefix)
-
-    assert received is not None
-    snapshot_log_idx, n_chunks, _ = received
-    assert n_chunks == 1, f"Expected 1 chunk (snapshot fits within chunk_size), got {n_chunks}"
-    assert_obj_ids(node_lagging, snapshot_log_idx, [0], kill_time)
-    assert_receiving_snapshot_logged(node_lagging, kill_time, nodes["disk_type"])
-
-
 def test_recover_after_s3_read_error_during_transfer(started_cluster):
     """After `readStrict` throws in `RemoteSnapshotLoader` (simulated via failpoint),
     the loader marks itself as broken and the follower recovers on the next NuRaft retry."""
+    use_phase("small")
     node_lagging = node9
     # Disarm any leftover failpoint from a previous failed run so it does not fire
     # unexpectedly during setup (before we are ready to observe the error).
@@ -363,9 +363,42 @@ def test_recover_after_s3_read_error_during_transfer(started_cluster):
         node_leader.query("SYSTEM DISABLE FAILPOINT s3_read_buffer_throw_expired_token")
 
 
+@pytest.mark.parametrize("nodes", LARGE_CHUNK_PARAMS)
+def test_recover_with_chunk_size_larger_than_snapshot(started_cluster, nodes):
+    """When chunk_size > snapshot size the whole snapshot is one NuRaft object (obj_id=0)."""
+    use_phase("large")
+    node_leader = nodes["leader"]
+    node_lagging = nodes["lagging"]
+    prefix = "/test_large_chunk_transfer"
+
+    cleanup_test_tree(cluster, node_leader, prefix)
+
+    kill_time = get_kill_timestamp(node_lagging)
+    node_lagging.stop_clickhouse(kill=True)
+
+    leader_zk = keeper_utils.get_fake_zk(cluster, node_leader.name)
+    fill_test_tree(leader_zk, prefix)
+
+    node_lagging.start_clickhouse(RESTART_TIMEOUT_SECONDS)
+    keeper_utils.wait_until_connected(cluster, node_lagging)
+    received = get_received_snapshot_info(node_lagging, kill_time)
+
+    leader_zk = keeper_utils.get_fake_zk(cluster, node_leader.name)
+    lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)
+    verify_test_tree(leader_zk, lagging_zk, prefix)
+    cleanup_test_tree(cluster, node_leader, prefix)
+
+    assert received is not None
+    snapshot_log_idx, n_chunks, _ = received
+    assert n_chunks == 1, f"Expected 1 chunk (snapshot fits within chunk_size), got {n_chunks}"
+    assert_obj_ids(node_lagging, snapshot_log_idx, [0], kill_time)
+    assert_receiving_snapshot_logged(node_lagging, kill_time, nodes["disk_type"])
+
+
 @pytest.mark.parametrize("nodes", COMPAT_PARAMS)
 def test_recover_from_snapshot_sent_by_old_leader(started_cluster, nodes):
     """Old leader (no chunking support) always sends a single NuRaft object (obj_id=0)."""
+    use_phase("compat")
     node_old_leader = nodes["old_leader"]
     node_lagging = nodes["lagging"]
     prefix = "/test_compat_snapshot_transfer"

--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test_concurrent.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test_concurrent.py
@@ -12,6 +12,8 @@ from helpers.keeper_snapshot_utils import (
     verify_test_tree,
     get_kill_timestamp,
     get_received_snapshot_info,
+    start_keeper_phase_only,
+    use_keeper_phase,
 )
 
 
@@ -49,18 +51,34 @@ node_concs4 = cluster.add_instance("node_concs4", main_configs=["configs/enable_
 node_concs5 = cluster.add_instance("node_concs5", main_configs=["configs/enable_keeper_conc_s3_5.xml"], user_configs=[_small_buf_cfg], stay_alive=True, with_minio=True, with_remote_database_disk=False)
 
 
+# A test exercises exactly one of these groups of independent Keeper clusters, so only
+# one group is kept running at a time (use_keeper_phase); the first group listed stays
+# running after cluster.start().
+KEEPER_PHASES = {
+    "local": [[node_conc1, node_conc2, node_conc3, node_conc4, node_conc5]],
+    "remote": [[node_concs1, node_concs2, node_concs3, node_concs4, node_concs5]],
+}
+
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
+        start_keeper_phase_only(cluster, KEEPER_PHASES, next(iter(KEEPER_PHASES)))
         yield cluster
     finally:
         cluster.shutdown()
 
 
 CONCURRENT_FOLLOWERS_PARAMS = [
-    pytest.param({"leader": node_conc1, "lagging": [node_conc4, node_conc5]}, id="local_disk"),
-    pytest.param({"leader": node_concs1, "lagging": [node_concs4, node_concs5]}, id="remote_disk"),
+    pytest.param(
+        {"leader": node_conc1, "lagging": [node_conc4, node_conc5], "phase": "local"},
+        id="local_disk",
+    ),
+    pytest.param(
+        {"leader": node_concs1, "lagging": [node_concs4, node_concs5], "phase": "remote"},
+        id="remote_disk",
+    ),
 ]
 
 
@@ -69,6 +87,7 @@ def test_concurrent_followers_fetch_snapshot(started_cluster, nodes):
     """Two followers lagging behind must both recover correctly when fetching
     the same snapshot concurrently from the leader. Tests shared loader access
     under concurrent load — especially the RemoteSnapshotLoader mutex on S3."""
+    use_keeper_phase(cluster, KEEPER_PHASES, nodes["phase"], RESTART_TIMEOUT_SECONDS)
     node_leader = nodes["leader"]
     lagging = nodes["lagging"]
     prefix = "/test_concurrent_followers_snapshot"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109173
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @ alexey-milovidov in https://github.com/ClickHouse/ClickHouse/pull/109173#issuecomment-5550677432 ("the ... fix task is yours").

`test.py` registers 18 long-lived servers (six independent 3-node Keeper clusters), `test_concurrent.py` another 10. They are the two heaviest files on `Integration tests (amd_asan_ubsan, db disk, 2/4)` (214 modules, 258 files, 444 servers); the next heaviest registers 8. The runner container is capped at 59.77 GiB (`--memory=64183296000`) under `pytest -n 3 --dist=loadfile`, so one worker holds a whole module. On 26.8 it fails 26 of 758 runs of that check; 26.7 fails 0 of 825. In both collapses I read, a co-tenant's worker dies first (`[gwN] node down: Not properly terminated`) and this module's servers follow with connect-refused or RST: [job 1](https://github.com/ClickHouse/ClickHouse/actions/runs/33623910464/job/100231164025), [job 2](https://github.com/ClickHouse/ClickHouse/actions/runs/33775078822/job/100728973141).

An idle sanitizer server costs about as much memory as a busy one, so every instance stays registered (coverage unchanged) while only one group runs: the local-disk and S3 cluster pair sharing a snapshot chunk setting, two of the six. Rotating per cluster would stop three more sanitizer servers (1.4-3.0 GiB each) but raise phase changes from 2 to 7 at this parameter order, where two already cost ~83 s; your call if you would rather have the memory.

Measured on one ASAN build with `docker stats`: peak container working set **26.2 -> 13.3-14.2 GiB**, sustained servers **18 -> 10**, wall clock 492 -> ~575 s (+17%). The 18-server spike at `cluster.start()` is unchanged, since it cannot start a subset. The four pinned-release servers stay up throughout: a release Keeper aborts on a snapshot from the newer server it is clustered with (`Unsupported snapshot version`).

<details><summary>Why not <code>is_sequential=True</code>, as in eb8874234f62</summary>

On this shard the sequential phase never runs, so the module would stop running altogether rather than run alone:

- it is gated on `not has_error` (`ci/jobs/integration_test_job.py:1995`);
- `has_error` is set from `test_result_parallel.is_error()` (`:1980-1987`);
- a graceful `--session-timeout` asserts status `ERROR` (`:1401-1409`);
- that `xdist.dsession.Interrupted: session-timeout` marker is present in all three jobs of this shard I measured: 26.7 at 7278.81 s, 26.8 at 7351.04 s and 7420.93 s, against a 7200 s budget.

That would remove the module's 9 passing tests along with its 26 failures, and it would change nothing on master, which never schedules this module on this shard.
</details>

This cuts demand, not the shard's own overrun; on the supply side #116591 (merged after the 26.8 cut) raises the release-branch set to 6 batches and #115785 would size workers from the job cgroup limit, neither overlapping this diff.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118297&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118297](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118297+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1353` (included in `26.9` and later)
<!-- ch-version-info:end -->