### PR TITLE
Do not apply the suspicious and experimental type checks to CREATE VIEW

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1169,9 +1169,9 @@ void InterpreterCreateQuery::validateTableStructure(const ASTCreateQuery & creat
 
     const auto & settings = getContext()->getSettingsRef();
 
-    /// If it's not attach and not materialized view to existing table,
-    /// we need to validate data types (check for experimental or suspicious types).
-    if (!create.attach && !create.is_materialized_view)
+    /// A view stores no data of its own, so the gates on types chosen for storage do not apply to it;
+    /// a materialized view's inner table is created by its own statement and validated there.
+    if (!create.attach && !create.isView())
     {
         DataTypeValidationSettings validation_settings(settings);
         for (const auto & name_and_type_pair : properties.columns.getAllPhysical())

--- a/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.reference
+++ b/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.reference
@@ -1,2 +1,3 @@
 7
 LowCardinality(Int16)
+FixedString(300)

--- a/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.reference
+++ b/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.reference
@@ -1,0 +1,2 @@
+7
+LowCardinality(Int16)

--- a/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.reference
+++ b/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.reference
@@ -1,3 +1,4 @@
 7
 LowCardinality(Int16)
+LowCardinality(DateTime)
 FixedString(300)

--- a/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.sql
+++ b/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.sql
@@ -1,0 +1,29 @@
+-- A view stores no data, so the suspicious/experimental type gates must not reject its column types.
+
+DROP TABLE IF EXISTS t;
+DROP VIEW IF EXISTS v;
+DROP VIEW IF EXISTS v_written;
+
+SET allow_suspicious_low_cardinality_types = 1;
+CREATE TABLE t (x LowCardinality(Int16)) ENGINE = Memory;
+INSERT INTO t VALUES (7);
+SET allow_suspicious_low_cardinality_types = 0;
+
+-- The type inferred from the SELECT is accepted, and it is the type the view really has.
+CREATE VIEW v AS SELECT x FROM t;
+SELECT x FROM v;
+SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 'v' AND name = 'x';
+
+-- The same statement with the column list spelled out: this is what SHOW CREATE prints and what is
+-- dispatched to the other hosts of a cluster, so it has to be accepted too.
+CREATE VIEW v_written (x LowCardinality(Int16)) AS SELECT x FROM t;
+
+-- A table stores its columns, so it stays refused, inferred type or not.
+CREATE TABLE t_as ENGINE = Memory AS SELECT x FROM t; -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
+
+-- The inner table of a materialized view is a table, so it stays refused as well.
+CREATE MATERIALIZED VIEW mv ENGINE = Memory AS SELECT x FROM t; -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
+
+DROP VIEW v_written;
+DROP VIEW v;
+DROP TABLE t;

--- a/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.sql
+++ b/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.sql
@@ -3,6 +3,7 @@
 DROP TABLE IF EXISTS t;
 DROP VIEW IF EXISTS v;
 DROP VIEW IF EXISTS v_written;
+DROP VIEW IF EXISTS v_fs;
 
 SET allow_suspicious_low_cardinality_types = 1;
 CREATE TABLE t (x LowCardinality(Int16)) ENGINE = Memory;
@@ -18,12 +19,17 @@ SELECT type FROM system.columns WHERE database = currentDatabase() AND table = '
 -- dispatched to the other hosts of a cluster, so it has to be accepted too.
 CREATE VIEW v_written (x LowCardinality(Int16)) AS SELECT x FROM t;
 
+-- A second, independently gated setting: the exemption is the whole check, not one type.
+CREATE VIEW v_fs AS SELECT toFixedString(materialize('a'), 300) AS x;
+SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 'v_fs' AND name = 'x';
+
 -- A table stores its columns, so it stays refused, inferred type or not.
 CREATE TABLE t_as ENGINE = Memory AS SELECT x FROM t; -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
 
 -- The inner table of a materialized view is a table, so it stays refused as well.
 CREATE MATERIALIZED VIEW mv ENGINE = Memory AS SELECT x FROM t; -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
 
+DROP VIEW v_fs;
 DROP VIEW v_written;
 DROP VIEW v;
 DROP TABLE t;

--- a/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.sql
+++ b/tests/queries/0_stateless/05087_create_view_inferred_suspicious_type.sql
@@ -3,11 +3,13 @@
 DROP TABLE IF EXISTS t;
 DROP VIEW IF EXISTS v;
 DROP VIEW IF EXISTS v_written;
+DROP VIEW IF EXISTS v_dict;
 DROP VIEW IF EXISTS v_fs;
+DROP DICTIONARY IF EXISTS dict;
 
 SET allow_suspicious_low_cardinality_types = 1;
-CREATE TABLE t (x LowCardinality(Int16)) ENGINE = Memory;
-INSERT INTO t VALUES (7);
+CREATE TABLE t (x LowCardinality(Int16), id LowCardinality(String)) ENGINE = Memory;
+INSERT INTO t VALUES (7, 'a');
 SET allow_suspicious_low_cardinality_types = 0;
 
 -- The type inferred from the SELECT is accepted, and it is the type the view really has.
@@ -18,6 +20,15 @@ SELECT type FROM system.columns WHERE database = currentDatabase() AND table = '
 -- The same statement with the column list spelled out: this is what SHOW CREATE prints and what is
 -- dispatched to the other hosts of a cluster, so it has to be accepted too.
 CREATE VIEW v_written (x LowCardinality(Int16)) AS SELECT x FROM t;
+
+-- The case reported in #57561: dictGet keeps the LowCardinality of its key argument, so the type
+-- inferred for the view's column is LowCardinality(DateTime).
+CREATE DICTIONARY dict (id String, timestamp DateTime)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(QUERY 'SELECT \'a\' AS id, now() AS timestamp'))
+LAYOUT(DIRECT());
+CREATE VIEW v_dict AS SELECT dictGet(dict, 'timestamp', id) AS ts FROM t;
+SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 'v_dict' AND name = 'ts';
 
 -- A second, independently gated setting: the exemption is the whole check, not one type.
 CREATE VIEW v_fs AS SELECT toFixedString(materialize('a'), 300) AS x;
@@ -30,6 +41,8 @@ CREATE TABLE t_as ENGINE = Memory AS SELECT x FROM t; -- { serverError SUSPICIOU
 CREATE MATERIALIZED VIEW mv ENGINE = Memory AS SELECT x FROM t; -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
 
 DROP VIEW v_fs;
+DROP VIEW v_dict;
+DROP DICTIONARY dict;
 DROP VIEW v_written;
 DROP VIEW v;
 DROP TABLE t;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/57561
Closes: https://github.com/ClickHouse/ClickHouse/issues/27863
Related: https://github.com/ClickHouse/ClickHouse/pull/110934


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `CREATE VIEW` being refused with `SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY` or `ILLEGAL_COLUMN` when a column type inferred from the view's own `SELECT` is one that `allow_suspicious_low_cardinality_types`, `allow_suspicious_fixed_string_types`, `allow_suspicious_variant_types`, `allow_experimental_nullable_tuple_type` or `enable_time_time64_type` gates. Those settings gate types chosen for storage, and a view stores no data; a materialized view was already exempt.

### Description

At default settings, `CREATE VIEW v AS SELECT x FROM t` is refused with `Code: 455` when the SELECT header contains `LowCardinality(Int16)`, while the same bare `SELECT` succeeds and returns that type. #57561 reaches it through `dictGet` over a `LowCardinality(String)` key, #27863 through `toInt16(toLowCardinality(...))`. The four sibling gates behave identically.

`validateDataType` gates types chosen for storage: its other callers get a type the query spells out (`CAST`, `ALTER`) or one inferred for a table that stores it (`StorageBigQuery`). An ordinary view declares nothing: the header is inferred from the SELECT, written into `create.columns_list` by `formatColumns`, then validated as if the user had written it. Materialized views were carved out of this pass unconditionally when it was introduced (`aaed83541517e23`); ordinary views were not. This extends that carve-out via `ASTCreateQuery::isView`.

A *written* column list on a view is now accepted too, and it has to be: that is the text `SHOW CREATE VIEW` prints, and the text the server serializes to other hosts (normalization runs before the `Replicated` enqueue and the `ON CLUSTER` dispatch). Before this change, executing what `SHOW CREATE` itself printed gave `Code: 455`.

The test covers the `dictGet` form from #57561; `CREATE TABLE ... AS SELECT` and a materialized view's inner table still refuse, and it asserts both. `02513_validate_data_types` and `03215_validate_type_in_alter_add_modify_column` still cover the untouched `CAST` and `ALTER` sites.

Not fixed here: `dictGet` still propagates `LowCardinality` from its key argument (intended, #63458). A suspicious or experimental type spelled into a view's column list no longer warns, though it is still never stored.

The suggestion I posted on #57561 is superseded: narrowing the guard to the inferred-columns flag does not survive the DDL replay above. #110934 rewrites this same condition for a different purpose, so whichever of the two lands second has to keep the view exemption.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118298&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118298](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118298+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


