### PR TITLE
Stabilize the newly-covered-lines coverage report with extra master baselines

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -672,15 +672,25 @@ if __name__ == "__main__":
 
             _sw = Utils.Stopwatch()
             try:
+                # Extra older master baselines downloaded by the diff script in
+                # this outcome; a transition must hold in all of them, filtering
+                # out lines that fire only occasionally on master.
+                _extra_baselines = tuple(
+                    sorted(
+                        str(p) for p in Path(TEMP_DIR).glob("base_llvm_coverage_*.info")
+                    )
+                )
                 _newly_covered_stats = generate_report(
                     current_info=str(_current_info_file),
                     baseline_info=str(_baseline_info_file),
                     output_path=_newly_covered_log,
+                    extra_baseline_infos=_extra_baselines,
                 )
                 _newly_info = (
                     f"{_newly_covered_stats['newly_covered']} newly covered lines in "
                     f"{_newly_covered_stats['newly_covered_files']} files, "
-                    f"{_newly_covered_stats['lost_coverage']} lines lost coverage"
+                    f"{_newly_covered_stats['lost_coverage']} lines lost coverage "
+                    f"(agreed by {_newly_covered_stats['baselines_used']} master baselines)"
                 )
                 print(f"Newly covered lines analysis: {_newly_info}")
                 newly_res = Result.create_from(

--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -114,6 +114,11 @@ if [ ${#patterns[@]} -eq 0 ]; then
   # agreement between several master runs, filtering out lines that fire only
   # occasionally on master (background/async code). Only this outcome consumes
   # them, so the downloads are gated here and C/C++ PRs pay nothing.
+  #
+  # The extras are best-effort: the analysis works with however many are
+  # present, so a flaked download must not fail the script (set -e) and turn an
+  # optional stabilization input into a CI-failure path. A failed download only
+  # removes its partial file - the slot is reused by the next candidate commit.
   EXTRA_BASELINES_MAX=3
   slot=2
   for (( j=FOUND_INDEX+1; j<${#COMMITS[@]}; j++ )); do
@@ -125,8 +130,12 @@ if [ ${#patterns[@]} -eq 0 ]; then
     echo "Checking extra baseline for commit ${TEST_COMMIT}..."
     if wget --spider "${COVERAGE_URL}" 2>&1 | grep -q '200 OK'; then
       echo "Found extra baseline #$((slot - 1)) at ${COVERAGE_URL}"
-      wget --quiet "${COVERAGE_URL}" -O "base_llvm_coverage_${slot}.info"
-      slot=$((slot + 1))
+      if wget --quiet "${COVERAGE_URL}" -O "base_llvm_coverage_${slot}.info"; then
+        slot=$((slot + 1))
+      else
+        rm -f "base_llvm_coverage_${slot}.info"
+        echo "WARNING: failed to download extra baseline from ${COVERAGE_URL}, continuing without it"
+      fi
     fi
   done
   echo "Downloaded $((slot - 2)) extra master baselines"

--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -34,6 +34,7 @@ if [ "${#COMMITS[@]}" -ne "${#COVERAGE_URLS[@]}" ]; then
 fi
 
 FOUND=0
+FOUND_INDEX=0
 FIRST_BASE_COMMIT=""
 for i in "${!COMMITS[@]}"; do
 TEST_COMMIT="${COMMITS[$i]}"
@@ -44,6 +45,7 @@ echo "Found coverage file at ${COVERAGE_URL}"
 wget --quiet "${COVERAGE_URL}" -O base_llvm_coverage.info
 FIRST_BASE_COMMIT="${TEST_COMMIT}"
 FOUND=1
+FOUND_INDEX=$i
 break
 fi
 done
@@ -52,10 +54,6 @@ if [ $FOUND -eq 0 ]; then
   echo "ERROR: Could not find baseline coverage file after checking ${#COMMITS[@]} commits"
   exit 1
 fi
-
-# Note: base_llvm_coverage_{2..6}.info (extra older master baselines) are not
-# downloaded anywhere. The slot loop below is a no-op unless something else
-# populates those files.
 
 export CURRENT_COMMIT
 export BASE_COMMIT
@@ -110,6 +108,28 @@ done < <(echo "$changed_files")
 
 if [ ${#patterns[@]} -eq 0 ]; then
   echo "No coverable C/C++ source files changed (contrib/ is excluded from coverage), skipping differential coverage report"
+  # In this outcome llvm_coverage_job.py runs the global newly-covered-lines
+  # analysis instead (see newly_covered_lines.py). Download up to
+  # EXTRA_BASELINES_MAX older master baselines so that analysis can require
+  # agreement between several master runs, filtering out lines that fire only
+  # occasionally on master (background/async code). Only this outcome consumes
+  # them, so the downloads are gated here and C/C++ PRs pay nothing.
+  EXTRA_BASELINES_MAX=3
+  slot=2
+  for (( j=FOUND_INDEX+1; j<${#COMMITS[@]}; j++ )); do
+    if [ $((slot - 2)) -ge "$EXTRA_BASELINES_MAX" ]; then
+      break
+    fi
+    TEST_COMMIT="${COMMITS[$j]}"
+    COVERAGE_URL="${COVERAGE_URLS[$j]}"
+    echo "Checking extra baseline for commit ${TEST_COMMIT}..."
+    if wget --spider "${COVERAGE_URL}" 2>&1 | grep -q '200 OK'; then
+      echo "Found extra baseline #$((slot - 1)) at ${COVERAGE_URL}"
+      wget --quiet "${COVERAGE_URL}" -O "base_llvm_coverage_${slot}.info"
+      slot=$((slot + 1))
+    fi
+  done
+  echo "Downloaded $((slot - 2)) extra master baselines"
   echo "no_cpp_changes" > "$OUTCOME_MARKER"
   exit 0
 fi
@@ -123,22 +143,6 @@ lcov --extract base_llvm_coverage.info "${patterns[@]}" \
   --ignore-errors inconsistent,corrupt,empty,unsupported,unused \
   --quiet \
   -o baseline.changed.info
-
-# If an extra older master baseline exists in slots 2-6, extract the same
-# changed-file slice from it too, for print_uncovered_code.py's LBC
-# cross-validation (intersecting them avoids false-positive LBC alerts from
-# lines that only occasionally fire in background/async code). Nothing
-# currently downloads these files, so this loop is presently a no-op.
-for slot in 2 3 4 5 6; do
-  src="base_llvm_coverage_${slot}.info"
-  if [ -f "$src" ] && [ -s "$src" ]; then
-    lcov --extract "$src" "${patterns[@]}" \
-      --ignore-errors inconsistent,corrupt,empty,unsupported,unused \
-      --quiet \
-      -o "baseline_${slot}.changed.info"
-    echo "Extracted changed-file slice from extra baseline #${slot}."
-  fi
-done
 
 current_sf_count=$(grep -c '^SF:' current.changed.info 2>/dev/null || true)
 baseline_sf_count=$(grep -c '^SF:' baseline.changed.info 2>/dev/null || true)

--- a/ci/jobs/scripts/newly_covered_lines.py
+++ b/ci/jobs/scripts/newly_covered_lines.py
@@ -8,10 +8,23 @@ input - but the global comparison is exactly what such a PR wants to see:
 which lines had zero hits on master and are executed now (what the new tests
 add), and which lines lost coverage (baseline noise or removed/disabled tests).
 
-Only `SF:`/`DA:` records are consulted. A line is compared only when both
-tracefiles instrument it; with an identical binary the instrumented line sets
-match, so lines present on one side only are reported as a diagnostic count
-rather than as coverage transitions.
+Only `SF:`/`DA:` records are consulted.
+
+Lines that fire only occasionally on master (background/async code) would show
+up as false transitions against a single baseline, so the analysis accepts
+extra older master baselines and requires every comparable baseline to agree:
+a line is newly covered only if it has 0 hits in all of them, and lost only if
+it has >0 hits in all of them.
+
+The extra baselines come from older master commits, whose source can differ
+from the PR's merge base, shifting line numbers. Instead of remapping, a
+baseline votes on a file only when its instrumented line set for that file is
+identical to the current run's: the DA line set comes from the static coverage
+mapping of the compiled code, not from execution, so equal sets mean the file
+did not change in between and the line numbers align; unequal sets mean the
+file changed and that baseline abstains for that file. Files on which no
+baseline can vote (including the primary one) are excluded and reported as a
+diagnostic count.
 """
 
 from pathlib import Path
@@ -86,55 +99,70 @@ def _render_transitions(title: str, per_file: dict[str, list[int]], out: list[st
     out.append("")
 
 
-def generate_report(current_info: str, baseline_info: str, output_path: str) -> dict:
+def generate_report(
+    current_info: str,
+    baseline_info: str,
+    output_path: str,
+    extra_baseline_infos: tuple[str, ...] = (),
+) -> dict:
     """Write the transitions report to output_path and return the totals.
 
     Returns {"newly_covered": N, "newly_covered_files": F,
              "lost_coverage": M, "lost_coverage_files": G,
-             "one_sided_lines": K}.
+             "baselines_used": B, "excluded_lines": K}.
     """
-    baseline = parse_tracefile(baseline_info)
+    baselines = [parse_tracefile(baseline_info)] + [
+        parse_tracefile(p) for p in extra_baseline_infos
+    ]
     current = parse_tracefile(current_info)
 
     newly_covered: dict[str, list[int]] = {}
     lost_coverage: dict[str, list[int]] = {}
-    one_sided_lines = 0
+    # Lines in files no baseline could vote on (changed between the baseline
+    # commits and the PR, or missing from every baseline).
+    excluded_lines = 0
 
     for source_file, current_lines in current.items():
-        baseline_lines = baseline.get(source_file)
-        if baseline_lines is None:
-            one_sided_lines += len(current_lines)
+        current_line_set = current_lines.keys()
+        voters = [
+            b[source_file]
+            for b in baselines
+            if source_file in b and b[source_file].keys() == current_line_set
+        ]
+        if not voters:
+            excluded_lines += len(current_lines)
             continue
         for lineno, count in current_lines.items():
-            base_count = baseline_lines.get(lineno)
-            if base_count is None:
-                one_sided_lines += 1
-            elif base_count == 0 and count > 0:
+            if count > 0 and all(v[lineno] == 0 for v in voters):
                 newly_covered.setdefault(source_file, []).append(lineno)
-            elif base_count > 0 and count == 0:
+            elif count == 0 and all(v[lineno] > 0 for v in voters):
                 lost_coverage.setdefault(source_file, []).append(lineno)
 
-    for source_file, baseline_lines in baseline.items():
-        current_lines = current.get(source_file)
-        if current_lines is None:
-            one_sided_lines += len(baseline_lines)
-        else:
-            one_sided_lines += len(baseline_lines.keys() - current_lines.keys())
-
     out: list[str] = [
-        "Line coverage transitions against the master baseline",
-        f"Baseline tracefile: {baseline_info}",
+        "Line coverage transitions against the master baselines",
         f"Current tracefile : {current_info}",
+        f"Baseline tracefiles ({len(baselines)}): "
+        + ", ".join([baseline_info, *extra_baseline_infos]),
+        "A transition is counted only when every baseline whose instrumented",
+        "line set matches the current run for that file agrees.",
         "",
     ]
-    _render_transitions("Newly covered (0 hits on master, >0 hits now)", newly_covered, out)
-    _render_transitions("Lost coverage (>0 hits on master, 0 hits now)", lost_coverage, out)
-    if one_sided_lines:
+    _render_transitions(
+        "Newly covered (0 hits in every master baseline, >0 hits now)",
+        newly_covered,
+        out,
+    )
+    _render_transitions(
+        "Lost coverage (>0 hits in every master baseline, 0 hits now)",
+        lost_coverage,
+        out,
+    )
+    if excluded_lines:
         out.append(
-            f"Diagnostic: {one_sided_lines} instrumented lines are present in only "
-            "one tracefile. With an identical binary this indicates path "
-            "normalization or instrumentation drift; these lines are not counted "
-            "as transitions."
+            f"Diagnostic: {excluded_lines} instrumented lines are in files no "
+            "baseline could vote on (instrumented line set differs from every "
+            "baseline, or the file is absent there); they are not counted as "
+            "transitions."
         )
     Path(output_path).write_text("\n".join(out) + "\n", encoding="utf-8")
 
@@ -143,5 +171,6 @@ def generate_report(current_info: str, baseline_info: str, output_path: str) -> 
         "newly_covered_files": len(newly_covered),
         "lost_coverage": sum(len(v) for v in lost_coverage.values()),
         "lost_coverage_files": len(lost_coverage),
-        "one_sided_lines": one_sided_lines,
+        "baselines_used": len(baselines),
+        "excluded_lines": excluded_lines,
     }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118051
Related: https://github.com/ClickHouse/ClickHouse/pull/117866
Related: https://github.com/ClickHouse/ClickHouse/pull/117922

The `Newly Covered Lines` report (added in https://github.com/ClickHouse/ClickHouse/pull/118051 for tests-only PRs forced with the `ci-coverage` label) compares against a single master baseline. Lines that fire only occasionally on master (background/async code) therefore show up as false transitions: on https://github.com/ClickHouse/ClickHouse/pull/117922 the report counted 955 "lost coverage" lines, all noise, and an inflated newly-covered count.

This PR stabilizes the report with extra master baselines:

- `generate_diff_coverage_report.sh` downloads up to 3 extra older master baselines, but only in the `no_cpp_changes` outcome (tests-only PRs forced with `ci-coverage`, or coverage-pipeline PRs). C++ PRs pay nothing, per the earlier decision that extra baselines do not help there: they stabilize only the master side of a comparison, and the "newly covered" claim is the one comparison where a single PR-side run is sufficient evidence.
- `newly_covered_lines.py` requires every comparable baseline to agree: a line is newly covered only if it has 0 hits in all of them, and lost only if it has more than 0 hits in all of them.
- Line shift between master commits is handled without git-diff remapping: a baseline votes on a file only when its instrumented `DA` line set for that file is identical to the current run's. The line set comes from the static coverage mapping, so equal sets mean the file did not change in between; unequal sets make that baseline abstain for that file.
- The dead slot-2..6 extraction loop is removed. It belonged to the LBC cross-validation deleted in `080b086f26b` and has had no consumer since.

Validation on the real tracefiles of the https://github.com/ClickHouse/ClickHouse/pull/117922 run, with 3 extra real master baselines (all four files 438 MB):

| Metric | 1 baseline | 4 baselines |
|---|---|---|
| Newly covered lines | 1303 in 252 files | 680 in 92 files |
| Lost coverage lines | 955 in 221 files | 156 in 46 files |

Every genuinely targeted file keeps its exact count (`SubstituteColumnOptimizer.cpp` 158, `AggregateFunctionDistinctDynamicTypes.cpp` 42, `OptimizeIfChains.cpp` 34, `MatcherNode.cpp` 31, ...), so the removed lines are confirmed master-side flakiness. The analysis takes 4.8 s and 460 MB RSS.

This PR touches the coverage pipeline scripts, so its own CI runs the coverage family and lands in `no_cpp_changes`, exercising the new path end to end.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118562&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118562](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118562+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.919` (included in `26.9` and later)
<!-- ch-version-info:end -->