### PR TITLE
Do not drop an alias-keyed additional_table_filters entry with parallel replicas

### DIFF
--- a/src/Analyzer/IQueryTreeNode.cpp
+++ b/src/Analyzer/IQueryTreeNode.cpp
@@ -282,7 +282,11 @@ QueryTreeNodePtr IQueryTreeNode::cloneAndReplace(const ReplacementMap & replacem
         old_pointer_to_new_pointer.emplace(node_to_clone, node_clone);
 
         node_clone->original_ast = node_to_clone->original_ast;
-        node_clone->setAlias(node_to_clone->alias);
+        /// Copy both alias fields verbatim. `setAlias` treats the node's current alias as the one
+        /// being renamed away, so on a fresh clone it would record the clone's empty alias as the
+        /// original and lose the alias the query was written with.
+        node_clone->alias = node_to_clone->alias;
+        node_clone->original_alias = node_to_clone->original_alias;
         node_clone->parenthesized = node_to_clone->parenthesized;
         node_clone->children = node_to_clone->children;
 

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -207,6 +207,61 @@ namespace ErrorCodes
 namespace
 {
 
+/// `__table<N>`, the alias analysis assigns to every table expression. The numbering is per query
+/// tree, and the rewrite that ships a query to replicas builds its own, so a name from this
+/// namespace does not denote the same relation on an initiator and on a follower.
+bool isGeneratedTableAlias(std::string_view name)
+{
+    static constexpr std::string_view prefix = "__table";
+    if (!name.starts_with(prefix) || name.size() == prefix.size())
+        return false;
+
+    return std::ranges::all_of(name.substr(prefix.size()), [](char c) { return c >= '0' && c <= '9'; });
+}
+
+/// True when some `additional_table_filters` key would select a different relation on a replica that
+/// replans the query: an alias, or a bare table name. A key equal to a storage's full name, or
+/// matching no table of the query, is stable; an identity without a database is not comparable.
+bool hasSessionRelativeAdditionalFilter(const TableExpressionNodePtr & join_tree, const Map & additional_table_filters)
+{
+    if (std::ranges::any_of(
+            additional_table_filters,
+            [](const Field & entry) { return isGeneratedTableAlias(entry.safeGet<Tuple>().at(0).safeGet<String>()); }))
+        return true;
+
+    for (const auto & table_expression : extractTableExpressions(join_tree, false, true))
+    {
+        const auto * table_node = table_expression->as<TableNode>();
+        const auto * table_function_node = table_expression->as<TableFunctionNode>();
+        if (!table_node && !table_function_node)
+            continue;
+
+        const auto & storage = table_node ? table_node->getStorage() : table_function_node->getStorage();
+        const bool matched = std::ranges::any_of(
+            additional_table_filters,
+            [&](const Field & entry)
+            {
+                const auto & key = entry.safeGet<Tuple>().at(0).safeGet<String>();
+                if (storage)
+                {
+                    const auto & storage_id = storage->getStorageID();
+                    if (!storage_id.hasDatabase())
+                        return true;
+                    if (key == storage_id.getFullNameNotQuoted())
+                        return false;
+                    if (key == storage_id.getTableName())
+                        return true;
+                }
+                return key == table_expression->getOriginalAlias();
+            });
+
+        if (matched)
+            return true;
+    }
+
+    return false;
+}
+
 /** Check that table and table function table expressions from planner context support transactions.
   *
   * There is precondition that table expression data for table expression nodes is collected in planner context.
@@ -2599,16 +2654,24 @@ void Planner::buildPlanForQueryNode()
     /// but on followers the rewritten `SELECT` uses fully qualified names and the follower's current
     /// database is the initiator's user-default DB, so the filter match is unreliable. Rather than
     /// patch the match (which differs case by case), disable the combination on the analyzer path.
-    /// With `serialize_query_plan` the initiator lowers `additional_table_filters` into an explicit
-    /// `FilterStep` and ships the serialized plan, so the follower never re-resolves the setting —
-    /// the combination works there and the check is skipped.
+    /// The check is skipped when the filter travels inside a shipped plan: with
+    /// `serialize_query_plan` and either the plan-based path or a local plan. Otherwise only the
+    /// entries a follower would match differently are refused, see `hasSessionRelativeAdditionalFilter`.
+    const auto & additional_table_filters = settings[Setting::additional_table_filters].value;
+
     if (query_context->canUseParallelReplicasOnInitiator()
-        && !settings[Setting::serialize_query_plan]
-        && !settings[Setting::additional_table_filters].value.empty())
+        && !additional_table_filters.empty()
+        && (!settings[Setting::serialize_query_plan]
+            || (!settings[Setting::parallel_replicas_plan_based]
+                && !ClusterProxy::canUseLocalPlanForParallelReplicas(query_context)
+                && hasSessionRelativeAdditionalFilter(query_node.getJoinTreeNodeTyped(), additional_table_filters))))
     {
         if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-                "additional_table_filters is not supported with parallel and without serialize_query_plan=1");
+                "additional_table_filters is not supported with parallel replicas unless the query plan "
+                "is shipped to the replicas, which requires serialize_query_plan=1 together with either "
+                "parallel_replicas_plan_based=1, or a local plan (parallel_replicas_local_plan=1 and "
+                "parallel_replicas_prefer_local_replica=1, and not inside a Distributed subquery)");
 
         auto & mutable_context = planner_context->getMutableQueryContext();
         mutable_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));

--- a/tests/queries/0_stateless/04207_pr_additional_filters.reference
+++ b/tests/queries/0_stateless/04207_pr_additional_filters.reference
@@ -52,3 +52,10 @@ Positions: 0
                        FUNCTION lessOrEquals(x : 0, 2_UInt8 :: 1) -> lessOrEquals(x, 2_UInt8) UInt8 : 2
               Positions: 2 0
                 ReadFromTable
+3
+3
+3
+3
+04207_atf_alias_local_plan	1
+04207_atf_alias_plan_based	1
+04207_atf_qualified_key	1

--- a/tests/queries/0_stateless/04207_pr_additional_filters.sql
+++ b/tests/queries/0_stateless/04207_pr_additional_filters.sql
@@ -75,5 +75,169 @@ SELECT count() FROM atf_p SETTINGS additional_table_filters = {'atf_p': 'x <= 2'
     distributed_aggregation_memory_efficient = 1, -- pin (randomized in CI): `MergingAggregated` prints its mode only when it is set
     parallel_replicas_plan_based = 0;
 
+-- An `additional_table_filters` key may also be the table's alias, which analysis renames while
+-- keeping the written form in `original_alias`; the planner must carry that across its query-tree
+-- clones, or the filter is dropped (issue #118513). Strict mode makes a lost exemption an error.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT count() FROM atf_p AS a SETTINGS additional_table_filters = {'a': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 1,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0,
+    parallel_replicas_prefer_local_replica = 1, -- pin: the local-plan exemption requires it
+    log_comment = '04207_atf_alias_local_plan';
+
+-- On the query-shipping path nothing is serialized: the followers get the rewritten `SELECT`, whose
+-- table alias is the generated one, so an alias key cannot be resolved there at all. Parallel
+-- replicas is disabled (best-effort) or rejected (strict) instead of dropping the filter.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT count() FROM atf_p AS a SETTINGS additional_table_filters = {'a': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 1,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0;
+
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT count() FROM atf_p AS a SETTINGS additional_table_filters = {'a': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0; -- { serverError SUPPORT_IS_DISABLED }
+
+-- `parallel_replicas_plan_based` distributes a plan fragment that carries the filter on both of its
+-- branches, so it keeps working without a local plan; strict mode turns a lost exemption into an
+-- error instead of a silent fall back to local execution.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT count() FROM atf_p AS a SETTINGS additional_table_filters = {'a': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 1,
+    log_comment = '04207_atf_alias_plan_based';
+
+-- A `database.table` key is matched by the storage's full name, which a follower replanning the
+-- rewritten `SELECT` resolves the same way, so the filter still reaches every replica. The alias is
+-- deliberately that same string: a full-name match settles the table whatever else the key names.
+-- The database is named because a settings value is a literal, while this test's own one is random,
+-- and the `system.one` entry matches no table of the query, so it must make no difference.
+DROP DATABASE IF EXISTS db_04207_atf;
+CREATE DATABASE db_04207_atf;
+CREATE TABLE db_04207_atf.atf_q (x UInt64) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO db_04207_atf.atf_q SELECT number FROM numbers(10);
+
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT sum(x) FROM db_04207_atf.atf_q AS `db_04207_atf.atf_q`
+SETTINGS additional_table_filters = {'system.one': 'dummy = 0', 'db_04207_atf.atf_q': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0,
+    log_comment = '04207_atf_qualified_key';
+
+-- A bare table name is matched against the current database, and a follower's is the user's default
+-- one, not the initiator's. It is refused whichever database is current here, because the two sides
+-- would otherwise disagree about whether the filter applies at all.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT sum(x) FROM db_04207_atf.atf_q AS a SETTINGS additional_table_filters = {'atf_q': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0; -- { serverError SUPPORT_IS_DISABLED }
+
+DROP DATABASE db_04207_atf;
+
+-- A quoted alias or table name may contain a dot itself, so the shape of the key decides nothing:
+-- `a.b` is an alias here, resolvable only on the initiator, and is refused like any other alias.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT count() FROM atf_p AS `a.b` SETTINGS additional_table_filters = {'a.b': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0; -- { serverError SUPPORT_IS_DISABLED }
+
+-- The generated aliases are not a stable namespace: the rewrite that ships a query builds its own
+-- numbering, and can add relations to it, so a key in that namespace can be applied on a follower
+-- and not here, adding a filter the same query never applies locally. Refused whether or not it
+-- names anything in this query.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT count() FROM atf_p AS a SETTINGS additional_table_filters = {'__table2': 'x <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0; -- { serverError SUPPORT_IS_DISABLED }
+
+-- Entries are matched against table functions as well, and their aliases are rewritten the same way,
+-- so a key naming one is refused exactly like a table's alias.
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+SELECT sum(a.x) FROM atf_p AS a JOIN numbers(10) AS n ON a.x = n.number
+SETTINGS additional_table_filters = {'n': 'number <= 2'},
+    enable_analyzer = 1,
+    enable_parallel_replicas = 2,
+    automatic_parallel_replicas_mode = 0,
+    max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_local_plan = 0,
+    serialize_query_plan = 1,
+    parallel_replicas_plan_based = 0; -- { serverError SUPPORT_IS_DISABLED }
+
 SYSTEM DISABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- The scenarios above must really have run with parallel replicas. Strict mode only proves the
+-- planner kept the exemption; execution can still decline it silently and apply the filter locally,
+-- which prints the same count. Read the newest row per `log_comment`, so that a run which stops
+-- engaging the replicas cannot be masked by an earlier one under a reused test database.
+SELECT log_comment, argMax(ProfileEvents['ParallelReplicasUsedCount'], event_time_microseconds) > 0 AS pr_used
+FROM system.query_log
+WHERE event_date >= yesterday()
+    AND type = 'QueryFinish'
+    AND is_initial_query = 1
+    AND current_database = currentDatabase()
+    AND log_comment IN ('04207_atf_alias_local_plan', '04207_atf_alias_plan_based', '04207_atf_qualified_key')
+GROUP BY log_comment
+ORDER BY log_comment
+SETTINGS enable_parallel_replicas = 0;
+
 DROP TABLE atf_p;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/118513
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results when an `additional_table_filters` entry is keyed by a table's alias and the query runs with parallel replicas. The filter was silently dropped, so the query returned unfiltered rows, and with `parallel_replicas_local_plan = 0` each row was additionally returned once per replica.


### Description

`SELECT count() FROM s AS a SETTINGS additional_table_filters = {'a': '...'}` silently returned the unfiltered count under parallel replicas with `serialize_query_plan = 1`, the profile of the `Stateless tests (distributed plan)` CI job.

Two defects, one invariant: the entry matches only where the written alias survives.

1. `IQueryTreeNode::cloneAndReplace` destroyed it. Analysis renames table aliases to `__tableN`, keeping the written one in `original_alias`, a field that exists only for this setting. The clone copied it with `setAlias`, which treats the current alias as the one renamed away, so a fresh clone recorded an empty original and `getOriginalAlias` returned `__table1`. The parallel-replicas planner clones the tree, so the key matched nothing and no `FilterStep` was built.

2. The `serialize_query_plan` exemption to the guard assumed a plan is always shipped. It is serialized on the local-plan branch and by `parallel_replicas_plan_based`, which distributes a fragment anyway; otherwise followers get the rewritten `SELECT` and resolve the setting themselves. There an entry survives only if both sides resolve it alike: a `database.table` key does, an alias or bare table name does not, since analysis renames the alias and a follower's current database is the user's default, not the initiator's. The latter are now refused, or run locally, which also removes the duplicated rows reported with `parallel_replicas_local_plan = 0`.

Two intended changes: an alias-keyed filter now applies where it was dropped, and a configuration whose entry the sides resolve differently loses parallelism; a `database.table` key keeps it. Not relaxed: `parallel_replicas_plan_based` without `serialize_query_plan` stays refused as on master, although that path does ship the filter.

Validation: `04207_pr_additional_filters` gains a scenario per arm, covering the key forms that must be refused and those that must not, the successful ones in strict mode so a lost exemption errors instead of silently falling back; it fails on master and passes here.
