### PR TITLE
AST fuzzer oracle: screen the definitions a read evaluates, not only the query text

### DIFF
--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/GetAggregatesVisitor.h>
 #include <Interpreters/executeQuery.h>
+#include <Interpreters/misc.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
@@ -928,6 +929,119 @@ bool referencesDistributedTableAnywhere(const ASTPtr & ast, const ContextPtr & c
     }
     for (const auto & child : ast->children)
         if (referencesDistributedTableAnywhere(child, context))
+            return true;
+    return false;
+}
+
+constexpr size_t MAX_DEFINITION_SCREEN_DEPTH = 8;
+
+/// A query names relations and columns; reading them evaluates the definitions
+/// stored behind those names. A view's body and an `ALIAS` column's expression
+/// are re-evaluated on every read, so each of the oracle's reads of one name can
+/// observe a different value: `now()` inside a view body drifts exactly as a
+/// written-out `now()` would, yet the query's own AST holds only an
+/// `ASTTableIdentifier` and the checks above never see it.
+///
+/// Screen those definitions with the same predicates that screen the query
+/// text, so that the verdict does not depend on whether a construct is spelled
+/// inline or hidden behind a name: a view over `numbers(10)` is then skipped
+/// exactly as an inline `FROM numbers(10)` is, and no separate policy exists
+/// for the hidden spelling. A view reading another view recurses; the depth cap
+/// bounds a chain closed into a cycle by `CREATE OR REPLACE`. Unresolvable
+/// metadata fails closed, as in `referencesDistributedTableAnywhere`.
+bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr & context, size_t depth = 0)
+{
+    if (!ast)
+        return false;
+    if (depth > MAX_DEFINITION_SCREEN_DEPTH)
+        return true;
+
+    if (const auto * table_id = ast->as<ASTTableIdentifier>())
+    {
+        try
+        {
+            /// Resolve the name as a read resolves it: a temporary view lives in the session
+            /// namespace, not a database, and a `{name:Identifier}` placeholder has no name
+            /// until substitution. A name that does not resolve cannot be proven safe.
+            const StorageID resolved = context->tryResolveStorageID(StorageID{table_id->getDatabaseName(), table_id->shortName()});
+            if (!resolved)
+                return true;
+
+            if (auto storage = DatabaseCatalog::instance().tryGetTable(resolved, context))
+            {
+                /// An engine that returns rows it does not store evaluates a definition that
+                /// is neither in this AST nor in its own metadata, so its engine name does
+                /// not say what a read of it evaluates.
+                if (storage->readsFromOtherTables())
+                    return true;
+
+                auto metadata = storage->getInMemoryMetadataPtr(context, /* bypass_metadata_cache = */ false);
+                ASTs definitions;
+
+                /// `isView()` is also true for `MaterializedView`, whose read goes
+                /// to the target table rather than to its stored `SELECT`, so its
+                /// body is not a read-time carrier. Match the engine name instead.
+                if (storage->getName() == "View")
+                {
+                    /// `hasSelectQuery()` tests `select_query`, which `StorageView`
+                    /// never sets; `inner_query` is what `readImpl` evaluates.
+                    const auto & inner_query = metadata->getSelectQuery().inner_query;
+                    if (!inner_query)
+                        return true;
+                    definitions.push_back(inner_query);
+                }
+
+                for (const auto & column : metadata->getColumns())
+                    if (column.default_desc.kind == ColumnDefaultKind::Alias && column.default_desc.expression)
+                        definitions.push_back(column.default_desc.expression);
+
+                for (const auto & definition : definitions)
+                    if (hasNonDeterministicFunctionsImpl(definition, context)
+                        || referencesSystemDatabaseAnywhere(definition, context->getCurrentDatabase())
+                        || referencesDistributedTableAnywhere(definition, context)
+                        || referencesUnscreenedDefinitionAnywhere(definition, context, depth + 1))
+                        return true;
+            }
+        }
+        catch (...)
+        {
+            /// Ok: fail closed. A name or metadata we cannot read cannot be proven safe, so
+            /// skip the query rather than risk a false oracle mismatch. Deliberately not
+            /// logged: this runs per-AST-node on a hot path.
+            return true;
+        }
+    }
+
+    /// `IN t` names a table and means `IN (SELECT * FROM t)`, as do argument 0 of `joinGet`
+    /// and of `dictGet`. Those operands are still plain `ASTIdentifier`s here, because the
+    /// rewrite to `ASTTableIdentifier` happens during analysis, after this check runs.
+    if (const auto * func = ast->as<ASTFunction>())
+    {
+        std::optional<size_t> table_argument_pos;
+        if (functionIsInOrGlobalInOperator(func->name))
+            table_argument_pos = 1;
+        else if (functionIsJoinGet(func->name) || functionIsDictGet(func->name))
+            table_argument_pos = 0;
+
+        if (table_argument_pos && func->arguments && func->arguments->children.size() > *table_argument_pos)
+        {
+            if (const auto * identifier = func->arguments->children[*table_argument_pos]->as<ASTIdentifier>())
+            {
+                /// A name that cannot be read as a table name, such as a `{name:Identifier}`
+                /// placeholder before substitution, cannot be proven safe either.
+                const ASTPtr table_id = identifier->createTable();
+                if (!table_id)
+                    return true;
+
+                /// An operand naming an alias or a CTE needs no exclusion: it resolves to no storage, which the branch above passes over.
+                if (referencesUnscreenedDefinitionAnywhere(table_id, context, depth))
+                    return true;
+            }
+        }
+    }
+
+    for (const auto & child : ast->children)
+        if (referencesUnscreenedDefinitionAnywhere(child, context, depth))
             return true;
     return false;
 }
@@ -2526,6 +2640,15 @@ bool QueryOracleChecker::check(const ASTPtr & query_ast, const ContextMutablePtr
     if (referencesDistributedTableAnywhere(query_ast, context))
     {
         LOG_TRACE(logger, "Oracle skip: query reads from a Distributed table");
+        return false;
+    }
+
+    /// A view body and an `ALIAS` column expression are evaluated on every read,
+    /// so a construct rejected when written in the query must be rejected when a
+    /// name hides it too, or the oracle's reads observe different values.
+    if (referencesUnscreenedDefinitionAnywhere(query_ast, context))
+    {
+        LOG_TRACE(logger, "Oracle skip: query reads a stored definition the gates reject");
         return false;
     }
 

--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -1,5 +1,6 @@
 #include <Interpreters/QueryOracleChecker.h>
 
+#include <Access/EnabledRowPolicies.h>
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 
 #include <Common/ProfileEvents.h>
@@ -978,6 +979,12 @@ bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr
                 /// Match the engine name: `isView()` is also true for `MaterializedView`.
                 if (storage->getName() == "View")
                 {
+                    /// A `DEFINER` view evaluates its body as the definer, so the row policies a read
+                    /// of it applies are that user's, while the screen below resolves them for the
+                    /// current one. `NONE` runs with no user at all, where no policy applies.
+                    if (metadata->sql_security_type == SQLSecurityType::DEFINER)
+                        return true;
+
                     /// `hasSelectQuery()` tests `select_query`, which `StorageView`
                     /// never sets; `inner_query` is what `readImpl` evaluates.
                     const auto & inner_query = metadata->getSelectQuery().inner_query;
@@ -992,6 +999,14 @@ bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr
                 for (const auto & column : metadata->getColumns())
                     if (column.default_desc.expression)
                         definitions.push_back(column.default_desc.expression);
+
+                /// A row policy filters every read of this name for the current user, with an
+                /// expression stored on the policy rather than in this metadata; the lookup a read
+                /// performs resolves a policy on the table and, failing that, one on the database.
+                auto row_policy = context->getRowPolicyFilter(
+                    resolved.getDatabaseName(), resolved.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+                if (row_policy && row_policy->expression)
+                    definitions.push_back(row_policy->expression);
 
                 for (const auto & definition : definitions)
                     if (hasNonDeterministicFunctionsImpl(definition, context)

--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -1025,20 +1025,14 @@ bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr
         }
     }
 
-    /// `IN t` names a table and means `IN (SELECT * FROM t)`, as do argument 0 of `joinGet`
-    /// and of `dictGet`. Those operands are still plain `ASTIdentifier`s here, because the
-    /// rewrite to `ASTTableIdentifier` happens during analysis, after this check runs.
+    /// `IN t` names a table and means `IN (SELECT * FROM t)`. That operand is still a plain
+    /// `ASTIdentifier` here, because the rewrite to `ASTTableIdentifier` happens during
+    /// analysis, after this check runs.
     if (const auto * func = ast->as<ASTFunction>())
     {
-        std::optional<size_t> table_argument_pos;
-        if (functionIsInOrGlobalInOperator(func->name))
-            table_argument_pos = 1;
-        else if (functionIsJoinGet(func->name) || functionIsDictGet(func->name))
-            table_argument_pos = 0;
-
-        if (table_argument_pos && func->arguments && func->arguments->children.size() > *table_argument_pos)
+        if (functionIsInOrGlobalInOperator(func->name) && func->arguments && func->arguments->children.size() > 1)
         {
-            if (const auto * identifier = func->arguments->children[*table_argument_pos]->as<ASTIdentifier>())
+            if (const auto * identifier = func->arguments->children[1]->as<ASTIdentifier>())
             {
                 /// A name that cannot be read as a table name, such as a `{name:Identifier}`
                 /// placeholder before substitution, cannot be proven safe either.

--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -936,19 +936,10 @@ bool referencesDistributedTableAnywhere(const ASTPtr & ast, const ContextPtr & c
 constexpr size_t MAX_DEFINITION_SCREEN_DEPTH = 8;
 
 /// A query names relations and columns; reading them evaluates the definitions
-/// stored behind those names. A view's body and an `ALIAS` column's expression
-/// are re-evaluated on every read, so each of the oracle's reads of one name can
-/// observe a different value: `now()` inside a view body drifts exactly as a
-/// written-out `now()` would, yet the query's own AST holds only an
-/// `ASTTableIdentifier` and the checks above never see it.
-///
-/// Screen those definitions with the same predicates that screen the query
-/// text, so that the verdict does not depend on whether a construct is spelled
-/// inline or hidden behind a name: a view over `numbers(10)` is then skipped
-/// exactly as an inline `FROM numbers(10)` is, and no separate policy exists
-/// for the hidden spelling. A view reading another view recurses; the depth cap
-/// bounds a chain closed into a cycle by `CREATE OR REPLACE`. Unresolvable
-/// metadata fails closed, as in `referencesDistributedTableAnywhere`.
+/// stored behind those names, and each read re-evaluates them, so the oracle's
+/// two reads of one name can observe different values while the query's own AST
+/// holds only an `ASTTableIdentifier`. A view reading another view recurses, and
+/// the depth cap bounds a chain closed into a cycle by `CREATE OR REPLACE`.
 bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr & context, size_t depth = 0)
 {
     if (!ast)
@@ -975,12 +966,16 @@ bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr
                 if (storage->readsFromOtherTables())
                     return true;
 
+                /// A `MaterializedView` read is forwarded to whatever its target name resolves to
+                /// at read time, and a refresh replaces that table, so this metadata does not
+                /// describe what a read of this name evaluates.
+                if (storage->getName() == "MaterializedView")
+                    return true;
+
                 auto metadata = storage->getInMemoryMetadataPtr(context, /* bypass_metadata_cache = */ false);
                 ASTs definitions;
 
-                /// `isView()` is also true for `MaterializedView`, whose read goes
-                /// to the target table rather than to its stored `SELECT`, so its
-                /// body is not a read-time carrier. Match the engine name instead.
+                /// Match the engine name: `isView()` is also true for `MaterializedView`.
                 if (storage->getName() == "View")
                 {
                     /// `hasSelectQuery()` tests `select_query`, which `StorageView`
@@ -991,8 +986,11 @@ bool referencesUnscreenedDefinitionAnywhere(const ASTPtr & ast, const ContextPtr
                     definitions.push_back(inner_query);
                 }
 
+                /// A read evaluates an `ALIAS` expression always, and any other kind for a column
+                /// the part does not store, which this metadata does not say. Supplying one also
+                /// pulls in the defaults its own expression needs, reaching an `EPHEMERAL` one.
                 for (const auto & column : metadata->getColumns())
-                    if (column.default_desc.kind == ColumnDefaultKind::Alias && column.default_desc.expression)
+                    if (column.default_desc.expression)
                         definitions.push_back(column.default_desc.expression);
 
                 for (const auto & definition : definitions)

--- a/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.reference
+++ b/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.reference
@@ -13,3 +13,6 @@ MATERIALIZED column with a non-deterministic expression: oracle skipped
 EPHEMERAL expression reached through a DEFAULT: oracle skipped
 IN over a non-deterministic definition: oracle skipped
 IN over a deterministic definition: oracle ran
+row policy with a non-deterministic filter: oracle skipped
+row policy with a deterministic filter: oracle ran
+DEFINER view over the definer's row policy: oracle skipped

--- a/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.reference
+++ b/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.reference
@@ -4,7 +4,12 @@ view over a view over a non-deterministic definition: oracle skipped
 view over a system table: oracle skipped
 temporary view over a non-deterministic definition: oracle skipped
 Alias engine over a non-deterministic definition: oracle skipped
+materialized view: oracle skipped
 ALIAS column with a non-deterministic expression: oracle skipped
 ALIAS column with a deterministic expression: oracle ran
+DEFAULT column with a non-deterministic expression: oracle skipped
+DEFAULT column with a deterministic expression: oracle ran
+MATERIALIZED column with a non-deterministic expression: oracle skipped
+EPHEMERAL expression reached through a DEFAULT: oracle skipped
 IN over a non-deterministic definition: oracle skipped
 IN over a deterministic definition: oracle ran

--- a/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.reference
+++ b/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.reference
@@ -1,0 +1,10 @@
+view over a non-deterministic definition: oracle skipped
+view over a deterministic definition: oracle ran
+view over a view over a non-deterministic definition: oracle skipped
+view over a system table: oracle skipped
+temporary view over a non-deterministic definition: oracle skipped
+Alias engine over a non-deterministic definition: oracle skipped
+ALIAS column with a non-deterministic expression: oracle skipped
+ALIAS column with a deterministic expression: oracle ran
+IN over a non-deterministic definition: oracle skipped
+IN over a deterministic definition: oracle ran

--- a/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.sh
+++ b/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.sh
@@ -9,11 +9,11 @@
 #              cost: a `--no-long` job skips this test.
 #
 # A query names relations and columns; reading them evaluates the definitions stored
-# behind those names. A view body and an `ALIAS` column expression are re-evaluated on
-# every read, so a non-deterministic function hidden behind either one makes each of the
-# oracle's reads observe a different value and the oracle reports a mismatch that is not
-# a wrong result. `QueryOracleChecker::check` must therefore screen those definitions,
-# not only the query text.
+# behind those names, and a read re-evaluates them, so a non-deterministic function
+# hidden behind any one of them makes each of the oracle's reads observe a different
+# value and the oracle reports a mismatch that is not a wrong result.
+# `QueryOracleChecker::check` must therefore screen those definitions, not only the
+# query text.
 #
 # The assertion is on `ASTFuzzerOracleChecks`, not on "the query succeeded": with
 # `ast_fuzzer_runs = 1` a random mutation can make a query oracle-ineligible for
@@ -29,7 +29,12 @@ $CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS oracle_definition_src;
     DROP TABLE IF EXISTS oracle_definition_alias;
     DROP TABLE IF EXISTS oracle_definition_det_alias;
+    DROP TABLE IF EXISTS oracle_definition_default;
+    DROP TABLE IF EXISTS oracle_definition_det_default;
+    DROP TABLE IF EXISTS oracle_definition_materialized;
+    DROP TABLE IF EXISTS oracle_definition_ephemeral;
     DROP TABLE IF EXISTS oracle_definition_alias_engine;
+    DROP VIEW IF EXISTS oracle_definition_mv;
     DROP VIEW IF EXISTS oracle_definition_nondet_view;
     DROP VIEW IF EXISTS oracle_definition_det_view;
     DROP VIEW IF EXISTS oracle_definition_inner_view;
@@ -68,10 +73,43 @@ $CLICKHOUSE_CLIENT --query "
     CREATE TABLE oracle_definition_det_alias (k UInt32, r UInt32 ALIAS k * 2) ENGINE = MergeTree ORDER BY k;
     INSERT INTO oracle_definition_det_alias SELECT number FROM numbers(50);
 
+    -- A column added after a part was written is not stored in it, so a read of that column
+    -- evaluates its \`DEFAULT\` expression, which is therefore a read-time definition too.
+    -- Two reads of this unchanged part return different values for \`r\`.
+    CREATE TABLE oracle_definition_default (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_default SELECT number FROM numbers(50);
+    ALTER TABLE oracle_definition_default ADD COLUMN r UInt32 DEFAULT rand();
+
+    -- Same shape, deterministic expression: separates \"screen a non-deterministic default\"
+    -- from \"screen every column that has a default\".
+    CREATE TABLE oracle_definition_det_default (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_det_default SELECT number FROM numbers(50);
+    ALTER TABLE oracle_definition_det_default ADD COLUMN r UInt32 DEFAULT k * 2;
+
+    -- \`MATERIALIZED\` is stored, so it reaches the same read-time path only for a part
+    -- written before the column existed.
+    CREATE TABLE oracle_definition_materialized (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_materialized SELECT number FROM numbers(50);
+    ALTER TABLE oracle_definition_materialized ADD COLUMN r UInt32 MATERIALIZED rand();
+
+    -- An \`EPHEMERAL\` column cannot be read directly, but supplying a missing column pulls in
+    -- the defaults of the columns its own expression needs, so \`rand()\` here is evaluated by
+    -- a read of \`r\` and the ephemeral expression is reachable after all.
+    CREATE TABLE oracle_definition_ephemeral (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_ephemeral SELECT number FROM numbers(50);
+    ALTER TABLE oracle_definition_ephemeral ADD COLUMN e UInt32 EPHEMERAL rand();
+    ALTER TABLE oracle_definition_ephemeral ADD COLUMN r UInt32 DEFAULT e;
+
     -- \`Alias\` reports its own engine name while reading, and reporting the metadata of,
     -- its target, so the target view's body is reachable but not named here.
     SET allow_experimental_alias_table_engine = 1;
     CREATE TABLE oracle_definition_alias_engine ENGINE = Alias(currentDatabase(), 'oracle_definition_nondet_view');
+
+    -- A materialized view read is forwarded to its target table, whose engine and column
+    -- defaults are in the target's metadata rather than in the view's, so no screen of this
+    -- name can describe what the read evaluates. Its own body is not read, hence not screened.
+    CREATE MATERIALIZED VIEW oracle_definition_mv ENGINE = MergeTree ORDER BY k
+        POPULATE AS SELECT k FROM oracle_definition_src;
 "
 
 get_checks()
@@ -249,11 +287,26 @@ assert_screened "temporary view over a non-deterministic definition" oracle_defi
 assert_screened "Alias engine over a non-deterministic definition" oracle_definition_alias_engine \
     "SELECT k, r FROM oracle_definition_alias_engine WHERE k > 5;"
 
+assert_screened "materialized view" oracle_definition_mv \
+    "SELECT k FROM oracle_definition_mv WHERE k > 5;"
+
 assert_screened "ALIAS column with a non-deterministic expression" oracle_definition_alias \
     "SELECT k, r FROM oracle_definition_alias WHERE k > 5;"
 
 assert_reaches_oracle "ALIAS column with a deterministic expression" oracle_definition_det_alias \
     "SELECT k, r FROM oracle_definition_det_alias WHERE k > 5;"
+
+assert_screened "DEFAULT column with a non-deterministic expression" oracle_definition_default \
+    "SELECT k, r FROM oracle_definition_default WHERE k > 5;"
+
+assert_reaches_oracle "DEFAULT column with a deterministic expression" oracle_definition_det_default \
+    "SELECT k, r FROM oracle_definition_det_default WHERE k > 5;"
+
+assert_screened "MATERIALIZED column with a non-deterministic expression" oracle_definition_materialized \
+    "SELECT k, r FROM oracle_definition_materialized WHERE k > 5;"
+
+assert_screened "EPHEMERAL expression reached through a DEFAULT" oracle_definition_ephemeral \
+    "SELECT k, r FROM oracle_definition_ephemeral WHERE k > 5;"
 
 assert_screened "IN over a non-deterministic definition" oracle_definition_in_view \
     "SELECT k FROM oracle_definition_src WHERE k IN oracle_definition_in_view;"
@@ -262,7 +315,12 @@ assert_reaches_oracle "IN over a deterministic definition" oracle_definition_in_
     "SELECT k FROM oracle_definition_src WHERE k IN oracle_definition_in_det_view;"
 
 $CLICKHOUSE_CLIENT --query "
+    DROP VIEW oracle_definition_mv;
     DROP TABLE oracle_definition_alias_engine;
+    DROP TABLE oracle_definition_ephemeral;
+    DROP TABLE oracle_definition_materialized;
+    DROP TABLE oracle_definition_det_default;
+    DROP TABLE oracle_definition_default;
     DROP VIEW oracle_definition_in_det_view;
     DROP VIEW oracle_definition_in_view;
     DROP VIEW oracle_definition_system_view;

--- a/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.sh
+++ b/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.sh
@@ -34,6 +34,14 @@ $CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS oracle_definition_materialized;
     DROP TABLE IF EXISTS oracle_definition_ephemeral;
     DROP TABLE IF EXISTS oracle_definition_alias_engine;
+    DROP TABLE IF EXISTS oracle_definition_row_policy;
+    DROP TABLE IF EXISTS oracle_definition_det_row_policy;
+    DROP TABLE IF EXISTS oracle_definition_definer_src;
+    DROP VIEW IF EXISTS oracle_definition_definer_view;
+    DROP ROW POLICY IF EXISTS oracle_definition_nondet_filter ON oracle_definition_row_policy;
+    DROP ROW POLICY IF EXISTS oracle_definition_det_filter ON oracle_definition_det_row_policy;
+    DROP ROW POLICY IF EXISTS oracle_definition_definer_filter ON oracle_definition_definer_src;
+    DROP USER IF EXISTS oracle_definition_definer_${CLICKHOUSE_DATABASE};
     DROP VIEW IF EXISTS oracle_definition_mv;
     DROP VIEW IF EXISTS oracle_definition_nondet_view;
     DROP VIEW IF EXISTS oracle_definition_det_view;
@@ -99,6 +107,35 @@ $CLICKHOUSE_CLIENT --query "
     INSERT INTO oracle_definition_ephemeral SELECT number FROM numbers(50);
     ALTER TABLE oracle_definition_ephemeral ADD COLUMN e UInt32 EPHEMERAL rand();
     ALTER TABLE oracle_definition_ephemeral ADD COLUMN r UInt32 DEFAULT e;
+
+    -- A row policy for the current user filters every read of the table it is attached to, and
+    -- its filter lives on the policy rather than in the table's metadata, so two reads of these
+    -- unchanged 50 rows return different subsets of them.
+    CREATE TABLE oracle_definition_row_policy (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_row_policy SELECT number FROM numbers(50);
+    CREATE ROW POLICY oracle_definition_nondet_filter ON oracle_definition_row_policy
+        USING (rand() % 2) = 0 TO ALL;
+
+    -- Same shape, deterministic filter: separates \"screen a non-deterministic policy\" from
+    -- \"reject every table that has a policy\".
+    CREATE TABLE oracle_definition_det_row_policy (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_det_row_policy SELECT number FROM numbers(50);
+    CREATE ROW POLICY oracle_definition_det_filter ON oracle_definition_det_row_policy
+        USING k < 1000000 TO ALL;
+
+    -- A \`DEFINER\` view evaluates its body as the definer, so the policy a read of it applies is
+    -- the definer's: this body names only \`k\`, the reader below has no policy on the base table,
+    -- and two reads of it still return different subsets.
+    CREATE TABLE oracle_definition_definer_src (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_definer_src SELECT number FROM numbers(50);
+    CREATE USER oracle_definition_definer_${CLICKHOUSE_DATABASE} IDENTIFIED WITH no_password;
+    GRANT SELECT ON ${CLICKHOUSE_DATABASE}.oracle_definition_definer_src
+        TO oracle_definition_definer_${CLICKHOUSE_DATABASE};
+    CREATE ROW POLICY oracle_definition_definer_filter ON oracle_definition_definer_src
+        USING (rand() % 2) = 0 TO oracle_definition_definer_${CLICKHOUSE_DATABASE};
+    CREATE VIEW oracle_definition_definer_view
+        DEFINER = oracle_definition_definer_${CLICKHOUSE_DATABASE} SQL SECURITY DEFINER
+        AS SELECT k FROM oracle_definition_definer_src;
 
     -- \`Alias\` reports its own engine name while reading, and reporting the metadata of,
     -- its target, so the target view's body is reachable but not named here.
@@ -314,7 +351,24 @@ assert_screened "IN over a non-deterministic definition" oracle_definition_in_vi
 assert_reaches_oracle "IN over a deterministic definition" oracle_definition_in_det_view \
     "SELECT k FROM oracle_definition_src WHERE k IN oracle_definition_in_det_view;"
 
+assert_screened "row policy with a non-deterministic filter" oracle_definition_row_policy \
+    "SELECT k FROM oracle_definition_row_policy WHERE k > 5;"
+
+assert_reaches_oracle "row policy with a deterministic filter" oracle_definition_det_row_policy \
+    "SELECT k FROM oracle_definition_det_row_policy WHERE k > 5;"
+
+assert_screened "DEFINER view over the definer's row policy" oracle_definition_definer_view \
+    "SELECT k FROM oracle_definition_definer_view WHERE k > 5;"
+
 $CLICKHOUSE_CLIENT --query "
+    DROP VIEW oracle_definition_definer_view;
+    DROP ROW POLICY oracle_definition_definer_filter ON oracle_definition_definer_src;
+    DROP USER oracle_definition_definer_${CLICKHOUSE_DATABASE};
+    DROP TABLE oracle_definition_definer_src;
+    DROP ROW POLICY oracle_definition_det_filter ON oracle_definition_det_row_policy;
+    DROP ROW POLICY oracle_definition_nondet_filter ON oracle_definition_row_policy;
+    DROP TABLE oracle_definition_det_row_policy;
+    DROP TABLE oracle_definition_row_policy;
     DROP VIEW oracle_definition_mv;
     DROP TABLE oracle_definition_alias_engine;
     DROP TABLE oracle_definition_ephemeral;

--- a/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.sh
+++ b/tests/queries/0_stateless/05099_ast_fuzzer_oracle_view_definition.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel, long
+# no-fasttest: SET ast_fuzzer_runs / ast_fuzzer_oracle are EXPERIMENTAL-tier settings and
+#              are not allowed when `allow_feature_tier=0` (the Fast test default).
+# no-parallel: required because the proof events are server-global.
+# long:        the flaky check repeats a test many times and fails any single run whose wall
+#              clock exceeds `TEST_MAX_RUN_TIME_IN_SECONDS`; the retry loops below cannot fit
+#              that budget. The tag waives that limit and lowers the repeat count. Accepted
+#              cost: a `--no-long` job skips this test.
+#
+# A query names relations and columns; reading them evaluates the definitions stored
+# behind those names. A view body and an `ALIAS` column expression are re-evaluated on
+# every read, so a non-deterministic function hidden behind either one makes each of the
+# oracle's reads observe a different value and the oracle reports a mismatch that is not
+# a wrong result. `QueryOracleChecker::check` must therefore screen those definitions,
+# not only the query text.
+#
+# The assertion is on `ASTFuzzerOracleChecks`, not on "the query succeeded": with
+# `ast_fuzzer_runs = 1` a random mutation can make a query oracle-ineligible for
+# unrelated reasons, so an absent mismatch alone cannot distinguish "screened" from
+# "never checked". A mismatch increments `ASTFuzzerOracleChecks` before comparing, so an
+# unscreened definition moves the counter.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS oracle_definition_src;
+    DROP TABLE IF EXISTS oracle_definition_alias;
+    DROP TABLE IF EXISTS oracle_definition_det_alias;
+    DROP TABLE IF EXISTS oracle_definition_alias_engine;
+    DROP VIEW IF EXISTS oracle_definition_nondet_view;
+    DROP VIEW IF EXISTS oracle_definition_det_view;
+    DROP VIEW IF EXISTS oracle_definition_inner_view;
+    DROP VIEW IF EXISTS oracle_definition_outer_view;
+    DROP VIEW IF EXISTS oracle_definition_system_view;
+    DROP VIEW IF EXISTS oracle_definition_in_view;
+    DROP VIEW IF EXISTS oracle_definition_in_det_view;
+
+    CREATE TABLE oracle_definition_src (k UInt32) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_src SELECT number FROM numbers(50);
+
+    -- The view body holds the non-determinism; the query below names only the view.
+    CREATE VIEW oracle_definition_nondet_view AS SELECT k, rand() AS r FROM oracle_definition_src;
+
+    -- Same shape, deterministic body: the anti-vacuity control below.
+    CREATE VIEW oracle_definition_det_view AS SELECT k, k * 2 AS r FROM oracle_definition_src;
+
+    -- Two levels of naming: only the inner body is non-deterministic, so reaching it
+    -- requires recursing through the outer definition.
+    CREATE VIEW oracle_definition_inner_view AS SELECT k, rand() AS r FROM oracle_definition_src;
+    CREATE VIEW oracle_definition_outer_view AS SELECT k, r FROM oracle_definition_inner_view;
+
+    -- The \`system\` reference is in the body, so only the definition screen can see it.
+    CREATE VIEW oracle_definition_system_view AS SELECT event, value FROM system.events;
+
+    -- Named as an \`IN\` operand, which is a plain identifier until analysis rewrites it.
+    -- \`k IN v\` requires a single-column \`v\`, so the two-column views above cannot be reused.
+    CREATE VIEW oracle_definition_in_view AS SELECT rand() % 50 AS k FROM oracle_definition_src;
+    CREATE VIEW oracle_definition_in_det_view AS SELECT k FROM oracle_definition_src;
+
+    -- The column expression holds the non-determinism; the query names only the column.
+    CREATE TABLE oracle_definition_alias (k UInt32, r UInt32 ALIAS rand()) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_alias SELECT number FROM numbers(50);
+
+    -- Same shape, deterministic expression: the second anti-vacuity control.
+    CREATE TABLE oracle_definition_det_alias (k UInt32, r UInt32 ALIAS k * 2) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO oracle_definition_det_alias SELECT number FROM numbers(50);
+
+    -- \`Alias\` reports its own engine name while reading, and reporting the metadata of,
+    -- its target, so the target view's body is reachable but not named here.
+    SET allow_experimental_alias_table_engine = 1;
+    CREATE TABLE oracle_definition_alias_engine ENGINE = Alias(currentDatabase(), 'oracle_definition_nondet_view');
+"
+
+get_checks()
+{
+    $CLICKHOUSE_CLIENT --query "SELECT sum(value) FROM system.events WHERE event = 'ASTFuzzerOracleChecks'"
+}
+
+# Runs one fuzzed query and echoes `<counter>TAB<logged query>`, so a caller can tell both how
+# many oracles had run and what the oracle saw from a single client invocation.
+#
+# The counter is read FIRST, before the fuzzer is enabled, which makes it the value that closes
+# the *previous* iteration rather than this one. That ordering is required, not stylistic: a
+# multi-statement `--query` stops at the first failing statement, and an oracle mismatch is
+# rethrown to the client, so a counter read placed after the query is lost in exactly the runs
+# where an oracle ran and disagreed.
+#
+# The query's own rows share the stream with the trace line and are dropped by the filter rather
+# than by `FORMAT Null`, because the oracle skips queries carrying an explicit FORMAT clause.
+# That also hides the expected error-level lines from mutations producing valid-but-nonsense
+# queries. A fuzzed query can contain arbitrary bytes, and the runner fails a test that writes
+# anything to stderr, so NUL bytes are stripped before the match and `grep -a` keeps it from
+# reporting the stream as binary instead of matching.
+# `$2` runs before the fuzzer is enabled and in the same session as the query, which is
+# what a session-bound object needs in order to exist, unfuzzed, when the query reads it.
+run_fuzzed()
+{
+    local out
+    out=$($CLICKHOUSE_CLIENT --query "
+        SELECT 'ORACLE_CHECKS=' || toString(sum(value)) FROM system.events WHERE event = 'ASTFuzzerOracleChecks';
+        ${2:-}
+        SET send_logs_level = 'trace';
+        SET ast_fuzzer_runs = 1;
+        SET ast_fuzzer_oracle = 1;
+        $1
+    " 2>&1 | tr -d '\0' | grep -a -o -E 'ORACLE_CHECKS=[0-9]+|Fuzzed query: .*')
+
+    printf '%s\t%s\n' \
+        "$(printf '%s\n' "$out" | grep -a -o -E 'ORACLE_CHECKS=[0-9]+' | tail -1 | cut -d '=' -f 2)" \
+        "$(printf '%s\n' "$out" | grep -a 'Fuzzed query: ' | tail -1)"
+}
+
+# A screened definition must never reach an oracle, so the counter must not move for a fuzzed
+# query that still names `$2`. A mutation may drop that reference instead of preserving it (the
+# fuzzer rewrites a WHERE predicate freely, so `k IN v` can become `k`), and an oracle running
+# on a query that no longer reads the definition is correct rather than a leak, so each move is
+# attributed to the query the server logged. A move that cannot be attributed counts as a leak.
+#
+# Each sample carries the counter as it stood before its own fuzzed query, so a move is visible
+# one sample after the query that caused it; the trailing read closes the last iteration.
+assert_screened()
+{
+    local label=$1
+    local object=$2
+    local query=$3
+    local prelude=${4:-}
+    local runs=10
+    local sample checks fuzzed prev_checks="" prev_fuzzed="" positions
+    local leaked=0
+    local i
+
+    for i in $(seq 1 $((runs + 1)))
+    do
+        if [[ "$i" -le "$runs" ]]
+        then
+            sample=$(run_fuzzed "$query" "$prelude")
+            checks=${sample%%$'\t'*}
+            fuzzed=${sample#*$'\t'}
+        else
+            checks=$(get_checks)
+            fuzzed=""
+        fi
+
+        # No counter at all means the invocation never reached its first statement, so this
+        # sample pairs with nothing: drop the pairing instead of attributing the gap to a query.
+        if [[ -z "$checks" ]]
+        then
+            prev_checks=""
+            prev_fuzzed=""
+            continue
+        fi
+
+        if [[ -n "$prev_checks" && "$checks" -gt "$prev_checks" ]]
+        then
+            # A parameterized identifier logs as `{fuzz_param_N:Identifier}`, so a move paired with
+            # one is unattributable by name; in a table position it is a leak whatever the
+            # placeholder stands for, because the screen rejects that name before any oracle runs.
+            # `ARRAY JOIN` / `IS DISTINCT FROM` end in those keywords but take a column: blind them.
+            positions=${prev_fuzzed//ARRAY JOIN/ARRAY-J}
+            positions=${positions//IS DISTINCT FROM/IS-DF}
+            if [[ -z "$prev_fuzzed" || "$prev_fuzzed" == *"$object"* \
+                  || "$positions" =~ (FROM|JOIN)[[:space:]]*\{[A-Za-z0-9_]*:Identifier\} \
+                  || "$positions" =~ IN[[:space:]]*\([[:space:]]*\{[A-Za-z0-9_]*:Identifier\}\) ]]
+            then
+                leaked=1
+                break
+            fi
+        fi
+
+        prev_checks=$checks
+        prev_fuzzed=$fuzzed
+    done
+
+    if [[ "$leaked" -eq 0 ]]
+    then
+        echo "$label: oracle skipped"
+    else
+        echo "$label: oracle ran on an unscreened definition"
+    fi
+}
+
+# Anti-vacuity: a screen that rejected every named definition wholesale would pass every
+# assertion above. One eligible pass that still names `$2` must reach an oracle. Attributed for
+# the same reason as above, and here it is what keeps the control sharp: a mutation that dropped
+# the reference is eligible whatever the screen does, so counting it would let a screen that
+# rejects the construct outright pass this assertion. Retried because a single mutation can break
+# oracle eligibility for reasons unrelated to the definition screen.
+assert_reaches_oracle()
+{
+    local label=$1
+    local object=$2
+    local query=$3
+    local sample checks fuzzed prev_checks="" prev_fuzzed=""
+    local ran=0
+    local i
+
+    for i in $(seq 1 100)
+    do
+        sample=$(run_fuzzed "$query")
+        checks=${sample%%$'\t'*}
+        fuzzed=${sample#*$'\t'}
+
+        if [[ -z "$checks" ]]
+        then
+            prev_checks=""
+            prev_fuzzed=""
+            continue
+        fi
+
+        if [[ -n "$prev_checks" && "$checks" -gt "$prev_checks" && "$prev_fuzzed" == *"$object"* ]]
+        then
+            ran=1
+            break
+        fi
+
+        prev_checks=$checks
+        prev_fuzzed=$fuzzed
+    done
+
+    if [[ "$ran" -eq 1 ]]
+    then
+        echo "$label: oracle ran"
+    else
+        echo "$label: oracle never ran on a query naming $object"
+    fi
+}
+
+assert_screened "view over a non-deterministic definition" oracle_definition_nondet_view \
+    "SELECT k, r FROM oracle_definition_nondet_view WHERE k > 5;"
+
+assert_reaches_oracle "view over a deterministic definition" oracle_definition_det_view \
+    "SELECT k, r FROM oracle_definition_det_view WHERE k > 5;"
+
+assert_screened "view over a view over a non-deterministic definition" oracle_definition_outer_view \
+    "SELECT k, r FROM oracle_definition_outer_view WHERE k > 5;"
+
+assert_screened "view over a system table" oracle_definition_system_view \
+    "SELECT event, value FROM oracle_definition_system_view WHERE value > 0;"
+
+# A temporary view lives in the session rather than in a database, so it is created in the
+# same client invocation as the query that reads it.
+assert_screened "temporary view over a non-deterministic definition" oracle_definition_temp_view \
+    "SELECT k, r FROM oracle_definition_temp_view WHERE k > 5;" \
+    "CREATE TEMPORARY VIEW oracle_definition_temp_view AS SELECT k, rand() AS r FROM oracle_definition_src;"
+
+assert_screened "Alias engine over a non-deterministic definition" oracle_definition_alias_engine \
+    "SELECT k, r FROM oracle_definition_alias_engine WHERE k > 5;"
+
+assert_screened "ALIAS column with a non-deterministic expression" oracle_definition_alias \
+    "SELECT k, r FROM oracle_definition_alias WHERE k > 5;"
+
+assert_reaches_oracle "ALIAS column with a deterministic expression" oracle_definition_det_alias \
+    "SELECT k, r FROM oracle_definition_det_alias WHERE k > 5;"
+
+assert_screened "IN over a non-deterministic definition" oracle_definition_in_view \
+    "SELECT k FROM oracle_definition_src WHERE k IN oracle_definition_in_view;"
+
+assert_reaches_oracle "IN over a deterministic definition" oracle_definition_in_det_view \
+    "SELECT k FROM oracle_definition_src WHERE k IN oracle_definition_in_det_view;"
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE oracle_definition_alias_engine;
+    DROP VIEW oracle_definition_in_det_view;
+    DROP VIEW oracle_definition_in_view;
+    DROP VIEW oracle_definition_system_view;
+    DROP VIEW oracle_definition_outer_view;
+    DROP VIEW oracle_definition_inner_view;
+    DROP VIEW oracle_definition_nondet_view;
+    DROP VIEW oracle_definition_det_view;
+    DROP TABLE oracle_definition_det_alias;
+    DROP TABLE oracle_definition_alias;
+    DROP TABLE oracle_definition_src;
+"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/91358

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`AST fuzzer (amd_release, oracle)` reported a TLP `WHERE` mismatch over `03322_initial_query_start_time_check`'s view `tmp` ([report](https://s3.amazonaws.com/clickhouse-test-reports/PRs/91358/8640f3397185cc700ffa06b44cfc01acd0aa02b7/pr/result_ast_fuzzer_amd_release_oracle.json)); @ alexey-milovidov asked for a separate fix PR ([comment](https://github.com/ClickHouse/ClickHouse/pull/91358#issuecomment-5557803785)).

The oracle screened the query as written: `check()` walked its AST for non-deterministic functions and tested a named table only for engine and database. `tmp`'s body evaluates `now()` on every read, and a query naming a view carries just an `ASTTableIdentifier`, so the arms read two states of one relation rather than a wrong result. Only the hidden spelling slipped through: `now()` already reports `isDeterministic() == false`.

I add one predicate, called once in `check()`, for all nine oracles. It resolves each name as a read does, then screens what that read evaluates with the existing predicates: a view's inner query, every column default expression (a read evaluates one for any column the part does not store, transitively reaching an `EPHEMERAL` one), and the row policy filter the read applies for the current user. What it cannot read fails closed: a `MaterializedView`, whose read is forwarded to a target resolved at read time, and a `DEFINER` view, which runs its body as another user whose policies this screen does not resolve. It also handles two spellings that hide a name: a forwarding engine (`Alias`, `Merge`, `Buffer`) and `IN t`.

Validation: `03322` under the oracle fails 8 of 40 runs before, 0 of 40 after; ablation builds redden its thirteen screened cases one at a time, and its five controls stay green. A screen can only skip a check, never fail one: 891 of 14527 stateless files create an object it rejects, 393 newly.

Still unscreened: an engine reading a query or source outside its metadata, and a session's `additional_result_filter`/`additional_table_filters`, owned by the settings gate (with `rand()`: 16 mismatches in 20 runs, 0 without).
<details>
<summary>Coverage census, and what a read can still evaluate unscreened</summary>

By grep over `tests/queries/0_stateless` (14527 files), an upper bound: creating a screened
object is not reading it under an eligible query.

| Rejected because | Files |
|---|---|
| creates a `MATERIALIZED VIEW`, or an `Alias`/`Merge`/`Buffer`/`Distributed` table | 834 |
| a column default expression is non-deterministic | 48 |
| a view's `SQL SECURITY` is `DEFINER` | 15 |
| a view body is non-deterministic | 7 |
| a row policy filter is non-deterministic | 3 |
| union | 891 |
| of which newly rejected here | 393 |

340 of the 393 come from the `MaterializedView` rule; recovering them by screening a plain view's
target was reviewed here and left out.

`joinGet`/`dictGet` argument 0 also names a relation, and is not screened: every function those two
predicates match is non-deterministic (43 `dictGet*`/`joinGet*`, `dictHas`, `dictIsIn`,
`naiveBayesClassifier*`), so the query is already skipped whichever spelling names it: over clean
fixtures, 0 oracles in 15 runs for either spelling of either function, and 14 of 20 for a control.

Two residuals, neither a definition this metadata holds:

- A **refresh target named directly**. Its own definitions are screened, but a refresh rewrites or
  exchanges its contents between the two arms. Answering that needs a `RefreshSet` lookup, a
  different question from what this metadata holds.
- An **engine whose read evaluates something outside its exposed metadata**: `Executable`
  runs private input queries plus a script per read, `TimeSeries` builds a query over
  its targets, and `Dictionary`, `File`, `S3`, `URL`, `Kafka` and 5 more read outside the server.
  None override `readsFromOtherTables`. That is 13 families over about 220 files, so naming two or
  three here would read as closing the class without doing so; the bounded form is a storage
  capability, changing what the oracle checks suite-wide.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118484&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118484](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118484+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

