### PR TITLE
Skip the unused key materialization in the aggregation bucket Top-K conversion

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -2678,6 +2678,10 @@ Aggregator::AggregatedChunk Aggregator::convertOneBucketToChunkTopK(
     /// The root is the worst kept candidate, so a new cell only pays the heap when it beats it.
     const auto worse_first = [&](const Candidate & a, const Candidate & b) { return better(a.value, b.value); };
 
+    /// Only the dataflow statistics cache consumes this byte count, so a null counter makes the
+    /// per-group key materialization below dead work.
+    const bool need_full_key_bytes = full_key_bytes != nullptr;
+
     /// Account for the full output using the same conversion as the final result. A serialized
     /// multi-key table stores a length-prefixed arena blob, whose size is not the size of the
     /// materialized key columns (in particular, every String key has an offset column).
@@ -2694,12 +2698,15 @@ Aggregator::AggregatedChunk Aggregator::convertOneBucketToChunkTopK(
     data.forEachValue(
         [&](const auto & key, auto & mapped)
         {
-            method.insertKeyIntoColumns(
-                key, key_size_columns.raw_key_columns, key_size_key_sizes, &key_size_serialization_settings);
-            for (auto * column : key_size_columns.raw_key_columns)
+            if (need_full_key_bytes)
             {
-                key_bytes += column->byteSizeAt(column->size() - 1);
-                column->popBack(1);
+                method.insertKeyIntoColumns(
+                    key, key_size_columns.raw_key_columns, key_size_key_sizes, &key_size_serialization_settings);
+                for (auto * column : key_size_columns.raw_key_columns)
+                {
+                    key_bytes += column->byteSizeAt(column->size() - 1);
+                    column->popBack(1);
+                }
             }
             const UInt64 value = count_of(mapped);
             if (top.size() < params.bucket_top_k)
@@ -2797,8 +2804,9 @@ Aggregator::AggregatedChunk Aggregator::mergeAndConvertOneBucketToChunk(
     auto method = merged_data.type;
     AggregatedChunk agg_chunk;
 
-    /// Filled by the Top-K conversion (zero otherwise): the untruncated key bytes to account in
-    /// the dataflow statistics, because the truncated chunk carries only the kept groups.
+    /// Filled by the Top-K conversion when the statistics ask for it (zero otherwise): the
+    /// untruncated key bytes to account in the dataflow statistics, because the truncated chunk
+    /// carries only the kept groups.
     UInt64 topk_full_key_bytes = 0;
 
     if (false) {} // NOLINT
@@ -2810,7 +2818,7 @@ Aggregator::AggregatedChunk Aggregator::mergeAndConvertOneBucketToChunk(
             updater->recordAggregationStateSizes(merged_data, bucket); \
         if (is_cancelled.load(std::memory_order_seq_cst)) \
             return {}; \
-        agg_chunk = convertOneBucketToChunk(merged_data, *merged_data.NAME, arena, final, bucket, &topk_full_key_bytes, full_group_count); \
+        agg_chunk = convertOneBucketToChunk(merged_data, *merged_data.NAME, arena, final, bucket, updater ? &topk_full_key_bytes : nullptr, full_group_count); \
         if (updater) \
         { \
             if (topk_full_key_bytes) \

--- a/tests/performance/aggregation_bucket_top_k.xml
+++ b/tests/performance/aggregation_bucket_top_k.xml
@@ -1,0 +1,7 @@
+<test>
+    <!-- The bucket-local Top-K conversion visits every group of every bucket, so a high group
+         count over a small scan makes the conversion, not the scan, the measured cost. -->
+
+    <query>SELECT URL, count() AS c FROM hits_10m_single GROUP BY URL ORDER BY c DESC LIMIT 10 SETTINGS query_plan_aggregation_bucket_top_k = 1 FORMAT Null</query>
+    <query>SELECT UserID, SearchPhrase, count() AS c FROM hits_10m_single GROUP BY UserID, SearchPhrase ORDER BY c DESC LIMIT 10 SETTINGS query_plan_aggregation_bucket_top_k = 1 FORMAT Null</query>
+</test>

--- a/tests/performance/aggregation_bucket_top_k.xml
+++ b/tests/performance/aggregation_bucket_top_k.xml
@@ -1,7 +1,9 @@
 <test>
-    <!-- The bucket-local Top-K conversion visits every group of every bucket, so a high group
-         count over a small scan makes the conversion, not the scan, the measured cost. -->
+    <!-- The bucket-local Top-K conversion (query_plan_aggregation_bucket_top_k) visits every group
+         of every bucket, so its cost is O(groups) while the rest of the query is O(rows). Query 1
+         is conversion-dominated by construction: one group per row, two String keys, no scan.
+         Query 2 is the realistic ClickBench shape (~0.2 groups/row), a regression guard only. -->
 
-    <query>SELECT URL, count() AS c FROM hits_10m_single GROUP BY URL ORDER BY c DESC LIMIT 10 SETTINGS query_plan_aggregation_bucket_top_k = 1 FORMAT Null</query>
-    <query>SELECT UserID, SearchPhrase, count() AS c FROM hits_10m_single GROUP BY UserID, SearchPhrase ORDER BY c DESC LIMIT 10 SETTINGS query_plan_aggregation_bucket_top_k = 1 FORMAT Null</query>
+    <query>SELECT concat('u', toString(number)) AS a, concat('v', toString(number + 1)) AS b, count() AS c FROM numbers_mt(10000000) GROUP BY a, b ORDER BY c DESC LIMIT 10 SETTINGS query_plan_enable_optimizations = 1, query_plan_aggregation_bucket_top_k = 1, group_by_two_level_threshold = 100000, group_by_two_level_threshold_bytes = 50000000, automatic_parallel_replicas_mode = 0 FORMAT Null</query>
+    <query>SELECT URL, count() AS c FROM hits_10m_single GROUP BY URL ORDER BY c DESC LIMIT 10 SETTINGS query_plan_enable_optimizations = 1, query_plan_aggregation_bucket_top_k = 1, group_by_two_level_threshold = 100000, group_by_two_level_threshold_bytes = 50000000, automatic_parallel_replicas_mode = 0 FORMAT Null</query>
 </test>


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/118333
Related: https://github.com/ClickHouse/ClickHouse/pull/116101


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The bucket-local Top-K conversion behind `query_plan_aggregation_bucket_top_k` no longer materializes every group's key to compute a byte count that only the automatic-parallel-replicas dataflow statistics consume, so `GROUP BY ... ORDER BY count() DESC LIMIT n` over high-cardinality keys spends less CPU in the final aggregation.

### Description

Reported and analysed by @ snelheidai in #118333; the numbers below are my own.

`Aggregator::convertOneBucketToChunkTopK` takes `full_key_bytes` as an opt-in out-parameter but produced it unconditionally, materializing every group's key into a throwaway one-row column set just to sum `byteSizeAt`; with a `serialized` or string method that deserializes the arena blob per group. Its one reader is the runtime dataflow statistics cache, live only while `automatic_parallel_replicas_mode` (default `0`) collects statistics. Three of the four call sites already passed `nullptr` and paid anyway.

The producer now honours that opt-in, and `mergeAndConvertOneBucketToChunk` supplies a counter only when an updater needs one. Equivalence is by construction: `topk_full_key_bytes` is read only inside `if (updater)`.

Measured on Release (clang-22), synthetic tables, `max_threads=8`, 20 contemporaneous base/fix pairs, `UserTimeMicroseconds`: **-27.4%** server CPU at 1.0 groups per row, **-7.0%** at 0.35, -3.9% at 0.05 (noise floor). The saving is O(groups) against O(rows) elsewhere, so it tracks group density; wall moved -24.5%, -10.2% and -1.0%. I did not run ClickBench, so its -9.2% suite figure is not restated here; `clickbench.xml` already runs those shapes.

`tests/performance/aggregation_bucket_top_k.xml` adds the shape that suite lacks: a conversion-dominated query (one group per row, two String keys, no scan), which moves **-17.4%** wall over 15 pairs on the harness's median-of-medians estimator, clear of the 15% it needs to report a change. Its second query guards the realistic `GROUP BY URL` shape, where the effect stays inside noise.

No new functional test: `04911_query_plan_aggregation_bucket_top_k` covers result identity and `03634_autopr_output_bytes_estimation` covers the statistics arm within 2.5x. Forcing the counter to `nullptr` moves that value 14.8x, so that arm is live.

#116101 is independent: its only `Aggregator.cpp` hunk stands down when `bucket_top_k` or an updater is set. Its trailing context includes the comment amended here, so whichever lands second takes a small textual conflict.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118374&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118374](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118374+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.851` (included in `26.9` and later)
- Backported to: `26.8.3.52`
<!-- ch-version-info:end -->