### PR TITLE
Fix flaky test_keeper_force_recovery by pinning Keeper leadership before the quorum is removed

### DIFF
--- a/tests/integration/test_keeper_force_recovery/test.py
+++ b/tests/integration/test_keeper_force_recovery/test.py
@@ -201,6 +201,16 @@ def test_cluster_recovery(started_cluster):
 
         node_zks = node_zks[:nodes_left]
 
+        # A node answers `mntr` with "not serving" whenever it sees no live leader: also
+        # while it campaigns, and while newly elected but not yet heartbeating. Pin the
+        # role on the peer stopped last, so node1 hears a leader until quorum is gone.
+        last_stopped = nodes[CLUSTER_SIZE - 1]
+        start = time.time()
+        while not keeper_utils.is_leader(cluster, last_stopped):
+            assert time.time() - start < 60, f"{last_stopped.name} did not become leader"
+            keeper_utils.send_4lw_cmd(cluster, last_stopped, "rqld")
+            time.sleep(2)
+
         for node in nodes[nodes_left:CLUSTER_SIZE]:
             node.stop_clickhouse()
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/117451
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a flaky `test_keeper_force_recovery::test_cluster_recovery` by pinning the Raft role before the test removes the quorum. Test-only change.

### Description

Asked for here: https://github.com/ClickHouse/ClickHouse/pull/117451#issuecomment-5563369250

`test_cluster_recovery` stops 3 of 5 Keeper nodes, waits for node1 to lose quorum, and asserts it answers `mntr` with `This instance is not currently serving requests`. Intermittently it gets leader statistics.

**Root cause**, and `SYSTEM RELOAD CONFIG` is not involved. `mntr` returns the sentinel whenever `isServerActive()` is false, which reduces to `is_leader_alive()` = `leader_ != -1 && hb_alive_`. It is equally false for a node merely campaigning, and for one that just won an election but has not yet sent its first heartbeat, since `become_leader()` never touches `hb_alive_`. The test stops the three peers sequentially with node1's role unpinned, so a quorum still exists during that loop and an election started there can be won. `wait_until_quorum_lost` returns on the first sentinel it sees, so it is satisfied transiently; node1 then heartbeats, serves again, and the assert sees statistics.

**The change**, +10 lines in one test file: pin the Raft role on the peer stopped last, before the loop, with the existing `rqld` command plus a bounded wait that hard-asserts the observable outcome, not `rqld`'s reply. node1 keeps hearing that leader until it dies, and once it can campaign only 2 of 5 voters remain, so its first not-serving answer is terminal. Both asserts and `helpers/keeper_utils.py` are unchanged; a poll there would mask a regression of this precondition. The other two `wait_until_quorum_lost` callers have no CIDB failure and are untouched.

**Validation** under `amd_tsan`: the defect reproduces on demand on master; a control arm sees no sentinel without an induced leadership change. With the pin, node1 never holds the role across the loop and its first not-serving answer holds; pinning node1 instead flips both signals. 20/20 on the test, 3/3 on the file, 3/3 on `test_cmd_rqld`, 5/5 baseline, no added cost (76.2 s per run against 88.8 s).

<details>
<summary>Measured timeline from the failing CI run, and how often it fires</summary>

From the carrier run's Keeper logs, node1 wins an election off a peer that is still voting after its SIGTERM, and the helper's single `mntr` lands inside the fresh-leader window:

```
14:14:18.271103  node5  SIGTERM
14:14:19.116478  node5  shutting down raft core        <- 845 ms later, still voting
14:14:19.141997  node1  vote granted -> granted 3, quorum 3
14:14:19.142014  node1  Server is elected as leader for term 2
14:14:19.205590  node1  [BECOME LEADER]                <- hb_alive_ still false
14:14:19.474413  node1  mntr  #1  -> sentinel          <- wait_until_quorum_lost returns here
14:14:19.642     node1  first heartbeat tick           -> hb_alive_ = true
14:14:19.953481  node1  mntr  #2  -> leader statistics <- the assert fails
14:14:29.152539  node1  will yield the leadership of this node
```

Only three `mntr` commands reached node1 in the whole run, so the helper exited on its first iteration rather than polling and timing out. `[BECOME LEADER]` to first heartbeat is about 435 ms, which is why the end-to-end failure is not schedulable from the test and the validation forces the underlying state instead.

CIDB rows for this test with `position(test_context_raw, 'not currently serving requests') > 0`, last 365 days. Keying on the needle matters: the test name pools unrelated defects at other lines.

```
d           pr      check_name                                              site
2026-09-06  117451  Integration tests (amd_tsan, 5/6)                       test.py:217
2026-05-15  104431  Integration tests (amd_msan, 3/6)                       test.py:218
2026-02-10  96055   Integration tests (amd_binary, 5/5)                     test.py:218
2025-11-22  90614   Integration tests (arm_binary, distributed plan, 3/4)   test.py:133
```

All four are the first of the two asserts; the line numbers differ only because the file changed.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118506&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118506](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118506+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.887` (included in `26.9` and later)
<!-- ch-version-info:end -->