### PR TITLE
Range-check a `UInt64` constant converted to `DateTime`

### DIFF
--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -398,8 +398,11 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
 
         if (which_type.isDateTime() && src.getType() == Field::Types::UInt64)
         {
-            /// `DateTime` stores `UInt32` under the hood, so `UInt64` is the canonical `Field` type and no conversion is needed.
-            return src;
+            /// `DateTime` stores `UInt32` under the hood, so `UInt64` is the canonical `Field` type,
+            /// but only a value that fits `UInt32` is representable: range-check it, or the column
+            /// insertion downstream truncates it modulo 2^32 and an exact `IN` constant matches an
+            /// unrelated row - `dt IN (toUInt64(4294967296))` matched the epoch row.
+            return convertNumericType<UInt32>(src, type, strict, convert_inexact_floats);
         }
 
         if (which_type.isTime() && (src.getType() == Field::Types::UInt64 || src.getType() == Field::Types::Int64))

--- a/tests/queries/0_stateless/05099_datetime_set_constant_range.reference
+++ b/tests/queries/0_stateless/05099_datetime_set_constant_range.reference
@@ -1,0 +1,17 @@
+a constant that does not fit the column
+0
+0
+3
+an OR chain of equalities, which the rewrite turns into IN
+0
+0
+a mixed set keeps the members that do fit
+1
+2
+constants that do fit are unchanged
+2
+0
+1
+the values table function takes the same path
+1970-01-01 00:00:01
+1970-01-01 00:00:01

--- a/tests/queries/0_stateless/05099_datetime_set_constant_range.sql
+++ b/tests/queries/0_stateless/05099_datetime_set_constant_range.sql
@@ -1,0 +1,38 @@
+-- A `DateTime` stores a `UInt32`, so a `UInt64` constant that does not fit it cannot equal any value
+-- of the column. The set builder took such a constant unchanged, and the column insertion truncated
+-- it modulo 2^32: `dt IN (toUInt64(4294967296))` matched the epoch row, and the `OR` chain that the
+-- disjunction rewrite turns into `IN` returned every row it wrapped onto.
+
+DROP TABLE IF EXISTS t_datetime_set;
+CREATE TABLE t_datetime_set (dt DateTime('UTC')) ENGINE = MergeTree ORDER BY dt;
+INSERT INTO t_datetime_set VALUES (0), (1), (2);
+
+SELECT 'a constant that does not fit the column';
+SELECT count() FROM t_datetime_set WHERE dt = toUInt64(4294967296);
+SELECT count() FROM t_datetime_set WHERE dt IN (toUInt64(4294967296));
+SELECT count() FROM t_datetime_set WHERE dt NOT IN (toUInt64(4294967296));
+
+SELECT 'an OR chain of equalities, which the rewrite turns into IN';
+SELECT count() FROM t_datetime_set
+WHERE dt = toUInt64(4294967296) OR dt = toUInt64(4294967297) OR dt = toUInt64(4294967298);
+SELECT count() FROM t_datetime_set
+WHERE dt = toUInt64(4294967296) OR dt = toUInt64(4294967297) OR dt = toUInt64(4294967298)
+SETTINGS optimize_min_equality_disjunction_chain_length = 100;
+
+SELECT 'a mixed set keeps the members that do fit';
+SELECT count() FROM t_datetime_set WHERE dt IN (toUInt64(1), toUInt64(4294967296));
+SELECT count() FROM t_datetime_set WHERE dt NOT IN (toUInt64(1), toUInt64(4294967296));
+
+SELECT 'constants that do fit are unchanged';
+SELECT count() FROM t_datetime_set WHERE dt IN (toUInt64(0), toUInt64(2));
+SELECT count() FROM t_datetime_set WHERE dt IN (toUInt64(4294967295));
+SELECT count() FROM t_datetime_set WHERE dt IN (toDateTime(1, 'UTC'));
+
+SELECT 'the values table function takes the same path';
+SELECT x FROM values('x DateTime(''UTC'')', toUInt64(1));
+SELECT CAST(toUInt64(1), 'DateTime(''UTC'')');
+-- A constant the column cannot hold is rejected there, as it is for `Date`, `Date32` and `UInt8`.
+SELECT x FROM values('x DateTime(''UTC'')', toUInt64(4294967296)); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT x FROM values('x Date', toUInt64(65536)); -- { serverError ARGUMENT_OUT_OF_BOUND }
+
+DROP TABLE t_datetime_set;


### PR DESCRIPTION
A `DateTime` stores a `UInt32`, so a `UInt64` constant that does not fit it cannot equal any value of the column. The conversion took such a constant unchanged - `UInt64` is the canonical `Field` type of `DateTime`, so it looked like nothing had to be done - and the column insertion downstream truncated it modulo 2^32:

```sql
CREATE TABLE t (dt DateTime('UTC')) ENGINE = MergeTree ORDER BY dt;
INSERT INTO t VALUES (0), (1), (2);

SELECT count() FROM t WHERE dt = toUInt64(4294967296);         -- 0
SELECT count() FROM t WHERE dt IN (toUInt64(4294967296));      -- 1, was wrong: matched the epoch row
SELECT count() FROM t WHERE dt NOT IN (toUInt64(4294967296));  -- 2, was wrong: a row lost

-- every equality is individually false, and the OR -> IN rewrite returned all rows:
SELECT count() FROM t
WHERE dt = toUInt64(4294967296) OR dt = toUInt64(4294967297) OR dt = toUInt64(4294967298);  -- 3, was wrong
```

The `Date`, `Date32` and `Time` branches next to it already range-check for the same reason; `DateTime` now does too. A constant outside the range is excluded from a set, as an out-of-range integer for a numeric column already was.

One note on the `values` path: the issue asks for `values('x DateTime', toUInt64(4294967296))` to produce what `CAST` produces (a wrapped `2106-02-07 06:28:15`). It now raises `ARGUMENT_OUT_OF_BOUND` instead, which is what that path already does for `Date`, `Date32` and even `UInt8` - `values('x UInt8', toUInt64(256))` has always been an error while `CAST` wraps. Rejecting it keeps `DateTime` consistent with every other type there.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117244

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a `UInt64` constant that does not fit `UInt32` matching an unrelated row of a `DateTime` column in `IN` (and in an `OR` chain of equalities, which is rewritten into `IN`): the constant was truncated modulo 2^32 instead of being excluded from the set.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118367&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118367](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118367+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
