### PR TITLE
Remove the share token from the DET New York Luma link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Upcoming meetups
 * [Boston Hands-on training: Building agents with ClickHouse and LibreChat Boston](https://luma.com/clickh-nw1d) - September 14th, 2026
 * [Amsterdam Meetup](https://luma.com/clickh-vu1p) - September 15th, 2026
 * [Cape Town Meetup](https://luma.com/clickh-dw1v) - September 15th, 2026
-* [DET New York](https://luma.com/xf3wghdh?tk=S0INUD) - September 17th, 2026
+* [DET New York](https://luma.com/xf3wghdh) - September 17th, 2026
 * [The Agentic Data Stack: Paris](https://luma.com/clickh-s2a1) - September 17th, 2026
 * [The Agentic Data Stack: Zurich](https://luma.com/clickh-oo1l) - September 17th, 2026
 * [Rows And Columns Summit](https://luma.com/event/evt-bQcR6tDKi8OmTXu) - September 22nd, 2026


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/117952: the `DET New York` entry in the upcoming meetups list of `README.md` linked a tokenized Luma share URL (`?tk=...`). The token is not part of the canonical event URL, so this switches the entry to the plain URL, as flagged by the automated review on that PR.

Related: https://github.com/ClickHouse/ClickHouse/pull/117952

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118424&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118424](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118424+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
