### PR TITLE
Accept a PostgreSQL Bind message that declares a binary parameter format but carries no value to decode

### DIFF
--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -845,16 +845,20 @@ public:
                 throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
                                 "Wrong parameter format code count {} in Bind message, it must not be negative", num_format_params);
             Int16 format_param = 0;
+            bool saw_non_text_format_code = false;
             for (Int16 i = 0; i < num_format_params; ++i)
             {
                 readBinaryBigEndian(format_param, payload_in);
                 if (format_param != 0)
-                    has_binary_format_param = true;
+                    saw_non_text_format_code = true;
             }
             readBinaryBigEndian(num_params, payload_in);
             if (num_params < 0)
                 throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
                                 "Wrong parameter count {} in Bind message, it must not be negative", num_params);
+            /// A format code only states how to decode a parameter value, and one code may be
+            /// broadcast to all parameters, so a message with no values has nothing to decode.
+            has_binary_format_param = saw_non_text_format_code && num_params > 0;
             for (int i = 0; i < num_params; ++i)
             {
                 Int32 sz_param = 0;

--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -856,9 +856,7 @@ public:
             if (num_params < 0)
                 throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT,
                                 "Wrong parameter count {} in Bind message, it must not be negative", num_params);
-            /// A format code only states how to decode a parameter value, and one code may be
-            /// broadcast to all parameters, so a message with no values has nothing to decode.
-            has_binary_format_param = saw_non_text_format_code && num_params > 0;
+            bool saw_param_value = false;
             for (int i = 0; i < num_params; ++i)
             {
                 Int32 sz_param = 0;
@@ -876,7 +874,11 @@ public:
                 String current_param(sz_param, 0);
                 payload_in.readStrict(current_param.data(), sz_param);
                 parameters.push_back(std::move(current_param));
+                saw_param_value = true;
             }
+            /// A format code only says how to decode a parameter value, so a message carrying no
+            /// value has nothing to decode: a NULL becomes the literal `NULL` whatever its format.
+            has_binary_format_param = saw_non_text_format_code && saw_param_value;
 
             /// Consume result format codes; this implementation always returns text.
             Int16 num_format_params_result = 0;

--- a/src/Core/tests/gtest_postgresql_protocol.cpp
+++ b/src/Core/tests/gtest_postgresql_protocol.cpp
@@ -510,8 +510,8 @@ TEST(PostgreSQLProtocol, BindRejectsBinaryFormatParameters)
         EXPECT_EQ(manager.getStatmentFromBind(), "SELECT 1");
     }
 
-    /// Two format codes with no values: the predicate keys on the value count, so the codes
-    /// describe nothing and the message is accepted.
+    /// Two format codes with no values: the codes describe nothing, so the message is accepted
+    /// even though the count matches no parameter.
     {
         std::string payload;
         payload.push_back('\0'); /// empty portal name
@@ -540,8 +540,8 @@ TEST(PostgreSQLProtocol, BindRejectsBinaryFormatParameters)
         EXPECT_NO_THROW(manager.attachBindQuery(std::move(msg)));
     }
 
-    /// A binary format code over a protocol NULL is still refused: the flag keys on the presence
-    /// of a value, not on whether that value carries bytes.
+    /// A binary format code over a protocol NULL carries no bytes to decode, so it is accepted
+    /// and the parameter is substituted as `NULL`.
     {
         std::string payload;
         payload.push_back('\0'); /// empty portal name
@@ -554,11 +554,97 @@ TEST(PostgreSQLProtocol, BindRejectsBinaryFormatParameters)
         std::string bytes = framePayload(std::move(payload));
 
         ReadBufferFromMemory in(bytes.data(), bytes.size());
+        auto msg = std::make_unique<Messaging::BindQuery>();
+        EXPECT_NO_THROW(msg->deserialize(in));
+        EXPECT_FALSE(msg->has_binary_format_param);
+        ASSERT_EQ(msg->parameters.size(), 1u);
+        EXPECT_FALSE(msg->parameters[0].has_value());
+
+        PreparedStatements::PreparedStatemetsManager manager(std::nullopt);
+        ASTPreparedStatement statement;
+        statement.function_name = "";
+        statement.function_body = "SELECT $1";
+        manager.addStatement(&statement);
+        EXPECT_NO_THROW(manager.attachBindQuery(std::move(msg)));
+        EXPECT_EQ(manager.getStatmentFromBind(), "SELECT NULL");
+    }
+
+    /// The flag is message-wide, not per parameter: with `C = N` the binary code covers only the
+    /// NULL, yet the text-coded value still carries bytes, and the message is refused.
+    {
+        std::string payload;
+        payload.push_back('\0'); /// empty portal name
+        payload.push_back('\0'); /// empty statement name
+        putInt16(payload, 2); /// one format code per parameter
+        putInt16(payload, 1); /// binary, for the NULL below
+        putInt16(payload, 0); /// text, for the value below
+        putInt16(payload, 2); /// two parameter values
+        putInt32(payload, -1); /// NULL: no value bytes follow
+        putInt32(payload, 2);
+        payload += "hi";
+        putInt16(payload, 0); /// no result format codes
+        std::string bytes = framePayload(std::move(payload));
+
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        Messaging::BindQuery msg;
+        EXPECT_NO_THROW(msg.deserialize(in));
+        EXPECT_TRUE(msg.has_binary_format_param);
+        ASSERT_EQ(msg.parameters.size(), 2u);
+        EXPECT_FALSE(msg.parameters[0].has_value());
+
+        EXPECT_TRUE(deserializeThenAttach(bytes));
+    }
+
+    /// Acceptance depends on neither the value count nor the broadcast form: a per-parameter code
+    /// array over NULLs alone is still nothing to decode.
+    {
+        std::string payload;
+        payload.push_back('\0'); /// empty portal name
+        payload.push_back('\0'); /// empty statement name
+        putInt16(payload, 2); /// one format code per parameter
+        putInt16(payload, 0); /// text
+        putInt16(payload, 1); /// binary
+        putInt16(payload, 2); /// two parameter values
+        putInt32(payload, -1); /// NULL: no value bytes follow
+        putInt32(payload, -1); /// NULL
+        putInt16(payload, 0); /// no result format codes
+        std::string bytes = framePayload(std::move(payload));
+
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        auto msg = std::make_unique<Messaging::BindQuery>();
+        EXPECT_NO_THROW(msg->deserialize(in));
+        EXPECT_FALSE(msg->has_binary_format_param);
+        ASSERT_EQ(msg->parameters.size(), 2u);
+
+        PreparedStatements::PreparedStatemetsManager manager(std::nullopt);
+        ASTPreparedStatement statement;
+        statement.function_name = "";
+        statement.function_body = "SELECT $1 + $2";
+        manager.addStatement(&statement);
+        EXPECT_NO_THROW(manager.attachBindQuery(std::move(msg)));
+        EXPECT_EQ(manager.getStatmentFromBind(), "SELECT NULL + NULL");
+    }
+
+    /// A zero-length value is a value: only the `-1` sentinel means no bytes follow, so a binary
+    /// code over an empty value is refused like any other.
+    {
+        std::string payload;
+        payload.push_back('\0'); /// empty portal name
+        payload.push_back('\0'); /// empty statement name
+        putInt16(payload, 1); /// one parameter format code
+        putInt16(payload, 1); /// binary
+        putInt16(payload, 1); /// one parameter value
+        putInt32(payload, 0); /// present, and empty
+        putInt16(payload, 0); /// no result format codes
+        std::string bytes = framePayload(std::move(payload));
+
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
         Messaging::BindQuery msg;
         EXPECT_NO_THROW(msg.deserialize(in));
         EXPECT_TRUE(msg.has_binary_format_param);
         ASSERT_EQ(msg.parameters.size(), 1u);
-        EXPECT_FALSE(msg.parameters[0].has_value());
+        ASSERT_TRUE(msg.parameters[0].has_value());
+        EXPECT_TRUE(msg.parameters[0]->empty());
 
         EXPECT_TRUE(deserializeThenAttach(bytes));
     }

--- a/src/Core/tests/gtest_postgresql_protocol.cpp
+++ b/src/Core/tests/gtest_postgresql_protocol.cpp
@@ -479,6 +479,36 @@ TEST(PostgreSQLProtocol, BindRejectsBinaryFormatParameters)
         putInt16(payload, -1); /// negative format-code count
         EXPECT_TRUE(deserializeThrows(framePayload(std::move(payload)), ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT));
     }
+
+    /// `C = 1` broadcasts one format code to all parameters, which is legal when the message
+    /// carries none; with no values there is no binary payload to decode.
+    {
+        std::string payload;
+        payload.push_back('\0'); /// empty portal name
+        payload.push_back('\0'); /// empty statement name
+        putInt16(payload, 1); /// one parameter format code
+        putInt16(payload, 1); /// binary, applied to all parameters
+        putInt16(payload, 0); /// zero parameter values
+        putInt16(payload, 0); /// no result format codes
+        std::string bytes = framePayload(std::move(payload));
+        bytes.push_back('X'); /// trailing marker: must remain unread after deserialize
+
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        auto msg = std::make_unique<Messaging::BindQuery>();
+        EXPECT_NO_THROW(msg->deserialize(in));
+        EXPECT_FALSE(msg->has_binary_format_param);
+        char marker = 0;
+        in.readStrict(&marker, 1);
+        EXPECT_EQ(marker, 'X');
+
+        PreparedStatements::PreparedStatemetsManager manager(std::nullopt);
+        ASTPreparedStatement statement;
+        statement.function_name = "";
+        statement.function_body = "SELECT 1";
+        manager.addStatement(&statement);
+        EXPECT_NO_THROW(manager.attachBindQuery(std::move(msg)));
+        EXPECT_EQ(manager.getStatmentFromBind(), "SELECT 1");
+    }
 }
 
 TEST(PostgreSQLProtocol, BindConsumesResultFormatCodesAndKeepsStreamAligned)

--- a/src/Core/tests/gtest_postgresql_protocol.cpp
+++ b/src/Core/tests/gtest_postgresql_protocol.cpp
@@ -509,6 +509,59 @@ TEST(PostgreSQLProtocol, BindRejectsBinaryFormatParameters)
         EXPECT_NO_THROW(manager.attachBindQuery(std::move(msg)));
         EXPECT_EQ(manager.getStatmentFromBind(), "SELECT 1");
     }
+
+    /// Two format codes with no values: the predicate keys on the value count, so the codes
+    /// describe nothing and the message is accepted.
+    {
+        std::string payload;
+        payload.push_back('\0'); /// empty portal name
+        payload.push_back('\0'); /// empty statement name
+        putInt16(payload, 2); /// two parameter format codes
+        putInt16(payload, 1); /// binary
+        putInt16(payload, 1); /// binary
+        putInt16(payload, 0); /// zero parameter values
+        putInt16(payload, 0); /// no result format codes
+        std::string bytes = framePayload(std::move(payload));
+        bytes.push_back('X'); /// trailing marker: must remain unread after deserialize
+
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        auto msg = std::make_unique<Messaging::BindQuery>();
+        EXPECT_NO_THROW(msg->deserialize(in));
+        EXPECT_FALSE(msg->has_binary_format_param);
+        char marker = 0;
+        in.readStrict(&marker, 1);
+        EXPECT_EQ(marker, 'X');
+
+        PreparedStatements::PreparedStatemetsManager manager(std::nullopt);
+        ASTPreparedStatement statement;
+        statement.function_name = "";
+        statement.function_body = "SELECT 1";
+        manager.addStatement(&statement);
+        EXPECT_NO_THROW(manager.attachBindQuery(std::move(msg)));
+    }
+
+    /// A binary format code over a protocol NULL is still refused: the flag keys on the presence
+    /// of a value, not on whether that value carries bytes.
+    {
+        std::string payload;
+        payload.push_back('\0'); /// empty portal name
+        payload.push_back('\0'); /// empty statement name
+        putInt16(payload, 1); /// one parameter format code
+        putInt16(payload, 1); /// binary
+        putInt16(payload, 1); /// one parameter value
+        putInt32(payload, -1); /// NULL: no value bytes follow
+        putInt16(payload, 0); /// no result format codes
+        std::string bytes = framePayload(std::move(payload));
+
+        ReadBufferFromMemory in(bytes.data(), bytes.size());
+        Messaging::BindQuery msg;
+        EXPECT_NO_THROW(msg.deserialize(in));
+        EXPECT_TRUE(msg.has_binary_format_param);
+        ASSERT_EQ(msg.parameters.size(), 1u);
+        EXPECT_FALSE(msg.parameters[0].has_value());
+
+        EXPECT_TRUE(deserializeThenAttach(bytes));
+    }
 }
 
 TEST(PostgreSQLProtocol, BindConsumesResultFormatCodesAndKeepsStreamAligned)

--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -1043,14 +1043,17 @@ def test_extended_query_ready_for_query_and_describe(started_cluster):
     assert "C" in types, f"connection must stay alive after a rejected Bind, got {types}"
     sock.close()
 
-    # `C = 1` applies one format code to all parameters and is legal with zero parameters, so a
-    # binary code there describes nothing and must not be rejected.
+    # `C = 1` applies one format code to all parameters, so a binary code over a message that
+    # carries no value to decode describes nothing and must not be rejected.
     def bind_format_codes_only(portal, stmt, codes, values):
         b = portal.encode() + b"\x00" + stmt.encode() + b"\x00" + struct.pack("!H", len(codes))
         for c in codes:
             b += struct.pack("!H", c)
         b += struct.pack("!H", len(values))
         for v in values:
+            if v is None:
+                b += struct.pack("!i", -1)  # protocol NULL: no value bytes follow
+                continue
             vb = v.encode()
             b += struct.pack("!i", len(vb)) + vb
         b += struct.pack("!H", 0)
@@ -1066,6 +1069,17 @@ def test_extended_query_ready_for_query_and_describe(started_cluster):
     types = read_until_ready()
     assert "E" not in types, f"a zero-parameter Bind carries no binary payload, got {types}"
     assert "C" in types, f"the zero-parameter statement must run, got {types}"
+
+    # A protocol NULL carries no value bytes either, so a binary code over it is also accepted.
+    sock.sendall(
+        parse("", "SELECT $1", (23,))
+        + bind_format_codes_only("", "", (1,), (None,))
+        + execute("")
+        + sync()
+    )
+    types = read_until_ready()
+    assert "E" not in types, f"an all-NULL Bind carries no binary payload, got {types}"
+    assert "C" in types, f"the all-NULL statement must run, got {types}"
 
     # A binary format code that does cover an actual value is still rejected.
     sock.sendall(

--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -1043,6 +1043,41 @@ def test_extended_query_ready_for_query_and_describe(started_cluster):
     assert "C" in types, f"connection must stay alive after a rejected Bind, got {types}"
     sock.close()
 
+    # `C = 1` applies one format code to all parameters and is legal with zero parameters, so a
+    # binary code there describes nothing and must not be rejected.
+    def bind_format_codes_only(portal, stmt, codes, values):
+        b = portal.encode() + b"\x00" + stmt.encode() + b"\x00" + struct.pack("!H", len(codes))
+        for c in codes:
+            b += struct.pack("!H", c)
+        b += struct.pack("!H", len(values))
+        for v in values:
+            vb = v.encode()
+            b += struct.pack("!i", len(vb)) + vb
+        b += struct.pack("!H", 0)
+        return _fe("B", b)
+
+    sock, read_until_ready = _pg_raw_extended_query_session(node)
+    sock.sendall(
+        parse("", "SELECT 1", ())
+        + bind_format_codes_only("", "", (1,), ())
+        + execute("")
+        + sync()
+    )
+    types = read_until_ready()
+    assert "E" not in types, f"a zero-parameter Bind carries no binary payload, got {types}"
+    assert "C" in types, f"the zero-parameter statement must run, got {types}"
+
+    # A binary format code that does cover an actual value is still rejected.
+    sock.sendall(
+        parse("", "SELECT $1", (23,))
+        + bind_format_codes_only("", "", (1,), ("5",))
+        + execute("")
+        + sync()
+    )
+    types = read_until_ready()
+    assert "E" in types, f"a binary parameter value must still be rejected, got {types}"
+    sock.close()
+
 
 def test_malformed_extended_message_recovers(started_cluster):
     # Reject malformed extended messages without desynchronizing recovery.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108469
Reported by the automated review on that PR: https://github.com/ClickHouse/ClickHouse/pull/108469#discussion_r3696158981


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A PostgreSQL wire-protocol `Bind` message that declares a binary parameter format code but supplies no value to decode, either zero parameter values or values that are all `NULL`, is no longer rejected with `NOT_IMPLEMENTED`. The defect only exists in unreleased code from #108469.


### Description

A wire-legal `Bind` (F) that declares a binary parameter format code but carries no value to decode is answered with `NOT_IMPLEMENTED` ("Binary format parameters are not supported in Bind messages"), so the statement never runs. Two shapes reach it: zero parameter values, and values that are all protocol `NULL` (length `-1`). A format-code count of one applies that code to all parameters, including none; PostgreSQL rejects only `numPFormats > 1 && numPFormats != numParams` (`src/backend/tcop/postgres.c`).

`BindQuery::deserialize` reads the format-code array before the values, the wire order, and armed `has_binary_format_param` for any non-zero code there. The flag meant "a non-text code appeared" where its consumer needs "a value here must be decoded from a non-text format"; those differ whenever no value carries bytes, and `getStatmentFromBind` already substitutes the literal `NULL` for an absent value, ignoring the format.

The flag is now assigned from whether any parameter carries bytes, after the codes and the values are consumed (the order that keeps the stream aligned). A zero-length value still counts, so binary values remain rejected and the malformed-count guards still fire first.

Deliberately unchanged: the flag stays message-wide rather than per parameter, so a mixed array whose binary code covers only `NULL`s is still refused when another parameter carries bytes; and a `C > 1` array with no values is still accepted where PostgreSQL reports a protocol violation. Both were accepted before #108469; separating them needs a per-parameter format-code mapping.

Measured over the wire on two Build-ID-verified servers, 13 `Bind` shapes: only the two all-`NULL` shapes change from `ErrorResponse` to a completed query; the other 11 are identical, including three controls that must stay refused.

Regressed by #108469, which no published release contains: the newest `26.8` tag predates its backport, and #118067 / #118068 / #118083 are open; branch `26.8` carries it (#118069).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118461&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118461](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118461+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1325` (included in `26.9` and later)
<!-- ch-version-info:end -->