### PR TITLE
Isolate the mutation in `03100_lwu_01_basics` from merges/mutations pool contention

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_01_basics.sql
+++ b/tests/queries/0_stateless/03100_lwu_01_basics.sql
@@ -7,13 +7,19 @@ SET enable_lightweight_update = 1;
 
 DROP TABLE IF EXISTS t_shared SYNC;
 
+-- `number_of_free_entries_in_pool_to_execute_mutation = 0` isolates the mutation of `APPLY PATCHES` from
+-- contention in the server-global merges/mutations pool: concurrent tests can occupy enough of the pool that
+-- the default threshold refuses to assign the mutation, and after `ATTACH` the merge-selecting task starts
+-- near `max_merge_selecting_sleep_ms`, so the next attempt happens only after 60 seconds and
+-- `mutations_sync = 2` times out.
 CREATE TABLE t_shared (id UInt64, c1 UInt64, c2 Int16)
 ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_shared/', '1')
 ORDER BY id
 SETTINGS
     enable_block_number_column = true,
     enable_block_offset_column = true,
-    remove_unused_patch_parts = false;
+    remove_unused_patch_parts = false,
+    number_of_free_entries_in_pool_to_execute_mutation = 0;
 
 INSERT INTO t_shared SELECT number, number, number FROM numbers(20);
 INSERT INTO t_shared SELECT number, number, number FROM numbers(100, 10);


### PR DESCRIPTION
`03100_lwu_01_basics` timed out in `ALTER TABLE t_shared APPLY PATCHES SETTINGS mutations_sync = 2` in the Fast test of https://github.com/ClickHouse/ClickHouse/pull/116885 (report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=116885&sha=76f996abfd704d65e2eeb35a9cc4de47ac9cf0ba&name_0=PR&name_1=Fast%20test).

The server log shows the merge-selecting task refusing to assign the mutation because the server-global merges/mutations pool was occupied by concurrent tests:

```
Number of queued mutations (0) is greater than max_replicated_mutations_in_queue (8) or there are not enough free threads for mutations (max_tasks_count (32) - occupied (25) < number_of_free_entries_in_pool_to_execute_mutation (8)), so won't select new parts to merge or mutate.
Scheduling next merge selecting task after 60000ms, current attempt status: Limited
```

The table had just been re-attached by the test (`DETACH TABLE` / `ATTACH TABLE`), and on attach `merge_selecting_sleep_ms` is initialised near `max_merge_selecting_sleep_ms` when the partition has few parts, so the next attempt came only after 60 s and the `mutations_sync = 2` wait hit its 60 s limit (`Failed to wait for mutation '0000000000', will recheck` repeated until `TIMEOUT_EXCEEDED`).

Set `number_of_free_entries_in_pool_to_execute_mutation = 0` on the table so its mutation does not depend on the pool occupancy of unrelated tests, as `02899_restore_parts_replicated_merge_tree` already does for the same reason (https://github.com/ClickHouse/ClickHouse/pull/112090). The test's output does not depend on this setting.

Related: https://github.com/ClickHouse/ClickHouse/pull/116885
Related: https://github.com/ClickHouse/ClickHouse/pull/112090

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118435&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118435](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118435+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
