### PR TITLE
Do not keep an `IN` set placeholder alive for `INTERPOLATE`

### DIFF
--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -6,6 +6,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/FilterDescription.h>
 
+#include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeNullable.h>
 
@@ -566,8 +567,24 @@ SortAnalysisResult analyzeSort(
         /// so here we add materialized ORDER BY columns manually, and append everything else after.
         ActionsDAG before_interpolate_actions_dag(before_sort_actions->dag.getResultColumns());
         for (const auto & out : actions_chain.getLastStepAvailableOutputColumns())
-            if (!before_sort_actions_dag_output_node_names.contains(out.name))
-                before_interpolate_actions_dag.getOutputs().push_back(&before_interpolate_actions_dag.addInput(out));
+        {
+            if (before_sort_actions_dag_output_node_names.contains(out.name))
+                continue;
+
+            /** The `Set` placeholder of an `IN` and the `Function` column of a lambda are not values: no
+              * `INTERPOLATE` expression can name them (their names are internal), and they cannot be
+              * materialized. Keeping one as an output carries it past the filter that consumes it into every
+              * step above, including ones that build rows out of the whole header: the `FINAL` merge of a
+              * `WITH FILL INTERPOLATE` query then failed with `CORRUPTED_DATA` ("Cannot get value from Set"),
+              * and the virtual row of an in-order read with `NOT_IMPLEMENTED` ("Cannot insert element into
+              * Set", #111831).
+              */
+            const WhichDataType which_type(out.type);
+            if (which_type.isSet() || which_type.isFunction())
+                continue;
+
+            before_interpolate_actions_dag.getOutputs().push_back(&before_interpolate_actions_dag.addInput(out));
+        }
 
         for (auto & interpolate_node : interpolate_list_node.getNodes())
         {

--- a/tests/queries/0_stateless/05108_interpolate_keeps_set_placeholder.reference
+++ b/tests/queries/0_stateless/05108_interpolate_keeps_set_placeholder.reference
@@ -1,0 +1,14 @@
+a FINAL read whose filter is an IN set moved into PREWHERE
+561
+561
+561
+a plain IN filter with WITH FILL INTERPOLATE
+0	7
+1	8
+2	8
+3	7
+INTERPOLATE of a column the filter reads
+0	x
+1	8
+2	8
+3	8x

--- a/tests/queries/0_stateless/05108_interpolate_keeps_set_placeholder.sql
+++ b/tests/queries/0_stateless/05108_interpolate_keeps_set_placeholder.sql
@@ -1,0 +1,54 @@
+-- `INTERPOLATE` keeps every column of the previous step alive, which used to include the `Set`
+-- placeholder of an `IN` predicate. That placeholder is not a value: carried past the filter that
+-- consumes it, it reaches steps that build rows out of the whole header, and the `FINAL` merge failed
+-- with 246 `CORRUPTED_DATA` ("Cannot get value from Set").
+
+DROP TABLE IF EXISTS t_interpolate_dict_source;
+DROP DICTIONARY IF EXISTS d_interpolate;
+DROP TABLE IF EXISTS t_interpolate_coalescing;
+DROP TABLE IF EXISTS t_interpolate_in;
+
+CREATE TABLE t_interpolate_dict_source (id UInt64, val UInt32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_interpolate_dict_source SELECT number, toUInt32(number % 97) FROM numbers(500);
+
+CREATE DICTIONARY d_interpolate (id UInt64, val UInt32 DEFAULT 0)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 't_interpolate_dict_source' DB currentDatabase()))
+LIFETIME(0)
+LAYOUT(FLAT());
+
+CREATE TABLE t_interpolate_coalescing (k UInt32, a Nullable(Int64), b Nullable(Int64))
+ENGINE = CoalescingMergeTree ORDER BY k SETTINGS index_granularity = 64;
+INSERT INTO t_interpolate_coalescing SELECT number, toInt64(number) * 2 - 100, NULL FROM numbers(400);
+-- A second unmerged part, so that FINAL actually merges.
+INSERT INTO t_interpolate_coalescing SELECT number, NULL, toInt64(number) * 3 FROM numbers(600) SETTINGS optimize_on_insert = 0;
+
+SELECT 'a FINAL read whose filter is an IN set moved into PREWHERE';
+SELECT count() FROM (
+    SELECT a, k FROM t_interpolate_coalescing FINAL
+    WHERE dictGet(currentDatabase() || '.d_interpolate', 'val', toUInt64(k) % 500) >= 6
+    ORDER BY k WITH FILL FROM 0 TO 38 INTERPOLATE (a AS 7))
+SETTINGS optimize_move_to_prewhere_if_final = 1;
+SELECT count() FROM (
+    SELECT a, k FROM t_interpolate_coalescing FINAL
+    WHERE dictGet(currentDatabase() || '.d_interpolate', 'val', toUInt64(k) % 500) >= 6
+    ORDER BY k WITH FILL FROM 0 TO 38 INTERPOLATE (a AS 7))
+SETTINGS optimize_move_to_prewhere_if_final = 0;
+SELECT count() FROM (
+    SELECT a, k FROM t_interpolate_coalescing FINAL
+    WHERE dictGet(currentDatabase() || '.d_interpolate', 'val', toUInt64(k) % 500) >= 6
+    ORDER BY k WITH FILL FROM 0 TO 38 INTERPOLATE (a AS 7))
+SETTINGS optimize_move_to_prewhere_if_final = 1, optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'a plain IN filter with WITH FILL INTERPOLATE';
+CREATE TABLE t_interpolate_in (k UInt32, s String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_interpolate_in VALUES (1, '8'), (2, '8');
+SELECT k, s FROM t_interpolate_in WHERE s IN ('8') ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS '7');
+
+SELECT 'INTERPOLATE of a column the filter reads';
+SELECT k, s FROM t_interpolate_in WHERE s IN ('8') ORDER BY k WITH FILL FROM 0 TO 4 INTERPOLATE (s AS s || 'x');
+
+DROP TABLE t_interpolate_in;
+DROP TABLE t_interpolate_coalescing;
+DROP DICTIONARY d_interpolate;
+DROP TABLE t_interpolate_dict_source;


### PR DESCRIPTION
`INTERPOLATE` keeps every column of the step below alive, because its expressions may name any of them. The
`Set` placeholder of an `IN` predicate is not one of those: its name is internal, no expression can name it,
and it cannot be materialized. Kept as an output it travelled past the filter that consumes it into every
step above, including ones that build rows out of the whole header:

```sql
SELECT a, k FROM coal FINAL WHERE dictGet('dict', 'val', toUInt64(k) % 500) >= 6
ORDER BY k WITH FILL FROM 0 TO 38 INTERPOLATE (a AS 7)
SETTINGS optimize_move_to_prewhere_if_final = 1;
-- Code: 246. DB::Exception: SummingSortedAlgorithm failed to read row 0 of column 1 (__set_...),
--   reason: Cannot get value from Set: While executing CoalescingSortedTransform. (CORRUPTED_DATA)
```

`optimize_inverse_dictionary_lookup` (on by default) is what turns the `dictGet` comparison into a membership
test against such a set, and `optimize_move_to_prewhere_if_final` is what puts it under the `FINAL` merge. The
virtual row of an in-order read hit the same placeholder from the other side (#111831, fixed in the virtual
row itself).

A `Set` column - and the `Function` column of a lambda, which is a placeholder in the same way - is no longer
kept for `INTERPOLATE`, so neither reaches a step that materializes rows.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112030
Related: https://github.com/ClickHouse/ClickHouse/issues/111831

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `CORRUPTED_DATA` ("Cannot get value from Set") for a `FINAL` query with `ORDER BY ... WITH FILL
INTERPOLATE` whose filter is an `IN` set moved into `PREWHERE`: the set placeholder column is no longer kept
alive past the filter.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118420&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118420](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118420+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.872` (included in `26.9` and later)
<!-- ch-version-info:end -->