### PR TITLE
Fix time series table accessors on parallel replicas

### DIFF
--- a/src/Analyzer/TableFunctionNode.cpp
+++ b/src/Analyzer/TableFunctionNode.cpp
@@ -12,6 +12,8 @@
 #include <Storages/IStorage.h>
 #include <Storages/StorageView.h>
 
+#include <TableFunctions/ITableFunction.h>
+
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSetQuery.h>
 
@@ -148,6 +150,7 @@ QueryTreeNodePtr TableFunctionNode::cloneImpl() const
 {
     auto result = std::make_shared<TableFunctionNode>(table_function_name);
 
+    result->table_function = table_function;
     result->storage = storage;
     result->storage_id = storage_id;
     result->storage_snapshot = storage_snapshot;
@@ -176,8 +179,15 @@ ASTPtr TableFunctionNode::toASTImpl(const ConvertToASTOptions & options) const
             table_function_ast->name = database_name + "." + storage_id.getTableName();
     }
 
-    const auto & arguments = getArguments();
-    table_function_ast->children.push_back(arguments.toAST(options));
+    auto arguments_ast = getArguments().toAST(options);
+
+    /// A table function may take an unqualified table name which would be resolved against a different current
+    /// database on a receiving server, so a resolved table function qualifies its arguments with the database name
+    /// (like `TableNode` always qualifies the table name with the database name).
+    if (table_function)
+        table_function->qualifyArgumentsWithDatabase(arguments_ast->children);
+
+    table_function_ast->children.push_back(std::move(arguments_ast));
     table_function_ast->arguments = table_function_ast->children.back();
 
     if (!settings_changes.empty())

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -109,7 +109,9 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 /// Version 14 registers the `IntersectOrExcept` step, so a plan with `INTERSECT` or `EXCEPT`
 /// can be shipped under `make_distributed_plan`.
 /// Version 15 registers the `LimitRange` step (`LIMIT [n] AFTER ... [UNTIL ...]`).
-static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 15;
+/// Version 16 adds the `use_parallel_replicas` flag (bit 8) on `ReadFromTableFunctionStep`, set on the coordinated
+/// read of a table function which returns a table (like `timeSeriesSamples`). Both sides gate the flag on the version.
+static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 16;
 /// The parallel-replicas remote plan is serialized once (at DBMS_QUERY_PLAN_SERIALIZATION_VERSION) and
 /// that one blob is reused for every replica, so a replica below this version must be excluded up front
 /// rather than sent a blob it cannot parse. Tied to DBMS_QUERY_PLAN_SERIALIZATION_VERSION itself so a
@@ -138,6 +140,8 @@ static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_ONLY_MERGE_
 /// First query-plan serialization version that registers a "LimitRange" step. Gates serializing a
 /// `LimitRangeStep` for `make_distributed_plan`.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_RANGE_STEP = 15;
+/// First query-plan serialization version with the `use_parallel_replicas` flag (bit 8) on `ReadFromTableFunctionStep`.
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TABLE_FUNCTION_PARALLEL_REPLICAS = 16;
 /// Version 1 added the initiator's settings changes to the task.
 /// Version 2 added per-stream streaming-exchange ports to exchange_stream_sources.
 /// Version 3 added the error code of a failed task to its status reply.

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2778,11 +2778,16 @@ void Planner::buildPlanForQueryNode()
         const auto & table_expression_nodes = extractTableExpressions(query_node_typed.getJoinTreeNodeTyped(), true, true);
         for (const auto & it : table_expression_nodes)
         {
-            auto * table_node = it->as<TableNode>();
-            if (!table_node)
+            const std::optional<TableExpressionModifiers> * modifiers_ptr = nullptr;
+            if (const auto * table_node = it->as<TableNode>())
+                modifiers_ptr = &table_node->getTableExpressionModifiers();
+            else if (const auto * table_function_node = it->as<TableFunctionNode>())
+                modifiers_ptr = &table_function_node->getTableExpressionModifiers();
+
+            if (!modifiers_ptr)
                 continue;
 
-            const auto & modifiers = table_node->getTableExpressionModifiers();
+            const auto & modifiers = *modifiers_ptr;
             /// A follower must keep the setting on for its own read-side `STREAM` refusal to fire.
             if (modifiers.has_value()
                 && (modifiers->hasFinal()

--- a/src/Planner/PlannerContext.h
+++ b/src/Planner/PlannerContext.h
@@ -80,7 +80,7 @@ public:
     const QueryNode * const parallel_replicas_node = nullptr;
     /// Table which is used with parallel replicas reading.
     /// It is the left-most table of the query (in JOINs, UNIONs and subqueries).
-    /// It's either a table or a table function which returns a table (like `timeSeriesTags` or `timeSeriesSamples`).
+    /// It's either a table or a table function which returns a table (like `timeSeriesSamples`).
     const ITableExpressionNode * const parallel_replicas_table = nullptr;
     /// UNION node whose every child query reads from a table eligible for parallel replicas.
     /// When set, each branch retains parallel replicas reading instead of having it disabled.

--- a/src/Planner/PlannerContext.h
+++ b/src/Planner/PlannerContext.h
@@ -80,7 +80,7 @@ public:
     const QueryNode * const parallel_replicas_node = nullptr;
     /// Table which is used with parallel replicas reading.
     /// It is the left-most table of the query (in JOINs, UNIONs and subqueries).
-    /// It's either a table or a table function which returns a table (like `timeSeriesTags`).
+    /// It's either a table or a table function which returns a table (like `timeSeriesTags` or `timeSeriesSamples`).
     const ITableExpressionNode * const parallel_replicas_table = nullptr;
     /// UNION node whose every child query reads from a table eligible for parallel replicas.
     /// When set, each branch retains parallel replicas reading instead of having it disabled.

--- a/src/Planner/PlannerContext.h
+++ b/src/Planner/PlannerContext.h
@@ -18,7 +18,7 @@ namespace DB
   */
 
 class QueryNode;
-class TableNode;
+class ITableExpressionNode;
 class UnionNode;
 
 struct FiltersForTableExpression
@@ -39,7 +39,7 @@ class GlobalPlannerContext
 public:
     GlobalPlannerContext(
         const QueryNode * parallel_replicas_node_,
-        const TableNode * parallel_replicas_table_,
+        const ITableExpressionNode * parallel_replicas_table_,
         const UnionNode * parallel_replicas_table_union_,
         FiltersForTableExpressionMap filters_for_table_expressions_)
         : parallel_replicas_node(parallel_replicas_node_)
@@ -80,7 +80,8 @@ public:
     const QueryNode * const parallel_replicas_node = nullptr;
     /// Table which is used with parallel replicas reading.
     /// It is the left-most table of the query (in JOINs, UNIONs and subqueries).
-    const TableNode * const parallel_replicas_table = nullptr;
+    /// It's either a table or a table function which returns a table (like `timeSeriesTags`).
+    const ITableExpressionNode * const parallel_replicas_table = nullptr;
     /// UNION node whose every child query reads from a table eligible for parallel replicas.
     /// When set, each branch retains parallel replicas reading instead of having it disabled.
     const UnionNode * const parallel_replicas_table_union = nullptr;

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -2531,22 +2531,21 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(TableExpressionNodePtr table_
                     /// It is just a safety check needed until we have a proper sending plan to replicas.
                     /// If we have a non-trivial storage like View it might create its own Planner inside read(), run findTableForParallelReplicas()
                     /// and find some other table that might be used for reading with parallel replicas. It will lead to errors.
-                    /// The chosen table and union children are TableNodes, so a table function matches
-                    /// neither and equality against them is meaningless when table_node is null.
-                    const bool no_tables_or_another_table_chosen_for_reading_with_parallel_replicas_mode
+                    const ITableExpressionNode * table_expression_node
+                        = table_node ? static_cast<const ITableExpressionNode *>(table_node) : table_function_node;
+                    const bool another_table_chosen_for_reading_with_parallel_replicas_mode
                         = query_context->canUseParallelReplicasOnFollower()
-                        && (!table_node || table_node != planner_context->getGlobalPlannerContext()->parallel_replicas_table);
-                    if (no_tables_or_another_table_chosen_for_reading_with_parallel_replicas_mode)
+                        && (table_expression_node != planner_context->getGlobalPlannerContext()->parallel_replicas_table);
+                    if (another_table_chosen_for_reading_with_parallel_replicas_mode)
                     {
                         bool disable_parallel_replicas_for_storage = true;
                         ContextPtr updated_context = effective_context;
-                        if (const UnionNode * table_union
-                            = table_node ? planner_context->getGlobalPlannerContext()->parallel_replicas_table_union : nullptr)
+                        if (const UnionNode * table_union = planner_context->getGlobalPlannerContext()->parallel_replicas_table_union)
                         {
                             SelectQueryOptions options;
                             for (const auto & child : table_union->getQueries().getNodes())
                             {
-                                if (table_node == findTableForParallelReplicas(child, options))
+                                if (table_expression_node == findTableForParallelReplicas(child, options))
                                 {
                                     disable_parallel_replicas_for_storage = false;
                                     break;

--- a/src/Planner/findParallelReplicasQuery.cpp
+++ b/src/Planner/findParallelReplicasQuery.cpp
@@ -66,7 +66,7 @@ bool isTableNodeEligibleForParallelReplicas(const TableNode & table_node, const 
     return isStorageEligibleForParallelReplicas(storage, has_final, context);
 }
 
-/// A table function returning a table (like `timeSeriesTags` or `timeSeriesSamples`) is read with parallel replicas in the same way as the table itself.
+/// A table function returning a table (like `timeSeriesSamples`) is read with parallel replicas in the same way as the table itself.
 static bool canUseTableFunctionForParallelReplicas(const TableFunctionNode & table_function_node, const ContextPtr & context)
 {
     bool has_final = table_function_node.hasTableExpressionModifiers() && table_function_node.getTableExpressionModifiers()->hasFinal();

--- a/src/Planner/findParallelReplicasQuery.cpp
+++ b/src/Planner/findParallelReplicasQuery.cpp
@@ -66,7 +66,7 @@ bool isTableNodeEligibleForParallelReplicas(const TableNode & table_node, const 
     return isStorageEligibleForParallelReplicas(storage, has_final, context);
 }
 
-/// A table function returning a table (like `timeSeriesTags`) is read with parallel replicas in the same way as the table itself.
+/// A table function returning a table (like `timeSeriesTags` or `timeSeriesSamples`) is read with parallel replicas in the same way as the table itself.
 static bool canUseTableFunctionForParallelReplicas(const TableFunctionNode & table_function_node, const ContextPtr & context)
 {
     bool has_final = table_function_node.hasTableExpressionModifiers() && table_function_node.getTableExpressionModifiers()->hasFinal();

--- a/src/Planner/findParallelReplicasQuery.cpp
+++ b/src/Planner/findParallelReplicasQuery.cpp
@@ -3,6 +3,7 @@
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/JoinNode.h>
 #include <Analyzer/QueryNode.h>
+#include <Analyzer/TableFunctionNode.h>
 #include <Analyzer/TableNode.h>
 #include <Analyzer/UnionNode.h>
 #include <Core/Settings.h>
@@ -42,7 +43,7 @@ namespace ErrorCodes
     extern const int UNSUPPORTED_METHOD;
 }
 
-bool isTableNodeEligibleForParallelReplicas(const TableNode & table_node, const StoragePtr & storage, const ContextPtr & context)
+static bool isStorageEligibleForParallelReplicas(const StoragePtr & storage, bool has_final, const ContextPtr & context)
 {
     const auto & settings = context->getSettingsRef();
 
@@ -53,10 +54,23 @@ bool isTableNodeEligibleForParallelReplicas(const TableNode & table_node, const 
         return false;
 
     /// Parallel replicas not supported with FINAL.
-    if (table_node.hasTableExpressionModifiers() && table_node.getTableExpressionModifiers()->hasFinal())
+    if (has_final)
         return false;
 
     return true;
+}
+
+bool isTableNodeEligibleForParallelReplicas(const TableNode & table_node, const StoragePtr & storage, const ContextPtr & context)
+{
+    bool has_final = table_node.hasTableExpressionModifiers() && table_node.getTableExpressionModifiers()->hasFinal();
+    return isStorageEligibleForParallelReplicas(storage, has_final, context);
+}
+
+/// A table function returning a table (like `timeSeriesTags`) is read with parallel replicas in the same way as the table itself.
+static bool canUseTableFunctionForParallelReplicas(const TableFunctionNode & table_function_node, const ContextPtr & context)
+{
+    bool has_final = table_function_node.hasTableExpressionModifiers() && table_function_node.getTableExpressionModifiers()->hasFinal();
+    return isStorageEligibleForParallelReplicas(table_function_node.getStorage(), has_final, context);
 }
 
 static bool canUseTableForParallelReplicas(const TableNode & table_node, const ContextPtr & context)
@@ -410,7 +424,7 @@ const QueryNode * findQueryForParallelReplicas(const QueryTreeNodePtr & query_tr
     return res;
 }
 
-static const TableNode * findTableForParallelReplicas(const IQueryTreeNode * query_tree_node, const ContextPtr & context)
+static const ITableExpressionNode * findTableForParallelReplicas(const IQueryTreeNode * query_tree_node, const ContextPtr & context)
 {
     std::stack<const IQueryTreeNode *> join_nodes;
     while (query_tree_node || !join_nodes.empty())
@@ -436,6 +450,10 @@ static const TableNode * findTableForParallelReplicas(const IQueryTreeNode * que
             }
             case QueryTreeNodeType::TABLE_FUNCTION:
             {
+                const auto & table_function_node = query_tree_node->as<TableFunctionNode &>();
+                if (canUseTableFunctionForParallelReplicas(table_function_node, context))
+                    return &table_function_node;
+
                 query_tree_node = nullptr;
                 break;
             }
@@ -502,7 +520,7 @@ static const TableNode * findTableForParallelReplicas(const IQueryTreeNode * que
     return nullptr;
 }
 
-const TableNode * findTableForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options)
+const ITableExpressionNode * findTableForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options)
 {
     if (select_query_options.only_analyze)
         return nullptr;
@@ -630,14 +648,20 @@ JoinTreeQueryPlan buildQueryPlanForParallelReplicas(
     removeGroupingFunctionSpecializations(modified_query_tree_for_ast);
     ASTPtr modified_query_ast = queryNodeToDistributedSelectQuery(modified_query_tree_for_ast);
 
-    const TableNode * table_node = findTableForParallelReplicas(modified_query_tree.get(), context);
-    if (!table_node)
+    const auto * table_expression_node = findTableForParallelReplicas(modified_query_tree.get(), context);
+    if (!table_expression_node)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't determine table for parallel replicas");
+
+    StorageID storage_id = StorageID::createEmpty();
+    if (const auto * table_node = table_expression_node->as<TableNode>())
+        storage_id = table_node->getStorageID();
+    else
+        storage_id = table_expression_node->as<TableFunctionNode &>().getStorageID();
 
     QueryPlan query_plan;
     ClusterProxy::executeQueryWithParallelReplicas(
         query_plan,
-        table_node->getStorageID(),
+        storage_id,
         header,
         processed_stage,
         modified_query_ast,

--- a/src/Planner/findQueryForParallelReplicas.h
+++ b/src/Planner/findQueryForParallelReplicas.h
@@ -8,6 +8,7 @@ namespace DB
 class QueryNode;
 class TableNode;
 class UnionNode;
+class ITableExpressionNode;
 
 class IQueryTreeNode;
 using QueryTreeNodePtr = std::shared_ptr<IQueryTreeNode>;
@@ -19,7 +20,8 @@ struct SelectQueryOptions;
 const QueryNode * findQueryForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
 
 /// Find a table from which we should read on follower replica. It's the left-most table within all JOINs and UNIONs.
-const TableNode * findTableForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
+/// The result is either a table or a table function which returns a table (like `timeSeriesTags`).
+const ITableExpressionNode * findTableForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
 
 class IStorage;
 using StoragePtr = std::shared_ptr<IStorage>;

--- a/src/Planner/findQueryForParallelReplicas.h
+++ b/src/Planner/findQueryForParallelReplicas.h
@@ -20,7 +20,7 @@ struct SelectQueryOptions;
 const QueryNode * findQueryForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
 
 /// Find a table from which we should read on follower replica. It's the left-most table within all JOINs and UNIONs.
-/// The result is either a table or a table function which returns a table (like `timeSeriesTags`).
+/// The result is either a table or a table function which returns a table (like `timeSeriesTags` or `timeSeriesSamples`).
 const ITableExpressionNode * findTableForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
 
 class IStorage;

--- a/src/Planner/findQueryForParallelReplicas.h
+++ b/src/Planner/findQueryForParallelReplicas.h
@@ -20,7 +20,7 @@ struct SelectQueryOptions;
 const QueryNode * findQueryForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
 
 /// Find a table from which we should read on follower replica. It's the left-most table within all JOINs and UNIONs.
-/// The result is either a table or a table function which returns a table (like `timeSeriesTags` or `timeSeriesSamples`).
+/// The result is either a table or a table function which returns a table (like `timeSeriesSamples`).
 const ITableExpressionNode * findTableForParallelReplicas(const QueryTreeNodePtr & query_tree_node, const SelectQueryOptions & select_query_options);
 
 class IStorage;

--- a/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
+++ b/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
@@ -16,6 +16,7 @@
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/JoinStepLogical.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Processors/QueryPlan/ReadFromTableFunctionStep.h>
 #include <Processors/QueryPlan/ReadFromTableStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
@@ -178,9 +179,11 @@ std::shared_ptr<const QueryPlan> createRemotePlanForParallelReplicas(
     addConvertingActions(*query_plan, header, context);
 
     // TODO: fix view with UNION case for enabled serialize_query_plan separately (use findReadingSteps() instead)
-    auto * node = findReadingStep<ReadFromTableStep>(query_plan->getRootNode());
-    if (node)
-        typeid_cast<ReadFromTableStep*>(node->step.get())->useParallelReplicas() = true;
+    if (auto * node = findReadingStep<ReadFromTableStep>(query_plan->getRootNode()))
+        typeid_cast<ReadFromTableStep *>(node->step.get())->useParallelReplicas() = true;
+    /// The coordinated table can also be returned by a table function (like `timeSeriesSamples`).
+    else if (auto * table_function_node = findReadingStep<ReadFromTableFunctionStep>(query_plan->getRootNode()))
+        typeid_cast<ReadFromTableFunctionStep *>(table_function_node->step.get())->useParallelReplicas() = true;
 
     return query_plan;
 }

--- a/src/Processors/QueryPlan/ReadFromTableFunctionStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromTableFunctionStep.cpp
@@ -15,10 +15,12 @@ namespace ErrorCodes
 ReadFromTableFunctionStep::ReadFromTableFunctionStep(
     SharedHeader header,
     std::string serialized_ast_,
-    TableExpressionModifiers table_expression_modifiers_)
+    TableExpressionModifiers table_expression_modifiers_,
+    bool use_parallel_replicas_)
     : ISourceStep(std::move(header))
     , serialized_ast(std::move(serialized_ast_))
     , table_expression_modifiers(std::move(table_expression_modifiers_))
+    , use_parallel_replicas(use_parallel_replicas_)
 {
 }
 
@@ -45,6 +47,8 @@ void ReadFromTableFunctionStep::serialize(Serialization & ctx) const
         flags |= 2;
     if (table_expression_modifiers.hasSampleOffsetRatio())
         flags |= 4;
+    if (use_parallel_replicas)
+        flags |= 8;
 
     writeIntBinary(flags, ctx.out);
     if (table_expression_modifiers.hasSampleSizeRatio())
@@ -52,6 +56,9 @@ void ReadFromTableFunctionStep::serialize(Serialization & ctx) const
 
     if (table_expression_modifiers.hasSampleOffsetRatio())
         serializeRational(*table_expression_modifiers.getSampleOffsetRatio(), ctx.out);
+
+    if (use_parallel_replicas)
+        writeIntBinary(use_parallel_replicas, ctx.out);
 }
 
 QueryPlanStepPtr ReadFromTableFunctionStep::deserialize(Deserialization & ctx)
@@ -81,8 +88,12 @@ QueryPlanStepPtr ReadFromTableFunctionStep::deserialize(Deserialization & ctx)
     if (flags & 4)
         sample_offset_ratio = deserializeRational(ctx.in);
 
+    char use_parallel_replicas = 0;
+    if (flags & 8)
+        readIntBinary(use_parallel_replicas, ctx.in);
+
     TableExpressionModifiers table_expression_modifiers(has_final, sample_size_ratio, sample_offset_ratio);
-    return std::make_unique<ReadFromTableFunctionStep>(ctx.output_header, std::move(serialized_ast), table_expression_modifiers);
+    return std::make_unique<ReadFromTableFunctionStep>(ctx.output_header, std::move(serialized_ast), table_expression_modifiers, use_parallel_replicas);
 }
 
 void registerReadFromTableFunctionStep(QueryPlanStepRegistry & registry);

--- a/src/Processors/QueryPlan/ReadFromTableFunctionStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromTableFunctionStep.cpp
@@ -1,6 +1,7 @@
 #include <Processors/QueryPlan/ReadFromTableFunctionStep.h>
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
 #include <Processors/QueryPlan/Serialization.h>
+#include <Core/ProtocolDefines.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 
@@ -9,7 +10,9 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int INCORRECT_DATA;
     extern const int NOT_IMPLEMENTED;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 ReadFromTableFunctionStep::ReadFromTableFunctionStep(
@@ -48,7 +51,14 @@ void ReadFromTableFunctionStep::serialize(Serialization & ctx) const
     if (table_expression_modifiers.hasSampleOffsetRatio())
         flags |= 4;
     if (use_parallel_replicas)
+    {
+        if (ctx.version < DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TABLE_FUNCTION_PARALLEL_REPLICAS)
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+                "Reading from a table function with parallel replicas requires query plan serialization version >= {}, "
+                "but the plan is serialized at version {}",
+                DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TABLE_FUNCTION_PARALLEL_REPLICAS, ctx.version);
         flags |= 8;
+    }
 
     writeIntBinary(flags, ctx.out);
     if (table_expression_modifiers.hasSampleSizeRatio())
@@ -90,7 +100,14 @@ QueryPlanStepPtr ReadFromTableFunctionStep::deserialize(Deserialization & ctx)
 
     char use_parallel_replicas = 0;
     if (flags & 8)
+    {
+        /// On an older stream the bit is garbage, so reject it (serialize checks the same).
+        if (ctx.version < DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TABLE_FUNCTION_PARALLEL_REPLICAS)
+            throw Exception(ErrorCodes::INCORRECT_DATA,
+                "The parallel replicas flag of a table function in a version {} query plan stream; it requires version >= {}",
+                ctx.version, DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_TABLE_FUNCTION_PARALLEL_REPLICAS);
         readIntBinary(use_parallel_replicas, ctx.in);
+    }
 
     TableExpressionModifiers table_expression_modifiers(has_final, sample_size_ratio, sample_offset_ratio);
     return std::make_unique<ReadFromTableFunctionStep>(ctx.output_header, std::move(serialized_ast), table_expression_modifiers, use_parallel_replicas);

--- a/src/Processors/QueryPlan/ReadFromTableFunctionStep.h
+++ b/src/Processors/QueryPlan/ReadFromTableFunctionStep.h
@@ -8,7 +8,9 @@ namespace DB
 class ReadFromTableFunctionStep : public ISourceStep
 {
 public:
-    ReadFromTableFunctionStep(SharedHeader header, std::string serialized_ast_, TableExpressionModifiers table_expression_modifiers_);
+    ReadFromTableFunctionStep(
+        SharedHeader header, std::string serialized_ast_, TableExpressionModifiers table_expression_modifiers_,
+        bool use_parallel_replicas_ = false);
 
     String getName() const override { return "ReadFromTableFunction"; }
 
@@ -21,9 +23,14 @@ public:
     const std::string & getSerializedAST() const { return serialized_ast; }
     TableExpressionModifiers getTableExpressionModifiers() const { return table_expression_modifiers; }
 
+    /// Whether the table returned by the table function is read with parallel replicas on the receiving replica.
+    bool useParallelReplicas() const { return use_parallel_replicas; }
+    bool & useParallelReplicas() { return use_parallel_replicas; }
+
 private:
     std::string serialized_ast;
     TableExpressionModifiers table_expression_modifiers;
+    bool use_parallel_replicas = false;
 };
 
 }

--- a/src/Processors/QueryPlan/resolveStorages.cpp
+++ b/src/Processors/QueryPlan/resolveStorages.cpp
@@ -270,6 +270,8 @@ static QueryPlanResourceHolder replaceReadingFromTable(QueryPlan::Node & node, Q
         bool use_parallel_replicas = false;
         if (reading_from_table)
             use_parallel_replicas = reading_from_table->useParallelReplicas();
+        else if (reading_from_table_function)
+            use_parallel_replicas = reading_from_table_function->useParallelReplicas();
 
         auto mutable_context = Context::createCopy(context);
         mutable_context->setSetting("allow_experimental_parallel_reading_from_replicas", use_parallel_replicas);

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -60,6 +60,12 @@ public:
 
     virtual void parseArguments(const ASTPtr & /*ast_function*/, ContextPtr /*context*/) {}
 
+    /// Rewrites the arguments so that they don't depend on the current database, for example qualifies
+    /// table names with a database name. It's used to serialize a query which is sent to other servers
+    /// (for example, to parallel replicas), where the current database can be different.
+    /// By default the arguments are left unchanged.
+    virtual void qualifyArgumentsWithDatabase(ASTs & /* arguments */) const {}
+
     /// Returns actual table structure probably requested from remote server, may fail
     virtual ColumnsDescription getActualTableStructure(ContextPtr /*context*/, bool is_insert_query) const = 0;
 

--- a/src/TableFunctions/TableFunctionPrometheusQuery.cpp
+++ b/src/TableFunctions/TableFunctionPrometheusQuery.cpp
@@ -1,6 +1,7 @@
 #include <TableFunctions/TableFunctionPrometheusQuery.h>
 
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/Converter.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -27,6 +28,21 @@ void TableFunctionPrometheusQuery<over_range>::parseArguments(const ASTPtr & ast
     config = StoragePrometheusQuery::getConfiguration(args, context, over_range);
 }
 
+
+template <bool over_range>
+void TableFunctionPrometheusQuery<over_range>::qualifyArgumentsWithDatabase(ASTs & arguments) const
+{
+    /// prometheusQuery( 'mydb', 'my_time_series_table', promql_query, evaluation_time )
+    /// prometheusQueryRange( 'mydb', 'my_time_series_table', promql_query, start_time, end_time, step )
+    size_t num_other_arguments = over_range ? 4 : 2;
+    if (arguments.size() < num_other_arguments + 1)
+        return;
+
+    const auto & time_series_storage_id = config.evaluation_settings.time_series_storage_id;
+    arguments.erase(arguments.begin(), arguments.end() - num_other_arguments);
+    arguments.insert(arguments.begin(), make_intrusive<ASTLiteral>(time_series_storage_id.table_name));
+    arguments.insert(arguments.begin(), make_intrusive<ASTLiteral>(time_series_storage_id.database_name));
+}
 
 template <bool over_range>
 ColumnsDescription

--- a/src/TableFunctions/TableFunctionPrometheusQuery.h
+++ b/src/TableFunctions/TableFunctionPrometheusQuery.h
@@ -24,6 +24,7 @@ public:
 
 private:
     void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;
+    void qualifyArgumentsWithDatabase(ASTs & arguments) const override;
 
     StoragePtr executeImpl(
         const ASTPtr & ast_function,

--- a/src/TableFunctions/TableFunctionTimeSeries.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeries.cpp
@@ -5,6 +5,7 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
 #include <Storages/StorageTimeSeries.h>
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -70,6 +71,16 @@ void TableFunctionTimeSeriesTarget<target_kind>::parseArguments(const ASTPtr & a
 
     time_series_storage_id = context->resolveStorageID(time_series_storage_id);
     target_table_type_name = getTargetTable(context)->getName();
+}
+
+
+template <ViewTarget::Kind target_kind>
+void TableFunctionTimeSeriesTarget<target_kind>::qualifyArgumentsWithDatabase(ASTs & arguments) const
+{
+    /// timeSeriesMetrics( 'mydb', 'my_time_series_table' )
+    arguments.clear();
+    arguments.push_back(make_intrusive<ASTLiteral>(time_series_storage_id.database_name));
+    arguments.push_back(make_intrusive<ASTLiteral>(time_series_storage_id.table_name));
 }
 
 

--- a/src/TableFunctions/TableFunctionTimeSeries.h
+++ b/src/TableFunctions/TableFunctionTimeSeries.h
@@ -22,6 +22,7 @@ public:
 
 private:
     void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;
+    void qualifyArgumentsWithDatabase(ASTs & arguments) const override;
 
     StoragePtr executeImpl(
         const ASTPtr & ast_function,

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
@@ -1,6 +1,7 @@
 #include <TableFunctions/TableFunctionTimeSeriesSelector.h>
 
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <TableFunctions/TableFunctionFactory.h>
 
@@ -23,6 +24,19 @@ void TableFunctionTimeSeriesSelector::parseArguments(const ASTPtr & ast_function
 
     auto & args = args_func.arguments->children;
     config = StorageTimeSeriesSelector::getConfiguration(args, context);
+}
+
+void TableFunctionTimeSeriesSelector::qualifyArgumentsWithDatabase(ASTs & arguments) const
+{
+    /// timeSeriesSelector( 'mydb', 'my_time_series_table', selector, min_time, max_time )
+    size_t num_other_arguments = 3;
+    if (arguments.size() < num_other_arguments + 1)
+        return;
+
+    const auto & time_series_storage_id = config.time_series_storage_id;
+    arguments.erase(arguments.begin(), arguments.end() - num_other_arguments);
+    arguments.insert(arguments.begin(), make_intrusive<ASTLiteral>(time_series_storage_id.table_name));
+    arguments.insert(arguments.begin(), make_intrusive<ASTLiteral>(time_series_storage_id.database_name));
 }
 
 ColumnsDescription TableFunctionTimeSeriesSelector::getActualTableStructure(ContextPtr /* context */, bool /* is_insert_query */) const

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.h
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.h
@@ -20,6 +20,7 @@ public:
 
 private:
     void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;
+    void qualifyArgumentsWithDatabase(ASTs & arguments) const override;
 
     StoragePtr executeImpl(
         const ASTPtr & ast_function,

--- a/tests/queries/0_stateless/04838_timeseries_tags_column_contains_all_tags.sql
+++ b/tests/queries/0_stateless/04838_timeseries_tags_column_contains_all_tags.sql
@@ -23,14 +23,11 @@ INSERT INTO ts (metric_name, tags, time_series) VALUES
 INSERT INTO ts (tags, time_series) VALUES
     ({'__name__': 'http_requests', 'job': 'crawler', 'instance': 'host2:8080'}, [(toDateTime64(1060, 3), 2.5)]);
 
--- The database is passed to `timeSeriesTags` explicitly, otherwise the queries fail
--- with parallel replicas: `timeSeriesTags` reads the inner MergeTree table directly, so the query
--- can be sent to another replica where the current database is different.
 SELECT 'stored tags:';
-SELECT metric_name, job_column, instance_column, tags FROM timeSeriesTags({CLICKHOUSE_DATABASE:String}, 'ts') ORDER BY tags;
+SELECT metric_name, job_column, instance_column, tags FROM timeSeriesTags(ts) ORDER BY tags;
 
 SELECT 'id is calculated from the stored columns:';
-SELECT countIf(id = tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(tags)))), count() FROM timeSeriesTags({CLICKHOUSE_DATABASE:String}, 'ts');
+SELECT countIf(id = tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(tags)))), count() FROM timeSeriesTags(ts);
 
 SELECT 'prometheusQuery:';
 SELECT tags, value FROM prometheusQuery(ts, 'http_requests', 1080) ORDER BY tags;
@@ -44,7 +41,7 @@ INSERT INTO ts (metric_name, tags, time_series) VALUES
 
 SELECT 'id is calculated by the altered id_generator:';
 SELECT countIf(id = tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, tags)))), count()
-FROM timeSeriesTags({CLICKHOUSE_DATABASE:String}, 'ts') WHERE tags['job'] = 'miner';
+FROM timeSeriesTags(ts) WHERE tags['job'] = 'miner';
 
 -- The time series inserted before the ALTER are still readable together with the new one.
 SELECT 'prometheusQuery after ALTER:';

--- a/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.sql
+++ b/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.sql
@@ -1,7 +1,5 @@
--- Tags: no-replicated-database, no-parallel-replicas
+-- Tags: no-replicated-database
 -- Tag no-replicated-database: plain `DETACH TABLE` is not allowed there, only `DETACH TABLE PERMANENTLY`.
--- Tag no-parallel-replicas: the initiator sends the argument of `timeSeriesTags` to the replicas unqualified,
--- so they look the table up in the `default` database, see https://github.com/ClickHouse/ClickHouse/issues/118130.
 
 SET allow_experimental_time_series_table = 1;
 

--- a/tests/queries/0_stateless/05059_time_series_create_as_keeps_settings.sql
+++ b/tests/queries/0_stateless/05059_time_series_create_as_keeps_settings.sql
@@ -30,11 +30,10 @@ SELECT extract(create_table_query, 'TAGS INNER ENGINE.*?(index_granularity = \d+
 FROM system.tables WHERE database = currentDatabase() AND name = 'ts_derived';
 
 -- The `job` column comes with the copied inner columns anyway, so check that it's actually filled -
--- that needs the `tags_to_columns` setting. The database is passed explicitly because with parallel
--- replicas the query can go to a replica where the current database is different.
+-- that needs the `tags_to_columns` setting.
 SELECT '-- the copied `tags_to_columns` fills the dedicated column';
 INSERT INTO ts_derived (metric_name, tags, time_series) VALUES ('m1', {'job': 'j1'}, [(1, 1.)]);
-SELECT metric_name, job FROM timeSeriesTags({CLICKHOUSE_DATABASE:String}, 'ts_derived') ORDER BY metric_name;
+SELECT metric_name, job FROM timeSeriesTags(ts_derived) ORDER BY metric_name;
 DROP TABLE ts_derived;
 
 SELECT '-- `AS` without `ENGINE`: the engine is taken from `ts_src` and the settings are merged the same way';

--- a/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.reference
+++ b/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.reference
@@ -13,6 +13,8 @@ m2	counter
 -- the same with a local plan
 2
 3
+-- FINAL
+2
 -- table functions on the right side of a JOIN
 3
 2

--- a/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.reference
+++ b/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.reference
@@ -1,0 +1,20 @@
+-- one-argument form
+m1
+m2
+1
+2
+3
+m1	gauge
+m2	counter
+-- every row is returned once
+2
+3
+2
+-- the same with a local plan
+2
+3
+-- table functions on the right side of a JOIN
+3
+2
+1
+1

--- a/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
+++ b/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
@@ -7,6 +7,7 @@
 -- See https://github.com/ClickHouse/ClickHouse/issues/118130
 
 SET allow_experimental_time_series_table = 1;
+SET enable_analyzer = 1;
 SET enable_parallel_replicas = 2, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'parallel_replicas', parallel_replicas_for_non_replicated_merge_tree = 1;
 SET parallel_replicas_local_plan = 0;
 SET automatic_parallel_replicas_mode = 0;

--- a/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
+++ b/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
@@ -9,6 +9,7 @@
 SET allow_experimental_time_series_table = 1;
 SET enable_parallel_replicas = 2, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'parallel_replicas', parallel_replicas_for_non_replicated_merge_tree = 1;
 SET parallel_replicas_local_plan = 0;
+SET automatic_parallel_replicas_mode = 0;
 
 DROP TABLE IF EXISTS ts;
 CREATE TABLE ts ENGINE = TimeSeries;

--- a/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
+++ b/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
@@ -30,6 +30,11 @@ SELECT '-- the same with a local plan';
 SELECT count() FROM (SELECT * FROM timeSeriesTags(ts)) SETTINGS optimize_trivial_count_query = 0, parallel_replicas_local_plan = 1;
 SELECT count() FROM (SELECT * FROM timeSeriesSamples(ts)) SETTINGS optimize_trivial_count_query = 0, parallel_replicas_local_plan = 1;
 
+-- FINAL is not supported with parallel replicas: the query is rejected when they are forced and runs without them otherwise.
+SELECT '-- FINAL';
+SELECT count() FROM (SELECT * FROM timeSeriesTags(ts) FINAL) SETTINGS optimize_trivial_count_query = 0; -- { serverError SUPPORT_IS_DISABLED }
+SELECT count() FROM (SELECT * FROM timeSeriesTags(ts) FINAL) SETTINGS optimize_trivial_count_query = 0, enable_parallel_replicas = 1;
+
 -- A JOIN with a MergeTree table on the left side is sent to the replicas as a whole,
 -- so the table functions on the right side must get the table name qualified with the database too.
 SELECT '-- table functions on the right side of a JOIN';

--- a/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
+++ b/tests/queries/0_stateless/05104_time_series_table_functions_parallel_replicas.sql
@@ -1,0 +1,44 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+
+-- Reading through `timeSeriesTags`, `timeSeriesSamples` and `timeSeriesMetrics` with parallel replicas.
+-- The test runs in its own database, so the replicas must receive the table name qualified with the database,
+-- and every replica must announce its parts to the coordinator instead of reading the whole table.
+-- See https://github.com/ClickHouse/ClickHouse/issues/118130
+
+SET allow_experimental_time_series_table = 1;
+SET enable_parallel_replicas = 2, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'parallel_replicas', parallel_replicas_for_non_replicated_merge_tree = 1;
+SET parallel_replicas_local_plan = 0;
+
+DROP TABLE IF EXISTS ts;
+CREATE TABLE ts ENGINE = TimeSeries;
+
+INSERT INTO ts (metric_name, tags, time_series) VALUES ('m1', {'job': 'j1'}, [(1, 1.), (2, 2.)]), ('m2', {'job': 'j2'}, [(1, 3.)]);
+INSERT INTO ts (metric_family, type, unit, help) VALUES ('m1', 'gauge', '', 'help for m1'), ('m2', 'counter', '', 'help for m2');
+
+SELECT '-- one-argument form';
+SELECT metric_name FROM timeSeriesTags(ts) ORDER BY metric_name;
+SELECT value FROM timeSeriesSamples(ts) ORDER BY value;
+SELECT metric_family_name, type FROM timeSeriesMetrics(ts) ORDER BY metric_family_name;
+
+SELECT '-- every row is returned once';
+SELECT count() FROM (SELECT * FROM timeSeriesTags(currentDatabase(), ts)) SETTINGS optimize_trivial_count_query = 0;
+SELECT count() FROM (SELECT * FROM timeSeriesSamples(currentDatabase(), ts)) SETTINGS optimize_trivial_count_query = 0;
+SELECT count() FROM (SELECT * FROM timeSeriesMetrics(currentDatabase(), ts)) SETTINGS optimize_trivial_count_query = 0;
+
+SELECT '-- the same with a local plan';
+SELECT count() FROM (SELECT * FROM timeSeriesTags(ts)) SETTINGS optimize_trivial_count_query = 0, parallel_replicas_local_plan = 1;
+SELECT count() FROM (SELECT * FROM timeSeriesSamples(ts)) SETTINGS optimize_trivial_count_query = 0, parallel_replicas_local_plan = 1;
+
+-- A JOIN with a MergeTree table on the left side is sent to the replicas as a whole,
+-- so the table functions on the right side must get the table name qualified with the database too.
+SELECT '-- table functions on the right side of a JOIN';
+CREATE TABLE mt (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO mt VALUES (1), (2), (3);
+SELECT count() FROM mt AS l INNER JOIN timeSeriesSamples(ts) AS r ON l.x = toUInt64(r.value);
+SELECT count() FROM mt AS l INNER JOIN timeSeriesSelector(ts, 'm1', toDateTime64(0, 3), toDateTime64(10, 3)) AS r ON l.x = toUInt64(r.value);
+SELECT count() FROM mt AS l INNER JOIN prometheusQuery(ts, 'm1', toDateTime64(10, 3)) AS r ON l.x = toUInt64(r.value);
+SELECT count() FROM mt AS l INNER JOIN (SELECT toUInt64(arrayMax(x -> x.2, time_series)) AS x FROM prometheusQueryRange(ts, 'm1', toDateTime64(0, 3), toDateTime64(10, 3), INTERVAL 1 SECOND)) AS r ON l.x = r.x;
+
+DROP TABLE mt;
+DROP TABLE ts;


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix time series table accessors: `SELECT * FROM timeSeriesSamples(ts)` now works on parallel replicas.

Fixes https://github.com/ClickHouse/ClickHouse/issues/118130

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118518&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118518](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118518+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
