### PR TITLE
Allow a dictionary whose remote source table shares its name

### DIFF
--- a/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -329,7 +329,11 @@ void registerDictionarySourceClickHouse(DictionarySourceFactory & factory)
         String dictionary_name = config.getString(".dictionary.name", "");
         String dictionary_database = config.getString(".dictionary.database", "");
 
-        if (dictionary_name == configuration->table && dictionary_database == configuration->db)
+        /// A dictionary must not read itself - it would recurse. That can only happen when the source is
+        /// this very server, so the name comparison is meaningful only for a local source: a table on
+        /// another server that merely happens to share the dictionary's database and table name is a
+        /// different object, and reading it is exactly what the dictionary is for.
+        if (configuration->is_local && dictionary_name == configuration->table && dictionary_database == configuration->db)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "ClickHouseDictionarySource table cannot be dictionary table");
 
         return std::make_unique<ClickHouseDictionarySource>(dict_struct, *configuration, sample_block, context);

--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -518,6 +518,69 @@ def test_clickhouse_remote(started_cluster):
     ) == "17\n"
 
 
+# https://github.com/ClickHouse/ClickHouse/issues/48597
+def test_clickhouse_remote_same_name(started_cluster):
+    # A dictionary must not read itself, but that can only happen when the source is this very server.
+    # A table on another server that merely happens to share the dictionary's database and table name
+    # is a different object, and reading it is exactly what the dictionary is for.
+    node4.query("DROP TABLE IF EXISTS test.same_name", user="admin")
+    node4.query(
+        "CREATE TABLE test.same_name (id UInt64, SomeValue1 UInt8, SomeValue2 String) ENGINE = MergeTree() ORDER BY id",
+        user="admin",
+    )
+    node4.query("INSERT INTO test.same_name VALUES (17, 17, 'remote')", user="admin")
+
+    node3.query("DROP DICTIONARY IF EXISTS test.same_name", user="admin")
+    node3.query(
+        """
+        CREATE DICTIONARY test.same_name(
+            id UInt64,
+            SomeValue1 UInt8,
+            SomeValue2 String
+        )
+        PRIMARY KEY id
+        LAYOUT(FLAT())
+        SOURCE(CLICKHOUSE(HOST 'node4' PORT 9000 USER 'default' PASSWORD 'default' TABLE 'same_name' DB 'test'))
+        LIFETIME(MIN 1 MAX 10)
+        """,
+        user="admin",
+    )
+
+    assert (
+        node3.query(
+            "SELECT dictGetUInt8('test.same_name', 'SomeValue1', toUInt64(17))",
+            user="admin",
+        )
+        == "17\n"
+    )
+
+    # A source on the local server that names the dictionary itself is still refused.
+    node3.query("DROP DICTIONARY IF EXISTS test.self_reference", user="admin")
+    node3.query(
+        """
+        CREATE DICTIONARY test.self_reference(
+            id UInt64,
+            SomeValue1 UInt8,
+            SomeValue2 String
+        )
+        PRIMARY KEY id
+        LAYOUT(FLAT())
+        SOURCE(CLICKHOUSE(TABLE 'self_reference' DB 'test'))
+        LIFETIME(MIN 1 MAX 10)
+        """,
+        user="admin",
+    )
+    with pytest.raises(QueryRuntimeException, match="cannot be dictionary table"):
+        node3.query(
+            "SELECT dictGetUInt8('test.self_reference', 'SomeValue1', toUInt64(17))",
+            user="admin",
+        )
+
+    node3.query("DROP DICTIONARY test.same_name", user="admin")
+    node3.query("DROP DICTIONARY test.self_reference", user="admin")
+    node4.query("DROP TABLE test.same_name", user="admin")
+
+
 # https://github.com/ClickHouse/ClickHouse/issues/38450
 #  suggests placing 'secure' in named_collections
 def test_secure(started_cluster):


### PR DESCRIPTION
A dictionary whose `SOURCE(CLICKHOUSE(...))` pointed at another server's table was rejected when that table happened to have the same database and table name as the dictionary itself:

```sql
-- on the initiator
CREATE DATABASE logger;
CREATE DICTIONARY logger.table_name (id UInt64, v String) PRIMARY KEY id
SOURCE(CLICKHOUSE(HOST '<other server>' PORT 9000 USER 'default' DB 'logger' TABLE 'table_name'))
LAYOUT(FLAT()) LIFETIME(MIN 0 MAX 300);

SELECT dictGetString('logger.table_name', 'v', toUInt64(1));
Code: 36. DB::Exception: ClickHouseDictionarySource table cannot be dictionary table. (BAD_ARGUMENTS)
```

even though `logger.table_name` on the other server is an ordinary table that returns data fine.

The guard is there so a dictionary cannot use itself as its own source, which would recurse. But it compared only the names:

```cpp
String dictionary_name = config.getString(".dictionary.name", "");
String dictionary_database = config.getString(".dictionary.database", "");

if (dictionary_name == configuration->table && dictionary_database == configuration->db)
    throw Exception(ErrorCodes::BAD_ARGUMENTS, "ClickHouseDictionarySource table cannot be dictionary table");
```

Self-reference is only possible when the source *is* this server, and `configuration->is_local` — set from the source's host and port a few lines above, in both the named-collection and the plain-config branch — already says whether it is. Gate the check on it.

Verified against two separate servers:

```
-- before: BAD_ARGUMENTS
-- after:
SELECT dictGetString('logger.table_name', 'v', toUInt64(1));
remote_value
```

and a genuine local self-reference is still refused:

```sql
CREATE DICTIONARY default.selfref (id UInt64, v String) PRIMARY KEY id
SOURCE(CLICKHOUSE(TABLE 'selfref' DB 'default')) LAYOUT(FLAT()) LIFETIME(0);

SELECT dictGetString('default.selfref', 'v', toUInt64(1));
Code: 36. DB::Exception: ClickHouseDictionarySource table cannot be dictionary table. (BAD_ARGUMENTS)
```

The test goes into `test_dictionaries_ddl`, which already has two nodes (`node3` reading from `node4`) for the neighbouring `test_clickhouse_remote` case, and covers both directions: the remote same-named source loads, and the local self-reference still throws.

Closes: https://github.com/ClickHouse/ClickHouse/issues/48597

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `ClickHouseDictionarySource table cannot be dictionary table` being raised for a dictionary whose source is a table on *another* ClickHouse server that happens to share the dictionary's database and table name. The check against a dictionary using itself as its own source now applies only when the source is the local server.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118441&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118441](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118441+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.915` (included in `26.9` and later)
<!-- ch-version-info:end -->