### PR TITLE
Make `checkStackSize` aware of the running coroutine's stack

### DIFF
--- a/src/Common/CoroutineStack.cpp
+++ b/src/Common/CoroutineStack.cpp
@@ -61,15 +61,19 @@ CoroutineStack::CoroutineStack(size_t stack_size_)
 {
 }
 
-boost::context::stack_context CoroutineStack::allocate() const
+boost::context::stack_context CoroutineStack::allocate()
 {
     Stopwatch watch;
 
     size_t num_pages = 1 + (stack_size - 1) / page_size;
+    size_t guard_bytes = 0;
 
     if constexpr (guardPagesEnabled())
+    {
         /// Add one page at bottom that will be used as guard-page
         num_pages += 1;
+        guard_bytes = page_size;
+    }
 
     size_t num_bytes = num_pages * page_size;
     void * data = ::aligned_alloc(page_size, num_bytes);
@@ -98,6 +102,8 @@ boost::context::stack_context CoroutineStack::allocate() const
 #if defined(BOOST_USE_VALGRIND)
     sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, data);
 #endif
+
+    last_allocated_bounds = {static_cast<const char *>(data) + guard_bytes, num_bytes - guard_bytes};
 
     ProfileEvents::increment(ProfileEvents::FiberStackAllocs);
     ProfileEvents::increment(ProfileEvents::FiberStackAllocBytes, num_bytes);

--- a/src/Common/CoroutineStack.h
+++ b/src/Common/CoroutineStack.h
@@ -14,12 +14,23 @@ public:
     /// way. We will have 80 pages with 4KB page size.
     static constexpr size_t default_stack_size = 320 * 1024; /// 64KB was not enough for tests
 
+    /// Address range a coroutine's frames may occupy: the allocation minus the guard page.
+    struct Bounds
+    {
+        const char * lowest = nullptr;
+        size_t size = 0;
+    };
+
     explicit CoroutineStack(size_t stack_size_ = default_stack_size);
 
-    boost::context::stack_context allocate() const;
+    boost::context::stack_context allocate();
     void deallocate(boost::context::stack_context & sctx) const;
+
+    /// Empty before the first allocate().
+    Bounds lastAllocatedBounds() const { return last_allocated_bounds; }
 
 private:
     const size_t stack_size;
     const size_t page_size;
+    Bounds last_allocated_bounds;
 };

--- a/src/Common/CoroutineStack.h
+++ b/src/Common/CoroutineStack.h
@@ -26,7 +26,7 @@ public:
     boost::context::stack_context allocate();
     void deallocate(boost::context::stack_context & sctx) const;
 
-    /// Empty before the first allocate().
+    /// Empty before the first `allocate`.
     Bounds lastAllocatedBounds() const { return last_allocated_bounds; }
 
 private:

--- a/src/Common/StackfulCoroutine.h
+++ b/src/Common/StackfulCoroutine.h
@@ -24,9 +24,10 @@ private:
     using CoroutinePtr = StackfulCoroutine *;
 
 public:
-    template <typename StackAlloc, typename Fn>
-    StackfulCoroutine(StackAlloc && salloc, Fn && fn)
-        : impl(std::allocator_arg_t(), std::forward<StackAlloc>(salloc), RoutineImpl<Fn>(std::forward<Fn>(fn)))
+    /// An lvalue reference, not a forwarding reference: the bounds below are read back out of the caller's allocator.
+    template <typename Fn>
+    StackfulCoroutine(CoroutineStack & salloc, Fn && fn)
+        : impl(std::allocator_arg_t(), salloc, RoutineImpl<Fn>(std::forward<Fn>(fn)))
         , coroutine_locals(FiberLocalStorage::create())
     {
         if (Silk::isInsideFiber())

--- a/src/Common/StackfulCoroutine.h
+++ b/src/Common/StackfulCoroutine.h
@@ -3,6 +3,7 @@
 #include <base/defines.h>
 #include <boost/context/fiber.hpp>
 
+#include <Common/CoroutineStack.h>
 #include <Common/Exception.h>
 #include <Common/FiberLocal.h>
 #include <Common/SilkFiberScheduler.h>
@@ -30,6 +31,10 @@ public:
     {
         if (Silk::isInsideFiber())
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Stackful coroutines cannot be created inside silk fibers");
+
+        /// The mem-initializer above already ran the allocation through `salloc`, so what it
+        /// recorded is this coroutine's stack.
+        stack_bounds = salloc.lastAllocatedBounds();
     }
 
     StackfulCoroutine() = default;
@@ -48,6 +53,7 @@ public:
             unwind();
             impl = std::move(other.impl);
             coroutine_locals = std::move(other.coroutine_locals);
+            stack_bounds = other.stack_bounds;
         }
         return *this;
     }
@@ -76,6 +82,9 @@ public:
     /// Defined in `StackfulCoroutine.cpp`: a static local in a header-defined function gives every
     /// shared object its own copy.
     static CoroutinePtr & getCurrentCoroutine();
+
+    /// Empty while this coroutine is being torn down, so a frame check during unwinding cannot fire.
+    const CoroutineStack::Bounds & getStackBounds() const { return stack_bounds; }
 
 private:
     template <typename Fn>
@@ -113,6 +122,10 @@ private:
     /// Destroying a coroutine that is suspended unwinds its stack: Called from the destructor body, while coroutine_locals is still alive.
     void unwind() noexcept
     {
+        /// Teardown runs with this coroutine published as current, and a destructor near the
+        /// allowance must not turn a forced unwind into an exception.
+        stack_bounds = {};
+
         if (!impl)
             return;
 
@@ -129,4 +142,5 @@ private:
 
     Impl impl;
     FiberLocalStorage::Holder coroutine_locals;
+    CoroutineStack::Bounds stack_bounds;
 };

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -2,6 +2,7 @@
 #include <base/defines.h> /// THREAD_SANITIZER
 #include <base/scope_guard.h>
 #include <Common/checkStackSize.h>
+#include <Common/CoroutineStack.h>
 #include <Common/Exception.h>
 #include <Common/ErrnoException.h>
 #include <Common/StackfulCoroutine.h>
@@ -45,6 +46,10 @@ struct StackBounds
 };
 
 constinit thread_local StackBounds stack_bounds;
+
+/// STACK_SIZE_FREE_RATIO below is calibrated against ~8 MiB thread stacks: its TSan value would
+/// leave a 320 KiB coroutine stack 16 KiB, less than an ordinary secure handshake already uses.
+constexpr size_t COROUTINE_STACK_RESERVE = 64 * 1024;
 }
 
 /**
@@ -138,11 +143,33 @@ static NO_INLINE size_t getStackSize(void ** out_address)
 
 void checkStackSize()
 {
-    /// Not implemented for coroutines.
-    if (StackfulCoroutine::getCurrentCoroutine())
+    /// Taken here rather than in a callee, whose own frame would shift every bound below.
+    const void * frame_address = __builtin_frame_address(0);
+
+    if (const StackfulCoroutine * coroutine = StackfulCoroutine::getCurrentCoroutine())
+    {
+        const CoroutineStack::Bounds bounds = coroutine->getStackBounds();
+
+        /// No stack to reason about, or none with room for the reserve.
+        if (bounds.size <= COROUTINE_STACK_RESERVE)
+            return;
+
+        uintptr_t frame = reinterpret_cast<uintptr_t>(frame_address);
+        uintptr_t lowest = reinterpret_cast<uintptr_t>(bounds.lowest);
+
+        /// resume() publishes the coroutine before switching to it, so frames of the parent stack
+        /// reach this point as well. Only the coroutine's own frames are measurable here.
+        if (frame < lowest || frame - lowest >= bounds.size)
+            return;
+
+        if (unlikely(frame - lowest < COROUTINE_STACK_RESERVE))
+            throwTooDeepRecursion(bounds.lowest, frame_address, lowest + bounds.size - frame, bounds.size);
+
         return;
+    }
 
 #if USE_SILK
+    /// Silk exposes no stack bounds: `silk::Fiber` is only forward-declared in its public header.
     if (silk::FiberScheduler::getCurrentFiberId().raw)
         return;
 #endif
@@ -154,7 +181,6 @@ void checkStackSize()
     if (unlikely(!stack_bounds.max_size))
         return;
 
-    const void * frame_address = __builtin_frame_address(0);
     uintptr_t int_frame_address = reinterpret_cast<uintptr_t>(frame_address);
     uintptr_t int_stack_address = reinterpret_cast<uintptr_t>(stack_bounds.address);
 

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -48,7 +48,7 @@ struct StackBounds
 constinit thread_local StackBounds stack_bounds;
 
 /// `STACK_SIZE_FREE_RATIO` below is calibrated against ~8 MiB thread stacks: its TSan value would
-/// leave a 320 KiB coroutine stack 16 KiB, less than an ordinary secure handshake already uses.
+/// allow a 320 KiB coroutine stack only 16384 B, which an ordinary secure handshake nearly exhausts.
 constexpr size_t COROUTINE_STACK_RESERVE = 64 * 1024;
 }
 

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -47,7 +47,7 @@ struct StackBounds
 
 constinit thread_local StackBounds stack_bounds;
 
-/// STACK_SIZE_FREE_RATIO below is calibrated against ~8 MiB thread stacks: its TSan value would
+/// `STACK_SIZE_FREE_RATIO` below is calibrated against ~8 MiB thread stacks: its TSan value would
 /// leave a 320 KiB coroutine stack 16 KiB, less than an ordinary secure handshake already uses.
 constexpr size_t COROUTINE_STACK_RESERVE = 64 * 1024;
 }
@@ -157,7 +157,7 @@ void checkStackSize()
         uintptr_t frame = reinterpret_cast<uintptr_t>(frame_address);
         uintptr_t lowest = reinterpret_cast<uintptr_t>(bounds.lowest);
 
-        /// resume() publishes the coroutine before switching to it, so frames of the parent stack
+        /// `resume` publishes the coroutine before switching to it, so frames of the parent stack
         /// reach this point as well. Only the coroutine's own frames are measurable here.
         if (frame < lowest || frame - lowest >= bounds.size)
             return;

--- a/src/Common/tests/gtest_coroutine_stack_guard.cpp
+++ b/src/Common/tests/gtest_coroutine_stack_guard.cpp
@@ -30,13 +30,15 @@ using namespace DB;
 /// fire fails an assertion instead of faulting.
 /// Consumption is measured between frame addresses, never between two locals' addresses: under ASan
 /// an address-taken local can live on the separately mapped fake stack. Each level still escapes its
-/// own local's address, which is what stops the compiler folding a recursion into a frameless loop.
+/// own local's address, which is what stops the compiler folding a recursion into a frameless loop;
+/// the same budget bounds the depth too, which no level that consumed a byte can reach.
 constexpr size_t recursion_budget = CoroutineStack::default_stack_size * 7 / 8;
 
 struct Observations
 {
     bool ran = false;
     bool budget_reached = false;
+    bool depth_capped = false;
     bool past_allowance = false;
 };
 
@@ -46,6 +48,12 @@ size_t NO_INLINE recurseUntilGuardTrips(size_t depth, uintptr_t first_frame, Obs
 
     char here = static_cast<char>(depth);
     __asm__ __volatile__("" : : "r"(&here) : "memory");
+    if (depth >= recursion_budget)
+    {
+        observations.depth_capped = true;
+        return depth;
+    }
+
     if (first_frame - reinterpret_cast<uintptr_t>(__builtin_frame_address(0)) >= recursion_budget)
     {
         observations.budget_reached = true;
@@ -71,6 +79,12 @@ size_t NO_INLINE descendThenSuspend(size_t depth, uintptr_t first_frame, Observa
 
     char here = static_cast<char>(depth);
     __asm__ __volatile__("" : : "r"(&here) : "memory");
+    if (depth >= recursion_budget)
+    {
+        observations.depth_capped = true;
+        return depth;
+    }
+
     if (first_frame - reinterpret_cast<uintptr_t>(__builtin_frame_address(0)) >= recursion_budget)
     {
         /// Establishes that the destructors above are ones a check would have thrown from, which is
@@ -193,6 +207,9 @@ TEST(CoroutineStackGuard, ThrowsOnDeepRecursionInsideCoroutine)
     try
     {
         executor.resume();
+        /// A fatal failure returns, so the fold-specific message has to come first.
+        if (observations.depth_capped)
+            FAIL() << "a build folded the recursion into a frameless loop";
         FAIL() << "checkStackSize() did not stop an unbounded recursion on a coroutine stack";
     }
     catch (const DB::Exception & e)

--- a/src/Common/tests/gtest_coroutine_stack_guard.cpp
+++ b/src/Common/tests/gtest_coroutine_stack_guard.cpp
@@ -28,6 +28,9 @@ using namespace DB;
 /// depth reached does not depend on how large the compiler makes a frame. The budget overshoots the
 /// guard's allowance yet stops short of the end of the stack, so a build where the guard does not
 /// fire fails an assertion instead of faulting.
+/// Consumption is measured between frame addresses, never between two locals' addresses: under ASan
+/// an address-taken local can live on the separately mapped fake stack. Each level still escapes its
+/// own local's address, which is what stops the compiler folding a recursion into a frameless loop.
 constexpr size_t recursion_budget = CoroutineStack::default_stack_size * 7 / 8;
 
 struct Observations
@@ -42,7 +45,8 @@ size_t NO_INLINE recurseUntilGuardTrips(size_t depth, uintptr_t first_frame, Obs
     checkStackSize();
 
     char here = static_cast<char>(depth);
-    if (first_frame - reinterpret_cast<uintptr_t>(&here) >= recursion_budget)
+    __asm__ __volatile__("" : : "r"(&here) : "memory");
+    if (first_frame - reinterpret_cast<uintptr_t>(__builtin_frame_address(0)) >= recursion_budget)
     {
         observations.budget_reached = true;
         return depth;
@@ -66,7 +70,8 @@ size_t NO_INLINE descendThenSuspend(size_t depth, uintptr_t first_frame, Observa
     CheckingOnDestruction unwind_probe;
 
     char here = static_cast<char>(depth);
-    if (first_frame - reinterpret_cast<uintptr_t>(&here) >= recursion_budget)
+    __asm__ __volatile__("" : : "r"(&here) : "memory");
+    if (first_frame - reinterpret_cast<uintptr_t>(__builtin_frame_address(0)) >= recursion_budget)
     {
         /// Establishes that the destructors above are ones a check would have thrown from, which is
         /// what makes the teardown assertions non-vacuous.
@@ -99,8 +104,7 @@ struct CoroutineTask : public AsyncTask
 
     void run(AsyncCallback, SuspendCallback suspend_callback) override
     {
-        char first_frame = 0;
-        const uintptr_t first_frame_address = reinterpret_cast<uintptr_t>(&first_frame);
+        const uintptr_t first_frame_address = reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
         observations.ran = true;
 
         switch (shape)

--- a/src/Common/tests/gtest_coroutine_stack_guard.cpp
+++ b/src/Common/tests/gtest_coroutine_stack_guard.cpp
@@ -37,12 +37,12 @@ struct Observations
     bool past_allowance = false;
 };
 
-size_t NO_INLINE recurseUntilGuardTrips(size_t depth, const char * first_frame, Observations & observations)
+size_t NO_INLINE recurseUntilGuardTrips(size_t depth, uintptr_t first_frame, Observations & observations)
 {
     checkStackSize();
 
     char here = static_cast<char>(depth);
-    if (first_frame - &here >= static_cast<ptrdiff_t>(recursion_budget))
+    if (first_frame - reinterpret_cast<uintptr_t>(&here) >= recursion_budget)
     {
         observations.budget_reached = true;
         return depth;
@@ -61,12 +61,12 @@ struct CheckingOnDestruction
 
 /// Descends without checking, so every destructor unwound from the bottom runs deeper than the
 /// guard's allowance.
-size_t NO_INLINE descendThenSuspend(size_t depth, const char * first_frame, Observations & observations, const SuspendCallback & suspend_callback)
+size_t NO_INLINE descendThenSuspend(size_t depth, uintptr_t first_frame, Observations & observations, const SuspendCallback & suspend_callback)
 {
     CheckingOnDestruction unwind_probe;
 
     char here = static_cast<char>(depth);
-    if (first_frame - &here >= static_cast<ptrdiff_t>(recursion_budget))
+    if (first_frame - reinterpret_cast<uintptr_t>(&here) >= recursion_budget)
     {
         /// Establishes that the destructors above are ones a check would have thrown from, which is
         /// what makes the teardown assertions non-vacuous.
@@ -100,6 +100,7 @@ struct CoroutineTask : public AsyncTask
     void run(AsyncCallback, SuspendCallback suspend_callback) override
     {
         char first_frame = 0;
+        const uintptr_t first_frame_address = reinterpret_cast<uintptr_t>(&first_frame);
         observations.ran = true;
 
         switch (shape)
@@ -108,10 +109,10 @@ struct CoroutineTask : public AsyncTask
                 checkStackSize();
                 return;
             case Shape::RecurseUntilGuardTrips:
-                recurseUntilGuardTrips(0, &first_frame, observations);
+                recurseUntilGuardTrips(0, first_frame_address, observations);
                 return;
             case Shape::DescendThenSuspend:
-                descendThenSuspend(0, &first_frame, observations, suspend_callback);
+                descendThenSuspend(0, first_frame_address, observations, suspend_callback);
                 return;
         }
     }
@@ -139,15 +140,29 @@ private:
 /// The usable stack is `default_stack_size` rounded up to a page, with the guard page on top of it
 /// rather than inside it. An 8 MiB thread stack cannot satisfy this, so the assertion also rules out
 /// a throw that came from the thread path against the wrong bounds.
-void expectCoroutineStackSizeReported(const std::string & message)
+void expectCoroutineStackBounds(const std::string & message)
 {
-    const std::string marker = "maximum stack size: ";
-    const size_t at = message.find(marker);
-    ASSERT_NE(at, std::string::npos) << message;
+    const std::string max_marker = "maximum stack size: ";
+    const size_t max_at = message.find(max_marker);
+    ASSERT_NE(max_at, std::string::npos) << message;
 
-    const size_t reported = std::stoull(message.substr(at + marker.size()));
+    const size_t reported = std::stoull(message.substr(max_at + max_marker.size()));
     EXPECT_GE(reported, CoroutineStack::default_stack_size) << message;
     EXPECT_LT(reported, CoroutineStack::default_stack_size + static_cast<size_t>(getPageSize())) << message;
+
+    /// The comma belongs to the marker: `"stack size: "` alone also matches inside `"maximum stack size: "`.
+    const std::string used_marker = ", stack size: ";
+    const size_t used_at = message.find(used_marker);
+    ASSERT_NE(used_at, std::string::npos) << message;
+    const size_t used = std::stoull(message.substr(used_at + used_marker.size()));
+
+    /// Mirrors `COROUTINE_STACK_RESERVE` in `checkStackSize.cpp`; pinned from the reported maximum
+    /// rather than shared with it, so widening either side alone fails here.
+    constexpr size_t contracted_reserve = 64 * 1024;
+    ASSERT_GT(reported, contracted_reserve) << message;
+    const size_t contracted_trip = reported - contracted_reserve;
+    EXPECT_GE(used, contracted_trip) << message;
+    EXPECT_LT(used, contracted_trip + static_cast<size_t>(getPageSize())) << message;
 }
 
 }
@@ -176,7 +191,7 @@ TEST(CoroutineStackGuard, ThrowsOnDeepRecursionInsideCoroutine)
         ASSERT_EQ(e.code(), DB::ErrorCodes::TOO_DEEP_RECURSION) << e.message();
         /// Not the bare error code: the parse-depth cap throws TOO_DEEP_RECURSION as well.
         ASSERT_NE(e.message().find("Stack size too large."), std::string::npos) << e.message();
-        expectCoroutineStackSizeReported(e.message());
+        expectCoroutineStackBounds(e.message());
     }
 
     EXPECT_FALSE(observations.budget_reached) << "recursion ran out of budget before the guard fired";

--- a/src/Common/tests/gtest_coroutine_stack_guard.cpp
+++ b/src/Common/tests/gtest_coroutine_stack_guard.cpp
@@ -121,7 +121,7 @@ struct CoroutineTask : public AsyncTask
     Observations & observations;
 };
 
-/// Creates its coroutine the way production does, through AsyncTaskExecutor's move-assignment.
+/// Creates its coroutine the way production does, through `AsyncTaskExecutor`'s move-assignment.
 class CoroutineTaskExecutor : public AsyncTaskExecutor
 {
 public:
@@ -162,7 +162,12 @@ void expectCoroutineStackBounds(const std::string & message)
     ASSERT_GT(reported, contracted_reserve) << message;
     const size_t contracted_trip = reported - contracted_reserve;
     EXPECT_GE(used, contracted_trip) << message;
-    EXPECT_LT(used, contracted_trip + static_cast<size_t>(getPageSize())) << message;
+
+    /// Slack for the single recursion frame between the last check that passed and the throw.
+    /// Deliberately not one OS page: where pages are 64 KiB that interval is wide enough to accept
+    /// a materially smaller reserve than the one being pinned.
+    constexpr size_t frame_slack = 4096;
+    EXPECT_LT(used, contracted_trip + frame_slack) << message;
 }
 
 }
@@ -189,7 +194,7 @@ TEST(CoroutineStackGuard, ThrowsOnDeepRecursionInsideCoroutine)
     catch (const DB::Exception & e)
     {
         ASSERT_EQ(e.code(), DB::ErrorCodes::TOO_DEEP_RECURSION) << e.message();
-        /// Not the bare error code: the parse-depth cap throws TOO_DEEP_RECURSION as well.
+        /// Not the bare error code: the parse-depth cap throws `TOO_DEEP_RECURSION` as well.
         ASSERT_NE(e.message().find("Stack size too large."), std::string::npos) << e.message();
         expectCoroutineStackBounds(e.message());
     }

--- a/src/Common/tests/gtest_coroutine_stack_guard.cpp
+++ b/src/Common/tests/gtest_coroutine_stack_guard.cpp
@@ -1,0 +1,211 @@
+#include <gtest/gtest.h>
+
+#include <Common/AsyncTaskExecutor.h>
+#include <Common/CoroutineStack.h>
+#include <Common/Exception.h>
+#include <Common/checkStackSize.h>
+
+#include <base/defines.h>
+#include <base/getPageSize.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace DB::ErrorCodes
+{
+    extern const int TOO_DEEP_RECURSION;
+}
+
+namespace
+{
+
+using namespace DB;
+
+/// The recursions below stop on their own measured consumption rather than on a frame count, so the
+/// depth reached does not depend on how large the compiler makes a frame. The budget overshoots the
+/// guard's allowance yet stops short of the end of the stack, so a build where the guard does not
+/// fire fails an assertion instead of faulting.
+constexpr size_t recursion_budget = CoroutineStack::default_stack_size * 7 / 8;
+
+struct Observations
+{
+    bool ran = false;
+    bool budget_reached = false;
+    bool past_allowance = false;
+};
+
+size_t NO_INLINE recurseUntilGuardTrips(size_t depth, const char * first_frame, Observations & observations)
+{
+    checkStackSize();
+
+    char here = static_cast<char>(depth);
+    if (first_frame - &here >= static_cast<ptrdiff_t>(recursion_budget))
+    {
+        observations.budget_reached = true;
+        return depth;
+    }
+
+    return recurseUntilGuardTrips(depth + 1, first_frame, observations) + static_cast<size_t>(here);
+}
+
+struct CheckingOnDestruction
+{
+    ~CheckingOnDestruction()
+    {
+        checkStackSize();
+    }
+};
+
+/// Descends without checking, so every destructor unwound from the bottom runs deeper than the
+/// guard's allowance.
+size_t NO_INLINE descendThenSuspend(size_t depth, const char * first_frame, Observations & observations, const SuspendCallback & suspend_callback)
+{
+    CheckingOnDestruction unwind_probe;
+
+    char here = static_cast<char>(depth);
+    if (first_frame - &here >= static_cast<ptrdiff_t>(recursion_budget))
+    {
+        /// Establishes that the destructors above are ones a check would have thrown from, which is
+        /// what makes the teardown assertions non-vacuous.
+        try
+        {
+            checkStackSize();
+        }
+        catch (const Exception &)
+        {
+            observations.past_allowance = true;
+        }
+
+        suspend_callback();
+        return depth;
+    }
+
+    return descendThenSuspend(depth + 1, first_frame, observations, suspend_callback) + static_cast<size_t>(here);
+}
+
+enum class Shape : uint8_t
+{
+    OrdinaryDepth,
+    RecurseUntilGuardTrips,
+    DescendThenSuspend,
+};
+
+struct CoroutineTask : public AsyncTask
+{
+    CoroutineTask(Shape shape_, Observations & observations_) : shape(shape_), observations(observations_) { }
+
+    void run(AsyncCallback, SuspendCallback suspend_callback) override
+    {
+        char first_frame = 0;
+        observations.ran = true;
+
+        switch (shape)
+        {
+            case Shape::OrdinaryDepth:
+                checkStackSize();
+                return;
+            case Shape::RecurseUntilGuardTrips:
+                recurseUntilGuardTrips(0, &first_frame, observations);
+                return;
+            case Shape::DescendThenSuspend:
+                descendThenSuspend(0, &first_frame, observations, suspend_callback);
+                return;
+        }
+    }
+
+    const Shape shape;
+    Observations & observations;
+};
+
+/// Creates its coroutine the way production does, through AsyncTaskExecutor's move-assignment.
+class CoroutineTaskExecutor : public AsyncTaskExecutor
+{
+public:
+    CoroutineTaskExecutor(Shape shape, Observations & observations)
+        : AsyncTaskExecutor(std::make_unique<CoroutineTask>(shape, observations), "gtest_coroutine_stack_guard")
+    {
+    }
+
+private:
+    bool checkBeforeTaskResume() override { return true; }
+    void afterTaskResume() override { }
+    void processAsyncEvent(int, Poco::Timespan, AsyncEventTimeoutType, const std::string &, uint32_t) override { }
+    void clearAsyncEvent() override { }
+};
+
+/// The usable stack is `default_stack_size` rounded up to a page, with the guard page on top of it
+/// rather than inside it. An 8 MiB thread stack cannot satisfy this, so the assertion also rules out
+/// a throw that came from the thread path against the wrong bounds.
+void expectCoroutineStackSizeReported(const std::string & message)
+{
+    const std::string marker = "maximum stack size: ";
+    const size_t at = message.find(marker);
+    ASSERT_NE(at, std::string::npos) << message;
+
+    const size_t reported = std::stoull(message.substr(at + marker.size()));
+    EXPECT_GE(reported, CoroutineStack::default_stack_size) << message;
+    EXPECT_LT(reported, CoroutineStack::default_stack_size + static_cast<size_t>(getPageSize())) << message;
+}
+
+}
+
+TEST(CoroutineStackGuard, NoThrowAtOrdinaryDepth)
+{
+    Observations observations;
+    CoroutineTaskExecutor executor(Shape::OrdinaryDepth, observations);
+
+    EXPECT_NO_THROW(executor.resume());
+    EXPECT_TRUE(observations.ran);
+}
+
+TEST(CoroutineStackGuard, ThrowsOnDeepRecursionInsideCoroutine)
+{
+    Observations observations;
+    CoroutineTaskExecutor executor(Shape::RecurseUntilGuardTrips, observations);
+
+    try
+    {
+        executor.resume();
+        FAIL() << "checkStackSize() did not stop an unbounded recursion on a coroutine stack";
+    }
+    catch (const DB::Exception & e)
+    {
+        ASSERT_EQ(e.code(), DB::ErrorCodes::TOO_DEEP_RECURSION) << e.message();
+        /// Not the bare error code: the parse-depth cap throws TOO_DEEP_RECURSION as well.
+        ASSERT_NE(e.message().find("Stack size too large."), std::string::npos) << e.message();
+        expectCoroutineStackSizeReported(e.message());
+    }
+
+    EXPECT_FALSE(observations.budget_reached) << "recursion ran out of budget before the guard fired";
+}
+
+TEST(CoroutineStackGuard, TeardownFromDeepStackDoesNotThrow)
+{
+    {
+        SCOPED_TRACE("cancel()");
+        Observations observations;
+        CoroutineTaskExecutor executor(Shape::DescendThenSuspend, observations);
+        EXPECT_NO_THROW(executor.resume());
+        ASSERT_TRUE(observations.past_allowance);
+        EXPECT_NO_THROW(executor.cancel());
+    }
+    {
+        SCOPED_TRACE("restart()");
+        Observations observations;
+        CoroutineTaskExecutor executor(Shape::DescendThenSuspend, observations);
+        EXPECT_NO_THROW(executor.resume());
+        ASSERT_TRUE(observations.past_allowance);
+        EXPECT_NO_THROW(executor.restart());
+    }
+    {
+        SCOPED_TRACE("destructor");
+        Observations observations;
+        auto executor = std::make_unique<CoroutineTaskExecutor>(Shape::DescendThenSuspend, observations);
+        EXPECT_NO_THROW(executor->resume());
+        ASSERT_TRUE(observations.past_allowance);
+        EXPECT_NO_THROW(executor.reset());
+    }
+}


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/113835
Related: https://github.com/ClickHouse/ClickHouse/pull/100371
Related: https://github.com/ClickHouse/ClickHouse/pull/113991

CI report for the core this was measured from (`AST fuzzer (arm_asan_ubsan)`, PR #100371):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100371&sha=ad61a2a689c80c003cfa300ceb67807082f7644b&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`checkStackSize` returned immediately inside a coroutine, so all 140 guarded call sites were no-ops on
a 320 KiB coroutine stack: an over-deep recursion there trips the guard page and kills the server
instead of raising `TOO_DEEP_RECURSION`. A complete core shows one thread's SP in the guard page above
identical frames filling 92% of it; `DataTypeFactory.cpp:122` documents a prior workaround for the same
stack.

`CoroutineStack::allocate` now records the usable range: 320 KiB in guarded and release builds
alike, the guard page sitting on top of it. `StackfulCoroutine` carries it and clears it
in `unwind`, so a forced unwind cannot become an exception. `checkStackSize` tests the frame against that
range with a 64 KiB reserve, returning on every uncertainty. `default_stack_size` is untouched.

The reserve is absolute, not `STACK_SIZE_FREE_RATIO`: that ratio is calibrated for 8 MiB thread stacks,
and its TSan value leaves this stack a 16384 B allowance that an ordinary secure handshake (measured
15768 B) all but exhausts. Against the resulting 256 KiB allowance, the worst SQL-reachable in-coroutine
descent measures under 104 KiB under sanitizers, 64 KiB in release.

Two residuals. `silk` fibers keep their own bypass: `silk::Fiber` is only forward-declared, so there is
no stack-bounds API, and `enable_silk_runtime` is off by default. And a bound only helps where a guard
exists: `DataTypeTuple::createSerializationInfo` recurses with no `checkStackSize` call.

This is a general bound and I cannot show it stops that occurrence: the recursing function is not
identifiable from the core. @ alexey-milovidov asked for one on that understanding:
https://github.com/ClickHouse/ClickHouse/issues/113835#issuecomment-5562864640 .

A gtest, not a functional test: the throw is not observable from SQL, since no SQL path I can construct
reaches the allowance. It fires the guard inside a real `AsyncTaskExecutor` coroutine, brackets the
reported maximum and used size so neither can drift, and fails without the `checkStackSize` hunk.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118531&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118531](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118531+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
