### PR TITLE
Make `match_max` effective in `05098_client_psql_describe_table`

### DIFF
--- a/tests/queries/0_stateless/05098_client_psql_describe_table.expect
+++ b/tests/queries/0_stateless/05098_client_psql_describe_table.expect
@@ -20,7 +20,10 @@ set history_file $CLICKHOUSE_TMP/$basename.history
 
 log_user 0
 set timeout 60
-match_max 100000
+# `match_max` without `-d` sets the buffer of the *current* spawn id, and nothing is spawned yet,
+# so without it the client below keeps expect's 2000-byte default - far less than one `\l` listing
+# of a shared server, whose oldest part expect then discards while matching.
+match_max -d 100000
 expect_after {
     -i $any_spawn_id eof     { exp_continue }
     -i $any_spawn_id timeout { exit 1 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make `match_max` take effect in `05098_client_psql_describe_table`, so the expect harness holds a whole `\l` listing instead of running with expect's 2000-byte default buffer.


### Description

`Stateless tests (arm_binary, parallel)` failed this one-day-old test (#118281) with `Reason: return code: 1`, its `expect_after` timeout arm, on #117423: [report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117423&sha=8f6c4316969230ee19799531b03487484cacf0b6&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29).

`match_max 100000` on line 23 runs before the `spawn` on line 41, and without `-d` it applies to the *current* spawn id, of which there is none yet, so the client ran with expect's 2000-byte default: a 6001-char buffer. The bare `\l` expands to `SHOW DATABASES`, which on that shared runner listed 69 databases, each padded to 219 chars by a concurrent test's ~200-char name, a 15,754-char burst, 2.6x the window. The `.expect.debuglog` shows expect forgetting output four times while matching the prompt after that `\l`, ending with the buffer pinned at 6001, a 13-char final read, and the timeout.

`match_max -d 100000` makes the value the test already asks for reach the `spawn`.

Verified locally: `[match_max]` after a `spawn` reports 2000 without `-d` and 100000 with it. Against a 17,679-char listing, the debuglogs of 50 runs hold 304 full-buffer discards without the change and 0 with it; reverting only the `-d` brings them back. 50/50 runs pass either way. The 60 s timeout itself is rate-dependent and did not reproduce locally; what is shown is that the assertion ran in a discard regime the declared buffer would have prevented.

Of the 62 `.expect` tests here, the other 60 set `match_max` the same ineffective way. As in #112160 this changes only the test that is failing, since a larger buffer also makes expect retain older output, which could affect negative `expect` patterns elsewhere. Bounding the listing instead, as #113713 did for `02105_backslash_letter_commands`, would drop the bare `\l` this line asserts and would let `expect "system"` match the echoed predicate; the listing therefore stays shared-server output, now with room for about 6x the measured burst.

Related: https://github.com/ClickHouse/ClickHouse/pull/117423

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118379&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118379](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118379+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
