### PR TITLE
Keep the sorting-key columns of a layered read through PREWHERE

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1178,6 +1178,22 @@ Pipe ReadFromMergeTree::readByLayers(
             in_order_column_names_to_read.push_back(column_name);
             column_names_set.insert(column_name);
         }
+
+        /// PREWHERE actions can remove an input column that only the prewhere condition needs, and the read
+        /// below applies PREWHERE before the sorting expression, so a column of the sorting key can be
+        /// missing from the block that expression is computed on ("Not found column ... in block"). Keep such
+        /// inputs, as the in-order read without layers does in `spreadMarkRangesAmongStreamsWithOrder`; the
+        /// columns the query does not need are dropped by the converting step at the end of
+        /// `initializePipeline`.
+        if (query_info.prewhere_info || query_info.row_level_filter)
+        {
+            NameSet sorting_columns;
+            for (const auto & column : storage_snapshot->metadata->getSortingKey().expression->getRequiredColumnsWithTypes())
+                sorting_columns.insert(column.name);
+
+            restorePrewhereInputs(query_info.row_level_filter.get(), query_info.prewhere_info.get(), sorting_columns);
+        }
+
         auto sorting_expr = storage_snapshot->metadata->getSortingKey().expression;
         const auto & sorting_columns = storage_snapshot->metadata->getSortingKey().column_names;
         std::vector<bool> reverse_flags = storage_snapshot->metadata->getSortingKeyReverseFlags();

--- a/tests/queries/0_stateless/05106_join_shard_by_pk_ranges_prewhere.reference
+++ b/tests/queries/0_stateless/05106_join_shard_by_pk_ranges_prewhere.reference
@@ -1,0 +1,10 @@
+a correlated EXISTS under OR, whose decorrelated join is sharded
+700
+700
+700
+a plain join with a filter that only PREWHERE reads
+42800
+42800
+and one that reads both key columns of the join
+71357
+71357

--- a/tests/queries/0_stateless/05106_join_shard_by_pk_ranges_prewhere.sql
+++ b/tests/queries/0_stateless/05106_join_shard_by_pk_ranges_prewhere.sql
@@ -1,0 +1,36 @@
+-- `query_plan_join_shard_by_pk_ranges = 1` reads both sides of a `full_sorting_merge` join in primary-key
+-- layers, and each layer computes the sorting key on top of the read. `PREWHERE` runs before that and may
+-- drop an input column that only the prewhere condition needs, so a column of the sorting key could be
+-- missing there and the query failed at execution with 10 `NOT_FOUND_COLUMN_IN_BLOCK`.
+
+DROP TABLE IF EXISTS t_shard_pk_prewhere;
+CREATE TABLE t_shard_pk_prewhere (s String, n UInt32, v Int64) ENGINE = MergeTree ORDER BY (s, n);
+INSERT INTO t_shard_pk_prewhere SELECT toString(number % 10), number, number % 7 FROM numbers(1000);
+
+SELECT 'a correlated EXISTS under OR, whose decorrelated join is sharded';
+SELECT count() FROM (
+    SELECT o.n FROM t_shard_pk_prewhere AS o
+    WHERE (EXISTS (SELECT 1 FROM t_shard_pk_prewhere AS i WHERE i.s = o.s AND v >= n)) OR o.n = 435)
+SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 1;
+SELECT count() FROM (
+    SELECT o.n FROM t_shard_pk_prewhere AS o
+    WHERE (EXISTS (SELECT 1 FROM t_shard_pk_prewhere AS i WHERE i.s = o.s AND v >= n)) OR o.n = 435)
+SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 0;
+SELECT count() FROM (
+    SELECT o.n FROM t_shard_pk_prewhere AS o
+    WHERE (EXISTS (SELECT 1 FROM t_shard_pk_prewhere AS i WHERE i.s = o.s AND v >= n)) OR o.n = 435)
+SETTINGS join_algorithm = 'hash';
+
+SELECT 'a plain join with a filter that only PREWHERE reads';
+SELECT count() FROM t_shard_pk_prewhere AS a INNER JOIN t_shard_pk_prewhere AS b ON a.s = b.s PREWHERE a.v > 3
+SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 1;
+SELECT count() FROM t_shard_pk_prewhere AS a INNER JOIN t_shard_pk_prewhere AS b ON a.s = b.s PREWHERE a.v > 3
+SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 0;
+
+SELECT 'and one that reads both key columns of the join';
+SELECT sum(a.n) FROM t_shard_pk_prewhere AS a INNER JOIN t_shard_pk_prewhere AS b ON a.s = b.s AND a.n = b.n PREWHERE a.v = 2
+SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 1;
+SELECT sum(a.n) FROM t_shard_pk_prewhere AS a INNER JOIN t_shard_pk_prewhere AS b ON a.s = b.s AND a.n = b.n PREWHERE a.v = 2
+SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 0;
+
+DROP TABLE t_shard_pk_prewhere;

--- a/tests/queries/0_stateless/05106_join_shard_by_pk_ranges_prewhere.sql
+++ b/tests/queries/0_stateless/05106_join_shard_by_pk_ranges_prewhere.sql
@@ -3,6 +3,9 @@
 -- drop an input column that only the prewhere condition needs, so a column of the sorting key could be
 -- missing there and the query failed at execution with 10 `NOT_FOUND_COLUMN_IN_BLOCK`.
 
+-- The correlated `EXISTS` below is a feature of the analyzer, so this test needs it.
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS t_shard_pk_prewhere;
 CREATE TABLE t_shard_pk_prewhere (s String, n UInt32, v Int64) ENGINE = MergeTree ORDER BY (s, n);
 INSERT INTO t_shard_pk_prewhere SELECT toString(number % 10), number, number % 7 FROM numbers(1000);


### PR DESCRIPTION
`query_plan_join_shard_by_pk_ranges = 1` reads both sides of a `full_sorting_merge` join in primary-key
layers, and each layer computes the table's sorting expression on top of the read. `PREWHERE` runs before
that and may remove an input column that only the prewhere condition needs, so a column of the sorting key
could be missing from the block the expression is computed on, and the query failed at execution:

```sql
CREATE TABLE t (s String, n UInt32, v Int64) ENGINE = MergeTree ORDER BY (s, n);
INSERT INTO t SELECT toString(number % 10), number, number % 7 FROM numbers(1000);

SELECT o.n FROM t AS o WHERE (EXISTS (SELECT 1 FROM t AS i WHERE i.s = o.s AND v >= n)) OR o.n = 435
SETTINGS join_algorithm = 'full_sorting_merge', query_plan_join_shard_by_pk_ranges = 1;
-- Code: 10. DB::Exception: Not found column n: in block s String String(size = 0). (NOT_FOUND_COLUMN_IN_BLOCK)
```

The layered read now restores those inputs, exactly as the in-order read without layers already does in
`spreadMarkRangesAmongStreamsWithOrder`. The columns the query itself does not need are dropped by the
converting step at the end of `initializePipeline`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112031

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `NOT_FOUND_COLUMN_IN_BLOCK` at execution time for a `full_sorting_merge` join under
`query_plan_join_shard_by_pk_ranges = 1` when `PREWHERE` removed a column of the table's sorting key.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118407&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118407](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118407+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
