### PR TITLE
Fix Paimon incremental read failing with REPLICA_IS_ALREADY_ACTIVE after a Keeper session loss

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -170,6 +170,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(kafka2_remove_zk_before_final_multi) \
     PAUSEABLE_ONCE(nats_pause_before_building_insert_pipeline) \
     PAUSEABLE_ONCE(keeper_map_delete_pause_before_multi) \
+    PAUSEABLE_ONCE(paimon_incremental_read_pause_before_is_active_remove) \
     PAUSEABLE(dummy_pausable_failpoint) \
     PAUSEABLE(paimon_incremental_read_pause_after_watermark_commit) \
     ONCE(execute_query_calling_empty_set_result_func_on_exception) \

--- a/src/Storages/ObjectStorage/DataLakes/Paimon/PaimonStreamState.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Paimon/PaimonStreamState.cpp
@@ -10,6 +10,7 @@
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 
 namespace DB
 {
@@ -18,6 +19,11 @@ namespace ErrorCodes
 {
 extern const int LOGICAL_ERROR;
 extern const int REPLICA_IS_ALREADY_ACTIVE;
+}
+
+namespace FailPoints
+{
+extern const char paimon_incremental_read_pause_before_is_active_remove[];
 }
 
 PaimonStreamState::PaimonStreamState(
@@ -162,14 +168,19 @@ bool PaimonStreamState::activate()
             {
                 /// Stale node from our previous session — safe to reclaim.
                 /// Use versioned delete (CAS) to guard against TOCTOU races.
+                FailPointInjection::pauseFailPoint(
+                    FailPoints::paimon_incremental_read_pause_before_is_active_remove);
                 auto remove_code = keeper->tryRemove(is_active_path, stat.version);
-                if (remove_code != Coordination::Error::ZOK)
+                /// ZNONODE is this removal's postcondition, not a failure: Keeper reaps the
+                /// ephemeral itself once the session that created it expires.
+                if (remove_code != Coordination::Error::ZOK && remove_code != Coordination::Error::ZNONODE)
                 {
                     LOG_WARNING(log, "Failed to remove stale is_active node at {} (code: {}). "
                         "Will retry on next attempt.", is_active_path.string(), remove_code);
                     return false;
                 }
-                LOG_INFO(log, "Removed stale is_active node from previous session at {}", is_active_path.string());
+                LOG_INFO(log, "Cleared stale is_active node from previous session at {} ({})",
+                    is_active_path.string(), remove_code);
             }
             else
             {

--- a/tests/integration/test_paimon_incremental_read/test.py
+++ b/tests/integration/test_paimon_incremental_read/test.py
@@ -21,6 +21,7 @@ CH_TABLE_NAME_AT_MOST_ONCE = "paimon_inc_read_at_most_once"
 CH_MV_PAIMON_TABLE = "paimon_mv_source"
 CH_MV_MERGETREE_TABLE = "paimon_mv_dest"
 CH_MV_NAME = "paimon_refresh_mv"
+CH_TABLE_NAME_ACTIVATE_RECLAIM = "paimon_inc_read_activate_reclaim"
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
@@ -425,3 +426,105 @@ def test_paimon_to_mergetree_via_refresh_mv(started_cluster):
     node.query(f"DROP VIEW IF EXISTS {CH_MV_NAME} SYNC;")
     node.query(f"DROP TABLE IF EXISTS {CH_MV_MERGETREE_TABLE} SYNC;")
     node.query(f"DROP TABLE IF EXISTS {CH_MV_PAIMON_TABLE} SYNC;")
+
+
+def test_paimon_incremental_read_activate_tolerates_reaped_is_active(started_cluster):
+    """A read after a Keeper session loss reclaims the `is_active` marker its own
+    previous session left behind, and must survive Keeper reaping that ephemeral
+    concurrently: the marker is visible to the reclaim path's `tryGet` and already
+    gone by its versioned `tryRemove`, which then reports ZNONODE. The marker here
+    is fabricated because it reproduces exactly that observable state, whereas
+    waiting for the real reap to land inside a two-round-trip window would make the
+    test nondeterministic."""
+    writer_container_id = cluster.get_instance_docker_id("paimon-incremental-writer")
+
+    warehouse_name = "warehouse_activate_reclaim"
+    warehouse_uri = f"file://{USER_FILES_PATH}/{warehouse_name}/"
+    warehouse_dir = f"{USER_FILES_PATH}/{warehouse_name}"
+    table_path = f"{USER_FILES_PATH}/{warehouse_name}/test.db/test_table"
+    # Unique per run: committed_snapshot persists in Keeper, so a rerun against
+    # the same cluster must not inherit an earlier run's watermark.
+    keeper_path = f"/clickhouse/paimon_activate_reclaim_{uuid.uuid4().hex}"
+    is_active_path = f"{keeper_path}/replicas/r1/is_active"
+    failpoint = "paimon_incremental_read_pause_before_is_active_remove"
+
+    _clean_warehouse(writer_container_id, warehouse_dir)
+
+    # Warm-up commit (snapshot 1), consumed to establish the baseline.
+    _run_writer(writer_container_id, warehouse_uri=warehouse_uri, start_id=0, rows_per_commit=1, commit_times=1)
+    _create_clickhouse_table_for_paimon_incremental_read(
+        CH_TABLE_NAME_ACTIVATE_RECLAIM, table_path, keeper_path=keeper_path
+    )
+    count_query = f"SELECT count() FROM {CH_TABLE_NAME_ACTIVATE_RECLAIM}"
+    _wait_until_query_result(count_query, "1\n", database="default")
+    _wait_until_query_result(count_query, "0\n", database="default")
+
+    zk = cluster.get_kazoo_client("zoo1")
+    reader = None
+    reader_result = {}
+    try:
+        # Read the server's own marker instead of hardcoding its payload format.
+        identifier = zk.get(is_active_path)[0]
+
+        # Snapshot 2: the batch the post-reconnect read must deliver.
+        _run_writer(writer_container_id, warehouse_uri=warehouse_uri, start_id=1, rows_per_commit=10, commit_times=1)
+
+        session_query = (
+            "SELECT client_id FROM system.zookeeper_connection WHERE name = 'default'"
+        )
+        old_session = node.query(session_query)
+        # Finalizes the shared session, so the Keeper handle latched in
+        # PaimonStreamState stays expired and the next read takes the
+        # needsNewKeeper() branch that calls activate().
+        node.query("SYSTEM RECONNECT ZOOKEEPER")
+        assert node.query(session_query) != old_session, (
+            f"the Keeper session was not replaced (still {old_session!r})"
+        )
+
+        deadline = time.monotonic() + 60
+        while zk.exists(is_active_path) is not None:
+            assert time.monotonic() < deadline, "the old session's is_active was never reaped"
+            time.sleep(0.5)
+
+        # Persistent, not ephemeral: activate() never inspects stat.ephemeralOwner,
+        # so persistence is invisible to the code under test while keeping a second
+        # Keeper session out of the test's failure modes.
+        zk.create(is_active_path, identifier)
+
+        node.query(f"SYSTEM ENABLE FAILPOINT {failpoint}")
+        reader = threading.Thread(
+            target=lambda: reader_result.update(
+                zip(("out", "err"), node.query_and_get_answer_with_error(count_query))
+            )
+        )
+        reader.start()
+
+        # Returns only once a thread has parked at the failpoint. Since the
+        # failpoint sits inside the identifier-matched branch, that proves the read
+        # entered the reclaim path with a marker it recognises as its own.
+        node.query(f"SYSTEM WAIT FAILPOINT {failpoint} PAUSE", timeout=60)
+        assert reader.is_alive(), (
+            f"the reader returned before parking at the failpoint: {reader_result!r}"
+        )
+
+        # The reap lands inside the read's tryGet/tryRemove window.
+        zk.delete(is_active_path)
+        node.query(f"SYSTEM NOTIFY FAILPOINT {failpoint}")
+
+        reader.join(timeout=120)
+        assert not reader.is_alive(), "the reader thread never finished"
+        assert not reader_result.get("err"), f"the read failed: {reader_result!r}"
+        # Not just "did not throw": the pending snapshot must still be delivered.
+        assert reader_result.get("out") == "10\n", (
+            f"the pending snapshot was not delivered: {reader_result!r}"
+        )
+        assert zk.get(f"{keeper_path}/committed_snapshot")[0] == b"2"
+        _wait_until_query_result(count_query, "0\n", database="default")
+    finally:
+        # The failpoint is process-global: an early failure must leave neither it
+        # armed nor the reader thread parked on it.
+        node.query(f"SYSTEM DISABLE FAILPOINT {failpoint}")
+        zk.stop()
+        if reader is not None:
+            reader.join(timeout=60)
+        node.query(f"DROP TABLE IF EXISTS {CH_TABLE_NAME_ACTIVATE_RECLAIM} SYNC;")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117630

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `SELECT` from a table with `paimon_incremental_read = 1` failing with
`REPLICA_IS_ALREADY_ACTIVE` ("Failed to activate Paimon replica after Keeper reconnection") on the
first read after the server's Keeper session was lost and re-established. Reclaiming the replica's own
stale `is_active` marker now treats Keeper having already reaped that ephemeral node as success,
instead of reporting a `replica_name` collision that did not happen.

### Description

After a Keeper session is lost and re-established, the first `SELECT` from a Paimon table with
`paimon_incremental_read = 1` could fail with `Code: 224`, `REPLICA_IS_ALREADY_ACTIVE`. It is
transient, but it is a hard query error, and the message blames a `replica_name` collision that
cannot happen on the branch producing it.

`PaimonStreamState::activate()` reclaims the `is_active` marker its own previous session left, with a
`tryGet` plus a versioned `tryRemove`. That node is Ephemeral, so Keeper reaps it server-side and
asynchronously; when the reap lands between the two round trips `tryRemove` returns `ZNONODE`
(`zkutil::ZooKeeper::tryRemove` returns that code rather than throwing). `ZNONODE` is precisely the
postcondition the removal wanted, but the check accepted only `ZOK`, so success was classified as
failure and `PaimonMetadata::iterate()` escalated it into a throw. The branch's own log line says it
will retry, and the other caller of the same predicate treats an identical `false` as a warning.

Accepting `ZNONODE` matches the tree's delete-to-absence idiom and cannot mask a real conflict: the
authoritative fence is the Ephemeral `create` immediately below, which still fails with
`ZNODEEXISTS` when another server owns the path, while `ZBADVERSION` and `ZNOTEMPTY` remain failures;
the marker is advisory anyway, since mutual exclusion is `processing_lock`. Afterwards every reachable
`false` does mean another writer, so the existing message is accurate.

The new integration test builds that window deterministically, with a `PAUSEABLE_ONCE` failpoint plus
`SYSTEM RECONNECT ZOOKEEPER`: it fails on master with exactly that `Code: 224`, passes with the fix,
20/20 repeats green. Not stateless, because `SYSTEM RECONNECT ZOOKEEPER` finalizes the server's shared
Keeper session.

No public issue exists for this; it came from an internal CI failure, and the mechanism, repro and fix
are derived entirely from public source. #117630 rewrites adjacent code here without touching
`activate()`, so expect small mechanical conflicts in `src/Common/FailPoint.cpp` and the
`PaimonStreamState.cpp` prologue.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118457&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118457](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118457+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.910` (included in `26.9` and later)
<!-- ch-version-info:end -->