### PR TITLE
Log "never" instead of a year-294247 timestamp for dictionary update time

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -741,7 +741,7 @@ public:
                         if (!should_update_flag)
                         {
                             info.next_update_time = calculateNextUpdateTime(info.object, info.error_count);
-                            LOG_TRACE(log, "Object '{}' not modified, will not reload. Next update at {}", info.name, to_string(info.next_update_time));
+                            LOG_TRACE(log, "Object '{}' not modified, will not reload. Next update at {}", info.name, describeUpdateTime(info.next_update_time));
                             continue;
                         }
 
@@ -1237,7 +1237,7 @@ private:
             info->last_successful_update_time = current_time;
         info->state_id = info->loading_id;
         info->next_update_time = next_update_time;
-        LOG_TRACE(log, "Next update time for '{}' was set to {}", info->name, to_string(next_update_time));
+        LOG_TRACE(log, "Next update time for '{}' was set to {}", info->name, describeUpdateTime(next_update_time));
     }
 
     /// Removes the references to the loading thread from the maps.
@@ -1255,6 +1255,16 @@ private:
         /// (We can't put the loading thread back to the thread pool immediately here because at this point
         /// the loading thread is about to finish but it's not finished yet right now.)
         recently_finished_loadings.push_back(loading_id);
+    }
+
+    /// `TimePoint::max()` is the "no automatic update is scheduled" sentinel; rendering it as a
+    /// timestamp prints a date in the year 294247, which reads like a scheduling bug rather than
+    /// like "never". Spell it out instead.
+    static String describeUpdateTime(TimePoint time)
+    {
+        if (time == TimePoint::max())
+            return "never";
+        return to_string(time);
     }
 
     /// Calculate next update time for loaded_object. Can be called without mutex locking,


### PR DESCRIPTION
`calculateNextUpdateTime` returns `TimePoint::max()` as the "no automatic update is scheduled" sentinel — for an object that does not support updates, and for one with `LIFETIME(0)`:

```cpp
static constexpr auto never = TimePoint::max();
...
/// do not update loadable objects with zero as lifetime
const auto & lifetime = loaded_object->getLifetime();
if (lifetime.min_sec == 0 && lifetime.max_sec == 0)
{
    LOG_TRACE(log, "Supposed update time for '{}' is never (loaded, lifetime 0)", ...);
    return never;
}
```

Two `TRACE` lines then render that sentinel through `to_string`, which prints it as a timestamp:

```
ExternalDictionariesLoader: Next update time for 'xxx' was set to 294247-01-10 04:00:54
```

Right after a `Could not update external dictionary '...', leaving the previous version` line, that reads like the retry scheduling is broken. It is what #48710 was reported as — "ClickHouse decided to retry later, but 'later' somehow got converted to 'never'" — where the behaviour was correct (`LIFETIME(0)` means no automatic updates, and a manual `SYSTEM RELOAD DICTIONARY` recovers) and only the log was misleading.

The `Error` line already special-cases the sentinel and appends nothing:

```cpp
auto next_update_time_description = [next_update_time]
{
    if (next_update_time == TimePoint::max())
        return String();
    return ", next update is scheduled at " + to_string(next_update_time);
};
```

Do the same for the two `TRACE` lines, via a small `describeUpdateTime` helper that prints `never`. `chrono_io.h` is left alone — its `to_string` is used widely, and its own comment already notes that `TimePoint::max()` renders awkwardly.

No behaviour change; logging only.

Closes: https://github.com/ClickHouse/ClickHouse/issues/48710

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The dictionary loader now logs `never` instead of a timestamp in the year 294247 when an object has no automatic update scheduled (for example a dictionary with `LIFETIME(0)`), which previously looked like a scheduling bug next to a failed-update message.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118443&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118443](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118443+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.878` (included in `26.9` and later)
<!-- ch-version-info:end -->