### PR TITLE
Document `show_named_collections_secrets` in the default configs

### DIFF
--- a/docs/concepts/features/configuration/server-config/named-collections.mdx
+++ b/docs/concepts/features/configuration/server-config/named-collections.mdx
@@ -61,6 +61,8 @@ To manage named collections with DDL a user must have the `named_collection_cont
       <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex replace=true>
       <access_management>1</access_management>
       <named_collection_control>1</named_collection_control>
+      <!-- Uncomment to also let this user see the values stored in named collections. -->
+      <!-- <show_named_collections_secrets>1</show_named_collections_secrets> -->
     </default>
   </users>
 </clickhouse>
@@ -69,6 +71,8 @@ To manage named collections with DDL a user must have the `named_collection_cont
 <Tip>
 In the above example the `password_sha256_hex` value is the hexadecimal representation of the SHA256 hash of the password.  This configuration for the user `default` has the attribute `replace=true` as in the default configuration has a plain text `password` set, and it is not possible to have both plain text and sha256 hex passwords set for a user.
 </Tip>
+
+`named_collection_control` allows the user to create, alter and drop named collections, but not to read back the values that are already stored in them. That is a separate privilege, `SHOW NAMED COLLECTIONS SECRETS`, enabled by the [`show_named_collections_secrets`](/concepts/features/configuration/settings/settings-users#show_named_collections_secrets-user-setting) setting. A user can only grant the privileges that they have themselves, so while `show_named_collections_secrets` is disabled, the user does not have the complete set of privileges and `GRANT ALL ON *.* TO another_user WITH GRANT OPTION` is rejected with `(Missing permissions: SHOW NAMED COLLECTIONS SECRETS ON *)`.
 
 ### Storage for named collections {#storage-for-named-collections}
 

--- a/docs/concepts/features/configuration/settings/settings-users.mdx
+++ b/docs/concepts/features/configuration/settings/settings-users.mdx
@@ -54,6 +54,8 @@ Structure of the `users` section:
         </auth_methods>
 
         <access_management>0|1</access_management>
+        <named_collection_control>0|1</named_collection_control>
+        <show_named_collections_secrets>0|1</show_named_collections_secrets>
 
         <networks incl="networks" replace="replace">
         </networks>
@@ -292,6 +294,46 @@ Possible values:
 - 1 — Enabled.
 
 Default value: 0.
+
+### named_collection_control {#named_collection_control-user-setting}
+
+This setting enables or disables the management of [named collections](/concepts/features/configuration/server-config/named-collections) for the user.
+It corresponds to the `NAMED COLLECTION ADMIN` privilege, except for `SHOW NAMED COLLECTIONS SECRETS`, which is controlled separately by [`show_named_collections_secrets`](#show_named_collections_secrets-user-setting).
+
+`named_collection_admin` is accepted as a synonym of this setting.
+
+Possible values:
+
+- 0 — Disabled.
+- 1 — Enabled.
+
+Default value: 0.
+
+### show_named_collections_secrets {#show_named_collections_secrets-user-setting}
+
+This setting enables or disables the `SHOW NAMED COLLECTIONS SECRETS` privilege for the user, which allows the user to see the values stored in [named collections](/concepts/features/configuration/server-config/named-collections), for example in the [`system.named_collections`](/reference/system-tables/named_collections) table.
+
+It is disabled by default: being able to manage named collections does not mean being able to read back the credentials that are already stored in them.
+
+This setting only has an effect together with `named_collection_control`, because with `named_collection_control` disabled all named collection privileges, including `SHOW NAMED COLLECTIONS SECRETS`, are revoked anyway.
+
+Possible values:
+
+- 0 — Disabled.
+- 1 — Enabled.
+
+Default value: 0.
+
+<Note>
+A user can only grant the privileges that they have themselves, so a user for whom any of `access_management`, `named_collection_control` and `show_named_collections_secrets` is disabled does not have the complete set of privileges and cannot pass it on to somebody else. For example, `GRANT ALL ON *.* TO another_user WITH GRANT OPTION` is rejected for a user with only `access_management` and `named_collection_control` enabled:
+
+```text
+Not enough privileges. To execute this query, it's necessary to have the grant ALL ON *.* WITH GRANT OPTION.
+(Missing permissions: SHOW NAMED COLLECTIONS SECRETS ON *)
+```
+
+Enable all three settings to make the user a complete administrator.
+</Note>
 
 ### grants {#grants-user-setting}
 

--- a/docs/concepts/features/security/access-rights.mdx
+++ b/docs/concepts/features/security/access-rights.mdx
@@ -157,7 +157,16 @@ Management queries:
 
 - Enable SQL-driven access control and account management for at least one user account.
 
-    By default, SQL-driven access control and account management is disabled for all users. You need to configure at least one user in the `users.xml` configuration file and set the values of the [`access_management`](/concepts/features/configuration/settings/settings-users#access_management-user-setting), `named_collection_control`, `show_named_collections`, and `show_named_collections_secrets` settings to 1.
+    The `users.xml` configuration file that ships with ClickHouse enables SQL-driven access control and account management for the `default` user by setting [`access_management`](/concepts/features/configuration/settings/settings-users#access_management-user-setting) and [`named_collection_control`](/concepts/features/configuration/settings/settings-users#named_collection_control-user-setting) to 1. For every other user both settings default to 0, so you need to set them explicitly.
+
+    [`show_named_collections_secrets`](/concepts/features/configuration/settings/settings-users#show_named_collections_secrets-user-setting) defaults to 0 even for the `default` user, because being able to manage named collections does not mean being able to read back the credentials that are already stored in them. A user can only grant the privileges that they have themselves, so as long as this setting is 0, the user does not have the complete set of privileges and a query such as `GRANT ALL ON *.* TO clickhouse_admin WITH GRANT OPTION` is rejected:
+
+    ```text
+    Not enough privileges. To execute this query, it's necessary to have the grant ALL ON *.* WITH GRANT OPTION.
+    (Missing permissions: SHOW NAMED COLLECTIONS SECRETS ON *)
+    ```
+
+    Set all three settings to 1 to make the user a complete administrator.
 
 ## Defining SQL users and roles {#defining-sql-users-and-roles}
 
@@ -173,9 +182,12 @@ This article shows the basics of defining SQL users and roles and applying those
     ```xml
     <access_management>1</access_management>
     <named_collection_control>1</named_collection_control>
-    <show_named_collections>1</show_named_collections>
+    <!-- Needed to make the user a complete administrator,
+         otherwise `GRANT ALL ... WITH GRANT OPTION` below is rejected. -->
     <show_named_collections_secrets>1</show_named_collections_secrets>
     ```
+
+    The first two settings are already enabled for the `default` user in the `users.xml` file that ships with ClickHouse; `show_named_collections_secrets` is commented out there and has to be uncommented.
 
 <Note>
     The `default` user is the only user that gets created with a fresh install, and is also the account used for internode communications, by default.

--- a/docs/guides/oss/deployment-and-scaling/examples/1-shard-2-replicas.mdx
+++ b/docs/guides/oss/deployment-and-scaling/examples/1-shard-2-replicas.mdx
@@ -337,7 +337,6 @@ Now modify each empty configuration file `users.xml` located at
     </profiles>
     <users>
         <default>
-            <access_management>1</access_management>
             <profile>default</profile>
             <networks>
                 <ip>::/0</ip>
@@ -345,7 +344,6 @@ Now modify each empty configuration file `users.xml` located at
             <quota>default</quota>
             <access_management>1</access_management>
             <named_collection_control>1</named_collection_control>
-            <show_named_collections>1</show_named_collections>
             <show_named_collections_secrets>1</show_named_collections_secrets>
         </default>
     </users>

--- a/docs/guides/oss/deployment-and-scaling/examples/2-shards-1-replica.mdx
+++ b/docs/guides/oss/deployment-and-scaling/examples/2-shards-1-replica.mdx
@@ -355,7 +355,6 @@ Now modify each empty configuration file `users.xml` located at
     </profiles>
     <users>
         <default>
-            <access_management>1</access_management>
             <profile>default</profile>
             <networks>
                 <ip>::/0</ip>
@@ -363,7 +362,6 @@ Now modify each empty configuration file `users.xml` located at
             <quota>default</quota>
             <access_management>1</access_management>
             <named_collection_control>1</named_collection_control>
-            <show_named_collections>1</show_named_collections>
             <show_named_collections_secrets>1</show_named_collections_secrets>
         </default>
     </users>

--- a/docs/guides/oss/deployment-and-scaling/examples/2-shards-2-replicas.mdx
+++ b/docs/guides/oss/deployment-and-scaling/examples/2-shards-2-replicas.mdx
@@ -386,7 +386,6 @@ Now modify each empty configuration file `users.xml` located at
     </profiles>
     <users>
         <default>
-            <access_management>1</access_management>
             <profile>default</profile>
             <networks>
                 <ip>::/0</ip>
@@ -394,7 +393,6 @@ Now modify each empty configuration file `users.xml` located at
             <quota>default</quota>
             <access_management>1</access_management>
             <named_collection_control>1</named_collection_control>
-            <show_named_collections>1</show_named_collections>
             <show_named_collections_secrets>1</show_named_collections_secrets>
         </default>
     </users>

--- a/docs/integrations/connectors/data-ingestion/kafka/kafka-table-engine-named-collections.mdx
+++ b/docs/integrations/connectors/data-ingestion/kafka/kafka-table-engine-named-collections.mdx
@@ -29,7 +29,6 @@ Ensure the user creating the named collection has the necessary access permissio
 ```xml
 <access_management>1</access_management>
 <named_collection_control>1</named_collection_control>
-<show_named_collections>1</show_named_collections>
 <show_named_collections_secrets>1</show_named_collections_secrets>
 ```
 

--- a/programs/server/embedded.xml
+++ b/programs/server/embedded.xml
@@ -66,6 +66,11 @@
 
             <access_management>1</access_management>
             <named_collection_control>1</named_collection_control>
+
+            <!-- Uncomment to also let this user see the values stored in named collections.
+                 Without it the user does not have the complete set of privileges,
+                 and a query such as `GRANT ALL ON *.* TO another_user WITH GRANT OPTION` will be rejected. -->
+            <!-- <show_named_collections_secrets>1</show_named_collections_secrets> -->
         </default>
     </users>
 

--- a/programs/server/users.xml
+++ b/programs/server/users.xml
@@ -114,6 +114,19 @@
             <!-- User can manipulate named collections. -->
             <named_collection_control>1</named_collection_control>
 
+            <!-- User can see the values stored in named collections, e.g. in the `system.named_collections` table.
+                 It is disabled by default: being able to manage named collections does not mean
+                 being able to read back the credentials that are already stored in them.
+
+                 Note that a user without this permission does not have the complete set of privileges,
+                 and therefore cannot pass the complete set on to somebody else: a query such as
+                 `GRANT ALL ON *.* TO another_user WITH GRANT OPTION` will be rejected with
+                 `Not enough privileges. ... (Missing permissions: SHOW NAMED COLLECTIONS SECRETS ON *)`,
+                 because a user can only grant the privileges that they have themselves.
+                 Uncomment the setting below to make this user a complete administrator.
+            -->
+            <!-- <show_named_collections_secrets>1</show_named_collections_secrets> -->
+
             <!-- User permissions can be granted here -->
             <!--
             <grants>


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/47092

The `default` user in the `users.xml` file that ships with ClickHouse has `access_management` and `named_collection_control` enabled, but not `show_named_collections_secrets`, so it does not have the complete set of privileges. A user can only grant the privileges that they have themselves, so `GRANT ALL ON *.* TO clickhouse_admin WITH GRANT OPTION` - the query the documentation tells you to run when bootstrapping a SQL administrator - is rejected:

```
Not enough privileges. To execute this query, it's necessary to have the grant ALL ON *.* WITH GRANT OPTION.
(Missing permissions: SHOW NAMED COLLECTIONS SECRETS ON *)
```

That is what the reporters of #47092 keep running into. It is not visible in CI, because `tests/config/users.d/access_management.xml` sets all three settings.

The behaviour is deliberately left as it is: being able to manage named collections does not mean being able to read back the credentials that are already stored in them, and that separation is worth keeping. What this changes is discoverability.

- `programs/server/users.xml` and `programs/server/embedded.xml` now carry `show_named_collections_secrets` commented out next to the other two settings, with a comment that explains why it is disabled and what leaving it disabled costs. Uncommenting the single line turns `SHOW GRANTS` for `default` into `GRANT ALL ON *.* TO default WITH GRANT OPTION`.
- The documentation asked for a `show_named_collections` setting that `UsersConfigParser` does not read at all - it was folded into `NAMED COLLECTION ADMIN` - so a reader who followed it word for word still ended up without the complete set of privileges. Removed from the four English pages that carried it.
- The documentation claimed that SQL-driven access control is disabled by default for every user, which stopped being true for `default` in 23.11.
- Added reference sections for `named_collection_control` and `show_named_collections_secrets`, including the fact that `show_named_collections_secrets` has no effect on its own, and that `named_collection_admin` is an accepted synonym of `named_collection_control`.

Verified against a local server with the shipped `users.xml`: unchanged with the new comment in place, and `GRANT ALL ON *.* TO default WITH GRANT OPTION` once the line is uncommented.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118303&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118303](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118303+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
