### PR TITLE
Decline `divide`/`multiply` monotonicity when an endpoint maps to `NaN`

### DIFF
--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -3835,6 +3835,39 @@ public:
             return {false, true, false, false};
         }
 
+        /** `divide` and `multiply` by a constant are modelled as monotonic from the constant alone, but a
+          * `Float` key column may hold `±inf`, and `-inf / inf`, `inf * 0` and `0 * inf` are all `NaN`. A
+          * `NaN` endpoint leaves a transformed range that no point compares into, so index analysis prunes
+          * every part and granule and the query silently loses the finite rows that do match. Only the
+          * transform can tell, so evaluate it at both endpoints, as the `plus`/`minus` branches below do for
+          * their own overflow question. Restricted to a `Float` result: no other result type has a `NaN`,
+          * and an integer division by a zero constant would raise here rather than answer one.
+          */
+        if ((name_view == "divide" || name_view == "multiply") && return_type
+            && isFloat(*removeNullable(recursiveRemoveLowCardinality(return_type))))
+        {
+            auto left_type = removeNullable(recursiveRemoveLowCardinality(left.type));
+            auto right_type = removeNullable(recursiveRemoveLowCardinality(right.type));
+            auto ret_type = removeNullable(recursiveRemoveLowCardinality(return_type));
+            const bool left_is_constant = left.column && isColumnConst(*left.column);
+
+            auto transform = [&](const Field & point)
+            {
+                ColumnsWithTypeAndName columns_with_constant
+                    = {{left_type->createColumnConst(1, left_is_constant ? (*left.column)[0] : point), left_type, left.name},
+                       {right_type->createColumnConst(1, left_is_constant ? point : (*right.column)[0]), right_type, right.name}};
+
+                auto col = Base::executeImpl(columns_with_constant, ret_type, 1);
+                Field point_transformed;
+                col->get(0, point_transformed);
+                return point_transformed;
+            };
+
+            if ((left_is_constant || (right.column && isColumnConst(*right.column)))
+                && (isNaNField(transform(left_point)) || isNaNField(transform(right_point))))
+                return {false, true, false, false};
+        }
+
         // For simplicity, we treat every single value interval as positive monotonic,
         // unless the function is undefined at that point (e.g. division by zero).
         if (accurateEquals(left_point, right_point))

--- a/tests/queries/0_stateless/05113_arithmetic_monotonicity_nan_endpoint.reference
+++ b/tests/queries/0_stateless/05113_arithmetic_monotonicity_nan_endpoint.reference
@@ -1,0 +1,17 @@
+a stored -inf endpoint mapped to NaN by the transform
+3
+3
+3
+3
+3
+each pruning layer on its own
+3
+3
+a constant that maps a stored 0 to NaN
+3
+3
+pruning still applies where no endpoint becomes NaN
+19
+59
+19
+1

--- a/tests/queries/0_stateless/05113_arithmetic_monotonicity_nan_endpoint.sql
+++ b/tests/queries/0_stateless/05113_arithmetic_monotonicity_nan_endpoint.sql
@@ -1,0 +1,43 @@
+-- Index analysis models `divide` and `multiply` by a constant as monotonic from the constant alone, but a
+-- `Float` key column may hold `±inf`, and `-inf / inf`, `inf * 0` and `0 * inf` are all `NaN`. The
+-- transformed range endpoint became `NaN`, which no point compares into, so every part and granule was
+-- pruned and the query silently returned nothing - including the finite rows that do match.
+
+DROP TABLE IF EXISTS t_monotonicity_nan;
+CREATE TABLE t_monotonicity_nan (k Float64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_monotonicity_nan VALUES (-inf), (1), (2), (3);
+
+SELECT 'a stored -inf endpoint mapped to NaN by the transform';
+SELECT count() FROM t_monotonicity_nan WHERE k / inf = 0;
+SELECT count() FROM t_monotonicity_nan WHERE k * 0 = 0;
+SELECT count() FROM t_monotonicity_nan WHERE k / inf = 0 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+SELECT count() FROM t_monotonicity_nan WHERE k * 0 = 0 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+SELECT count() FROM values('k Float64', (-inf), (1), (2), (3)) WHERE k / inf = 0;
+
+SELECT 'each pruning layer on its own';
+SELECT count() FROM t_monotonicity_nan WHERE k / inf = 0 SETTINGS use_statistics_for_part_pruning = 0;
+SELECT count() FROM t_monotonicity_nan WHERE k / inf = 0 SETTINGS use_primary_key = 0;
+
+SELECT 'a constant that maps a stored 0 to NaN';
+DROP TABLE IF EXISTS t_monotonicity_nan_zero;
+CREATE TABLE t_monotonicity_nan_zero (k Float64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_monotonicity_nan_zero VALUES (0), (1), (2), (3);
+SELECT count() FROM t_monotonicity_nan_zero WHERE k * inf = inf;
+SELECT count() FROM t_monotonicity_nan_zero WHERE k * inf = inf SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+
+SELECT 'pruning still applies where no endpoint becomes NaN';
+DROP TABLE IF EXISTS t_monotonicity_finite;
+CREATE TABLE t_monotonicity_finite (k Float64) ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 1;
+INSERT INTO t_monotonicity_finite SELECT number FROM numbers(100);
+SELECT count() FROM t_monotonicity_finite WHERE k / 2 > 40;
+SELECT count() FROM t_monotonicity_finite WHERE k * 2 > 80;
+SELECT count() FROM t_monotonicity_finite WHERE k / 2 > 40 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+-- Granule counts depend on settings the test runner randomizes, so compare the two numbers rather than
+-- pinning them: the point is that some granules are still skipped.
+SELECT toUInt64OrZero(extract(explain, 'Granules: (\\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \\d+/(\\d+)')) AS granules_pruned
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_finite WHERE k / 2 > 40)
+WHERE explain LIKE '%Granules: %/%';
+
+DROP TABLE t_monotonicity_finite;
+DROP TABLE t_monotonicity_nan_zero;
+DROP TABLE t_monotonicity_nan;


### PR DESCRIPTION
Index analysis models `divide` and `multiply` by a constant as monotonic from the constant alone. A `Float`
key column may hold `±inf`, and `-inf / inf`, `inf * 0` and `0 * inf` are all `NaN`, so the transformed range
endpoint became `NaN` - a range no point compares into - and every part and granule was pruned:

```sql
CREATE TABLE t (k Float64) ENGINE = MergeTree ORDER BY k;
INSERT INTO t VALUES (-inf), (1), (2), (3);

SELECT count() FROM t WHERE k / inf = 0;   -- 0, expected 3
SELECT count() FROM t WHERE k * 0 = 0;     -- 0, expected 3
```

Both pruning layers were affected on their own - the primary key index and the statistics-based part pruning
(`use_statistics_for_part_pruning`, on by default) - so the query silently returned nothing at default
settings. No `NaN` appears in the data or in the query: a legal `±inf` in the column is enough.

Only the transform can tell, so it is now evaluated at both endpoints - as the `plus`/`minus` branches
already do for their own overflow question - and monotonicity is declined when either result is `NaN`. The
check is restricted to a `Float` result: no other result type has a `NaN`, and an integer division by a zero
constant would raise here rather than answer one. Pruning for ranges that stay finite is unchanged, which
the test pins.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118121

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed queries silently returning no rows when a `Float` primary key column holds `±inf` and the predicate's
arithmetic maps that endpoint to `NaN`, e.g. `WHERE k / inf = 0` or `WHERE k * 0 = 0`: index and statistics
pruning dropped every part and granule.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118468&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118468](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118468+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
