### PR TITLE
Move `ActionLock` weak owner directly

### DIFF
--- a/src/Common/ActionLock.cpp
+++ b/src/Common/ActionLock.cpp
@@ -11,9 +11,10 @@ ActionLock::ActionLock(const ActionBlocker & blocker) : counter_ptr(blocker.coun
         ++(*counter);
 }
 
-ActionLock::ActionLock(ActionLock && other) noexcept
+ActionLock::ActionLock(ActionLock && other) noexcept : counter_ptr(std::move(other.counter_ptr))
 {
-    *this = std::move(other);
+    /// After move other.counter_ptr still points to counter, reset it explicitly
+    other.counter_ptr.reset();
 }
 
 ActionLock & ActionLock::operator=(ActionLock && other) noexcept

--- a/src/Common/tests/gtest_action_blocker.cpp
+++ b/src/Common/tests/gtest_action_blocker.cpp
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <vector>
 #include <thread>
+#include <utility>
 
 #include <Common/ActionBlocker.h>
 #include <Common/ActionLock.h>
@@ -58,6 +59,39 @@ TEST(ActionLock, TestConstructorWithActionBlocker)
     EXPECT_FALSE(lock.expired());
     EXPECT_TRUE(blocker.isCancelled());
     EXPECT_EQ(1, blocker.getCounter().load());
+}
+
+TEST(ActionLock, TestMoveConstructor)
+{
+    ActionBlocker blocker;
+
+    {
+        auto lock = blocker.cancel();
+        ActionLock moved_lock(std::move(lock));
+
+        EXPECT_TRUE(lock.expired());
+        EXPECT_FALSE(moved_lock.expired());
+        EXPECT_TRUE(blocker.isCancelled());
+        EXPECT_EQ(1, blocker.getCounter().load());
+    }
+
+    EXPECT_FALSE(blocker.isCancelled());
+    EXPECT_EQ(0, blocker.getCounter().load());
+}
+
+TEST(ActionLock, TestMoveConstructorFromExpired)
+{
+    ActionLock lock;
+    {
+        ActionBlocker blocker;
+        lock = blocker.cancel();
+        EXPECT_FALSE(lock.expired());
+    }
+
+    ActionLock moved_lock(std::move(lock));
+
+    EXPECT_TRUE(lock.expired());
+    EXPECT_TRUE(moved_lock.expired());
 }
 
 TEST(ActionLock, TestMoveAssignmentToEmpty)


### PR DESCRIPTION
Move construction of `ActionLock` can take ownership of the weak counter directly instead of delegating through move assignment on an empty target.

The constructor now initializes `counter_ptr` from the source lock and then resets the source lock, matching the existing move-assignment invariant that the moved-from lock must not decrement the counter later. The added tests cover both live-owner and expired-owner move construction: the live case keeps the cancellation count at `1` until the moved lock is destroyed, and the expired case remains expired after the move.

### Changelog category (leave one):
- Not for changelog


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118309&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118309](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118309+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
