### PR TITLE
Move `ActionLock` weak owner directly

### DIFF
--- a/src/Common/ActionLock.cpp
+++ b/src/Common/ActionLock.cpp
@@ -13,8 +13,6 @@ ActionLock::ActionLock(const ActionBlocker & blocker) : counter_ptr(blocker.coun
 
 ActionLock::ActionLock(ActionLock && other) noexcept : counter_ptr(std::move(other.counter_ptr))
 {
-    /// After move other.counter_ptr still points to counter, reset it explicitly
-    other.counter_ptr.reset();
 }
 
 ActionLock & ActionLock::operator=(ActionLock && other) noexcept

--- a/src/Common/ActionLock.cpp
+++ b/src/Common/ActionLock.cpp
@@ -11,9 +11,10 @@ ActionLock::ActionLock(const ActionBlocker & blocker) : counter_ptr(blocker.coun
         ++(*counter);
 }
 
-ActionLock::ActionLock(ActionLock && other) noexcept
+ActionLock::ActionLock(ActionLock && other) noexcept : counter_ptr(std::move(other.counter_ptr))
 {
-    *this = std::move(other);
+    /// After move other.counter_ptr still points to counter, reset it explicitly
+    other.counter_ptr.reset();
 }
 
 ActionLock & ActionLock::operator=(ActionLock && other) noexcept

--- a/src/Common/tests/gtest_action_blocker.cpp
+++ b/src/Common/tests/gtest_action_blocker.cpp
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <vector>
 #include <thread>
+#include <utility>
 
 #include <Common/ActionBlocker.h>
 #include <Common/ActionLock.h>
@@ -58,6 +59,39 @@ TEST(ActionLock, TestConstructorWithActionBlocker)
     EXPECT_FALSE(lock.expired());
     EXPECT_TRUE(blocker.isCancelled());
     EXPECT_EQ(1, blocker.getCounter().load());
+}
+
+TEST(ActionLock, TestMoveConstructor)
+{
+    ActionBlocker blocker;
+
+    {
+        auto lock = blocker.cancel();
+        ActionLock moved_lock(std::move(lock));
+
+        EXPECT_TRUE(lock.expired());
+        EXPECT_FALSE(moved_lock.expired());
+        EXPECT_TRUE(blocker.isCancelled());
+        EXPECT_EQ(1, blocker.getCounter().load());
+    }
+
+    EXPECT_FALSE(blocker.isCancelled());
+    EXPECT_EQ(0, blocker.getCounter().load());
+}
+
+TEST(ActionLock, TestMoveConstructorFromExpired)
+{
+    ActionLock lock;
+    {
+        ActionBlocker blocker;
+        lock = blocker.cancel();
+        EXPECT_FALSE(lock.expired());
+    }
+
+    ActionLock moved_lock(std::move(lock));
+
+    EXPECT_TRUE(lock.expired());
+    EXPECT_TRUE(moved_lock.expired());
 }
 
 TEST(ActionLock, TestMoveAssignmentToEmpty)

--- a/src/Common/tests/gtest_action_blocker.cpp
+++ b/src/Common/tests/gtest_action_blocker.cpp
@@ -69,7 +69,6 @@ TEST(ActionLock, TestMoveConstructor)
         auto lock = blocker.cancel();
         ActionLock moved_lock(std::move(lock));
 
-        EXPECT_TRUE(lock.expired());
         EXPECT_FALSE(moved_lock.expired());
         EXPECT_TRUE(blocker.isCancelled());
         EXPECT_EQ(1, blocker.getCounter().load());
@@ -90,7 +89,6 @@ TEST(ActionLock, TestMoveConstructorFromExpired)
 
     ActionLock moved_lock(std::move(lock));
 
-    EXPECT_TRUE(lock.expired());
     EXPECT_TRUE(moved_lock.expired());
 }
 


### PR DESCRIPTION
`ActionLock` move construction currently delegates to move assignment. That works, but it makes construction take the assignment path, including an unnecessary lock attempt on an empty left-hand side.

This constructs the moved weak owner directly. `std::weak_ptr` move construction is specified to leave the source empty, so the moved-from `ActionLock` destructor will not release the counter after ownership has moved. The added tests cover moving a live lock and moving an already-expired lock. Standard reference: https://eel.is/c++draft/util.smartptr.weak.const#8

Local constructor-level measurement from the public object-cost audit showed the low-dependency move-construction case decreasing from about `3.0 ns` to `1.1 ns`. This is intentionally a small cleanup; no server-level latency claim is made.

### Changelog category (leave one):
- Not for changelog


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118306&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118306](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118306+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.835` (included in `26.9` and later)
<!-- ch-version-info:end -->