### PR TITLE
Build the PREWHERE and row-level filter sets when a query is planned to `FetchColumns`

### DIFF
--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2711,17 +2711,6 @@ void Planner::buildPlanForQueryNode()
         QueryProcessingStage::toString(select_query_options.to_stage),
         select_query_options.only_analyze ? " only analyze" : "");
 
-    if (select_query_options.to_stage == QueryProcessingStage::FetchColumns)
-        return;
-
-    PlannerQueryProcessingInfo query_processing_info(from_stage, select_query_options.to_stage);
-    QueryAnalysisResult query_analysis_result(query_tree, query_processing_info, planner_context);
-    auto expression_analysis_result = buildExpressionAnalysisResult(query_tree,
-        query_plan.getCurrentHeader()->getColumnsWithTypeAndName(),
-        planner_context,
-        query_processing_info,
-        join_tree_query_plan.source_constants);
-
     auto useful_sets = std::move(join_tree_query_plan.useful_sets);
 
     for (auto & [_, table_expression_data] : planner_context->getTableExpressionNodeToData())
@@ -2732,6 +2721,23 @@ void Planner::buildPlanForQueryNode()
         if (table_expression_data.getRowLevelFilterActions())
             appendSetsFromActionsDAG(*table_expression_data.getRowLevelFilterActions(), useful_sets);
     }
+
+    if (select_query_options.to_stage == QueryProcessingStage::FetchColumns)
+    {
+        /// The reader evaluates PREWHERE and row-level filter expressions itself, so the sets they
+        /// reference need their sources attached even though no expression step is added past here.
+        if (!select_query_options.only_analyze)
+            addBuildSubqueriesForSetsStepIfNeeded(query_plan, select_query_options, planner_context, useful_sets);
+        return;
+    }
+
+    PlannerQueryProcessingInfo query_processing_info(from_stage, select_query_options.to_stage);
+    QueryAnalysisResult query_analysis_result(query_tree, query_processing_info, planner_context);
+    auto expression_analysis_result = buildExpressionAnalysisResult(query_tree,
+        query_plan.getCurrentHeader()->getColumnsWithTypeAndName(),
+        planner_context,
+        query_processing_info,
+        join_tree_query_plan.source_constants);
 
     if (query_processing_info.isIntermediateStage())
     {

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.reference
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.reference
@@ -1,0 +1,5 @@
+k	UInt64					
+v	Variant(Int64, UInt64)					
+16
+16
+8

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.reference
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.reference
@@ -1,5 +1,5 @@
 k	UInt64					
 v	Variant(Int64, UInt64)					
-16
-16
 8
+8
+4

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.reference
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.reference
@@ -3,3 +3,4 @@ v	Variant(Int64, UInt64)
 8
 8
 4
+8

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
@@ -1,0 +1,29 @@
+-- Tags: shard
+
+-- A `Merge` asks every child for a processing stage. A child column that does not convert to the
+-- merged header type order-preservingly forces that stage down to `FetchColumns`, and a
+-- `Distributed` child then forwards `FetchColumns` to the shard, which plans the whole query
+-- there, PREWHERE included.
+
+SET prefer_localhost_replica = 0;
+
+CREATE TABLE t_fc_u (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t_fc_i (k UInt64, v Int64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_fc_u SELECT number, number FROM numbers(4);
+INSERT INTO t_fc_i SELECT number, number FROM numbers(4);
+CREATE TABLE t_fc_dist_u AS t_fc_u ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), t_fc_u);
+CREATE TABLE t_fc_dist_i AS t_fc_i ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), t_fc_i);
+
+-- `v` is the column whose conversion into the merged header type is not order-preserving, so it is
+-- what puts the queries below on the `FetchColumns` path. Pinned, so a change to the type
+-- unification reddens here instead of leaving those queries exercising nothing.
+DESCRIBE TABLE merge(currentDatabase(), '^t_fc_dist_[ui]$');
+
+-- PREWHERE is evaluated by the reader itself, so its set has to be built on the shard.
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u);
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u) SETTINGS prefer_localhost_replica = 1;
+
+-- Control: a single matched table needs no type unification, so its stage is delegated as usual and
+-- this line passes without the fix. It keeps the test keyed on the stage rather than on `merge()`
+-- plus `GLOBAL IN` in general.
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_u$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u);

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
@@ -19,11 +19,13 @@ CREATE TABLE t_fc_dist_i AS t_fc_i ENGINE = Distributed(test_cluster_two_shards_
 -- unification reddens here instead of leaving those queries exercising nothing.
 DESCRIBE TABLE merge(currentDatabase(), '^t_fc_dist_[ui]$');
 
--- PREWHERE is evaluated by the reader itself, so its set has to be built on the shard.
-SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u);
-SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u) SETTINGS prefer_localhost_replica = 1;
+-- PREWHERE is evaluated by the reader itself, so its set has to be built on the shard. Every set
+-- below is a strict subset of the keys present, so the counts also distinguish a read that applied
+-- the predicate from one that ignored it.
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u WHERE k < 2);
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u WHERE k < 2) SETTINGS prefer_localhost_replica = 1;
 
 -- Control: a single matched table needs no type unification, so its stage is delegated as usual and
 -- this line passes without the fix. It keeps the test keyed on the stage rather than on `merge()`
 -- plus `GLOBAL IN` in general.
-SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_u$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u);
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_u$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u WHERE k < 2);

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
@@ -26,6 +26,13 @@ SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOB
 SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u WHERE k < 2) SETTINGS prefer_localhost_replica = 1;
 
 -- Control: a single matched table needs no type unification, so its stage is delegated as usual and
--- this line passes without the fix. It keeps the test keyed on the stage rather than on `merge()`
+-- this line passes without the fix. It keeps the test keyed on the stage rather than on `merge`
 -- plus `GLOBAL IN` in general.
 SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_u$') PREWHERE k GLOBAL IN (SELECT k FROM t_fc_dist_u WHERE k < 2);
+
+-- A row-level filter is the reader's other set carrier. The policy predicate holds the only set
+-- here, so with `PREWHERE k < 4` matching every row the count is decided by the policy alone. It
+-- reads `numbers` because the predicate is re-resolved on the shard, where a table name does not.
+CREATE ROW POLICY r05099 ON t_fc_u, t_fc_i USING k IN (SELECT number FROM numbers(2)) TO ALL;
+SELECT count() FROM merge(currentDatabase(), '^t_fc_dist_[ui]$') PREWHERE k < 4;
+DROP ROW POLICY r05099 ON t_fc_u, t_fc_i;

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
@@ -7,6 +7,11 @@
 
 SET prefer_localhost_replica = 0;
 
+-- Pinned off: with a serialized plan the `Merge` gets an empty header for its `Distributed` child
+-- at `FetchColumns`, so on master every query over this shape already fails with
+-- `THERE_IS_NO_COLUMN` - a set-free `PREWHERE k < 4` included. #113413 covers that, not this test.
+SET serialize_query_plan = 0;
+
 CREATE TABLE t_fc_u (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k;
 CREATE TABLE t_fc_i (k UInt64, v Int64) ENGINE = MergeTree ORDER BY k;
 INSERT INTO t_fc_u SELECT number, number FROM numbers(4);

--- a/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
+++ b/tests/queries/0_stateless/05099_prewhere_global_in_fetch_columns_stage.sql
@@ -7,6 +7,11 @@
 
 SET prefer_localhost_replica = 0;
 
+-- Pinned on: the old analyzer answers 0 for any `PREWHERE` over this shape, set or not, and fails a
+-- bare `count()` over it with `THERE_IS_NO_COLUMN`. That is a separate pre-existing defect, and the
+-- planner exercised below is the analyzer's.
+SET enable_analyzer = 1;
+
 -- Pinned off: with a serialized plan the `Merge` gets an empty header for its `Distributed` child
 -- at `FetchColumns`, so on master every query over this shape already fails with
 -- `THERE_IS_NO_COLUMN` - a set-free `PREWHERE k < 4` included. #113413 covers that, not this test.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/96886


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `Not-ready Set is passed as the second argument for function 'globalIn'` when a `PREWHERE` or row-level filter expression containing an `IN` subquery is evaluated by a query planned to the `FetchColumns` stage, for example a shard query behind `Merge` over `Distributed`, or `clickhouse-client --stage fetch_columns`.


### Description

`Planner::buildPlanForQueryNode` returned early when `to_stage == FetchColumns`, and that return preceded both the `useful_sets` construction and the sole call of `addBuildSubqueriesForSetsStepIfNeeded`. `setQueryPlan`, reached only from inside that builder, is the only filler of `FutureSetFromSubquery::source`, so a `FetchColumns` planner run could never attach a set source: no `DelayedCreatingSetsStep` is added and the reader threads abort in `FunctionIn::executeImpl` (`in.cpp:155`) below `MergeTreeRangeReader::executePrewhereActionsAndFilterColumns`. A read at that stage still evaluates `PREWHERE` and row-level filters itself, so those sets are needed there. The old analyzer is no reference here: at that stage it silently returns no rows for the same query.

This moves the `useful_sets` construction above the early return and calls the existing builder inside it, under the same `!only_analyze` gate. The adjacent `addBuildSubqueriesForMaterializedCTEsIfNeeded` is deliberately left alone: a set subquery over a materialized CTE already works there.

Reachable two ways: a `Merge` whose child column does not convert order-preservingly falls back to `FetchColumns` and a `Distributed` child forwards that stage to the shard ([reported failure](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=96886&sha=e63fb36ee9e42d3065ac5b0c12b56bff50b205c0&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29), also on master); or `clickhouse-client --stage fetch_columns`, with no `Merge` or `Distributed`.

Every asserted line of the new test aborts an unfixed server with that message and those frames (`'globalIn'` for the `PREWHERE` arms, `'in'` for the row-policy one), and each count separates a filtered read from an unfiltered one. The arms cover the shard route, the `prefer_localhost_replica = 1` local plan, and a row policy as the reader's other set carrier; a single-table control passes on both trees, keeping the test keyed on the stage. A serial, randomization-free A/B over 145 related tests is identical on both trees.

#114955 adds the same attachment in `resolveStorages.cpp`, on the serialized-plan route and only when a row policy is re-planned there, so whichever merges second drops a now-redundant call.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118359&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118359](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118359+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1429` (included in `26.9` and later)
<!-- ch-version-info:end -->