### PR TITLE
Fix(PostgreSQL): COPY TSV format

### DIFF
--- a/src/Parsers/ParserCopyQuery.cpp
+++ b/src/Parsers/ParserCopyQuery.cpp
@@ -156,7 +156,7 @@ bool ParserCopyQuery::parseOptions(Pos & pos, boost::intrusive_ptr<ASTCopyQuery>
         if (format->as<ASTIdentifier>()->full_name == "csv")
             node->format = ASTCopyQuery::Formats::CSV;
         else if (format->as<ASTIdentifier>()->full_name == "tsv")
-            node->format = ASTCopyQuery::Formats::CSV;
+            node->format = ASTCopyQuery::Formats::TSV;
         else if (format->as<ASTIdentifier>()->full_name == "binary")
             node->format = ASTCopyQuery::Formats::Binary;
         else


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description in CHANGELOG.md):

Fix PostgreSQL wire-protocol `COPY` so `FORMAT tsv` uses the TSV format.

### Description

`FORMAT tsv` was assigned `ASTCopyQuery::Formats::CSV`. Change it to `ASTCopyQuery::Formats::TSV`.

### Tests

- `git diff --check`

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118319&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118319](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118319+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
