### PR TITLE
Stop the parts cleanup in three transaction tests that read a rolled back part

### DIFF
--- a/tests/queries/0_stateless/01172_transaction_counters.sql
+++ b/tests/queries/0_stateless/01172_transaction_counters.sql
@@ -2,13 +2,17 @@
 
 drop table if exists txn_counters;
 
-create table txn_counters (n Int64, creation_tid DEFAULT transactionID()) engine=MergeTree order by n SETTINGS old_parts_lifetime=3600;
+create table txn_counters (n Int64, creation_tid DEFAULT transactionID()) engine=MergeTree order by n SETTINGS old_parts_lifetime=3600, merge_tree_clear_old_parts_interval_seconds=100000;
 
 insert into txn_counters(n) values (1);
 select transactionID();
 
--- stop background cleanup
+-- A merge would add a differently named part to the listings below
 system stop merges txn_counters;
+-- A rolled back part's `remove_time` is 0, so `old_parts_lifetime` does not hold it and the parts
+-- cleanup could delete it before the assertions below read `system.parts`. This statement cannot
+-- stop an iteration already in flight; the pinned interval above keeps that one's parts pass shut.
+system stop cleanup txn_counters;
 
 set throw_on_unsupported_query_inside_transaction=0;
 

--- a/tests/queries/0_stateless/01172_transaction_counters.sql
+++ b/tests/queries/0_stateless/01172_transaction_counters.sql
@@ -1,4 +1,8 @@
--- Tags: no-ordinary-database
+-- Tags: no-ordinary-database, no-shared-merge-tree
+-- no-shared-merge-tree: the assertions below need the rolled back part to stay in `system.parts`, and
+-- `StorageSharedMergeTree` does not implement `ActionLocks::Cleanup`. It removes parts from
+-- `PartsKillerThread` on the server-wide `parts_kill_delay_period` instead, which a stateless test
+-- cannot pin, so neither the `SYSTEM STOP CLEANUP` below nor the pinned interval holds the part there.
 
 drop table if exists txn_counters;
 

--- a/tests/queries/0_stateless/04057_transaction_version_metadata_lifecycle.sql
+++ b/tests/queries/0_stateless/04057_transaction_version_metadata_lifecycle.sql
@@ -5,8 +5,12 @@
 
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (n Int64) ENGINE = MergeTree ORDER BY n
-    SETTINGS old_parts_lifetime=3600;
+    SETTINGS old_parts_lifetime=3600, merge_tree_clear_old_parts_interval_seconds=100000;
 SYSTEM STOP MERGES t;
+-- A rolled back part's `remove_time` is 0, so `old_parts_lifetime` does not hold it and the parts
+-- cleanup could delete it before the assertions below read `system.parts`. This statement cannot
+-- stop an iteration already in flight; the pinned interval above keeps that one's parts pass shut.
+SYSTEM STOP CLEANUP t;
 SET throw_on_unsupported_query_inside_transaction=0;
 
 -- 1. Non-transactional insert: creation_csn = NonTransactionalCSN = 1,

--- a/tests/queries/0_stateless/04057_transaction_version_metadata_lifecycle.sql
+++ b/tests/queries/0_stateless/04057_transaction_version_metadata_lifecycle.sql
@@ -1,4 +1,8 @@
--- Tags: no-ordinary-database
+-- Tags: no-ordinary-database, no-shared-merge-tree
+-- no-shared-merge-tree: the assertions below need the rolled back part to stay in `system.parts`, and
+-- `StorageSharedMergeTree` does not implement `ActionLocks::Cleanup`. It removes parts from
+-- `PartsKillerThread` on the server-wide `parts_kill_delay_period` instead, which a stateless test
+-- cannot pin, so neither the `SYSTEM STOP CLEANUP` below nor the pinned interval holds the part there.
 -- Test: version metadata (creation_csn, removal_tid, removal_csn) is correctly
 -- reflected in system.parts after transactional operations.
 -- This covers the refactored VersionMetadata class hierarchy and its persistence.

--- a/tests/queries/0_stateless/04060_transaction_snapshot_visibility.sql
+++ b/tests/queries/0_stateless/04060_transaction_snapshot_visibility.sql
@@ -8,8 +8,12 @@
 
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (n Int64) ENGINE = MergeTree ORDER BY n
-    SETTINGS old_parts_lifetime=3600;
+    SETTINGS old_parts_lifetime=3600, merge_tree_clear_old_parts_interval_seconds=100000;
 SYSTEM STOP MERGES t;
+-- A rolled back part's `remove_time` is 0, so `old_parts_lifetime` does not hold it and the parts
+-- cleanup could delete it before the assertions below read `system.parts`. This statement cannot
+-- stop an iteration already in flight; the pinned interval above keeps that one's parts pass shut.
+SYSTEM STOP CLEANUP t;
 SET throw_on_unsupported_query_inside_transaction=0;
 
 -- Non-transactional inserts land at creation_csn = NonTransactionalCSN = 1

--- a/tests/queries/0_stateless/04060_transaction_snapshot_visibility.sql
+++ b/tests/queries/0_stateless/04060_transaction_snapshot_visibility.sql
@@ -1,4 +1,8 @@
--- Tags: no-ordinary-database, no-parallel-replicas
+-- Tags: no-ordinary-database, no-parallel-replicas, no-shared-merge-tree
+-- no-shared-merge-tree: the assertions below need the rolled back part to stay in `system.parts`, and
+-- `StorageSharedMergeTree` does not implement `ActionLocks::Cleanup`. It removes parts from
+-- `PartsKillerThread` on the server-wide `parts_kill_delay_period` instead, which a stateless test
+-- cannot pin, so neither the `SYSTEM STOP CLEANUP` below nor the pinned interval holds the part there.
 -- Test: MVCC snapshot isolation for INSERT and DROP operations.
 -- Verifies that:
 --   1. Uncommitted inserts are not visible at snapshot 1 (NonTransactionalCSN).


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a flaky failure of three transaction tests that read a rolled back part from `system.parts`.


### Description

`01172_transaction_counters`, `04057_transaction_version_metadata_lifecycle` and `04060_transaction_snapshot_visibility` assert that a part created by a rolled back transaction is still listed in `system.parts` with `creation_csn = 18446744073709551615`. The background parts cleanup can delete it first, and the run loses that line:

```
 4	all_1_1_0	1	(0,0,'00000000-0000-0000-0000-000000000000')	0
-4	all_2_2_0	18446744073709551615	(0,0,'00000000-0000-0000-0000-000000000000')	0
 4	all_3_3_0	0	(0,0,'00000000-0000-0000-0000-000000000000')	0
```

`MergeTreeTransaction::rollback` removes the part with `clear_without_timeout = true`, so `remove_time = 0` and `grabOldParts` may take it at any `old_parts_lifetime`; `canBeRemoved` is true outright for `RolledBackCSN`. `SYSTEM STOP MERGES` does not stop that remover: `MergeTreeCleanupThread` has its own blocker, taken only by `SYSTEM STOP CLEANUP`, so 01172's `-- stop background cleanup` comment was wrong and is repaired here. One public sighting, with the query below; 04057 and 04060 carry the identical assertion.

Fix, per test: `SYSTEM STOP CLEANUP <table>` beside `SYSTEM STOP MERGES`, plus `merge_tree_clear_old_parts_interval_seconds = 100000` in the `CREATE TABLE` (precedents `04338_replace_partition_no_resurrect_after_restart.sql`, `04813_merge_over_rolled_back_gap_part.sh`). The statement alone is not a barrier: `run` checks the blocker once, before `iterate`, so the iteration queued at `CREATE TABLE` can still run its parts pass; the pinned interval shuts that pass. No assertion or `.reference` byte changes. A suite-wide `remove_rolled_back_parts_immediately = 0` is ruled out by `01173_transaction_control_queries.sql:83`, and the arm below shows it does not help anyway.

All three also take `no-shared-merge-tree`: `IStorage::getActionLock` returns an empty lock by default and `ActionLocksManager::add` keeps it only `if (!action_lock.expired())`, so on an engine without `ActionLocks::Cleanup` the statement blocks nothing, and `02491_part_log_has_table_uuid.sh` records that `StorageSharedMergeTree` removes parts from `PartsKillerThread` on the server-wide `parts_kill_delay_period` instead, which a `.sql` test cannot pin. The tag is honored under `--cloud` and `--replace-replicated-with-shared`; a lane setting only `--replace-non-replicated-with-shared` rewrites the engine without honoring it, which I left to the harness rather than change a predicate 111 other tests share. Public CI sets none of the three flags.

<details>
<summary>The public sighting, the measured arms, and why not <code>remove_rolled_back_parts_immediately = 0</code></summary>

The sentinel row has to be removed and not replaced, otherwise the needle also matches the
unrelated non-transactional-insert shape:

```sql
SELECT check_start_time, pull_request_number, check_name FROM default.checks
WHERE test_name = '01172_transaction_counters' AND test_status IN ('FAIL','ERROR')
  AND base_repo = 'ClickHouse/ClickHouse' AND position(test_context_raw,'result differs') > 0
  AND position(test_context_raw, concat(' -4', char(9), 'all_2_2_0')) > 0
  AND position(test_context_raw, concat(' +4', char(9), 'all_2_2_0')) = 0

2026-06-15 01:02:23   62614   Stateless tests (arm_asan_ubsan, azure, parallel)
```

04057's and 04060's older `AsyncInsert`-lane failures are that different, already-blacklisted
mechanism. The forcing below is `merge_tree_clear_old_parts_interval_seconds = 0`,
`cleanup_delay_period = 1` and a 2 s delay before the assertions; 5 runs per test per arm, plus 50
randomized runs per test on the final tree (150/150).

| tree under test | 01172 | 04057 | 04060 |
|---|---|---|---|
| unchanged | 0/5 pass | 0/5 pass | 0/5 pass |
| + `SYSTEM STOP CLEANUP` only | 5/5 | 5/5 | 5/5 |
| + the pinned interval only | 5/5 | 5/5 | 5/5 |
| + `remove_rolled_back_parts_immediately = 0` | 0/5 pass | 0/5 pass | 0/5 pass |
| + the 2 s delay only, no cleanup settings | 5/5 | 5/5 | 5/5 |
| this PR, forcing minus the pinned setting | 5/5 | 5/5 | 5/5 |

The statement-only arm is green because this forcing cannot land inside the startup window; that
window is closed by reading `run` and `iterate`, not by an arm. `remove_rolled_back_parts_immediately
= 0` does not help at all: it only disables the `creation_csn == Tx::RolledBackCSN` disjunct in
`grabOldParts` while `reached_removal_time` stays true through `remove_time = 0`. The delay-only arm
shows the failure comes from the cleanup.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118377&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118377](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118377+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.244` (included in `26.10` and later)
<!-- ch-version-info:end -->