### PR TITLE
Re-decide the build-type-dependent test configs when bugfix validation swaps the binary

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1249,6 +1249,10 @@ def main():
                         CH.set_memory_ratio(0.7)
                     else:
                         CH.reset_memory_ratio()
+                    # The configs `install.sh` selects by build flavour must follow
+                    # the binary for the same reason: decided for `build_types[0]`,
+                    # one of them makes the swapped-in server reject its own settings.
+                    CH.install_build_type_configs()
                     # Fail closed if the server cannot come back up after the
                     # binary swap: running tests against a dead server would
                     # produce `Server died` FAILs that the bugfix inverter

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -332,11 +332,20 @@ class ClickHouseProc:
         # `install.sh` shifts away its first two positionals, so the client config
         # dir has to be passed as well or the flag is consumed in its place.
         client_config_dir = Path(self.ch_config_dir).parent / "clickhouse-client"
-        Shell.run(
-            f"./tests/config/install.sh {self.ch_config_dir} {client_config_dir} --build-type-configs-only",
-            verbose=True,
-            strict=True,
-        )
+        # A server is started from each replica tree as well, so each tree needs its
+        # own decision. They hold a populated `config.d` only in `DBReplicated` runs,
+        # so probing for them selects exactly the installed ones.
+        config_dirs = [self.ch_config_dir] + [
+            d
+            for d in (self.ch_config_dir_replica_1, self.ch_config_dir_replica_2)
+            if Path(d, "config.d").is_dir()
+        ]
+        for config_dir in config_dirs:
+            Shell.run(
+                f"./tests/config/install.sh {config_dir} {client_config_dir} --build-type-configs-only",
+                verbose=True,
+                strict=True,
+            )
 
     def create_log_export_config(self, config_dir=None):
         # Write into the config dir the server actually reads. Callers that run

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -323,6 +323,21 @@ class ClickHouseProc:
                 f"Removed {file_path}; server default max_server_memory_usage_to_ram_ratio applies"
             )
 
+    def install_build_type_configs(self):
+        """Re-decide the test configs that `install.sh` selects by probing the
+        installed binary's build flavour. Needed when the same installed config
+        tree is reused to launch a different build type (the bugfix-validation
+        loop swaps binaries without reinstalling configs): one left from the
+        previous build type makes the server reject its own settings."""
+        # `install.sh` shifts away its first two positionals, so the client config
+        # dir has to be passed as well or the flag is consumed in its place.
+        client_config_dir = Path(self.ch_config_dir).parent / "clickhouse-client"
+        Shell.run(
+            f"./tests/config/install.sh {self.ch_config_dir} {client_config_dir} --build-type-configs-only",
+            verbose=True,
+            strict=True,
+        )
+
     def create_log_export_config(self, config_dir=None):
         # Write into the config dir the server actually reads. Callers that run
         # the server from a non-default location (e.g. `ClickHouseService` under

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -22,6 +22,7 @@ NO_AZURE=0
 KEEPER_INJECT_AUTH=1
 REMOTE_DATABASE_DISK=0
 LLVM_COVERAGE=0
+BUILD_TYPE_CONFIGS_ONLY=0
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -49,6 +50,7 @@ while [[ "$#" -gt 0 ]]; do
 
         --encrypted-storage) USE_ENCRYPTED_STORAGE=1 ;;
         --llvm-coverage) LLVM_COVERAGE=1 ;;
+        --build-type-configs-only) BUILD_TYPE_CONFIGS_ONLY=1 ;;
         *) echo "Unknown option: $1" ; exit 1 ;;
     esac
     shift
@@ -89,6 +91,59 @@ function is_fast_build()
     # sanitizers and debug builds are slow
     [ "$(clickhouse local --query "SELECT value NOT LIKE '%-fsanitize=%' AND value LIKE '%-DNDEBUG%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" == "1" ]
 }
+
+# Print 1 or 0 for a CXX_FLAGS pattern in the installed binary, or fail. An unanswered probe
+# must not read as false: the false arm below installs the config an msan server refuses to
+# start on. `countIf` keeps the query total, since restricting it to the row yields no output.
+function build_option_flag()
+{
+    local description=$1 pattern=$2 value rc=0
+    value=$(clickhouse local --query \
+        "SELECT countIf(name = 'CXX_FLAGS' AND value LIKE '$pattern') > 0 FROM system.build_options") || rc=$?
+    if [ "$rc" != "0" ] || { [ "$value" != "0" ] && [ "$value" != "1" ]; }; then
+        echo "install.sh: cannot determine whether this is a $description (exit $rc, output '$value')" >&2
+        return 1
+    fi
+    echo "$value"
+}
+
+# Install the configs whose presence depends on the build flavour of the binary installed right
+# now. Idempotent in both directions, so a tree installed for one build type can be re-decided
+# for another (see --build-type-configs-only).
+function install_build_type_configs()
+{
+    local is_memory_sanitizer is_sanitizer
+    # Resolve both probes before touching either file, so a failing probe cannot leave a
+    # half-adjusted tree.
+    is_memory_sanitizer=$(build_option_flag "MemorySanitizer build" '%-fsanitize=memory%')
+    # A runtime sanitizer build is marked with -DSANITIZER (cmake/sanitize.cmake). Do not test
+    # for -fsanitize=, which also matches CFI (cfi-vcall, cfi-derived-cast): its checks trap on
+    # a bad vcall or cast without a sanitizer runtime, so symbolization runs at full speed.
+    is_sanitizer=$(build_option_flag "sanitizer build" '%-DSANITIZER%')
+
+    # A non-zero global_profiler_* period is rejected by an msan server while it parses its own
+    # settings, so the config must be absent rather than merely unused there.
+    if [ "$is_memory_sanitizer" = "1" ]; then
+        rm -f $DEST_SERVER_PATH/config.d/serverwide_trace_collector.xml
+    else
+        ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
+    fi
+
+    if [ "$is_sanitizer" = "1" ]; then
+        ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/
+    else
+        rm -f $DEST_SERVER_PATH/config.d/trace_log_no_symbolize.xml
+    fi
+}
+
+# Re-decide the build-flavour-dependent configs of an already installed tree, leaving the rest
+# of it as it is, for callers that replace the binary underneath it. Must return before the
+# `rm -rf config.d` below, which would otherwise wipe the tree this mode was asked to adjust.
+if [ "$BUILD_TYPE_CONFIGS_ONLY" = "1" ]; then
+    echo "Going to install build-type-dependent test configs into $DEST_SERVER_PATH"
+    install_build_type_configs
+    exit 0
+fi
 
 echo "Going to install test configs from $SRC_PATH into $DEST_SERVER_PATH"
 
@@ -235,23 +290,7 @@ esac
 ln -sf $SRC_PATH/config.d/zero_copy_destructive_operations.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/handlers.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/threadpool_writer_pool_size.yaml $DEST_SERVER_PATH/config.d/
-function is_sanitizer_build()
-{
-    # A runtime sanitizer build is marked with -DSANITIZER (cmake/sanitize.cmake). Do not test for
-    # -fsanitize=, which also matches CFI (cfi-vcall, cfi-derived-cast): its checks trap on a bad
-    # vcall or cast without a sanitizer runtime, so symbolization runs at full speed.
-    [ "$(clickhouse local --query "SELECT value LIKE '%-DSANITIZER%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" = "1" ]
-}
-function is_memory_sanitizer_build()
-{
-    [ "$(clickhouse local --query "SELECT value LIKE '%-fsanitize=memory%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" = "1" ]
-}
-if ! is_memory_sanitizer_build; then
-    ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
-fi
-if is_sanitizer_build; then
-    ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/
-fi
+install_build_type_configs
 ln -sf $SRC_PATH/config.d/memory_profiler.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/process_query_plan_packet.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION

Related: https://github.com/ClickHouse/ClickHouse/pull/113107


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bugfix validation now re-decides the build-type-dependent server configs each time it swaps in another build type's binary, so the MemorySanitizer build no longer refuses to start on a config installed for the sanitizer build.


### Description

Since #113107 an msan server rejects a non-zero `global_profiler_real_time_period_ns`, and both
`Bugfix validation (functional tests, amd64|aarch64)` legs are red on every PR whose build-type
list reaches `*_msan`: `Server startup (amd_msan)` ERROR and `Scraping system tables` FAIL with
`Code: 48 ... not supported in a MemorySanitizer build`. 16 CIDB rows across two unrelated PRs,
both arches, none on master and none before #113107 merged.

`install.sh` links `serverwide_trace_collector.xml` unless the *installed* binary is msan, and it
runs once, in the START stage, against `build_types[0]` (always `*_asan_ubsan`). The validation
loop then swaps the binary for each remaining build type without re-deciding that config, so the
msan server throws while parsing its own settings and never starts. `build_types[1:]` is also how a test that did
not reproduce on the first build type is retried, so such a bug-fix PR can no longer be
validated on either arch.

`trace_log_no_symbolize.xml` is the mirror case on the `*_debug` swap: linked for the sanitizer
binary, it stays behind and leaves in-flush symbolization off, unreachable so far only because the
loop breaks at `*_msan` first.

So the configs are re-decided after each swap, beside the existing
`set_memory_ratio`/`reset_memory_ratio` re-derivation, which is there for the same reason. The probes
now fail closed instead of mislinking: in an `if` condition bash suppresses `set -e`, so an
unanswerable probe read as false, which is the arm that installs the msan-fatal config.

The `/etc/clickhouse-server{1,2}` copies of a `DBReplicated` run are re-decided too, since a
server runs from each; no configured job combines the two today (the bugfix legs are per-arch, and
`--bugfix-validation --db-replicated` aborts inside `install.sh` regardless).

Validated with the real master-HEAD `amd_asan_ubsan`/`amd_msan`/`amd_debug` binaries: the abort
reproduces before the change, every tree starts after it, and a normal install produces an
identical config tree. Touching `ci/jobs/functional_tests.py` runs both bugfix legs on
this PR itself.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118459&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118459](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118459+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1088` (included in `26.9` and later)
<!-- ch-version-info:end -->