### PR TITLE
Give an inlined view's subquery the name of the view

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -5775,7 +5775,7 @@ void QueryAnalyzer::resolveJoin(QueryTreeNodePtr & join_node, IdentifierResolveS
   * This replaces the TableNode wrapping a StorageView with a QueryNode/UnionNode built from the
   * view's inner query AST, making the view transparent to the analyzer and all optimization passes.
   */
-void QueryAnalyzer::inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node, IdentifierResolveScope & scope) const
+void QueryAnalyzer::inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node, IdentifierResolveScope & scope)
 {
     if (!scope.context->getSettingsRef()[Setting::analyzer_inline_views])
         return;
@@ -5956,7 +5956,13 @@ void QueryAnalyzer::inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node
     }
 
     /// Preserve alias: the outer query references columns via the view name or user-provided alias.
-    result_node->setAlias(table_node->getAlias());
+    /// A view used without an alias lends its own name to the inlined subquery: the subquery carries no
+    /// name of its own, and `joined_subquery_requires_alias` (on by default) rejects a join with an
+    /// unnamed subquery, so joining a view by its name used to fail with `ALIAS_REQUIRED` under inlining
+    /// while the same query runs without it. The name also stays available as a qualifier, as it is
+    /// without inlining.
+    const bool aliased_by_view_name = table_node->getAlias().empty();
+    result_node->setAlias(aliased_by_view_name ? storage_id.getTableName() : table_node->getAlias());
 
     /// Fix scope tracking: the old TableNode pointer was inserted during initializeQueryJoinTreeNode.
     auto * old_ptr = join_tree_node.get();
@@ -5964,6 +5970,9 @@ void QueryAnalyzer::inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node
 
     join_tree_node = std::move(result_node);
     scope.table_expressions_in_resolve_process.insert(join_tree_node.get());
+
+    if (aliased_by_view_name)
+        table_expressions_aliased_by_inlined_view_name.insert(join_tree_node.get());
 }
 
 /** Resolve query join tree.
@@ -6161,9 +6170,18 @@ void QueryAnalyzer::resolveQueryJoinTreeNode(QueryTreeNodePtr & join_tree_node, 
               * expression namespace, so it replaces the speculative entry (example: SELECT number AS x FROM (SELECT 1) AS x).
               * Genuine duplicate aliases between table expressions are rejected earlier by TableExpressionsAliasVisitor.
               */
+            /** The alias of a view inlined without an alias of its own is the view's name, and a table name
+              * may repeat in a FROM section: `FROM v JOIN v USING (k)` is accepted without inlining, where
+              * a reference to `v` resolves to the first of the two. Keep that resolution instead of
+              * rejecting the query only because the view was inlined.
+              */
+            const bool duplicate_of_an_inlined_view_name
+                = table_expressions_aliased_by_inlined_view_name.contains(table_expression_node.get())
+                && table_expressions_aliased_by_inlined_view_name.contains(it->second.get());
+
             if (it->second->getNodeType() == QueryTreeNodeType::IDENTIFIER)
                 it->second = table_expression_node;
-            else
+            else if (!duplicate_of_an_inlined_view_name)
                 throw Exception(ErrorCodes::MULTIPLE_EXPRESSIONS_FOR_ALIAS,
                     "Duplicate aliases {} for table expressions in FROM section are not allowed. Try to register {}. Already registered {}.",
                     alias_name,

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -4433,6 +4433,18 @@ void QueryAnalyzer::initializeTableExpressionData(const TableExpressionNodePtr &
     {
         table_expression_data.table_name = query_node ? query_node->getCTEName() : union_node->getCTEName();
         table_expression_data.table_expression_description = "subquery";
+
+        /** An inlined view keeps the name it had as a table expression, so that references qualified by
+          * the view name, with or without the database name, resolve the way they do without inlining -
+          * where a table name qualifies references even when the table expression also has an alias.
+          * Example: `SELECT default.v.b FROM t JOIN default.v USING (k)`.
+          */
+        auto inlined_view_it = table_expression_to_inlined_view_name.find(table_expression_node.get());
+        if (inlined_view_it != table_expression_to_inlined_view_name.end())
+        {
+            table_expression_data.database_name = inlined_view_it->second.storage_id.database_name;
+            table_expression_data.table_name = inlined_view_it->second.storage_id.table_name;
+        }
     }
     else if (table_function_node)
     {
@@ -5971,8 +5983,7 @@ void QueryAnalyzer::inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node
     join_tree_node = std::move(result_node);
     scope.table_expressions_in_resolve_process.insert(join_tree_node.get());
 
-    if (aliased_by_view_name)
-        table_expressions_aliased_by_inlined_view_name.insert(join_tree_node.get());
+    table_expression_to_inlined_view_name.emplace(join_tree_node.get(), InlinedViewName{storage_id, aliased_by_view_name});
 }
 
 /** Resolve query join tree.
@@ -6175,9 +6186,16 @@ void QueryAnalyzer::resolveQueryJoinTreeNode(QueryTreeNodePtr & join_tree_node, 
               * a reference to `v` resolves to the first of the two. Keep that resolution instead of
               * rejecting the query only because the view was inlined.
               */
+            auto takes_the_name_of_an_inlined_view = [&](const IQueryTreeNode * node)
+            {
+                auto inlined_view_it = table_expression_to_inlined_view_name.find(node);
+                return inlined_view_it != table_expression_to_inlined_view_name.end()
+                    && inlined_view_it->second.is_the_alias_as_well;
+            };
+
             const bool duplicate_of_an_inlined_view_name
-                = table_expressions_aliased_by_inlined_view_name.contains(table_expression_node.get())
-                && table_expressions_aliased_by_inlined_view_name.contains(it->second.get());
+                = takes_the_name_of_an_inlined_view(table_expression_node.get())
+                && takes_the_name_of_an_inlined_view(it->second.get());
 
             if (it->second->getNodeType() == QueryTreeNodeType::IDENTIFIER)
                 it->second = table_expression_node;

--- a/src/Analyzer/Resolve/QueryAnalyzer.h
+++ b/src/Analyzer/Resolve/QueryAnalyzer.h
@@ -294,7 +294,7 @@ private:
 
     void resolveQueryJoinTreeNode(QueryTreeNodePtr & join_tree_node, IdentifierResolveScope & scope, QueryExpressionsAliasVisitor & expressions_visitor);
 
-    void inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node, IdentifierResolveScope & scope) const;
+    void inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node, IdentifierResolveScope & scope);
 
     void resolveQuery(const QueryTreeNodePtr & query_node, IdentifierResolveScope & scope);
 
@@ -316,6 +316,11 @@ private:
     std::unordered_set<IQueryTreeNode *> windows_in_resolve_process;
 
     std::unordered_map<IQueryTreeNode *, QueryTreeNodePtr> cte_copy_to_original_map;
+
+    /// Table expressions whose alias is the name of the view they were inlined from, see
+    /// `inlineViewSubqueryIfNeeded`. That alias stands in for a table name, which a `FROM` section may
+    /// carry more than once, so a duplicate of it is resolved the way a duplicate table name is.
+    std::unordered_set<const IQueryTreeNode *> table_expressions_aliased_by_inlined_view_name;
 
     /// Function name to user defined lambda map
     std::unordered_map<std::string, QueryTreeNodePtr> function_name_to_user_defined_lambda;

--- a/src/Analyzer/Resolve/QueryAnalyzer.h
+++ b/src/Analyzer/Resolve/QueryAnalyzer.h
@@ -317,10 +317,20 @@ private:
 
     std::unordered_map<IQueryTreeNode *, QueryTreeNodePtr> cte_copy_to_original_map;
 
-    /// Table expressions whose alias is the name of the view they were inlined from, see
-    /// `inlineViewSubqueryIfNeeded`. That alias stands in for a table name, which a `FROM` section may
-    /// carry more than once, so a duplicate of it is resolved the way a duplicate table name is.
-    std::unordered_set<const IQueryTreeNode *> table_expressions_aliased_by_inlined_view_name;
+    /** The name of the view a table expression was inlined from, see `inlineViewSubqueryIfNeeded`.
+      * A view keeps its name as a qualifier once inlined, exactly as it does without inlining: `v.c` and
+      * `db.v.c` address it, and an alias of its own does not take that name away.
+      */
+    struct InlinedViewName
+    {
+        StorageID storage_id;
+        /// The view had no alias of its own, so its name became the alias of the inlined subquery. Unlike
+        /// a user-provided alias, a table name may repeat in a `FROM` section, so a duplicate of it is
+        /// resolved the way a duplicate table name is instead of being rejected.
+        bool is_the_alias_as_well;
+    };
+
+    std::unordered_map<const IQueryTreeNode *, InlinedViewName> table_expression_to_inlined_view_name;
 
     /// Function name to user defined lambda map
     std::unordered_map<std::string, QueryTreeNodePtr> function_name_to_user_defined_lambda;

--- a/tests/queries/0_stateless/05104_inline_view_join_alias.reference
+++ b/tests/queries/0_stateless/05104_inline_view_join_alias.reference
@@ -1,0 +1,20 @@
+a join with the view written without an alias
+50
+50
+columns qualified by the view name
+50	49
+50	49
+the same view on both sides, neither aliased
+100
+100
+an alias of its own still wins
+50
+50
+a view over a view, and a view over a union
+50
+50
+100
+100
+a comma join, which the restriction covers as well
+50
+50

--- a/tests/queries/0_stateless/05104_inline_view_join_alias.reference
+++ b/tests/queries/0_stateless/05104_inline_view_join_alias.reference
@@ -4,12 +4,20 @@ a join with the view written without an alias
 columns qualified by the view name
 50	49
 50	49
+columns qualified by the database name and the view name
+50	49
+50	49
 the same view on both sides, neither aliased
 100
 100
 an alias of its own still wins
 50
 50
+a view name qualifies even next to an alias of its own, as a table name does
+50	49
+50	49
+50	49
+50	49
 a view over a view, and a view over a union
 50
 50

--- a/tests/queries/0_stateless/05104_inline_view_join_alias.sql
+++ b/tests/queries/0_stateless/05104_inline_view_join_alias.sql
@@ -1,0 +1,54 @@
+-- `analyzer_inline_views = 1` replaces a `VIEW` in the join tree with the view's body. The body carried no
+-- name of its own, so `joined_subquery_requires_alias` (on by default) rejected a join with a view written
+-- without an alias, and the query failed with 206 `ALIAS_REQUIRED` while the same query runs without
+-- inlining. The inlined subquery now takes the view's name, which also keeps that name usable as a
+-- qualifier and repeatable in a `FROM` section, as the view itself is.
+
+SET joined_subquery_requires_alias = 1;
+
+DROP TABLE IF EXISTS t_inline_left;
+DROP TABLE IF EXISTS t_inline_right;
+DROP VIEW IF EXISTS v_inline;
+DROP VIEW IF EXISTS v_inline_over_view;
+DROP VIEW IF EXISTS v_inline_union;
+
+CREATE TABLE t_inline_left (k UInt32, v Int64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t_inline_right (k UInt32, b Int64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_inline_left SELECT number, number FROM numbers(50);
+INSERT INTO t_inline_right SELECT number, number FROM numbers(100);
+
+CREATE VIEW v_inline AS SELECT * FROM t_inline_right;
+CREATE VIEW v_inline_over_view AS SELECT * FROM v_inline;
+CREATE VIEW v_inline_union AS SELECT * FROM t_inline_right UNION ALL SELECT * FROM t_inline_right;
+
+SELECT 'a join with the view written without an alias';
+SELECT count() FROM t_inline_left INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count() FROM t_inline_left INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 0;
+
+SELECT 'columns qualified by the view name';
+SELECT count(), max(v_inline.b) FROM t_inline_left INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count(), max(v_inline.b) FROM t_inline_left INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 0;
+
+SELECT 'the same view on both sides, neither aliased';
+SELECT count() FROM v_inline INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count() FROM v_inline INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 0;
+
+SELECT 'an alias of its own still wins';
+SELECT count() FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count() FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 0;
+
+SELECT 'a view over a view, and a view over a union';
+SELECT count() FROM t_inline_left INNER JOIN v_inline_over_view USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count() FROM t_inline_left INNER JOIN v_inline_over_view USING (k) SETTINGS analyzer_inline_views = 0;
+SELECT count() FROM t_inline_left INNER JOIN v_inline_union USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count() FROM t_inline_left INNER JOIN v_inline_union USING (k) SETTINGS analyzer_inline_views = 0;
+
+SELECT 'a comma join, which the restriction covers as well';
+SELECT count() FROM t_inline_left, v_inline WHERE t_inline_left.k = v_inline.k SETTINGS analyzer_inline_views = 1;
+SELECT count() FROM t_inline_left, v_inline WHERE t_inline_left.k = v_inline.k SETTINGS analyzer_inline_views = 0;
+
+DROP VIEW v_inline_union;
+DROP VIEW v_inline_over_view;
+DROP VIEW v_inline;
+DROP TABLE t_inline_right;
+DROP TABLE t_inline_left;

--- a/tests/queries/0_stateless/05104_inline_view_join_alias.sql
+++ b/tests/queries/0_stateless/05104_inline_view_join_alias.sql
@@ -29,6 +29,10 @@ SELECT 'columns qualified by the view name';
 SELECT count(), max(v_inline.b) FROM t_inline_left INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 1;
 SELECT count(), max(v_inline.b) FROM t_inline_left INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 0;
 
+SELECT 'columns qualified by the database name and the view name';
+SELECT count(), max({CLICKHOUSE_DATABASE:Identifier}.v_inline.b) FROM t_inline_left INNER JOIN {CLICKHOUSE_DATABASE:Identifier}.v_inline USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count(), max({CLICKHOUSE_DATABASE:Identifier}.v_inline.b) FROM t_inline_left INNER JOIN {CLICKHOUSE_DATABASE:Identifier}.v_inline USING (k) SETTINGS analyzer_inline_views = 0;
+
 SELECT 'the same view on both sides, neither aliased';
 SELECT count() FROM v_inline INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 1;
 SELECT count() FROM v_inline INNER JOIN v_inline USING (k) SETTINGS analyzer_inline_views = 0;
@@ -36,6 +40,12 @@ SELECT count() FROM v_inline INNER JOIN v_inline USING (k) SETTINGS analyzer_inl
 SELECT 'an alias of its own still wins';
 SELECT count() FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 1;
 SELECT count() FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 0;
+
+SELECT 'a view name qualifies even next to an alias of its own, as a table name does';
+SELECT count(), max(v_inline.b) FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count(), max(v_inline.b) FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 0;
+SELECT count(), max({CLICKHOUSE_DATABASE:Identifier}.v_inline.b) FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 1;
+SELECT count(), max({CLICKHOUSE_DATABASE:Identifier}.v_inline.b) FROM t_inline_left INNER JOIN v_inline AS x USING (k) SETTINGS analyzer_inline_views = 0;
 
 SELECT 'a view over a view, and a view over a union';
 SELECT count() FROM t_inline_left INNER JOIN v_inline_over_view USING (k) SETTINGS analyzer_inline_views = 1;


### PR DESCRIPTION
`analyzer_inline_views = 1` replaces a `VIEW` in the join tree with the view's body. The body carried no name
of its own, so `joined_subquery_requires_alias` (on by default) rejected a join with a view written without
an alias:

```sql
CREATE TABLE t1 (k UInt32, v Int64) ENGINE = MergeTree ORDER BY k;
CREATE TABLE t2 (k UInt32, b Int64) ENGINE = MergeTree ORDER BY k;
CREATE VIEW v2 AS SELECT * FROM t2;

SELECT count() FROM t1 INNER JOIN v2 USING (k) SETTINGS analyzer_inline_views = 1;
-- Code: 206. DB::Exception: JOIN  INNER JOIN ... USING (k) no alias for subquery or table function
--   SELECT * FROM default.t2 ... (ALIAS_REQUIRED)
```

while the same query runs without inlining. The name was lost for qualification as well, so `v2.b` could not
be resolved under inlining either.

The inlined subquery now keeps the view's name as a table expression name, the way a table keeps its name -
not as an alias, since a user alias is unique in a `FROM` section while a table name is not. The name is
recorded as qualifier metadata (`table_expression_to_inlined_view_name`) and consulted by every analyzer
path that names a table expression: `v.b` and `db.v.b` resolve, no alias is required for the join, `SELECT *`
qualifies ambiguous columns with `db.v.b` as for a non-inlined `VIEW`, and `FROM v JOIN v USING (k)` or
`FROM v AS v JOIN v USING (k)` are accepted as they are without inlining.

Closes: https://github.com/ClickHouse/ClickHouse/issues/113245

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `ALIAS_REQUIRED` for a join with a `VIEW` written without an alias under the experimental setting
`analyzer_inline_views = 1`: the inlined subquery now keeps the view's name as a table expression name, so it
needs no alias and stays usable as a column qualifier, with or without the database name.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118401&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118401](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118401+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

