### PR TITLE
Remove the false `isInjective` claim from `reverseUTF8`

### DIFF
--- a/src/Functions/reverseUTF8.cpp
+++ b/src/Functions/reverseUTF8.cpp
@@ -87,7 +87,12 @@ struct NameReverseUTF8
 {
     static constexpr auto name = "reverseUTF8";
 };
-using FunctionReverseUTF8 = FunctionStringToString<ReverseUTF8Impl, NameReverseUTF8, true>;
+/// Not injective: a byte that announces a multi-byte sequence with fewer bytes remaining than the
+/// sequence needs is reversed as a single byte, so `reverseUTF8('a\xC2')` and `reverseUTF8('\xC2a')`
+/// are the same two bytes. Claiming injectivity let `optimize_injective_functions_in_group_by` and
+/// `optimize_injective_functions_inside_uniq` group and count by the argument, returning one group
+/// per argument instead of one per result value.
+using FunctionReverseUTF8 = FunctionStringToString<ReverseUTF8Impl, NameReverseUTF8, false>;
 
 }
 

--- a/tests/queries/0_stateless/05110_reverse_utf8_not_injective.reference
+++ b/tests/queries/0_stateless/05110_reverse_utf8_not_injective.reference
@@ -1,0 +1,10 @@
+the two inputs that collide
+C261	C261	1
+GROUP BY the result
+1
+1
+uniqExact of the result
+1
+1
+valid UTF-8 still groups by the result
+2	abc

--- a/tests/queries/0_stateless/05110_reverse_utf8_not_injective.sql
+++ b/tests/queries/0_stateless/05110_reverse_utf8_not_injective.sql
@@ -1,0 +1,21 @@
+-- `reverseUTF8` is not injective: a byte announcing a multi-byte sequence with fewer bytes remaining
+-- than it needs is reversed as a single byte, so two different inputs give the same output. It used to
+-- declare itself injective, and `optimize_injective_functions_in_group_by` and
+-- `optimize_injective_functions_inside_uniq` (both on by default) then grouped and counted by the
+-- argument, returning one group per argument instead of one per result value.
+
+SELECT 'the two inputs that collide';
+SELECT hex(reverseUTF8('a\xC2')), hex(reverseUTF8('\xC2a')), reverseUTF8('a\xC2') = reverseUTF8('\xC2a');
+
+SELECT 'GROUP BY the result';
+SELECT count() FROM (SELECT reverseUTF8(s) AS k FROM (SELECT arrayJoin(['a\xC2', '\xC2a']) AS s) GROUP BY k);
+SELECT count() FROM (SELECT reverseUTF8(s) AS k FROM (SELECT arrayJoin(['a\xC2', '\xC2a']) AS s) GROUP BY k)
+SETTINGS optimize_injective_functions_in_group_by = 0;
+
+SELECT 'uniqExact of the result';
+SELECT uniqExact(reverseUTF8(s)) FROM (SELECT arrayJoin(['a\xC2', '\xC2a']) AS s);
+SELECT uniqExact(reverseUTF8(s)) FROM (SELECT arrayJoin(['a\xC2', '\xC2a']) AS s)
+SETTINGS optimize_injective_functions_inside_uniq = 0;
+
+SELECT 'valid UTF-8 still groups by the result';
+SELECT count(), min(k) FROM (SELECT reverseUTF8(s) AS k FROM (SELECT arrayJoin(['abc', 'cba', 'abc']) AS s) GROUP BY k);


### PR DESCRIPTION
`reverseUTF8` is not injective. A byte that announces a multi-byte sequence with fewer bytes remaining than
the sequence needs is reversed as a single byte, so two different inputs give one output:

```sql
SELECT hex(reverseUTF8('a\xC2')), hex(reverseUTF8('\xC2a')), reverseUTF8('a\xC2') = reverseUTF8('\xC2a');
-- C261  C261  1
```

`optimize_injective_functions_in_group_by` and `optimize_injective_functions_inside_uniq`, both on by
default, trusted the claim and grouped and counted by the argument:

```sql
SELECT count() FROM (SELECT reverseUTF8(s) AS k FROM (SELECT arrayJoin(['a\xC2', '\xC2a']) AS s) GROUP BY k);
-- 2, and the two rows carry the same key value
SELECT uniqExact(reverseUTF8(s)) FROM (SELECT arrayJoin(['a\xC2', '\xC2a']) AS s);
-- 2
```

The per-value result of the function on invalid UTF-8 is documented as undefined, but the function is still a
function of its argument, and one `GROUP BY` row per distinct result value is not a per-value property.

Same class as the claims removed from `MACNumToString`, `unhex`/`unbin` and `UUIDStringToNum`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118085
Related: https://github.com/ClickHouse/ClickHouse/pull/117210

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed wrong results for `GROUP BY` and `uniq*` over `reverseUTF8`. It declared itself injective, so the
default-enabled `optimize_injective_functions_in_group_by` and `optimize_injective_functions_inside_uniq`
grouped and counted by the raw argument, and inputs that reverse to the same bytes came back as separate
groups.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118432&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118432](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118432+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.874` (included in `26.9` and later)
<!-- ch-version-info:end -->