### PR TITLE
Keep 02932_refreshable_materialized_views_1's rmv_b refresh off the distributed cache write path

### DIFF
--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.reference
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.reference
@@ -8,7 +8,7 @@ CREATE MATERIALIZED VIEW default.rmv_a\nREFRESH EVERY 2 YEAR\n(\n    `x` UInt64\
 <5: no refresh>	3
 <6: refreshed>	2
 <7: refreshed>	Scheduled	2052-02-03 04:05:06	2054-01-01 00:00:00
-CREATE MATERIALIZED VIEW default.rmv_b\nREFRESH EVERY 2 YEAR DEPENDS ON default.rmv_a\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS y\nFROM default.rmv_a
+CREATE MATERIALIZED VIEW default.rmv_b\nREFRESH EVERY 2 YEAR DEPENDS ON default.rmv_a\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS y\nFROM default.rmv_a\nSETTINGS force_write_through_distributed_cache = 0
 <7.5: created dependent>	2052-11-11 11:11:11
 <8: refreshed>	20
 <9: refreshed>	rmv_a	Scheduled	2054-01-01 00:00:00
@@ -26,4 +26,5 @@ CREATE MATERIALIZED VIEW default.rmv_b\nREFRESH EVERY 2 YEAR DEPENDS ON default.
 <17: chain-refreshed>	rmv_a	Scheduled	2062-01-01 00:00:00
 <17: chain-refreshed>	rmv_b	Scheduled	2062-01-01 00:00:00
 <18: removed dependency>	rmv_b	Scheduled	2062-03-03 03:03:03	2062-03-03 03:03:03	2064-01-01 00:00:00
-CREATE MATERIALIZED VIEW default.rmv_b\nREFRESH EVERY 2 YEAR\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS y\nFROM default.rmv_a
+CREATE MATERIALIZED VIEW default.rmv_b\nREFRESH EVERY 2 YEAR\n(\n    `y` Int32\n)\nENGINE = MergeTree\nORDER BY y\nSETTINGS index_granularity = 8192\nDEFINER = default SQL SECURITY DEFINER\nAS SELECT x * 10 AS y\nFROM default.rmv_a\nSETTINGS force_write_through_distributed_cache = 0
+<19: pin reached the refresh>	['0']

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
@@ -130,8 +130,10 @@ $CLICKHOUSE_CLIENT -q "select '<6: refreshed>', * from rmv_a;"
 query_no_scheduling "select '<7: refreshed>', status, last_success_time, next_refresh_time from refreshes"
 
 # Create a dependent view, refresh it once.
+# A distributed cache write stalls a full receive timeout before retrying, and the retry envelope
+# can outlast the bounded waits below, so rmv_b's refresh commit is kept off that path.
 $CLICKHOUSE_CLIENT -q "
-    create materialized view rmv_b refresh every 2 year depends on rmv_a (y Int32) engine MergeTree order by y empty as select x*10 as y from rmv_a;
+    create materialized view rmv_b refresh every 2 year depends on rmv_a (y Int32) engine MergeTree order by y empty as select x*10 as y from rmv_a settings force_write_through_distributed_cache = 0;
     show create rmv_b;
     system test view rmv_b set fake time '2052-11-11 11:11:11';
     system refresh view rmv_b;
@@ -185,6 +187,13 @@ $CLICKHOUSE_CLIENT -q "
 wait_for "select status, last_refresh_time from refreshes where view = 'rmv_b' -- $LINENO" == 'Scheduled 2062-03-03 03:03:03'
 query_no_scheduling "select '<18: removed dependency>', view, status, last_success_time, last_refresh_time, next_refresh_time from refreshes where view = 'rmv_b'"
 $CLICKHOUSE_CLIENT -q "show create rmv_b;"
+# The pin is only useful if the refresh actually runs with it, which SHOW CREATE cannot show.
+$CLICKHOUSE_CLIENT -q "
+    system flush logs query_log;
+    select '<19: pin reached the refresh>', groupUniqArray(Settings['force_write_through_distributed_cache'])
+    from system.query_log
+    where event_date >= yesterday() and current_database = currentDatabase()
+      and log_comment like 'refresh of %.rmv_b%' and query_kind = 'Insert' and type = 'QueryFinish';"
 
 # Can't use the same time unit multiple times.
 $CLICKHOUSE_CLIENT -q "

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Tags: atomic-database
+# Tags: atomic-database, long
+# long: the refresh schedules this waits on put it right at the 180s cap the flaky check
+#   applies to untagged tests, so it tips over on some runs.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/114974
Related: https://github.com/ClickHouse/ClickHouse/pull/117032
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/114974
Related: https://github.com/ClickHouse/ClickHouse/pull/117032

The bounded waits involved come from #114974 and #117032, both mine and merged. No open issue tracks this one.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

**The problem.** The bounded waits here share one budget: `WAIT_TOTAL_S=30` less the dump and kill graces leaves `WAIT_POLL_S = 20` seconds of polling. Three cannot be satisfied until `rmv_b`'s refresh commits, and `rmv_b` is `engine MergeTree`, so committing means writing a part. Through a distributed cache, a lost connection on that write waits a full `distributed_cache_receive_timeout_milliseconds` (default `10000`, `src/Core/Settings.cpp:7602`) before its first retry, and ten attempts are permitted (`:7596`). One stall consumes half the window and the retry envelope can outlast it, so the wait expires with the view still `Running` and its row counters already final.

Widening the window is not available: `--timeout` is per test case and Fast test passes `--timeout 60` (`ci/jobs/fast_test.py:386`), so a budget big enough for the retry envelope would be killed before the expiry diagnostic printed.

**The change.** Pin `force_write_through_distributed_cache = 0` on `rmv_b`'s stored SELECT, which "Overrides the server setting `enable_write_through_distributed_cache` for a single query" (`Settings.cpp:7578`). Only that refresh's part write leaves the cache path; the setting is inert without a distributed cache. Stored SELECT settings do reach a background refresh, through `InterpreterSetQuery::applySettingsFromQuery` in `StorageMaterializedView::prepareRefresh` (`StorageMaterializedView.cpp:665`). Two `SHOW CREATE rmv_b` reference lines gain the rendered clause. No timing constant, tag or source change.

**Validation.** The test now asserts the pin on the refresh's own `INSERT` into the temp inner table, read from `system.query_log` and located by `log_comment`, since the client's `CREATE` records the setting too. Removing the clause reds that assertion (the setting reads unset), so it cannot regress silently. The reference was regenerated with `clickhouse-test --record`. 50/50 randomized runs pass, slowest 13.4 s; `_2` and `_3` stay green and deliberately unpinned, keeping coverage of refresh commits into MergeTree targets.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118345&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118345](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118345+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.241` (included in `26.10` and later)
<!-- ch-version-info:end -->