### PR TITLE
Use normal text merges for `SettingsChangesHistory.cpp`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@ contrib/* linguist-vendored
 *.h linguist-language=C++
 tests/queries/0_stateless/data_json/* binary
 tests/queries/0_stateless/*.reference -crlf
-src/Core/SettingsChangesHistory.cpp merge=union


### PR DESCRIPTION
Remove `merge=union` for `SettingsChangesHistory.cpp` so conflicting settings history edits require explicit resolution. When backporting a change to a version block absent from the release branch, `union` can silently restore the removed block and unrelated entries; it can also produce duplicate version blocks, which cause a `LOGICAL_ERROR` exception when the history is initialized.

The rule was introduced to combine independent additions without conflicts. Normal text merging still handles non-conflicting edits automatically. Overlapping edits must be reconciled within the correct version block; a backport should preserve the release branch's history and apply only the intended setting changes. This restores normal text merging for checkouts containing this change; older checkouts retaining the rule still need an override or the same removal.

Validated with an isolated Git merge: `union` reported success while restoring a removed version block and an unrelated entry; the updated attributes left the file conflicted. The repository whitespace style check for `.gitattributes` and `git diff --check` passed.

Related: https://github.com/ClickHouse/ClickHouse/pull/66042
Related: https://github.com/ClickHouse/ClickHouse/pull/118095

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use normal text merging for settings changes history so conflicting edits require explicit resolution instead of silently combining incompatible version blocks.

### Documentation entry:
- [x] No documentation update is required.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118460&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118460](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118460+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.877` (included in `26.9` and later)
<!-- ch-version-info:end -->