### PR TITLE
Fix port and portRFC parsing before URL queries and fragments

### DIFF
--- a/src/Functions/URL/port.cpp
+++ b/src/Functions/URL/port.cpp
@@ -117,7 +117,7 @@ private:
         bool saw_digit = false;
         while (p < end)
         {
-            if (*p == '/')
+            if (*p == '/' || *p == '?' || *p == '#')
                 break;
             if (!isNumericASCII(*p))
                 return default_port;

--- a/src/Functions/tests/gtest_port_function.cpp
+++ b/src/Functions/tests/gtest_port_function.cpp
@@ -126,6 +126,14 @@ TEST(PortFunction, NoUserinfo)
     EXPECT_EQ(evaluateFunction("port", {"https://example.com:443"}), UInt64(443));
 }
 
+TEST(PortFunction, QueryAndFragment)
+{
+    EXPECT_EQ(evaluateFunction("port", {"https://example.com:8443?x=1"}), UInt64(8443));
+    EXPECT_EQ(evaluateFunction("port", {"https://example.com:8443#fragment"}), UInt64(8443));
+    EXPECT_EQ(evaluateFunction("portRFC", {"https://example.com:8443?x=1"}), UInt64(8443));
+    EXPECT_EQ(evaluateFunction("portRFC", {"https://example.com:8443#fragment"}), UInt64(8443));
+}
+
 TEST(PortFunction, EdgeCases)
 {
     // Empty URL - should return 0


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `port()` and `portRFC()` returning the default port for valid URLs with a query string or fragment after the port.

### Description

`port()` and `portRFC()` stop parsing an explicit port only at `/`.

For a URL such as `https://example.com:8443?x=1`, `extractPort` reads the port and then sees `?`. Since `?` is not a digit or `/`, the function returns the default port instead of `8443`. The same happens for `#`.

The URL host parser already treats `/`, `?`, and `#` as the end of the authority. Stop port parsing at the same delimiters. The existing host parsing behavior is unchanged.

### Tests

- Added coverage for `port()` with a query string and fragment.
- Added the same coverage for `portRFC()`.
- `git diff --check`

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118482&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118482](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118482+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1061` (included in `26.9` and later)
<!-- ch-version-info:end -->