### PR TITLE
Fix the sign of `lcm` for wide integers

### DIFF
--- a/src/Functions/lcm.cpp
+++ b/src/Functions/lcm.cpp
@@ -2,6 +2,8 @@
 #include <Functions/FunctionBinaryArithmetic.h>
 #include <Functions/GCDLCMImpl.h>
 
+#include <base/extended_types.h>
+
 #include <boost/integer/common_factor.hpp>
 
 
@@ -11,7 +13,10 @@ namespace abs_impl
 template <typename T>
 constexpr T abs(T value) noexcept
 {
-    if constexpr (std::is_signed_v<T>)
+    /// `is_signed_v` from `base/extended_types.h`, not the `std` trait: the latter is `false` for the
+    /// wide integers (`Int128`, `Int256`), so a negative one was returned unchanged and the negative
+    /// quotient below wrapped when converted to the unsigned type, negating the result of `lcm`.
+    if constexpr (is_signed_v<T>)
     {
         if (value >= 0 || value == std::numeric_limits<T>::min())
             return value;

--- a/tests/queries/0_stateless/05109_lcm_wide_integer_sign.reference
+++ b/tests/queries/0_stateless/05109_lcm_wide_integer_sign.reference
@@ -1,0 +1,15 @@
+one negative argument
+12	12
+12	12
+12	12
+12	12
+both negative, and both positive
+12	12
+12	12
+gcd, which was never affected
+2	2
+over a column, not a constant
+-6	-4	12
+-6	4	12
+6	-4	12
+6	4	12

--- a/tests/queries/0_stateless/05109_lcm_wide_integer_sign.sql
+++ b/tests/queries/0_stateless/05109_lcm_wide_integer_sign.sql
@@ -1,0 +1,25 @@
+-- `lcm` returned a negative result when exactly one argument was negative and the computation ran in a
+-- wide integer type: the sign branch of its `abs` helper was selected with the `std` trait, which is
+-- `false` for `Int128`/`Int256`, so the negative value passed through and the unsigned conversion of the
+-- negative quotient wrapped. With both arguments negative the two wraps cancelled, which is what the
+-- existing tests covered.
+
+SELECT 'one negative argument';
+SELECT lcm(toInt128(-6), toInt128(4)), lcm(toInt128(6), toInt128(-4));
+SELECT lcm(toInt256(-6), toInt256(4)), lcm(toInt256(6), toInt256(-4));
+SELECT lcm(toInt128(-6), toInt8(4)), lcm(toInt8(-6), toInt128(4));
+SELECT lcm(toInt64(-6), toInt64(4)), lcm(toInt32(-6), toInt32(4));
+
+SELECT 'both negative, and both positive';
+SELECT lcm(toInt128(-6), toInt128(-4)), lcm(toInt128(6), toInt128(4));
+SELECT lcm(toInt256(-6), toInt256(-4)), lcm(toInt256(6), toInt256(4));
+
+SELECT 'gcd, which was never affected';
+SELECT gcd(toInt128(-6), toInt128(4)), gcd(toInt256(-6), toInt256(4));
+
+SELECT 'over a column, not a constant';
+DROP TABLE IF EXISTS t_lcm_wide;
+CREATE TABLE t_lcm_wide (a Int128, b Int128) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_lcm_wide VALUES (-6, 4), (6, -4), (-6, -4), (6, 4);
+SELECT a, b, lcm(a, b) FROM t_lcm_wide ORDER BY a, b;
+DROP TABLE t_lcm_wide;


### PR DESCRIPTION
`lcm` returned a negative result when exactly one argument was negative and the computation ran in a wide
integer type, so the sign of the result depended only on the width of the argument types:

```sql
SELECT lcm(toInt128(-6), toInt128(4));   -- -12
SELECT lcm(toInt64(-6), toInt64(4));     -- 12
```

The `abs` helper of the function selects its sign branch with `std::is_signed_v`, which is `false` for
`Int128`/`Int256` (the codebase trait `is_signed_v` is the one that knows them), so a negative argument was
returned unchanged, the quotient `abs(a) / gcd(a, b)` came out negative and wrapped when converted to the
unsigned type, and the product converted back to the negated `lcm`. With both arguments negative the two
wraps cancelled, which is the case the existing tests cover.

`gcd` was never affected: it takes the absolute value through `boost::integer::gcd`, which consults
`std::numeric_limits<T>::is_signed`, and the wide integers do specialize `std::numeric_limits`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118348

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `lcm` returning a negative result for `Int128` and `Int256` arguments when exactly one of them is
negative, e.g. `lcm(toInt128(-6), toInt128(4))` returned `-12` instead of `12`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118431&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118431](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118431+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.873` (included in `26.9` and later)
<!-- ch-version-info:end -->