### PR TITLE
Fix two flaky NATS JetStream skipped-message assertions on the graceful-restart arm

### DIFF
--- a/tests/integration/test_storage_nats/test_nats_jet_stream.py
+++ b/tests/integration/test_storage_nats/test_nats_jet_stream.py
@@ -1463,10 +1463,11 @@ def test_nats_jet_stream_skipped_broken_message_is_not_redelivered_after_reconne
     #
     # The broker's own delivery counter is the oracle, and it is read while the malformed message is
     # the only one published, so the count is a statement about that message alone: one delivery
-    # means the skip survived the reconnect, two mean it was handed back. Only the hard kill can be
-    # measured that way, for the reason the guard below gives. The ACK deadline is far beyond every
-    # wait here, so a redelivery cannot come from anywhere else, and the run holds the flush interval
-    # open so the reconnect lands inside a cycle.
+    # means the skip survived the reconnect, two mean it was handed back. Losing the recovery's
+    # publish can only keep the count at one, so this is asked on both arms; only the
+    # acknowledgement itself is asked where the guard below says. The ACK deadline is far beyond
+    # every wait here, so a redelivery cannot come from anywhere else, and the run holds the flush
+    # interval open so the reconnect lands inside a cycle.
     asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
 
     # Anchored before the table exists, so the first streaming cycle counts however quickly it
@@ -1528,23 +1529,24 @@ def test_nats_jet_stream_skipped_broken_message_is_not_redelivered_after_reconne
     # than still being in flight when the counter is read.
     _wait_for_parked_pull_request()
 
-    # Only the hard kill can be measured here. It answers nothing on its way out, so the recovery
-    # runs after the client has reconnected and what it decides for the skipped message reaches a
+    # Only the hard kill can be asked for the acknowledgement itself. It answers nothing on its way
+    # out, so the recovery runs after the client has reconnected and its acknowledgement reaches a
     # live broker. A graceful shutdown answers the parked pull request as it exits, so the recovery
-    # publishes into a connection whose JetStream side is already down, and both an acknowledgement
-    # and a hand-back are fire-and-forget publishes whose status the client discards, so either can
-    # be lost. Everything below this block is asserted on both arms.
+    # publishes into a connection whose JetStream side is already down, and neither `natsMsg_Ack` nor
+    # `natsMsg_Nak` waits for the server, so the publish can be lost and the floor stay at zero.
     if kill is nats_helpers.hard_kill_nats:
         # The recovery acknowledged the skipped message and the broker has it, so the skip is
         # committed rather than merely not redelivered yet.
         _wait_for_ack_floor(1)
 
-        # A hand-back is a NAK, which the broker redelivers at once, so one delivery for the single
-        # message published so far means the skip survived the reconnect.
-        consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
-        assert consumer_seq == 1, (
-            "the skipped message was handed back to the broker and delivered again: "
-            "{} deliveries for one message".format(consumer_seq))
+    # A hand-back is a NAK, which the broker redelivers at once, so one delivery for the single
+    # message published so far means the skip survived the reconnect. This holds on both arms: the
+    # cycle consumed the message before the restart, so one delivery is the floor, and losing the
+    # recovery's publish can only keep the count there.
+    consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
+    assert consumer_seq == 1, (
+        "the skipped message was handed back to the broker and delivered again: "
+        "{} deliveries for one message".format(consumer_seq))
 
     # A stale subscription consumes nothing, so the view holding this row also means the recovery
     # did happen - deferred to a cycle that holds nothing rather than skipped altogether. It waits

--- a/tests/integration/test_storage_nats/test_nats_jet_stream.py
+++ b/tests/integration/test_storage_nats/test_nats_jet_stream.py
@@ -1461,10 +1461,12 @@ def test_nats_jet_stream_skipped_broken_message_is_not_redelivered_after_reconne
     # would undo the skip - the malformed message is delivered again and parsed again, and a
     # reconnect in front of the first good row can keep the table reprocessing the same bad input.
     #
-    # The broker's own delivery counter is the oracle: the consumer sequence counts every delivery,
-    # redeliveries included, so it stays at one per message exactly when nothing was handed back.
-    # The ACK deadline is far beyond every wait below, so a redelivery cannot come from anywhere
-    # else, and the run holds the flush interval open so the reconnect lands inside a cycle.
+    # The broker's own delivery counter is the oracle, and it is read while the malformed message is
+    # the only one published, so the count is a statement about that message alone: one delivery
+    # means the skip survived the reconnect, two mean it was handed back. Only the hard kill can be
+    # measured that way, for the reason the guard below gives. The ACK deadline is far beyond every
+    # wait here, so a redelivery cannot come from anywhere else, and the run holds the flush interval
+    # open so the reconnect lands inside a cycle.
     asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
 
     # Anchored before the table exists, so the first streaming cycle counts however quickly it
@@ -1499,13 +1501,50 @@ def test_nats_jet_stream_skipped_broken_message_is_not_redelivered_after_reconne
         cluster, "test_stream", "test_subject", [json.dumps({"key": "not a number", "value": "neither"})]))
     _wait_for_ack_pending(1)
 
+    # Anchored immediately before the restart, so the recovery the wait below looks for is the one
+    # this restart provokes rather than an earlier one.
+    recovery_anchor = nats_helpers.log_line_count(instance)
+
     _restart_nats(nats_cluster, kill = kill)
 
     # The restart lands inside the same cycle, while the skipped message is still held: the wait
     # above read that state off the broker, and the flush interval is far longer than the restart
-    # takes. Nothing is asserted about the state afterwards - the recovery acknowledges a skipped
-    # message as soon as it runs, so the count seen here depends on how quickly the client
-    # reconnects. What the skip is worth is measured by the delivery counter at the end.
+    # takes.
+    #
+    # Only a recovery the source performs inside its own cycle holds a skipped message across the
+    # reconnect. The background task reaches a consumer between cycles instead, where the cycle it
+    # follows has already acknowledged what it held, so accepting that line would let the assertions
+    # below pass on a run that never reached the state under test. Retrying is not available for the
+    # same reason: a second restart would land after that acknowledgement.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if nats_helpers.count_in_log_after(instance, IN_SOURCE_RESUBSCRIBE_LOG_LINE, recovery_anchor) > 0:
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("no streaming source performed an in-source recovery")
+
+    # The replacement subscription has its own request parked, so the recovery has finished rather
+    # than still being in flight when the counter is read.
+    _wait_for_parked_pull_request()
+
+    # Only the hard kill can be measured here. It answers nothing on its way out, so the recovery
+    # runs after the client has reconnected and what it decides for the skipped message reaches a
+    # live broker. A graceful shutdown answers the parked pull request as it exits, so the recovery
+    # publishes into a connection whose JetStream side is already down, and both an acknowledgement
+    # and a hand-back are fire-and-forget publishes whose status the client discards, so either can
+    # be lost. Everything below this block is asserted on both arms.
+    if kill is nats_helpers.hard_kill_nats:
+        # The recovery acknowledged the skipped message and the broker has it, so the skip is
+        # committed rather than merely not redelivered yet.
+        _wait_for_ack_floor(1)
+
+        # A hand-back is a NAK, which the broker redelivers at once, so one delivery for the single
+        # message published so far means the skip survived the reconnect.
+        consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
+        assert consumer_seq == 1, (
+            "the skipped message was handed back to the broker and delivered again: "
+            "{} deliveries for one message".format(consumer_seq))
 
     # A stale subscription consumes nothing, so the view holding this row also means the recovery
     # did happen - deferred to a cycle that holds nothing rather than skipped altogether. It waits
@@ -1519,11 +1558,6 @@ def test_nats_jet_stream_skipped_broken_message_is_not_redelivered_after_reconne
         check_callback = lambda num_rows: int(num_rows) == 1)
     assert int(result) == 1, "consumption did not resume, view holds {} rows".format(result)
 
-    consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
-    assert consumer_seq == 2, (
-        "the skipped message was handed back to the broker and delivered again: "
-        "{} deliveries for two messages".format(consumer_seq))
-
 
 @pytest.mark.parametrize("kill", BROKER_RESTARTS)
 def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats_cluster, kill):
@@ -1533,8 +1567,10 @@ def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats
     # become a row, so the recovery hands it back to the broker instead of holding the resubscribe
     # up, and the rows published after the reconnect reach this query rather than leaving it to sit
     # on a stale subscription until `rabbitmq_max_wait_ms` runs out. With `nats_commit_on_select`
-    # the redelivery is skipped again and acknowledged where the query commits what it read, so the
-    # skip costs one extra delivery and nothing is left outstanding.
+    # the redelivery is skipped again and acknowledged where the query commits what it read, so
+    # after a hard kill the skip costs one extra delivery and nothing is left outstanding. A
+    # graceful shutdown can lose the hand-back on its way out, and then the broker never redelivers:
+    # the count stays at two and the skipped message stays outstanding until the ACK deadline.
     #
     # The ACK deadline is far beyond every wait below, so a redelivery can only come from the
     # recovery handing the message back, which makes the broker's delivery counter the oracle.
@@ -1575,21 +1611,28 @@ def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats
     asyncio.run(publish_messages(cluster, "test_stream", "test_subject", [json.dumps({"key": 42, "value": 42})]))
     assert TSV(select.get_answer()) == TSV("42")
 
-    # Three deliveries for two messages: the recovery handed the skipped message back instead of
-    # committing it on behalf of a query that had returned nothing yet, and the redelivery was
-    # skipped again straight away. Two would mean it was consumed before the query committed
-    # anything, which is what a cancelled query must not leave behind.
-    deadline = time.monotonic() + 60
-    consumer_seq = 0
-    while time.monotonic() < deadline:
-        consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
-        if consumer_seq >= 3:
-            break
-        time.sleep(0.2)
+    # Only the hard kill can be measured here, for the reason the sibling test states: it answers
+    # nothing on its way out, so the hand-back reaches a live broker and its redelivery is the third
+    # delivery below. A graceful shutdown answers the parked pull request as it exits, so the
+    # recovery NAKs into a connection whose JetStream side is already going down, and a NAK is a
+    # fire-and-forget publish whose status the client discards - when it is dropped the broker never
+    # redelivers and the count stays at two.
+    if kill is nats_helpers.hard_kill_nats:
+        # Three deliveries for two messages: the recovery handed the skipped message back instead of
+        # committing it on behalf of a query that had returned nothing yet, and the redelivery was
+        # skipped again straight away. Two would mean it was consumed before the query committed
+        # anything, which is what a cancelled query must not leave behind.
+        deadline = time.monotonic() + 60
+        consumer_seq = 0
+        while time.monotonic() < deadline:
+            consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
+            if consumer_seq >= 3:
+                break
+            time.sleep(0.2)
 
-    assert consumer_seq >= 3, (
-        "the recovery acknowledged the skipped message before the query committed anything: "
-        "{} deliveries for two messages".format(consumer_seq))
+        assert consumer_seq >= 3, (
+            "the recovery acknowledged the skipped message before the query committed anything: "
+            "{} deliveries for two messages".format(consumer_seq))
 
     # The query did commit, so the row it returned is consumed by the time it returns, and so is the
     # skipped message where its redelivery reached the query before that row did. It does not have

--- a/tests/integration/test_storage_nats/test_nats_jet_stream.py
+++ b/tests/integration/test_storage_nats/test_nats_jet_stream.py
@@ -1575,7 +1575,7 @@ def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats
     # the count stays at two and the skipped message stays outstanding until the ACK deadline.
     #
     # The ACK deadline is far beyond every wait below, so a redelivery can only come from the
-    # recovery handing the message back, which makes the broker's delivery counter the oracle.
+    # recovery handing the message back, which makes the broker's own counters the oracle.
     asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
 
     instance.query(
@@ -1613,28 +1613,14 @@ def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats
     asyncio.run(publish_messages(cluster, "test_stream", "test_subject", [json.dumps({"key": 42, "value": 42})]))
     assert TSV(select.get_answer()) == TSV("42")
 
-    # Only the hard kill can be measured here, for the reason the sibling test states: it answers
-    # nothing on its way out, so the hand-back reaches a live broker and its redelivery is the third
-    # delivery below. A graceful shutdown answers the parked pull request as it exits, so the
-    # recovery NAKs into a connection whose JetStream side is already going down, and a NAK is a
-    # fire-and-forget publish whose status the client discards - when it is dropped the broker never
-    # redelivers and the count stays at two.
-    if kill is nats_helpers.hard_kill_nats:
-        # Three deliveries for two messages: the recovery handed the skipped message back instead of
-        # committing it on behalf of a query that had returned nothing yet, and the redelivery was
-        # skipped again straight away. Two would mean it was consumed before the query committed
-        # anything, which is what a cancelled query must not leave behind.
-        deadline = time.monotonic() + 60
-        consumer_seq = 0
-        while time.monotonic() < deadline:
-            consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
-            if consumer_seq >= 3:
-                break
-            time.sleep(0.2)
-
-        assert consumer_seq >= 3, (
-            "the recovery acknowledged the skipped message before the query committed anything: "
-            "{} deliveries for two messages".format(consumer_seq))
+    # The query returned a row, so it committed what it read, and the message it passed over is not
+    # part of that: the recovery had to hand it back to the broker rather than commit it on behalf of
+    # a query that had returned nothing yet, which is what a cancelled query must not leave behind.
+    # A graceful shutdown answers the parked pull request as it exits, so there the recovery publishes
+    # into a connection whose JetStream side is already going down and the hand-back can be dropped;
+    # a hard kill answers nothing, so its recovery reaches a live broker.
+    _wait_for_the_skipped_message_not_to_be_committed(
+        hand_back_may_be_lost = kill is not nats_helpers.hard_kill_nats)
 
     # The query did commit, so the row it returned is consumed by the time it returns, and so is the
     # skipped message where its redelivery reached the query before that row did. It does not have
@@ -1643,6 +1629,32 @@ def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats
     # it outstanding until the ACK deadline with nothing left to pull it. What must hold is that the
     # only thing the broker may still count as outstanding is that skipped message, never the row.
     _wait_for_nothing_but_the_first_message_outstanding()
+
+
+def _wait_for_the_skipped_message_not_to_be_committed(
+        hand_back_may_be_lost, consumer_name = "test_consumer", time_limit_sec = 60):
+    # A hand-back is a NAK, which the broker redelivers at once, so a third delivery for two messages
+    # is the skipped message going back and being skipped again. Where that NAK can be dropped there
+    # is no third delivery, and then what the broker holds is what says the message was not
+    # committed: a NAK it never saw leaves the message delivered and unacknowledged, so it is the one
+    # message outstanding with the acknowledgement floor still below it, while a commit moves that
+    # floor past it and so reaches neither state.
+    deadline = time.monotonic() + time_limit_sec
+    info = None
+    while time.monotonic() < deadline:
+        info = asyncio.run(get_consumer_info(cluster, "test_stream", consumer_name))
+        if info.delivered.consumer_seq >= 3:
+            return
+        if hand_back_may_be_lost and info.num_ack_pending == 1 and info.ack_floor.stream_seq == 0:
+            logging.debug("the hand-back did not reach the broker: {} deliveries, {} outstanding".format(
+                info.delivered.consumer_seq, info.num_ack_pending))
+            return
+        time.sleep(0.2)
+
+    raise AssertionError(
+        "the recovery acknowledged the skipped message before the query committed anything: "
+        "{} deliveries for two messages, {} outstanding, acknowledgement floor {}".format(
+            info.delivered.consumer_seq, info.num_ack_pending, info.ack_floor.stream_seq))
 
 
 def _wait_for_nothing_but_the_first_message_outstanding(consumer_name = "test_consumer", time_limit_sec = 60):


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115343
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed two flaky NATS JetStream integration test assertions that counted broker deliveries after a graceful broker restart, where the recovery's acknowledgement or hand-back can be lost.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/115343 (added both tests).

Two delivery-count assertions in `test_nats_jet_stream.py` fail on the `graceful_restart` arm in opposite directions: the streaming test asserts `consumer_seq == 2` and gets 3, because a stale replacement subscription hands back a message in flight; the direct-`SELECT` test asserts `consumer_seq >= 3` and gets 2, because the hand-back's NAK is lost. The second reddens master.

A graceful shutdown answers the parked pull request during JetStream teardown, so the client closes the subscription while the connection still reads CONNECTED and the in-source recovery runs inside that window. What it does with the skipped message it holds is published on `$JS.ACK` without waiting for the server, so a successful send does not mean the broker got it. A hard kill answers nothing, so its recovery reaches a live broker and neither signature appears.

An oracle belongs on an arm only where its value differs with and without the defect. The streaming count passes that: read before the good message is published it speaks about the malformed message alone, one delivery being the floor, so `== 1` runs on both arms. The direct-`SELECT` count needs help, since a dropped NAK leaves the same 2 a commit leaves; it is read together with what the broker holds, a NAK never seen leaving the message outstanding with the floor still below it where a commit moves that floor past it. Both arms still require the third delivery; only the graceful arm also accepts that outstanding state. `_wait_for_ack_floor(1)`, which a lost ACK breaks with nothing to separate it, stays hard-kill-only.

Not fixed here: a graceful restart can drop the recovery's ACK or NAK, costing one duplicate delivery or one message outstanding until its ACK deadline; at-least-once permits both.

<details>
<summary><b>Validation and CI provenance</b> (click to expand)</summary>

ASan+UBSan build; window counts from the instance log. 50 runs per test per arm. `IRowInputFormat: Skipped 1 rows with errors` per window is 2 when the hand-back landed and the message came again, 1 when it did not.

| test | arm | runs | failed | skipped counts |
|---|---|---|---|---|
| `..._is_not_redelivered_after_reconnect` | hard_kill | 50 | 0 | `{1: 50}` |
| `..._is_not_redelivered_after_reconnect` | graceful_restart | 50 | 0 | `{1: 50}` |
| `..._direct_select_resumes...` | hard_kill | 50 | 0 | `{2: 50}` |
| `..._direct_select_resumes...` | graceful_restart | 50 | 0 | `{1: 8, 2: 42}` |

The last row is why the count alone cannot carry the graceful arm: in 8 of 50 graceful runs the NAK was dropped and `consumer_seq` stayed at 2, where `>= 3` failed, all 8 with a second recovery. The streaming rows are why its count needs no help: one delivery, 50/50, on both arms. With `== 1` on both arms, and again with the composite oracle, a further 25 runs per arm each gave 0 failures.

No regression: whole file 56/56, `test_nats_core.py` plus `test_system_stop.py` 62/62.

Five mutations confirm nothing is vacuous: flipping the background branch to `ReturnToBroker` reddens the streaming test 12/12 on each arm (2 deliveries for one message); flipping the non-background branch to `Acknowledge`, the regression the direct-`SELECT` assertion names, reddens 25/25 on each of its arms with `2 deliveries, 0 outstanding, floor 2`; deleting the commit-time `ackConsumed` reddens both its arms through the outstanding-message check; changing the recovery log line makes the new control fail loudly; and restoring the old anchor shows it was already satisfied before the restart.

Master red, direct-`SELECT`: `Integration tests (amd_msan, 4/8)` at `dc55f29979c9`: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=dc55f29979c9ecaeac1bbad4144f2252fad5e020&name_0=MasterCI

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118521&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118521](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118521+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.921` (included in `26.9` and later)
<!-- ch-version-info:end -->