### PR TITLE
Do not request ClickHouse-framed compression from SQLancer++'s JDBC connection

### DIFF
--- a/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
+++ b/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
@@ -11,9 +11,10 @@
    The legacy driver's HTTP response parser can't handle current ClickHouse
    server output.
 2. Extend the `CLICKHOUSE.url` template in `dbconfigs/jdbc.properties` to carry
-   `user` and `password` query parameters. SQLancer++'s generic provider only
-   passes the URL string (no JDBC Properties) into `DriverManager.getConnection`,
-   so the new driver - which requires credentials - needs them embedded here.
+   `user` and `password` query parameters and to turn ClickHouse-framed response
+   compression off. SQLancer++'s generic provider only passes the URL string (no
+   JDBC Properties) into `DriverManager.getConnection`, so the new driver - which
+   requires credentials - needs them embedded here.
 3. Replace the `IS TRUE` postfix in `GeneralNoRECOracle.java` with `!= 0`.
    NoREC's row-counter must agree with `WHERE <expr>`, which ClickHouse
    evaluates by truthiness (any non-zero numeric is included, `NULL` is
@@ -67,9 +68,12 @@ CLICKHOUSE_URL = re.compile(
 # `--password` when they differ from the built-in defaults (`sqlancer`), so
 # even with explicit CLI flags those defaults fall through to the properties
 # file - meaning the entries below need real values.
+# `compress=false` is required: client-v2 requests ClickHouse-framed responses by
+# default and decodes only the LZ4 method byte (0x82), while the server frames
+# them with its default codec, ZSTD (0x90).
 NEW_CLICKHOUSE_LINES = (
     "CLICKHOUSE.url=jdbc:clickhouse://{host}:{port}/{database}"
-    "?user={user}&password={password}\n"
+    "?user={user}&password={password}&compress=false\n"
     "CLICKHOUSE.user=sqlancer\n"
     "CLICKHOUSE.password=sqlancer"
 )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108786


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The SQLancer++ check no longer asks the server for ClickHouse-framed (`compress=1`) responses, which its pinned `clickhouse-jdbc` driver cannot decode now that the default codec is `ZSTD`.


### Description

`SQLancerPP (arm_asan_ubsan)` and `(arm_release)` both returned **0 OK / 4 FAIL** on master
`e568d262`, every oracle dying with `Failed to create any table`: zero oracle coverage.
[report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=e568d262dc86ddfaa8a3f2016797c0b35e937206&name_0=NightlySQLancer&name_1=SQLancerPP%20%28arm_asan_ubsan%29)

**The server is not at fault.** #108786 made `ZSTD(3)` the default codec, and HTTP `compress=1` frames
with it (`HTTPHandler.cpp:763` passes no codec to `CompressedWriteBuffer`), moving the method byte from
`0x82` to `0x90`. `com.clickhouse:clickhouse-jdbc` client-v2 requests `compress=1` by default and
installs an LZ4-only decoder, so every response with a body throws `Invalid LZ4 magic byte: '-112'`.
Bodyless statements still work, hence `successful statements: 80%`; the post-`CREATE` probe is
`SELECT * FROM <t>`, so every table fails.

It landed between the last healthy nightly (`de1002bf2625`) and this one; the frame byte off both
artifacts reads `82`, then `90`. Nothing crashed: the 20.7M-line
`clickhouse-server.log.err.zst` holds no `<Fatal>` line, no sanitizer report, and no error across
309,618 `SELECT`s.

The fix stops the only connection this repo controls from requesting framed responses, in the URL
template already patched here. Neither alternative works: the HTTP path takes no codec argument, so
`&network_compression_method=LZ4` still yields `90` (measured), and no released driver decodes `0x90`
(v0.10.0 included), so a pin bump is a no-op. Against the broken binary the driver throws on the plain
URL and passes with `&compress=false`; on `de1002bf2625`, either way. The published `sqlancer-test`
image reproduces the CI row; fed this script's output it exits 0, oracles comparing. The workflow
is schedule-only (`13 6 */3 * *`, master), so the first CI confirmation is the next nightly.

Two disclosures. The plain `SQLancer` job shares the driver and breaks identically, but builds its
connection inside `ClickHouse/sqlancer` with no URL or env hook reachable from `ci/`. Every
`clickhouse-jdbc` / client-v2 user up to v0.10.0 fails against 26.9 the same way; that fix,
dispatching on the method byte, is in another repo.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118541&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118541](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118541+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.898` (included in `26.9` and later)
<!-- ch-version-info:end -->