### PR TITLE
Fix sendQueryPlan error message in MultiplexedConnections

### DIFF
--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -108,7 +108,7 @@ void MultiplexedConnections::sendQueryPlan(const QueryPlan & query_plan)
     std::lock_guard lock(cancel_mutex);
 
     if (!sent_query)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot send scalars data: query not yet sent.");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot send query plan: query not yet sent.");
 
     for (ReplicaState & state : replica_states)
     {


### PR DESCRIPTION
This fixes an incorrect error message in `MultiplexedConnections::sendQueryPlan()`.

When `sendQueryPlan()` is called before a query has been sent, the error message incorrectly says:

```text
Cannot send scalars data: query not yet sent.
```

It now correctly says:

```text
Cannot send query plan: query not yet sent.

```

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118405&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118405](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118405+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.876` (included in `26.9` and later)
<!-- ch-version-info:end -->