### PR TITLE
Stop stateless tests from stranding metadata that names a dropped named collection

### DIFF
--- a/tests/queries/0_stateless/04318_remote_storage_engine_access.sh
+++ b/tests/queries/0_stateless/04318_remote_storage_engine_access.sh
@@ -68,13 +68,17 @@ ${CLICKHOUSE_CLIENT} --user "$user" --query "SELECT x FROM $db.t_remote_infer OR
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE $db.t_remote_infer"
 
 echo "-- 3. a Remote table built from a named collection blocks DROP NAMED COLLECTION"
+# The assertion below needs the table attached. ast_fuzzer_any_query = 0: a fuzzed DETACH would stop the
+# drop below being refused, and a `__fuzz_N` clone inheriting the collection reference would leave
+# metadata naming the collection dropped at the end.
 ${CLICKHOUSE_CLIENT} <<EOF
+SET ast_fuzzer_any_query = 0;
 DROP NAMED COLLECTION IF EXISTS $collection;
 CREATE NAMED COLLECTION $collection AS host = '127.0.0.1', database = '$db', table = 'local_target', user = 'default';
 CREATE TABLE $db.t_remote_nc (x UInt64) ENGINE = Remote($collection);
 EOF
 ${CLICKHOUSE_CLIENT} --query "DROP NAMED COLLECTION $collection" 2>&1 | grep -c -m1 "NAMED_COLLECTION_IS_USED\|is used by"
-${CLICKHOUSE_CLIENT} --query "DROP TABLE $db.t_remote_nc"
+${CLICKHOUSE_CLIENT} --query "SET ast_fuzzer_any_query = 0; DROP TABLE $db.t_remote_nc"
 ${CLICKHOUSE_CLIENT} --query "DROP NAMED COLLECTION $collection"
 
 ${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user"

--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format_named_collection.sh
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format_named_collection.sh
@@ -15,15 +15,17 @@ printf '{"a":1,"b":"Hello"}\n{"a":2,"b":"World"}\n' > "$ABS_NOEXT_NC"
 # Reuse a leftover collection rather than recreating it: dropping it is refused while a leftover table
 # still references it.
 ${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
+# ast_fuzzer_any_query = 0: the AST fuzzer replays table DDL as a DETACH, or as a `__fuzz_N` clone that
+# inherits the collection reference, either of which leaves metadata naming the collection dropped below.
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
 # The persisted engine definition carries a concrete format, not 'auto' (quoted literal, so that the
 # random database name in the DDL cannot match).
 ${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%''auto''%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
 # Reload after the source file is removed succeeds (no format re-inference).
-${CLICKHOUSE_CLIENT} -q "DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 rm -f "$ABS_NOEXT_NC"
-${CLICKHOUSE_CLIENT} -q "ATTACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; ATTACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
 # Chained so the collection outlives the table: metadata must never reference a missing collection.
-${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"

--- a/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
+++ b/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
@@ -26,7 +26,10 @@ $CLICKHOUSE_CLIENT -q "
         use_environment_credentials = 1
 "
 
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC"
+# ast_fuzzer_any_query = 0: the AST fuzzer replays table DDL as a DETACH, or as a `__fuzz_N` clone that
+# inherits the collection reference, either of which leaves metadata naming the collection dropped below.
+# The CREATE that must fail needs no pin: the fuzzer only replays a statement that succeeded.
+$CLICKHOUSE_CLIENT -q "SET ast_fuzzer_any_query = 0; DROP TABLE IF EXISTS ${TABLE} SYNC"
 
 # Without the override the S3Queue would resolve the server's environment credentials, so it is rejected.
 $CLICKHOUSE_CLIENT -q "
@@ -38,10 +41,11 @@ $CLICKHOUSE_CLIENT -q "
 # With the session-level override the table is created (the override reaches the S3 client built in the
 # storage constructor).
 $CLICKHOUSE_CLIENT -q "
+    SET ast_fuzzer_any_query = 0;
     CREATE TABLE ${TABLE} (x UInt8) ENGINE = S3Queue(${NC}, format = 'TSV')
     SETTINGS mode = 'ordered', s3_allow_server_credentials_in_user_queries = 1
 "
 echo "s3queue_override: created"
 
 # Chained so the collection outlives the table: metadata must never reference a missing collection.
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC" && $CLICKHOUSE_CLIENT -q "DROP NAMED COLLECTION IF EXISTS ${NC}"
+$CLICKHOUSE_CLIENT -q "SET ast_fuzzer_any_query = 0; DROP TABLE IF EXISTS ${TABLE} SYNC" && $CLICKHOUSE_CLIENT -q "DROP NAMED COLLECTION IF EXISTS ${NC}"

--- a/tests/queries/0_stateless/04511_remote_named_collection_complex_overrides.sh
+++ b/tests/queries/0_stateless/04511_remote_named_collection_complex_overrides.sh
@@ -14,10 +14,14 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #
 # Named collections are server-global, so the collection names are scoped to the (unique) test
 # database to avoid collisions across concurrent runs.
+#
+# ast_fuzzer_any_query = 0: the AST fuzzer replays table DDL as a DETACH, or as a `__fuzz_N` clone that
+# inherits the collection reference, either of which leaves metadata naming a collection dropped below.
 NC_FULL="nc_remote_full_${CLICKHOUSE_DATABASE}"
 NC_BARE="nc_remote_bare_${CLICKHOUSE_DATABASE}"
 
 ${CLICKHOUSE_CLIENT} --query "
+SET ast_fuzzer_any_query = 0;
 DROP TABLE IF EXISTS nc_target;
 CREATE TABLE nc_target (x UInt8) ENGINE = Memory;
 INSERT INTO nc_target VALUES (1), (2), (3);

--- a/tests/queries/0_stateless/04512_remote_missing_named_collection.sh
+++ b/tests/queries/0_stateless/04512_remote_missing_named_collection.sh
@@ -23,6 +23,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # database to avoid collisions across concurrent runs. The arms detach PERMANENTLY so that a server
 # restart while the collection is missing still boots: startup skips a permanently detached table
 # without constructing its storage, while `ATTACH TABLE` still replays the on-disk definition.
+#
+# ast_fuzzer_any_query = 0: the AST fuzzer replays table DDL as a DETACH, or as a `__fuzz_N` clone that
+# inherits the collection reference and is not detached permanently, either of which leaves metadata
+# naming a collection these arms drop.
 NC_TF="nc_missing_tf_${CLICKHOUSE_DATABASE}"
 NC_SK="nc_missing_sk_${CLICKHOUSE_DATABASE}"
 NC_LIVE="nc_live_${CLICKHOUSE_DATABASE}"
@@ -52,7 +56,7 @@ CREATE NAMED COLLECTION ${NC_LIVE} AS host = '127.0.0.1', db = '${CLICKHOUSE_DAT
 ${CLICKHOUSE_CLIENT} --query "
 -- The arm needs the collection to be missing while the table's metadata still references it, which
 -- is the state the dependency guard exists to prevent, so this arm opts out of the guard.
-SET check_named_collection_dependencies = 0;
+SET check_named_collection_dependencies = 0, ast_fuzzer_any_query = 0;
 CREATE TABLE t_engine_tf ENGINE = Remote(${NC_TF}, database = merge(currentDatabase(), '^nc_target\$'));
 SELECT count() FROM t_engine_tf;
 DETACH TABLE t_engine_tf PERMANENTLY SYNC;
@@ -62,6 +66,7 @@ run_and_classify '(a) engine, database = merge(...):' "${NC_TF}" "ATTACH TABLE t
 # Recreating the collection makes the very same metadata attach and read, so the persisted
 # definition was always correct and only the missing collection made it unloadable.
 ${CLICKHOUSE_CLIENT} --query "
+SET ast_fuzzer_any_query = 0;
 CREATE NAMED COLLECTION ${NC_TF} AS host = '127.0.0.1';
 ATTACH TABLE t_engine_tf;
 SELECT count() FROM t_engine_tf;
@@ -72,7 +77,7 @@ DROP NAMED COLLECTION ${NC_TF};
 # (b) The same defect with a non-table-function override, which used to report a different
 #     unrelated error: the fix is the fall-through itself, not a `merge`-specific special case.
 ${CLICKHOUSE_CLIENT} --query "
-SET check_named_collection_dependencies = 0;
+SET check_named_collection_dependencies = 0, ast_fuzzer_any_query = 0;
 CREATE TABLE t_engine_sk ENGINE = Remote(${NC_SK}, sharding_key = rand());
 SELECT count() FROM t_engine_sk;
 DETACH TABLE t_engine_sk PERMANENTLY SYNC;
@@ -80,6 +85,7 @@ DROP NAMED COLLECTION ${NC_SK};
 "
 run_and_classify '(b) engine, sharding_key = rand():' "${NC_SK}" "ATTACH TABLE t_engine_sk"
 ${CLICKHOUSE_CLIENT} --query "
+SET ast_fuzzer_any_query = 0;
 CREATE NAMED COLLECTION ${NC_SK} AS host = '127.0.0.1', db = '${CLICKHOUSE_DATABASE}', \`table\` = 'nc_target';
 ATTACH TABLE t_engine_sk;
 DROP TABLE t_engine_sk;
@@ -106,6 +112,7 @@ run_and_classify '(g) unknown cluster, no override:' 'no_such_cluster' \
 
 # (h) A live collection is unaffected, and the definition still round-trips.
 ${CLICKHOUSE_CLIENT} --query "
+SET ast_fuzzer_any_query = 0;
 SELECT count() FROM remote(${NC_LIVE}, sharding_key = rand());
 CREATE TABLE t_live ENGINE = Remote(${NC_LIVE}, sharding_key = rand());
 SELECT count() FROM t_live;
@@ -113,6 +120,7 @@ SELECT count() FROM t_live;
 ${CLICKHOUSE_CLIENT} --query "SHOW CREATE TABLE t_live" | sed "s/${NC_LIVE}/NC_LIVE/g"
 
 ${CLICKHOUSE_CLIENT} --query "
+SET ast_fuzzer_any_query = 0;
 DROP TABLE t_live;
 DROP NAMED COLLECTION ${NC_LIVE};
 DROP TABLE nc_target;

--- a/tests/queries/0_stateless/04626_s3_base_setting_named_collection.sh
+++ b/tests/queries/0_stateless/04626_s3_base_setting_named_collection.sh
@@ -25,14 +25,13 @@ NC="nc_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 # of the test. Reuse a leftover collection instead of recreating it - its contents are deterministic -
 # and let the `DROP TABLE IF EXISTS` below remove a leftover table.
 ${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = '${FILE}', access_key_id = 'test', secret_access_key = 'testtest', format = 'TSV'"
-${CLICKHOUSE_CLIENT} -q "SET s3_base = '${BUCKET_URL}/'; DROP TABLE IF EXISTS test_s3_base_nc; CREATE TABLE test_s3_base_nc (n UInt32, s String) ENGINE = S3(${NC});"
+# ast_fuzzer_any_query = 0: the AST fuzzer replays table DDL as a DETACH, or as a `__fuzz_N` clone that
+# inherits the collection reference, either of which leaves metadata naming the collection dropped below.
+${CLICKHOUSE_CLIENT} -q "SET s3_base = '${BUCKET_URL}/', ast_fuzzer_any_query = 0; DROP TABLE IF EXISTS test_s3_base_nc; CREATE TABLE test_s3_base_nc (n UInt32, s String) ENGINE = S3(${NC});"
 ${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE test_s3_base_nc FORMAT TabSeparatedRaw" | grep -cF "url = '${BUCKET_URL}/${FILE}'"
 # The table must survive DETACH/ATTACH in a session where s3_base is not set.
-${CLICKHOUSE_CLIENT} -q "DETACH TABLE test_s3_base_nc"
-${CLICKHOUSE_CLIENT} -q "ATTACH TABLE test_s3_base_nc"
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; DETACH TABLE test_s3_base_nc"
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; ATTACH TABLE test_s3_base_nc"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM test_s3_base_nc"
-# Drop the named collection only after the table drop has succeeded. Under the stress test the
-# server can be killed mid-test; the failed `DROP TABLE` is then skipped while the `DROP NAMED
-# COLLECTION` succeeds against the restarted server, leaving a table whose `ATTACH` references a
-# missing named collection, and the next server restart fails to load metadata.
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base_nc" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"
+# Chained so the collection outlives the table: metadata must never reference a missing collection.
+${CLICKHOUSE_CLIENT} -q "SET ast_fuzzer_any_query = 0; DROP TABLE test_s3_base_nc" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113117

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Pin `ast_fuzzer_any_query = 0` on the table DDL of six stateless tests that build a table from a SQL-created named collection, so the server-side AST fuzzer cannot leave metadata behind that names a collection the test then drops.

### Description

Under the Stress profile a table can survive its own `DROP TABLE` while the test's `DROP NAMED COLLECTION` still runs. The next server start then cannot load the leftover metadata, and with `async_load_databases = 0` (a coin flip in `stress_runner.sh`) that aborts the **whole server**, so CIDB records only `Cannot start clickhouse-server`.

Two injections combine. `ignore_drop_queries_probability` makes `InterpreterDropQuery` either ignore a `DROP TABLE` or rewrite it to `TRUNCATE`; for `S3` (implements `truncate`) and `Distributed` (takes the ignore branch) the client still gets rc 0 with the table present, so an exit-code-gated teardown proceeds. `ast_fuzzer_any_query` then lets the fuzzer replay that DDL as a `DETACH` (metadata kept) or a `__fuzz_N` clone inheriting the collection reference. The collection drop's guard uses `isTableExist`, false for a detached table, so the collection goes.

Fix: pin `ast_fuzzer_any_query = 0` on the invocations issuing table DDL for that table, restoring the setting's own default there only; `SELECT` and `SHOW CREATE` stay fuzzed. Merged precedent: `03822_named_collection_drop_dependency_check.sh`. Commit 2 (the two `Remote` siblings, 0 CIDB hits) is droppable whole to land only the proven ones.

I do **not** pin `ignore_drop_queries_probability`: #113117 removed those as useless, and with it forced to 1 and the pin in place every carrier fails *loudly* (`NAMED_COLLECTION_IS_USED`, or `Code: 48`) instead of stranding. Both directions: with a strand on disk the server exits 210 with `Caught exception while loading metadata`; with the pins, 24 armed runs of all six tests leave nothing behind and it boots clean. Removing the pin strands again.

`04512`'s `remote()` arms need a shard on port 9000, so it is left to this PR's CI (its pristine version fails identically here). `04626` keeps a pre-existing ~20% stress-profile failure rate from the fuzzer mutating its data-producing `INSERT` (base 4/50), a different invariant, left unpinned so the `s3()` URI path stays covered.

<details>
<summary>CIDB evidence and the three deliberately unpinned files</summary>

Signature: `test_name = 'Cannot start clickhouse-server'` with `NAMED_COLLECTION_DOESNT_EXIST` in the context.
30 days: **14 rows, 13 distinct PRs, 0 with `pull_request_number = 0`**, every one a `Stress test (*)`:

| carrier test | hits | stranded object |
|---|---|---|
| `04320_url_engine_dispatch_partition_and_format_named_collection.sh` | 6 | the table, and `__fuzz_4` clones |
| `04626_s3_base_setting_named_collection.sh` | 3 | the table, left detached |
| `04512_remote_missing_named_collection.sh` | 3 | `t_engine_sk` / `t_engine_tf` |
| `04327_s3queue_server_credentials.sh` | 1 | a `__fuzz_4` clone |
| `03822_named_collection_drop_dependency_check.sh` | 1 | a `__fuzz_1` clone (already pinned) |

At 45 days it adds two rows with `pull_request_number = 0` and `head_ref = 'master'` (2026-08-07
`arm_msan`, 2026-07-31 `arm_tsan`), both stranding `04320_..._n`, so this is not PR-only.

The carrier list is mechanical: a candidate creates and drops a collection SQL-side and persists an
engine definition naming it via `CREATE TABLE`, `CREATE OR REPLACE TABLE` or a full-definition
`ATTACH TABLE` (an `ASTCreateQuery` writing the same metadata, so grepping for `CREATE TABLE` alone
misses it). Ten candidates; three are left alone, re-checked with the injections armed:

* `04070_url_base_setting.sh`, `04546_postgresql_engine_settings.sql`: `URL` and `PostgreSQL` override
  neither `truncate` nor `storesDataOnDisk`, so the only reachable branch raises
  `Code: 48 Truncate is not supported by storage ...`, aborting the statement stream *before* the
  collection drop. The collection outlives the table, the safe direction.
* `04891_nats_credential_file_path_restriction.sql`: its metadata-writing statement is a full-definition
  `ATTACH` with an explicit UUID, so in an `Atomic` database a clone either collides with the live
  table's UUID or is rejected by `InterpreterCreateQuery`.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118504&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118504](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118504+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1318` (included in `26.9` and later)
<!-- ch-version-info:end -->