### PR TITLE
Do not resolve a table function to answer a `system.columns` size query

### DIFF
--- a/src/Storages/StorageTableFunction.h
+++ b/src/Storages/StorageTableFunction.h
@@ -78,6 +78,18 @@ public:
         return storage ? storage->getDataPaths() : Strings{};
     }
 
+    ColumnSizeByName getColumnSizes() const override
+    {
+        auto storage = nestedIfResolved();
+        return storage ? storage->getColumnSizes() : ColumnSizeByName{};
+    }
+
+    ColumnSizeByName getColumnSizes(const Names & columns, bool calculate_subcolumn_sizes) const override
+    {
+        auto storage = nestedIfResolved();
+        return storage ? storage->getColumnSizes(columns, calculate_subcolumn_sizes) : ColumnSizeByName{};
+    }
+
     std::optional<UInt64> totalRows(ContextPtr query_context) const override
     {
         auto storage = nestedIfResolved();

--- a/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.reference
+++ b/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.reference
@@ -14,6 +14,7 @@ tablefunc06	Proxy		CREATE TABLE default.tablefunc06 (`a` Int32) AS s3(\'http://s
 tablefunc07	Proxy		CREATE TABLE default.tablefunc07 (`x` String) AS url(\'http://some_addr:9000/nonexistent\')	[]	1	1
 Proxy
 \N	\N
+x	0	0	0
 \N	\N
 5
 5	1
@@ -22,3 +23,7 @@ Proxy
 1
 0
 5
+1
+0
+10000
+1

--- a/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.sql
+++ b/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.sql
@@ -102,9 +102,13 @@ CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc11 (x String) AS merge(cu
 SELECT data_compressed_bytes > 0 FROM system.columns
     WHERE database = currentDatabase() AND table = 'tablefunc11';
 SELECT count() FROM {CLICKHOUSE_DATABASE:Identifier}.tablefunc11;
-SELECT data_compressed_bytes > 0 FROM system.columns
-    WHERE database = currentDatabase() AND table = 'tablefunc11';
+SELECT (data_compressed_bytes, data_uncompressed_bytes, marks_bytes)
+     = (SELECT (data_compressed_bytes, data_uncompressed_bytes, marks_bytes) FROM system.columns
+        WHERE database = currentDatabase() AND table = 'sizes_src' AND name = 'x')
+    FROM system.columns WHERE database = currentDatabase() AND table = 'tablefunc11';
 
--- Not covered: `lifetime_rows`/`lifetime_bytes` (only `Buffer` reports them), a forwarded lock (only a `timeSeries*` target holds one), `tryGetColumnSizes` (no proxy overrides it) and the `StorageTableProxy` stand-in of `lazy_load_tables`.
+-- Not covered: `lifetime_rows`/`lifetime_bytes` (only `Buffer` reports them), a forwarded lock
+-- (only a `timeSeries*` target holds one), `tryGetColumnSizes` (no proxy overrides it) and the
+-- `StorageTableProxy` stand-in of `lazy_load_tables`.
 
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier};

--- a/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.sql
+++ b/tests/queries/0_stateless/02888_system_tables_with_inaccessible_table_function.sql
@@ -51,6 +51,8 @@ SELECT engine FROM system.tables WHERE name = 'tablefunc01' and database=current
 SYSTEM STOP MERGES {CLICKHOUSE_DATABASE:Identifier}.tablefunc07;
 SYSTEM START MERGES {CLICKHOUSE_DATABASE:Identifier}.tablefunc07;
 SELECT lifetime_rows, lifetime_bytes FROM system.tables WHERE database = currentDatabase() AND name = 'tablefunc07';
+SELECT name, data_compressed_bytes, data_uncompressed_bytes, marks_bytes
+    FROM system.columns WHERE database = currentDatabase() AND table = 'tablefunc07';
 
 -- Once the table function is resolved, the nested storage answers again.
 CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.mem (x UInt64) ENGINE = Memory;
@@ -89,6 +91,20 @@ DROP TABLE IF EMPTY {CLICKHOUSE_DATABASE:Identifier}.tablefunc10 SETTINGS ignore
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 'tablefunc10';
 SELECT count() FROM {CLICKHOUSE_DATABASE:Identifier}.mem;
 
--- Not covered: `lifetime_rows`/`lifetime_bytes` (only `Buffer` reports them) and a forwarded lock (only a `timeSeries*` target holds one).
+-- The column sizes of a resolved proxy come from the nested storage. Only a wide part tracks them
+-- per column, so a compact one would report zero either way.
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.sizes_src (x String) ENGINE = MergeTree ORDER BY x
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO {CLICKHOUSE_DATABASE:Identifier}.sizes_src SELECT toString(number) FROM numbers(10000);
+SELECT data_compressed_bytes > 0 FROM system.columns
+    WHERE database = currentDatabase() AND table = 'sizes_src';
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.tablefunc11 (x String) AS merge(currentDatabase(), '^sizes_src$');
+SELECT data_compressed_bytes > 0 FROM system.columns
+    WHERE database = currentDatabase() AND table = 'tablefunc11';
+SELECT count() FROM {CLICKHOUSE_DATABASE:Identifier}.tablefunc11;
+SELECT data_compressed_bytes > 0 FROM system.columns
+    WHERE database = currentDatabase() AND table = 'tablefunc11';
+
+-- Not covered: `lifetime_rows`/`lifetime_bytes` (only `Buffer` reports them), a forwarded lock (only a `timeSeries*` target holds one), `tryGetColumnSizes` (no proxy overrides it) and the `StorageTableProxy` stand-in of `lazy_load_tables`.
 
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier};


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A table created with `CREATE TABLE ... AS <table function>(...)` is no longer resolved to answer a `system.columns` size query about it. Previously selecting `data_compressed_bytes`, `data_uncompressed_bytes` or `marks_bytes` contacted the endpoint of every such table, so one unreachable endpoint made the whole scan fail. Until such a table is first accessed it now reports zero sizes.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/55027

Follows merged #116774, which closed this class for `system.tables` and disclosed this residual: "Not addressed: the same gap on that proxy and on `getColumnSizes` (`system.columns`)".

```sql
CREATE TABLE t_url (x String) AS url('http://some_addr:9000/nonexistent');
SELECT name, data_compressed_bytes FROM system.columns WHERE table = 't_url';
-- Code: 198 ... Not found address of host: some_addr ... While executing Columns. (DNS_ERROR)
```

The same query without a size column returns the row fine, so a local catalog scan is refused only because an unrelated remote endpoint is unreachable.

**Root cause.** `StorageSystemColumns` fetches the size map only when a size column is selected, and asks through `tryGetColumnSizes`. Nothing in the table-function proxy chain overrides it, so `IStorage`'s default runs, and its body is a virtual call to `getColumnSizes`, which `StorageProxy` forwards through `getNested`. For `StorageTableFunctionProxy` that executes the table function.

**Change.** Two non-forcing overrides in one header, in the block the six from #116774 already occupy: forward when the nested storage exists, otherwise return an empty map, which the caller already renders as zero.

**Disclosed.** An unresolved `file`, `url` or object-storage proxy now reports zero rather than the fabricated `getFakeColumnSizes` constants it reports once resolved; those are a prewhere hint, not a measurement, and prewhere runs on a resolved storage. A resolved `merge` proxy over a dropped database still propagates `UNKNOWN_DATABASE`, since the proxy routes through `getColumnSizes` rather than `tryGetColumnSizes`. The same gap on `StorageTableProxy` (`lazy_load_tables`) is out of scope here and covered by #113389.

**Validation.** The extended test fails on master on two independent lines and passes with the fix, 50 of 50 runs and 50 of 50 on S3 storage. Reading such a table still reports the real error, and a resolved proxy still reports the nested storage's real sizes.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118302&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118302](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118302+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.819` (included in `26.9` and later)
<!-- ch-version-info:end -->