### PR TITLE
Set the Keeper component in IMergeTreeDataPart::removeIfNeeded

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1093,6 +1093,8 @@ bool IMergeTreeDataPart::mayStoreDataInCaches() const
 
 void IMergeTreeDataPart::removeIfNeeded()
 {
+    auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::removeIfNeeded");
+
     if (is_removed)
         return;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113386
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #113386

`IMergeTreeDataPart::removeIfNeeded` probes the part directory with `getDataPartStorage().exists()` before deleting it, with no Keeper component set. On a disk whose metadata storage is backed by Keeper that probe is a Keeper request, and `pushRequest` throws `LOGICAL_ERROR: Current component is empty` when no component is set and `enforce_keeper_component_tracking` is on, aborting the server in debug and sanitizer builds. `Exception` calls `abortOnFailedAssertion` for `LOGICAL_ERROR` in its constructor, so neither the `try`/`catch (...)` around the probe nor the one in the part destructor can suppress it.

`remove()` already carries this guard, added in `1fdf222a6ba85`, but it is called two lines *below* the probe, so that guard is never reached in time.

I guarded the shared method rather than a call site. Two of its nine call sites are the part destructors, `~MergeTreeDataPartWide` and `~MergeTreeDataPartCompact`, which have no enclosing operation to carry a component, so no caller-side edit can reach them. The per-caller approach was already tried here: `MergePlainMergeTreeTask::cancel` and `MutatePlainMergeTreeTask::cancel` set a component immediately before calling `removeIfNeeded`, while `MergeFromLogEntryTask::cancel`, `MutateFromLogEntryTask::cancel`, `MergeTask::cancel` and `MutateTask::cancel` do not. One guard on the shared method covers all nine, and `ComponentGuard` is a thread-local save/restore, so a caller that already set a component keeps its own attribution once removal returns.

No test: `metadata_type=keeper` is registered only under `CLICKHOUSE_CLOUD`, which a community build sets to 0, and it is the only metadata storage that reaches Keeper from `existsDirectory`, so that disk cannot be configured here. Category is `CI Fix or Improvement` because the abort cannot happen in an official stable build.

<details>
<summary>Validation</summary>

The guard is unobservable on a plain disk, so I proved it live at the probe instead. With a temporary `LOG_ERROR` of `Coordination::getCurrentComponent()` immediately above the probe, a cancelled insert reaches it with `component=''` without the guard and `component='IMergeTreeDataPart::removeIfNeeded'` with it. Both triggers behave the same: an insert whose `throwIf` fires on a later block, and an insert violating a `CONSTRAINT`. A second temporary probe around the call in `~MergeTreeDataPartWide` shows an outer component restored after removal returns, so the guard nests rather than leaks. All instrumentation was reverted; the diff is the two lines shown.

`strings` on the two binaries is the same statement without instrumentation: the exact literal `IMergeTreeDataPart::removeIfNeeded` appears once with the change and zero times without it, while the `__PRETTY_FUNCTION__` spelling `void DB::IMergeTreeDataPart::removeIfNeeded()` is present in both, which is the control for that probe.

No-op on a plain disk: 42 stateless tests over `lightweight_update`, table constraints and part drop/detach/removal, 38 passing. The four failures are artifacts of a hand-started server rather than of the change: `05020` invokes the client binary with no `--port`, `04034` needs the `parallel_replicas` cluster, and two long `SYSTEM SYNC REPLICA` tests time out. Three of the four, including one of the two timeouts, were re-run on a binary built without the change and failed identically.

No randomized 50/50 run applies: no test file is added or changed.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118559&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118559](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118559+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.943` (included in `26.9` and later)
<!-- ch-version-info:end -->