### PR TITLE
Fix the Code Review job failing to post its verdict on pull requests with many comments

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -575,6 +575,30 @@ class GH:
         return ""
 
     @classmethod
+    def _json_loads_paginated(cls, output):
+        """Parse the output of a ``gh api --paginate`` call into a single list.
+
+        ``gh api --paginate`` prints one JSON document per page, so on a
+        resource with more than one page the output is a concatenation of
+        several documents and ``json.loads`` fails with ``Extra data``. Decode
+        the documents one after another and concatenate them, which also
+        handles the single-page case unchanged.
+        """
+        decoder = json.JSONDecoder()
+        result = []
+        position = 0
+        while position < len(output):
+            if output[position].isspace():
+                position += 1
+                continue
+            page, position = decoder.raw_decode(output, position)
+            if isinstance(page, list):
+                result.extend(page)
+            else:
+                result.append(page)
+        return result
+
+    @classmethod
     def _gh_graphql_json(cls, query, variables, verbose=False):
         """Run a GraphQL query via ``gh api graphql`` and return parsed JSON."""
         parts = [f"gh api graphql -f query={shlex.quote(query)}"]
@@ -934,7 +958,7 @@ class GH:
         output = cls.get_output_with_retries(cmd_list, verbose=verbose)
         if output:
             try:
-                for comment in json.loads(output):
+                for comment in cls._json_loads_paginated(output):
                     if TAG_START in comment["body"] and TAG_END in comment["body"]:
                         comment_id = comment["id"]
                         if verbose:
@@ -1005,7 +1029,7 @@ class GH:
             )
             return False
         try:
-            comments = json.loads(output)
+            comments = cls._json_loads_paginated(output)
         except json.JSONDecodeError as e:
             print(
                 f"WARNING: failed to parse gh api response as JSON ({e}); "
@@ -1326,7 +1350,7 @@ class GH:
             print("ERROR: Failed to fetch commit statuses")
             return None
         try:
-            statuses_list = json.loads(output)
+            statuses_list = cls._json_loads_paginated(output)
         except json.JSONDecodeError as ex:
             print(f"ERROR: Failed to parse commit statuses: {ex}")
             return None


### PR DESCRIPTION
`gh api --paginate` prints one JSON document per page, so parsing the whole output with a single `json.loads` fails with `Extra data` as soon as the resource has more than one page. On a pull request with more than one page of comments this makes `GH.post_updateable_comment` give up:

```
WARNING: failed to parse gh api response as JSON (Extra data: line 2 column 1 (char 152235)); output starts with: '[{"body":"Workflow [[PR](...
ERROR: Command '['/usr/bin/python3', '-m', 'ci.praktika.gh', 'post-or-update', '--tag', 'review', '--file', './ci/tmp/copilot_review.md']' returned non-zero exit status 1.
```

The `Code Review` job then fails *after* having produced its review, so the `AI Review` verdict is never posted and the job is red for a reason unrelated to the code under review. Any long-running pull request reaches this state and can no longer get a review verdict.

Reproduced against a real two-page comment list (https://github.com/ClickHouse/ClickHouse/pull/76867, 103 comments): `json.loads` fails with exactly the error above, while the new decoder returns all 103 comments and finds the tagged one to update.

This decodes the documents one after another and concatenates them - which leaves the single-page case unchanged - in the three reads that hand a paginated result to `json.loads`: the two comment lists and the commit statuses. Malformed output still raises `json.JSONDecodeError`, so the existing handlers keep reporting it.

Failing job log: https://s3.amazonaws.com/clickhouse-test-reports/PRs/76867/5305fc2bd4a17f1c8a382ddaa3743ebfb97fdaca/pr/code_review/job.log
Related: https://github.com/ClickHouse/ClickHouse/pull/76867

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118542&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118542](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118542+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.918` (included in `26.9` and later)
<!-- ch-version-info:end -->