### PR TITLE
Filter `system.remote_data_paths` by `disk_name` before traversing disks

### DIFF
--- a/src/Storages/System/StorageSystemRemoteDataPaths.cpp
+++ b/src/Storages/System/StorageSystemRemoteDataPaths.cpp
@@ -18,6 +18,7 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Storages/VirtualColumnUtils.h>
 
 namespace fs = std::filesystem;
 
@@ -151,7 +152,7 @@ public:
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
 
-    /// TODO: void applyFilters(ActionDAGNodes added_filter_nodes) can be implemented to filter out disk names
+    void applyFilters(ActionDAGNodes added_filter_nodes) override;
 
 private:
     std::shared_ptr<const StorageLimitsList> storage_limits;
@@ -208,6 +209,44 @@ void StorageSystemRemoteDataPaths::readImpl(
         header,
         max_block_size);
     query_plan.addStep(std::move(read_step));
+}
+
+void ReadFromSystemRemoteDataPaths::applyFilters(ActionDAGNodes added_filter_nodes)
+{
+    SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
+
+    const ActionsDAG::Node * predicate = nullptr;
+    if (filter_actions_dag)
+        predicate = filter_actions_dag->getOutputs().at(0);
+
+    if (!predicate)
+        return;
+
+    /// Reading one disk walks its whole `store` and `data` subtree and reads the metadata of every
+    /// file in it, which on a disk with shared metadata (`plain`, `plain_rewritable`) or on a `web`
+    /// disk means listing the object storage. There is no way to narrow that traversal down, so a
+    /// query that names the disks it is interested in must not pay for all the others: on a server
+    /// that holds a large table on some other object-storage disk, the difference is minutes.
+    auto disk_name_column = ColumnString::create();
+    for (const auto & [disk_name, _] : disks)
+        disk_name_column->insertData(disk_name.data(), disk_name.size());
+
+    Block block{ColumnWithTypeAndName(std::move(disk_name_column), std::make_shared<DataTypeString>(), "disk_name")};
+    VirtualColumnUtils::filterBlockWithPredicate(predicate, block, context);
+
+    /// A predicate that says nothing about `disk_name` leaves every row in place.
+    const auto & filtered_column = *block.getByPosition(0).column;
+    NameSet requested_disks;
+    for (size_t i = 0; i < filtered_column.size(); ++i)
+        requested_disks.emplace(filtered_column.getDataAt(i));
+
+    for (auto it = disks.begin(); it != disks.end();)
+    {
+        if (requested_disks.contains(it->first))
+            ++it;
+        else
+            it = disks.erase(it);
+    }
 }
 
 void ReadFromSystemRemoteDataPaths::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & /*settings*/)

--- a/tests/queries/0_stateless/05100_system_remote_data_paths_disk_name_filter.reference
+++ b/tests/queries/0_stateless/05100_system_remote_data_paths_disk_name_filter.reference
@@ -1,0 +1,5 @@
+own disk	1
+other disk	0
+no such disk	0
+in list	1
+expression	1

--- a/tests/queries/0_stateless/05100_system_remote_data_paths_disk_name_filter.sql
+++ b/tests/queries/0_stateless/05100_system_remote_data_paths_disk_name_filter.sql
@@ -1,0 +1,46 @@
+-- Tags: no-fasttest
+-- no-fasttest: needs object storage disks (MinIO).
+
+-- `system.remote_data_paths` walks `store` and `data` on every disk it is given and reads the
+-- metadata of every file it finds, so a `disk_name` predicate is pushed into the set of disks the
+-- source traverses. These are the cases that pruning must get right; that the requested disk is
+-- still traversed at all is also covered by `03000_traverse_shadow_system_data_paths`, and that a
+-- query without a `disk_name` predicate keeps every disk by `test_disk_over_web_server`.
+--
+-- Every query below names a disk on purpose: an unfiltered read of this table costs a full
+-- traversal of every object storage disk on the server, which is minutes when one of them holds a
+-- large table.
+
+DROP TABLE IF EXISTS t_05100;
+
+CREATE TABLE t_05100 (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS storage_policy = 's3_no_cache';
+INSERT INTO t_05100 SELECT number FROM numbers(10);
+
+-- The table's own files are found through the filtered read.
+SELECT 'own disk', count() > 0
+FROM system.remote_data_paths
+WHERE disk_name = 's3_no_cache'
+    AND local_path LIKE concat('%', (SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase() AND name = 't_05100'), '%');
+
+-- Pruning is per disk: asking for another disk must not report this table's files.
+SELECT 'other disk', count()
+FROM system.remote_data_paths
+WHERE disk_name = 's3_disk'
+    AND local_path LIKE concat('%', (SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase() AND name = 't_05100'), '%');
+
+-- A name that no disk has prunes everything.
+SELECT 'no such disk', count() FROM system.remote_data_paths WHERE disk_name = 'no_such_disk_05100';
+
+-- `IN` must keep the disk that exists, next to one that does not.
+SELECT 'in list', count() > 0
+FROM system.remote_data_paths
+WHERE disk_name IN ('no_such_disk_05100', 's3_no_cache')
+    AND local_path LIKE concat('%', (SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase() AND name = 't_05100'), '%');
+
+-- The same read, expressed so that the pruning has to evaluate a function of `disk_name`.
+SELECT 'expression', count() > 0
+FROM system.remote_data_paths
+WHERE startsWith(disk_name, 's3_no_cache')
+    AND local_path LIKE concat('%', (SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase() AND name = 't_05100'), '%');
+
+DROP TABLE t_05100;


### PR DESCRIPTION
Reading `system.remote_data_paths` walks `store` and `data` on every disk in the server's disk map and reads the metadata of every file it finds. Nothing narrowed that down — `ReadFromSystemRemoteDataPaths` carried a `TODO` for exactly this — so `WHERE disk_name = '...'` paid for a full traversal of every object storage disk and only then dropped the rows of the disks that were not asked for. On a disk with shared metadata (`plain`, `plain_rewritable`) or a `web` disk, that traversal also means listing the object storage.

It is not a small constant. A stateless test that read this table with `WHERE disk_name = 's3_no_cache'` took **474–532 s** per run (the limit is 180 s) on a server that happened to hold `test.hits_s3` and the `tpch` tables on its other object storage disks, while every other query in the same test took under four seconds — from that job's own `query_log.tsv`:

| query | duration |
|---|---|
| `SELECT count(DISTINCT remote_path) FROM system.remote_data_paths WHERE disk_name = 's3_no_cache' …` | 474–532 s (9 runs) |
| `ALTER … MOVE PARTITION` / `REPLACE PARTITION` on the same tables | 1.5–3.8 s |
| `SYSTEM WAIT BLOBS CLEANUP` | 0.011–0.229 s |

`applyFilters` now evaluates the predicate against a one-column block of the disk names and traverses only the disks that survive it. A predicate that says nothing about `disk_name` — or mentions it only inside a disjunction with another column — leaves every disk in place, which is what `VirtualColumnUtils::filterBlockWithPredicate` does with a partial predicate.

Verified in a local rig built from `tests/config`, against a server holding ~1200 files across its object storage disks:

- `WHERE disk_name = 's3_no_cache'` returns the same 27 rows as the unfiltered read, in **59 ms instead of 348 ms**;
- `WHERE size >= 0` and `WHERE disk_name = 's3_no_cache' OR size >= 0` still see every disk (1135 rows on `s3_cache`, 27 on `s3_no_cache`);
- `WHERE disk_name != 's3_no_cache'` prunes that disk and keeps the rest.

The new `05100_system_remote_data_paths_disk_name_filter` covers the pruning cases: the requested disk, another disk, a name no disk has, `IN` next to a name that does not exist, and a function of `disk_name`. Every query in it names a disk on purpose — an unfiltered read of this table is the expensive shape this pull request is about, so the test must not issue one. The two properties that need an unfiltered read are already covered elsewhere: that the requested disk is still traversed by `03000_traverse_shadow_system_data_paths`, and that a query without a `disk_name` predicate keeps every disk by `test_disk_over_web_server`.

Related: https://github.com/ClickHouse/ClickHouse/pull/101039

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Push the `disk_name` filter of `system.remote_data_paths` into the disk traversal, so a query that names the disks it needs no longer walks every object storage disk on the server.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118400&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118400](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118400+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1327` (included in `26.9` and later)
<!-- ch-version-info:end -->