### PR TITLE
Fix flaky LayeredConfiguration.ReplaceByLabelConcurrentReads unit test

### DIFF
--- a/src/Common/tests/gtest_layered_configuration.cpp
+++ b/src/Common/tests/gtest_layered_configuration.cpp
@@ -86,6 +86,8 @@ TEST(LayeredConfiguration, ReplaceByLabelConcurrentReads)
     std::atomic<bool> stop{false};
     std::atomic<size_t> read_count{0};
     std::atomic<bool> saw_bad_value{false};
+    std::atomic<size_t> readers_saw_replacement{0};
+    std::atomic<size_t> readers_saw_initial{0};
 
     // Spawn reader threads that continuously read from the config.
     constexpr size_t num_readers = 4;
@@ -95,18 +97,35 @@ TEST(LayeredConfiguration, ReplaceByLabelConcurrentReads)
     {
         readers.emplace_back([&]
         {
-            while (!stop.load(std::memory_order_relaxed))
+            bool counted_initial = false;
+            bool counted_replacement = false;
+            do
             {
                 std::string val = lc->getString("key", "missing");
-                // The value should always be either "initial", one of the
-                // replacement values, or "missing" if we hit a transient
-                // between configs. But it should never be corrupted garbage.
-                if (val != "initial" && val != "missing" && !val.starts_with("round_"))
+                // replace() swaps the layer under the same mutex every getString() takes, so a reader always
+                // observes a complete config: "initial" before the first replacement, "round_N" after. Anything
+                // else, including the "missing" default, means the key was not visible and is a defect.
+                if (val != "initial" && !val.starts_with("round_"))
                     saw_bad_value.store(true, std::memory_order_relaxed);
+                if (!counted_initial && val == "initial")
+                {
+                    counted_initial = true;
+                    readers_saw_initial.fetch_add(1, std::memory_order_relaxed);
+                }
+                if (!counted_replacement && val.starts_with("round_"))
+                {
+                    counted_replacement = true;
+                    readers_saw_replacement.fetch_add(1, std::memory_order_relaxed);
+                }
                 read_count.fetch_add(1, std::memory_order_relaxed);
-            }
+            } while (!stop.load(std::memory_order_relaxed));
         });
     }
+
+    // Every reader observes the pre-replacement value before the first replacement below: the value
+    // cannot change while this waits, so each reader reaches the count on its first read.
+    while (readers_saw_initial.load(std::memory_order_relaxed) < num_readers)
+        std::this_thread::yield();
 
     // Writer thread: rapidly replace the config many times.
     constexpr size_t num_replacements = 1000;
@@ -114,6 +133,11 @@ TEST(LayeredConfiguration, ReplaceByLabelConcurrentReads)
     {
         auto new_cfg = makeMapConfig("key", "round_" + std::to_string(i));
         lc->replace("default", new_cfg, 0, true);
+        // Hold here until every reader has observed a replaced value, so the reads interleave with
+        // the replacements instead of all landing after the last one.
+        if (i == 0)
+            while (readers_saw_replacement.load(std::memory_order_relaxed) < num_readers)
+                std::this_thread::yield();
     }
 
     stop.store(true, std::memory_order_relaxed);
@@ -121,7 +145,9 @@ TEST(LayeredConfiguration, ReplaceByLabelConcurrentReads)
         t.join();
 
     EXPECT_FALSE(saw_bad_value.load());
-    EXPECT_GT(read_count.load(), 0u);
+    EXPECT_GE(read_count.load(), num_readers);
+    EXPECT_EQ(num_readers, readers_saw_initial.load());
+    EXPECT_EQ(num_readers, readers_saw_replacement.load());
 
     // After all replacements, the last value should be visible.
     EXPECT_EQ("round_999", lc->getString("key"));

--- a/src/Common/tests/gtest_layered_configuration.cpp
+++ b/src/Common/tests/gtest_layered_configuration.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <thread>
 #include <vector>
 #include <atomic>
@@ -122,22 +123,34 @@ TEST(LayeredConfiguration, ReplaceByLabelConcurrentReads)
         });
     }
 
+    // Bounded, so a config that stops making a value visible fails the assertions after the join
+    // instead of hanging the sequential unit-test binary. 60 s dwarfs the ~100 ms these waits take.
+    // Returns the count reached, for the caller whose counter can still be completed after the loop.
+    auto wait_for_all_readers = [](const std::atomic<size_t> & counter, size_t target)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        while (counter.load(std::memory_order_relaxed) < target && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::yield();
+        return counter.load(std::memory_order_relaxed);
+    };
+
     // Every reader observes the pre-replacement value before the first replacement below: the value
-    // cannot change while this waits, so each reader reaches the count on its first read.
-    while (readers_saw_initial.load(std::memory_order_relaxed) < num_readers)
-        std::this_thread::yield();
+    // cannot change while this waits, so each reader reaches the count on its first read. No snapshot
+    // is needed: counting "initial" is only possible before the first replacement lands.
+    wait_for_all_readers(readers_saw_initial, num_readers);
 
     // Writer thread: rapidly replace the config many times.
     constexpr size_t num_replacements = 1000;
+    size_t saw_replacement_in_loop = 0;
     for (size_t i = 0; i < num_replacements; ++i)
     {
         auto new_cfg = makeMapConfig("key", "round_" + std::to_string(i));
         lc->replace("default", new_cfg, 0, true);
-        // Hold here until every reader has observed a replaced value, so the reads interleave with
-        // the replacements instead of all landing after the last one.
+        // Hold here until every reader has observed a replaced value, so the reads interleave with the
+        // replacements instead of all landing after the last one. Assert the count taken here: after the
+        // loop every reader can still reach round_999, so the live count cannot show when it got there.
         if (i == 0)
-            while (readers_saw_replacement.load(std::memory_order_relaxed) < num_readers)
-                std::this_thread::yield();
+            saw_replacement_in_loop = wait_for_all_readers(readers_saw_replacement, num_readers);
     }
 
     stop.store(true, std::memory_order_relaxed);
@@ -147,7 +160,7 @@ TEST(LayeredConfiguration, ReplaceByLabelConcurrentReads)
     EXPECT_FALSE(saw_bad_value.load());
     EXPECT_GE(read_count.load(), num_readers);
     EXPECT_EQ(num_readers, readers_saw_initial.load());
-    EXPECT_EQ(num_readers, readers_saw_replacement.load());
+    EXPECT_EQ(num_readers, saw_replacement_in_loop);
 
     // After all replacements, the last value should be visible.
     EXPECT_EQ("round_999", lc->getString("key"));


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a race in the `LayeredConfiguration.ReplaceByLabelConcurrentReads` unit test that could report a spurious failure, and made every reader thread read both before and after a configuration replacement.

### Description

`LayeredConfiguration.ReplaceByLabelConcurrentReads` failed in `Unit tests (asan_ubsan)`:

```
src/Common/tests/gtest_layered_configuration.cpp:124: Failure
Expected: (read_count.load()) > (0u), actual: 0 vs 0
```

[Report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116135&sha=ce86cba51d2a38640bf0f58687e4203fa04714ef&name_0=PR) (bystander PR).

**Root cause.** Four readers loop on an atomic `stop` flag; main runs 1000 `replace()` calls and only then stores `stop = true`. Nothing orders a reader's first `stop.load()` before that store, and the uncontended loop is sub-millisecond while thread start latency on a loaded host is not, so every reader can see `stop` first and exit without reading. Pinned to one CPU this reproduces on master, 67 of 200 repeats, and only that assertion fails.

**Change,** test only. Each mechanism has its own assertion and control:

| mechanism | assertion | control |
|---|---|---|
| `do`/`while` reader loop: one read is unconditional | `EXPECT_GE(read_count, num_readers)`, was `> 0u` | 67 of 200, on master |
| main waits for four reads of the pre-replacement value | `EXPECT_EQ(num_readers, readers_saw_initial)` | 195 of 200 |
| main then holds for four reads of a replaced value | `EXPECT_EQ(num_readers, saw_replacement_in_loop)` | 185 of 200 |

Every reader's window now spans a replacement with 999 to come. Both waits stop at a 60 s deadline, so a `replace()` that stops making the new layer visible fails here rather than spinning until the 90 minute watchdog in `ci/jobs/unit_tests_job.py` kills the whole binary; the hold then asserts the count taken *at the hold*, because after the loop every reader can still reach `round_999`.

The reader also stops accepting the `"missing"` default: `replace()` assigns the layer in place under the same `_mutex` every getter takes, so accepting it would hide a layer that went transiently invisible.

This is the only test covering `replace()` under concurrent readers, the shape of a config reload on a serving server (`programs/server/Server.cpp:2459`, `programs/keeper/Keeper.cpp:662`).

<details>
<summary>Runtime and CIDB history (1 failure in 186,777 runs over 180 days)</summary>

2100 runs of this file with this change over four scheduling conditions, 0 failures, so the 60 s deadline is 526 times the slowest run and a healthy run cannot reach it. Reaching it is not a pass either: with `replace()` made invisible the unbounded form printed nothing past `[ RUN      ]` and was still spinning after 842 s, the shipped form fails in 60.0 s naming the counter; and with the hold expired and every replaced-value read forced after the loop, asserting the live counter passes 30 of 30 while asserting the snapshot fails 30 of 30. Before this change a *passing* run could also cover nothing: 8 of 20 pinned runs on master saw no replacement value, 4 of them passing. Per-run wall time over 500 repeats each: unpinned, which is what CI does, a 5 ms median and 13 ms worst, unchanged; pinned to a single CPU, a 30 ms median and 114 ms worst, because the waits then compete with the readers for the one CPU.

```sql
SELECT count() AS total_runs, countIf(test_status IN ('FAIL','ERROR')) AS failures
FROM default.checks
WHERE test_name = 'LayeredConfiguration.ReplaceByLabelConcurrentReads'
  AND check_start_time > now() - INTERVAL 180 DAY
```

```
total_runs  failures
186777      1
```

Per check over that window: tsan 46936, msan 46068, asan_ubsan 45414 (the one failure), amd_llvm_coverage 45056, ubsan 1650, asan 1636, and 17 across six smaller configurations. The rate is low because the failure needs the readers to lose the CPU for the whole replacement loop, which is why it surfaced on a saturated runner.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118505&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118505](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118505+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.900` (included in `26.9` and later)
<!-- ch-version-info:end -->