### PR TITLE
Remove dead call-depth instrumentation from the per-test coverage build

### DIFF
--- a/.claude/docs/relevant_tests.md
+++ b/.claude/docs/relevant_tests.md
@@ -15,7 +15,7 @@ database (CIDB) that records which lines each test covered in recent nightly run
 ```
 NightlyCoverage CI job (nightly at 02:13 UTC)
   └─ Build amd_per_test_coverage binary
-       (WITH_COVERAGE=ON -DWITH_COVERAGE_DEPTH=ON -finstrument-functions-after-inlining)
+       (-DWITH_COVERAGE=ON -DWITH_COVERAGE_DEPTH=ON)
   └─ Run stateless tests including --long (clickhouse-test --collect-per-test-coverage)
        ├─ SYSTEM SET COVERAGE TEST 'test_name'  (before each test)
        └─ SYSTEM SET COVERAGE TEST ''           (flush + reset counters)
@@ -255,7 +255,7 @@ Found 275 relevant tests
 
 Defined in `ci/workflows/nightly_coverage.py`. Runs nightly at 02:13 UTC on master.
 Uses `coverage_build_jobs[1]` = `Build (amd_llvm_coverage_per_test)` which builds
-with `WITH_COVERAGE=ON -DWITH_COVERAGE_DEPTH=ON -finstrument-functions-after-inlining`.
+with `-DWITH_COVERAGE=ON -DWITH_COVERAGE_DEPTH=ON`.
 
 **Long tests are included** (removed `--no-long` from per-test coverage runs in
 `ci/jobs/functional_tests.py`), so tests like `00900_long_parquet` and

--- a/base/base/coverage.cpp
+++ b/base/base/coverage.cpp
@@ -213,14 +213,6 @@ static void xrayHandler(int32_t func_id, XRayEntryType type)
 
 #endif // CLICKHOUSE_XRAY_INSTRUMENT_COVERAGE
 
-/// Stubs for -finstrument-functions (kept for link compatibility with builds that
-/// add the flag without XRay).
-extern "C" void __cyg_profile_func_enter(void *, void *) __attribute__((no_instrument_function));
-void __cyg_profile_func_enter(void *, void *) {}
-
-extern "C" void __cyg_profile_func_exit(void *, void *) __attribute__((no_instrument_function));
-void __cyg_profile_func_exit(void *, void *) {}
-
 
 std::vector<CovCounter> getCurrentCoveredNameRefs()
 {

--- a/base/base/coverage.h
+++ b/base/base/coverage.h
@@ -41,10 +41,10 @@ void resetCoverage();
 ///                         array; 0 = entry, 1…N = branch/statement counters.  Gives
 ///                         statement-level region granularity.
 /// min_depth             — minimum call-stack depth at which the function was entered
-///                         since the last counter reset, as tracked by the
-///                         -finstrument-functions shadow stack (see coverage.cpp).
-///                         255 means "depth not tracked" (binary built without the flag).
-///                         Depth 1 = called directly by the test driver; higher = indirect.
+///                         since the last counter reset, when built with
+///                         -DCLICKHOUSE_XRAY_INSTRUMENT_COVERAGE=1 (1 = called directly
+///                         by the test driver, 255 = depth not tracked).  Otherwise it is
+///                         the function's entry call count, capped at 254.
 using CovCounter = std::tuple<uint64_t, uint64_t, uint32_t, uint8_t>;
 
 /// Return (name_hash, func_hash, counter_id) triples for every counter > 0

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -155,7 +155,7 @@ endif()
 # Default coverage instrumentation (dumping the coverage map on exit)
 option(WITH_COVERAGE "Instrumentation for code coverage with default implementation" OFF)
 
-option(WITH_COVERAGE_DEPTH "Shadow call-stack depth tracking via -finstrument-functions-after-inlining (requires WITH_COVERAGE)" OFF)
+option(WITH_COVERAGE_DEPTH "Per-test coverage collection via SYSTEM SET COVERAGE TEST (requires WITH_COVERAGE)" OFF)
 
 option(WITH_COVERAGE_XRAY
     "Use XRay instrumentation for exact call-depth tracking (requires WITH_COVERAGE and ENABLE_XRAY). Builds with -DCLICKHOUSE_XRAY_INSTRUMENT_COVERAGE=1. XRay maps runtime function text addresses to LLVM profile records, solving the PIE FunctionPointer=0 limitation."
@@ -187,9 +187,6 @@ if (WITH_COVERAGE)
         # LLVMCoverageMapping.cpp, and SYSTEM SET COVERAGE TEST are compiled in.
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_COVERAGE=1")
         set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -DWITH_COVERAGE=1")
-        message (STATUS "Enabled call-depth shadow stack via -finstrument-functions-after-inlining")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -finstrument-functions-after-inlining")
-        set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -finstrument-functions-after-inlining")
         # -mllvm -enable-value-profiling=true activates indirect-call value profiling so that
         # __llvm_profile_instrument_target() records virtual-dispatch targets at runtime.
         # Without this flag, LLVMProfileData::Values is always NULL and indirect-call data

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -4919,7 +4919,13 @@ def run_tests_array(
     # %c enables continuous mode so a client killed mid-write (query timeouts
     # SIGKILL the whole process group) leaves a valid profile instead of a
     # truncated one.
-    os.environ["LLVM_PROFILE_FILE"] = f"clickhouse-client-proc{process_index}-%c%2m.profraw"
+    # Per-test coverage discards client profiles, and under %c concurrently running
+    # clients store their counters into a shared file-backed mapping of one pool file,
+    # so that lane would pay for a profile nobody reads.
+    profile_pattern = "%2m" if args.collect_per_test_coverage else "%c%2m"
+    os.environ["LLVM_PROFILE_FILE"] = (
+        f"clickhouse-client-proc{process_index}-{profile_pattern}.profraw"
+    )
 
     OP_SQUARE_BRACKET = colored("[", args, attrs=["bold"])
     CL_SQUARE_BRACKET = colored("]", args, attrs=["bold"])


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Description

`03147_system_columns_access_checks` is killed at the 600s per-test cap on `Stateless tests (amd_llvm_coverage_per_test, per_test_coverage, 5/8)` on two consecutive nightlies ([2026-09-04](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=55ebb8f7b3e0af5558e4a1a8286f5bc83b7fe424&name_0=NightlyCoverage), [2026-09-05](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=afb5ae2d43dae563811346711a7285f9a7f65064&name_0=NightlyCoverage)) after 17 days at 95-130s; the kill lands inside its 1000-table fixture, so its duration oracle asserts nothing there.

`0599d405a0661f3` replaced the `-finstrument-functions` shadow stack with an entry call count read from the profile counters, but `WITH_COVERAGE_DEPTH` still adds `-finstrument-functions-after-inlining` to the global C and C++ flags, so every function entry and exit in the binary, contrib included, calls two empty stubs in `base/base/coverage.cpp`. `base/base` is compiled with `${COVERAGE_FLAGS}`, so those stubs carry their own counters: on `SELECT count() FROM numbers(10000000)` they reach 6213755 and 6212763, 5.3x the next hottest function counter and 23.5% of all counter increments. Once continuous mode began working those counters moved into a `MAP_SHARED` mapping of a merge-pool file, so concurrent clients store into the same file-backed pages at call frequency.

Deleting them cannot change what per-test coverage measures: the hooks are empty, `min_depth` comes from the entry counter or from XRay, and the `WITH_COVERAGE_DEPTH` macro comes from the CMake option. Measured, `coverageDiag()` `map_size` drops by exactly 2, nothing else moves, and the runner's coverage self-test and `system.coverage_indirect_calls` stay green. The second commit stops requesting continuous mode for client profiles this lane discards.

<details>
<summary>Local A/B, the lane's cmake flags, 8 CPUs pinned, randomization off, arms interleaved</summary>

Medians; `03147` n=6-7 per arm, the others 1-3.

| test | master | +deletion | +both commits |
|---|---|---|---|
| `03147_system_columns_access_checks` | 150.2s | 93.2s | 34.8s |
| `01161_all_system_tables` | 59.2s | 31.2s | 14.9s |
| `02475_bson_each_row_format` (115 clients, never two at once) | 14.0s | 12.8s | 12.1s |

`02475` is the control: clients that never overlap never share a live mapping, and it does not move. Nothing got slower. Ranges: master 113-199s, deletion 79-130s, both 33-37s. 44 tests on this lane exceed their 17-day maximum by >=1.5x on both failing days.

</details>

On my host the failing arm runs at 113-199s, not at the cap, so this measures the mechanism's size, not that CI lands under 600s. Everything here sits behind `WITH_COVERAGE_DEPTH`, which only `Build (amd_llvm_coverage_per_test)` sets and only `nightly_coverage.py` schedules, so PR CI neither runs nor builds it; a build break there is this diff's real risk, so I built both arms cold with that job's cmake flags. Owner's call, not taken here: this lane reads no client `.profraw`, so client profiling could be dropped rather than switched. No related open issue found.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Drop the orphaned `-finstrument-functions-after-inlining` instrumentation and its two empty `__cyg_profile_func_*` stubs from the `WITH_COVERAGE_DEPTH` build, and stop requesting LLVM continuous mode for client profiles on the per-test coverage lane.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118370&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118370](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118370+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1339` (included in `26.9` and later)
<!-- ch-version-info:end -->