### PR TITLE
Reject a skip index whose expression cannot be evaluated

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1209,7 +1209,10 @@ void MergeTreeData::checkProperties(
                     checkMinMaxIndexForJSON(index);
                 MergeTreeIndexFactory::instance().validate(index, attach, *getSettings());
 
-                if (!attach)
+                /// An index the server generates from a setting is not the user's declaration, so it
+                /// must not be the reason a statement is refused; `addImplicitIndicesForColumn` drops
+                /// one it cannot validate instead of failing the statement.
+                if (!attach && !index.isImplicitlyCreated())
                 {
                     if (auto failure = tryEvaluateIndexExpression(index))
                     {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1216,15 +1216,13 @@ void MergeTreeData::checkProperties(
                         const IndexDescription * old_index = nullptr;
                         /// The create path and the projection recursion pass the same metadata object as both
                         /// arguments, so an index found there is the one being declared and nothing can be inherited.
+                        /// Definitions are not compared: `RENAME COLUMN` rewrites an index's AST without redeclaring it.
                         if (&old_metadata != &new_metadata)
                             for (const auto & candidate : old_metadata.secondary_indices)
                                 if (candidate.name == index.name)
                                     old_index = &candidate;
 
-                        const bool inherited = old_index && old_index->definition_ast && index.definition_ast
-                            && old_index->definition_ast->getTreeHash(/*ignore_aliases=*/true)
-                                == index.definition_ast->getTreeHash(/*ignore_aliases=*/true)
-                            && tryEvaluateIndexExpression(*old_index);
+                        const bool inherited = old_index && tryEvaluateIndexExpression(*old_index);
 
                         if (!inherited)
                             std::rethrow_exception(failure);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1030,8 +1030,8 @@ static std::exception_ptr tryEvaluateIndexExpression(const IndexDescription & in
         for (const auto & column : index.expression->getRequiredColumnsWithTypes())
             header.insert({column.type->createColumn(), column.type, column.name});
 
-        /// The call `ExpressionTransform` makes on this same DAG while merging, so an expression a merge
-        /// accepts cannot be rejected here.
+        /// The same dry run a merge performs: it rebuilds this expression's AST under the storage
+        /// context and hands the result to `ExpressionTransform::transformHeader`, which is this call.
         index.expression->getActionsDAG().updateHeader(header);
     }
     catch (...)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1214,8 +1214,8 @@ void MergeTreeData::checkProperties(
                     if (auto failure = tryEvaluateIndexExpression(index))
                     {
                         const IndexDescription * old_index = nullptr;
-                        /// The create path passes the same metadata object as both arguments, so an index found
-                        /// there is the one being declared and nothing can be inherited.
+                        /// The create path and the projection recursion pass the same metadata object as both
+                        /// arguments, so an index found there is the one being declared and nothing can be inherited.
                         if (&old_metadata != &new_metadata)
                             for (const auto & candidate : old_metadata.secondary_indices)
                                 if (candidate.name == index.name)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1003,6 +1003,45 @@ static void checkKeyExpression(const ExpressionActions & expr, const Block & sam
     }
 }
 
+/// A function that opts out of constant folding may do context-dependent work (an access check, a remote
+/// call) before it looks at the row count, and the expression here was analyzed with the context of the user
+/// running the DDL rather than the storage's, so probing such an expression could answer a different question.
+static bool indexExpressionMayBeProbed(const IndexDescription & index)
+{
+    if (!index.expression)
+        return false;
+
+    for (const auto & node : index.expression->getActionsDAG().getNodes())
+        if (node.type == ActionsDAG::ActionType::FUNCTION
+            && (!node.function_base || !node.function_base->isSuitableForConstantFolding()))
+            return false;
+
+    return true;
+}
+
+static std::exception_ptr tryEvaluateIndexExpression(const IndexDescription & index)
+{
+    if (!indexExpressionMayBeProbed(index))
+        return {};
+
+    try
+    {
+        Block header;
+        for (const auto & column : index.expression->getRequiredColumnsWithTypes())
+            header.insert({column.type->createColumn(), column.type, column.name});
+
+        /// The call `ExpressionTransform` makes on this same DAG while merging, so an expression a merge
+        /// accepts cannot be rejected here.
+        index.expression->getActionsDAG().updateHeader(header);
+    }
+    catch (...)
+    {
+        return std::current_exception();
+    }
+
+    return {};
+}
+
 void MergeTreeData::checkProperties(
     const StorageInMemoryMetadata & new_metadata,
     const StorageInMemoryMetadata & old_metadata,
@@ -1169,6 +1208,28 @@ void MergeTreeData::checkProperties(
                 if (!attach && !allow_minmax_index_for_json)
                     checkMinMaxIndexForJSON(index);
                 MergeTreeIndexFactory::instance().validate(index, attach, *getSettings());
+
+                if (!attach)
+                {
+                    if (auto failure = tryEvaluateIndexExpression(index))
+                    {
+                        const IndexDescription * old_index = nullptr;
+                        /// The create path passes the same metadata object as both arguments, so an index found
+                        /// there is the one being declared and nothing can be inherited.
+                        if (&old_metadata != &new_metadata)
+                            for (const auto & candidate : old_metadata.secondary_indices)
+                                if (candidate.name == index.name)
+                                    old_index = &candidate;
+
+                        const bool inherited = old_index && old_index->definition_ast && index.definition_ast
+                            && old_index->definition_ast->getTreeHash(/*ignore_aliases=*/true)
+                                == index.definition_ast->getTreeHash(/*ignore_aliases=*/true)
+                            && tryEvaluateIndexExpression(*old_index);
+
+                        if (!inherited)
+                            std::rethrow_exception(failure);
+                    }
+                }
             }
             catch (Exception & e)
             {

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
@@ -15,3 +15,6 @@ F an expression containing a function that opts out of constant folding is not p
 1
 G LowCardinality alone is probed, a Nullable operand is not
 2
+H an index the server generates itself never fails a user statement
+1
+1

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
@@ -13,3 +13,5 @@ C4 index over a wrapped type
 2
 F an expression containing a function that opts out of constant folding is not probed
 1
+G LowCardinality alone is probed, a Nullable operand is not
+2

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
@@ -11,5 +11,5 @@ C3 index over arithmetic
 2
 C4 index over a wrapped type
 2
-F an expression a merge would not dry-run either is left alone
+F an expression containing a function that opts out of constant folding is not probed
 1

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.reference
@@ -1,0 +1,15 @@
+A CREATE TABLE declaring an index expression that cannot be evaluated
+B ALTER TABLE ADD INDEX declaring one
+2
+E an ALTER whose own effect makes an existing index unevaluable
+2
+C1 index over a column
+2
+C2 index over a comparison against a literal of the column type
+2
+C3 index over arithmetic
+2
+C4 index over a wrapped type
+2
+F an expression a merge would not dry-run either is left alone
+1

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
@@ -54,7 +54,7 @@ INSERT INTO t_wrapped VALUES (NULL, 2);
 OPTIMIZE TABLE t_wrapped FINAL;
 SELECT count() FROM t_wrapped;
 
-SELECT 'F an expression a merge would not dry-run either is left alone';
+SELECT 'F an expression containing a function that opts out of constant folding is not probed';
 CREATE TABLE t_unfoldable (c0 String, c1 Int8, INDEX i0 throwIf(c0 = c1, 'x') TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 't_unfoldable';
 

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
@@ -1,0 +1,67 @@
+DROP TABLE IF EXISTS t_create;
+DROP TABLE IF EXISTS t_alter;
+DROP TABLE IF EXISTS t_modify;
+DROP TABLE IF EXISTS t_plain;
+DROP TABLE IF EXISTS t_literal;
+DROP TABLE IF EXISTS t_arith;
+DROP TABLE IF EXISTS t_wrapped;
+DROP TABLE IF EXISTS t_unfoldable;
+
+SELECT 'A CREATE TABLE declaring an index expression that cannot be evaluated';
+CREATE TABLE t_create (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1; -- { serverError NO_COMMON_TYPE }
+
+SELECT 'B ALTER TABLE ADD INDEX declaring one';
+CREATE TABLE t_alter (c0 String, c1 Int8) ENGINE = MergeTree ORDER BY c1;
+ALTER TABLE t_alter ADD INDEX i0 c0 = c1 TYPE set(0); -- { serverError NO_COMMON_TYPE }
+INSERT INTO t_alter VALUES ('a', 1);
+INSERT INTO t_alter VALUES ('b', 2);
+OPTIMIZE TABLE t_alter FINAL;
+SELECT count() FROM t_alter;
+
+SELECT 'E an ALTER whose own effect makes an existing index unevaluable';
+CREATE TABLE t_modify (c0 Int8, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
+ALTER TABLE t_modify MODIFY COLUMN c0 String; -- { serverError NO_COMMON_TYPE }
+INSERT INTO t_modify VALUES (1, 1);
+INSERT INTO t_modify VALUES (2, 2);
+OPTIMIZE TABLE t_modify FINAL;
+SELECT count() FROM t_modify;
+
+SELECT 'C1 index over a column';
+CREATE TABLE t_plain (c0 String, c1 Int8, INDEX i0 c0 TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
+INSERT INTO t_plain VALUES ('a', 1);
+INSERT INTO t_plain VALUES ('b', 2);
+OPTIMIZE TABLE t_plain FINAL;
+SELECT count() FROM t_plain;
+
+SELECT 'C2 index over a comparison against a literal of the column type';
+CREATE TABLE t_literal (c0 String, c1 Int8, INDEX i0 c0 = 'x' TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
+INSERT INTO t_literal VALUES ('a', 1);
+INSERT INTO t_literal VALUES ('x', 2);
+OPTIMIZE TABLE t_literal FINAL;
+SELECT count() FROM t_literal;
+
+SELECT 'C3 index over arithmetic';
+CREATE TABLE t_arith (c0 String, c1 Int8, INDEX i0 c1 + 1 TYPE minmax) ENGINE = MergeTree ORDER BY c1;
+INSERT INTO t_arith VALUES ('a', 1);
+INSERT INTO t_arith VALUES ('b', 2);
+OPTIMIZE TABLE t_arith FINAL;
+SELECT count() FROM t_arith;
+
+SELECT 'C4 index over a wrapped type';
+CREATE TABLE t_wrapped (c0 LowCardinality(Nullable(String)), c1 Int8, INDEX i0 c0 TYPE bloom_filter) ENGINE = MergeTree ORDER BY c1;
+INSERT INTO t_wrapped VALUES ('a', 1);
+INSERT INTO t_wrapped VALUES (NULL, 2);
+OPTIMIZE TABLE t_wrapped FINAL;
+SELECT count() FROM t_wrapped;
+
+SELECT 'F an expression a merge would not dry-run either is left alone';
+CREATE TABLE t_unfoldable (c0 String, c1 Int8, INDEX i0 throwIf(c0 = c1, 'x') TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 't_unfoldable';
+
+DROP TABLE t_alter;
+DROP TABLE t_modify;
+DROP TABLE t_plain;
+DROP TABLE t_literal;
+DROP TABLE t_arith;
+DROP TABLE t_wrapped;
+DROP TABLE t_unfoldable;

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
@@ -6,6 +6,9 @@ DROP TABLE IF EXISTS t_literal;
 DROP TABLE IF EXISTS t_arith;
 DROP TABLE IF EXISTS t_wrapped;
 DROP TABLE IF EXISTS t_unfoldable;
+DROP TABLE IF EXISTS t_lc;
+DROP TABLE IF EXISTS t_nullable;
+DROP TABLE IF EXISTS t_lc_nullable;
 
 SELECT 'A CREATE TABLE declaring an index expression that cannot be evaluated';
 CREATE TABLE t_create (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1; -- { serverError NO_COMMON_TYPE }
@@ -58,6 +61,14 @@ SELECT 'F an expression containing a function that opts out of constant folding 
 CREATE TABLE t_unfoldable (c0 String, c1 Int8, INDEX i0 throwIf(c0 = c1, 'x') TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 't_unfoldable';
 
+SELECT 'G LowCardinality alone is probed, a Nullable operand is not';
+-- A `Nullable` operand takes `defaultImplementationForNulls`' zero-row early return, so the
+-- declaration is not type-checked and stays accepted; the failure still surfaces on `INSERT`.
+CREATE TABLE t_lc (c0 LowCardinality(String), c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1; -- { serverError NO_COMMON_TYPE }
+CREATE TABLE t_nullable (c0 Nullable(String), c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
+CREATE TABLE t_lc_nullable (c0 LowCardinality(Nullable(String)), c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name IN ('t_nullable', 't_lc_nullable');
+
 DROP TABLE t_alter;
 DROP TABLE t_modify;
 DROP TABLE t_plain;
@@ -65,3 +76,5 @@ DROP TABLE t_literal;
 DROP TABLE t_arith;
 DROP TABLE t_wrapped;
 DROP TABLE t_unfoldable;
+DROP TABLE t_nullable;
+DROP TABLE t_lc_nullable;

--- a/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
+++ b/tests/queries/0_stateless/05080_ill_typed_skip_index_expression.sql
@@ -9,6 +9,7 @@ DROP TABLE IF EXISTS t_unfoldable;
 DROP TABLE IF EXISTS t_lc;
 DROP TABLE IF EXISTS t_nullable;
 DROP TABLE IF EXISTS t_lc_nullable;
+DROP TABLE IF EXISTS t_implicit;
 
 SELECT 'A CREATE TABLE declaring an index expression that cannot be evaluated';
 CREATE TABLE t_create (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1; -- { serverError NO_COMMON_TYPE }
@@ -69,6 +70,16 @@ CREATE TABLE t_nullable (c0 Nullable(String), c1 Int8, INDEX i0 c0 = c1 TYPE set
 CREATE TABLE t_lc_nullable (c0 LowCardinality(Nullable(String)), c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
 SELECT count() FROM system.tables WHERE database = currentDatabase() AND name IN ('t_nullable', 't_lc_nullable');
 
+SELECT 'H an index the server generates itself never fails a user statement';
+CREATE TABLE t_implicit (c0 String, c1 Int8, a UInt8 ALIAS c0 = c1) ENGINE = MergeTree ORDER BY c1
+    SETTINGS add_minmax_index_for_numeric_columns = 1;
+SELECT count() FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 't_implicit' AND name = 'auto_minmax_index_a';
+ALTER TABLE t_implicit RENAME COLUMN a TO b;
+SELECT count() FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 't_implicit' AND name = 'auto_minmax_index_b';
+ALTER TABLE t_implicit ADD INDEX i0 c0 = c1 TYPE set(0); -- { serverError NO_COMMON_TYPE }
+
 DROP TABLE t_alter;
 DROP TABLE t_modify;
 DROP TABLE t_plain;
@@ -78,3 +89,4 @@ DROP TABLE t_wrapped;
 DROP TABLE t_unfoldable;
 DROP TABLE t_nullable;
 DROP TABLE t_lc_nullable;
+DROP TABLE t_implicit;

--- a/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.reference
+++ b/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.reference
@@ -1,0 +1,17 @@
+D1 a table already carrying such an index still attaches
+ok
+D2 an unrelated ALTER on it is still allowed
+ok
+D3 a new index the ALTER declares itself is still rejected
+1
+D4 a well-typed new index on the same table is accepted
+ok
+i0
+i2
+D5 dropping it repairs the table
+ok
+merge ok
+2
+D6 redeclaring the index under its own name is not inherited
+1
+ok

--- a/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.reference
+++ b/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.reference
@@ -12,6 +12,11 @@ D5 dropping it repairs the table
 ok
 merge ok
 2
-D6 redeclaring the index under its own name is not inherited
-1
+D6 an already-unevaluable index of the same name is not re-checked
+ok
+minmax
+ok
+D7 renaming a column the index references is still allowed
+ok
+c2 = c1
 ok

--- a/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.sh
+++ b/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# ATTACH TABLE with an inline definition is only accepted by the Ordinary database engine,
+# whose creation emits a warning.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+ORD="${CLICKHOUSE_DATABASE}_ord"
+
+$CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS ${ORD}"
+$CLICKHOUSE_CLIENT --allow_deprecated_database_ordinary=1 -q "CREATE DATABASE ${ORD} ENGINE = Ordinary"
+
+# A table declared before this check existed keeps loading, so an upgrade cannot strand one.
+echo 'D1 a table already carrying such an index still attaches'
+$CLICKHOUSE_CLIENT -q "ATTACH TABLE ${ORD}.g (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1" \
+    && echo ok
+
+echo 'D2 an unrelated ALTER on it is still allowed'
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g ADD COLUMN x UInt8" && echo ok
+
+echo 'D3 a new index the ALTER declares itself is still rejected'
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g ADD INDEX i1 c1 = c0 TYPE set(0)" 2>&1 | grep -c 'NO_COMMON_TYPE'
+
+echo 'D4 a well-typed new index on the same table is accepted'
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g ADD INDEX i2 c1 + 1 TYPE minmax" && echo ok
+$CLICKHOUSE_CLIENT -q "SELECT name FROM system.data_skipping_indices WHERE database = '${ORD}' AND table = 'g' ORDER BY name"
+
+echo 'D5 dropping it repairs the table'
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g DROP INDEX i0" && echo ok
+# An inline VALUES list still leaves the client reading stdin, which never closes here.
+$CLICKHOUSE_CLIENT -q "INSERT INTO ${ORD}.g VALUES ('a', 1, 0)" < /dev/null
+$CLICKHOUSE_CLIENT -q "INSERT INTO ${ORD}.g VALUES ('b', 2, 0)" < /dev/null
+$CLICKHOUSE_CLIENT -q "OPTIMIZE TABLE ${ORD}.g FINAL" && echo 'merge ok'
+$CLICKHOUSE_CLIENT -q "SELECT count() FROM ${ORD}.g"
+
+echo 'D6 redeclaring the index under its own name is not inherited'
+$CLICKHOUSE_CLIENT -q "ATTACH TABLE ${ORD}.g2 (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g2 DROP INDEX i0, ADD INDEX i0 c0 = c1 TYPE minmax" 2>&1 | grep -c 'NO_COMMON_TYPE'
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g2 ADD COLUMN x UInt8" && echo ok
+
+$CLICKHOUSE_CLIENT -q "DROP DATABASE ${ORD} SYNC"

--- a/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.sh
+++ b/tests/queries/0_stateless/05081_ill_typed_skip_index_expression_attach.sh
@@ -36,9 +36,16 @@ $CLICKHOUSE_CLIENT -q "INSERT INTO ${ORD}.g VALUES ('b', 2, 0)" < /dev/null
 $CLICKHOUSE_CLIENT -q "OPTIMIZE TABLE ${ORD}.g FINAL" && echo 'merge ok'
 $CLICKHOUSE_CLIENT -q "SELECT count() FROM ${ORD}.g"
 
-echo 'D6 redeclaring the index under its own name is not inherited'
+echo 'D6 an already-unevaluable index of the same name is not re-checked'
 $CLICKHOUSE_CLIENT -q "ATTACH TABLE ${ORD}.g2 (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1"
-$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g2 DROP INDEX i0, ADD INDEX i0 c0 = c1 TYPE minmax" 2>&1 | grep -c 'NO_COMMON_TYPE'
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g2 DROP INDEX i0, ADD INDEX i0 c0 = c1 TYPE minmax" && echo ok
+$CLICKHOUSE_CLIENT -q "SELECT type FROM system.data_skipping_indices WHERE database = '${ORD}' AND table = 'g2' AND name = 'i0'"
 $CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g2 ADD COLUMN x UInt8" && echo ok
+
+echo 'D7 renaming a column the index references is still allowed'
+$CLICKHOUSE_CLIENT -q "ATTACH TABLE ${ORD}.g3 (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g3 RENAME COLUMN c0 TO c2" && echo ok
+$CLICKHOUSE_CLIENT -q "SELECT expr FROM system.data_skipping_indices WHERE database = '${ORD}' AND table = 'g3' AND name = 'i0'"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE ${ORD}.g3 DROP INDEX i0" && echo ok
 
 $CLICKHOUSE_CLIENT -q "DROP DATABASE ${ORD} SYNC"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/69597


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`CREATE TABLE` and `ALTER TABLE ... ADD INDEX` now reject a skip index whose expression cannot be evaluated, such as `INDEX i c0 = c1 TYPE set(0)` over `String` and `Int8`, and an `ALTER TABLE ... MODIFY COLUMN` that would leave an existing index in that state is rejected too. Such a declaration used to be accepted, after which every `INSERT` and merge failed with `NO_COMMON_TYPE`, and `MATERIALIZE INDEX` retried that error forever. Closes #69597.


### Description

```sql
CREATE TABLE t (c0 String, c1 Int8, INDEX i0 c0 = c1 TYPE set(0)) ENGINE = MergeTree ORDER BY c1;
INSERT INTO t VALUES ('a', 1); -- Code: 386 NO_COMMON_TYPE; so does every merge
```

`IndexDescription::initExpressionInfo` takes the expression's `sample_block` from
`ExpressionActions::getSampleBlock`, which reports DAG result types and executes nothing, so
`equals(String, Int8)` passes overload resolution and is accepted. A merge's `ExpressionStep` header
then goes through `ActionsDAG::updateHeader`, a zero-row dry run where `getLeastSupertype` throws.

I ask it in the per-index loop of `MergeTreeData::checkProperties`: `updateHeader` on the index's DAG
over a zero-row header, the dry run a merge performs (`ExpressionTransform::transformHeader`).

Three gates keep it narrow. The probe is skipped unless every function node satisfies
`isSuitableForConstantFolding`: such a function may do context-dependent work at zero rows, and this
DAG carries the altering user's context, not the storage's. Only a violation the statement
introduces is reported, compared against the old metadata's index of that name, so a table declared
before this check still attaches, still alters, and `DROP INDEX` repairs it. And an index the server
generates itself (`add_minmax_index_for_*`, off by default) is never probed: the user declared no
index there.

Residuals. A zero-row dry run decides type errors only: a data-dependent failure stays accepted, and
so does a `Nullable` operand, where `defaultImplementationForNulls` returns an empty result first
(`IFunction.cpp:311-319`). So do an ill-typed generated index, an expression wrapped in a function
that opts out of folding (`identity(c0 = c1)`), and a full-definition `ATTACH`; master accepts all
three unchanged. Key expressions have the same hole (`KeyDescription.cpp:190`). Like the
neighbouring `!attach` validations, it can still reject a grandfathered index where a route
re-derives an existing table with `attach = false` (`setTableStructure` applying an older replica's
entry, `SYSTEM RESTORE DATABASE REPLICA`); exempting those needs a flag threaded into
`checkProperties`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118373&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118373](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118373+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.243` (included in `26.10` and later)
<!-- ch-version-info:end -->