### PR TITLE
Use emplacement for `ProfileEvents` snapshots

### DIFF
--- a/src/Interpreters/ProfileEventsExt.cpp
+++ b/src/Interpreters/ProfileEventsExt.cpp
@@ -176,7 +176,7 @@ DB::Block getProfileEvents(
             prev_group_snapshot != last_sent_snapshots.end()
             ? CountersIncrement(group_counters, prev_group_snapshot->second)
             : CountersIncrement(group_counters);
-        new_snapshots[0] = std::move(group_counters);
+        new_snapshots.emplace(0, std::move(group_counters));
     }
     last_sent_snapshots = std::move(new_snapshots);
 


### PR DESCRIPTION
Avoid default-constructing and then move-assigning a `ProfileEvents::Counters::Snapshot` in the one-entry `ThreadIdToCountersSnapshot` map created for profile-event packets.

`new_snapshots` is a local empty map in `ProfileEvents::getProfileEvents`, and key `0` is the fixed group snapshot key. Constructing the value with `emplace` preserves the key behavior while avoiding one temporary empty `Counters::Snapshot` value before the real snapshot is moved into the map.

Local object-cost research measured the old path as creating one avoidable `Counters::Snapshot` allocation for each emitted profile-events sample. At the measured event count that temporary snapshot requested 12,464 bytes and occupied 14,336 bytes in the allocator, but this change does not alter retained profile-event state or protocol output.

### Changelog category (leave one):
- Not for changelog


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118308&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118308](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118308+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
