### PR TITLE
Keep explicit settings when an HTTP request also selects a profile

### DIFF
--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -309,12 +309,14 @@ void SettingsConstraints::clamp(const Settings & current_settings, SettingsChang
 
 void SettingsConstraints::checkOrClamp(const Settings & current_settings, SettingsChanges & changes, ReactionOnViolation reaction, SettingSource source) const
 {
-    /// If we filter out settings that match the current default here, `compatibility` will silently override them.
-    /// So when `compatibility` is present, we keep unchanged settings so they are applied after `compatibility`.
-    bool has_compatibility_setting = changes.tryGet("compatibility") != nullptr;
+    /// Dropping a change that matches the current value is only sound if nothing applied later moves that
+    /// value. `compatibility` replays old defaults and `profile` applies a settings profile, so when either
+    /// is in the same change set, unchanged settings are kept and re-applied in their original position.
+    bool keep_unchanged_settings
+        = changes.tryGet("compatibility") != nullptr || changes.tryGet("profile") != nullptr;
     std::erase_if(changes, [&](SettingChange & change)
     {
-        return !checkImpl(current_settings, change, reaction, source, /*ignore_unchanged_settings=*/has_compatibility_setting);
+        return !checkImpl(current_settings, change, reaction, source, /*ignore_unchanged_settings=*/keep_unchanged_settings);
     });
 }
 
@@ -444,7 +446,12 @@ bool SettingsConstraints::checkImpl(const Settings & current_settings,
         Field current_value;
         if (getCurrentValueOfSetting(current_settings, change.name, current_value)
             && new_value == castValueOfSetting<Settings>(change.name, current_value))
-            return true;
+        {
+            /// A kept change becomes a real one once the mover shifts the value, so the restriction on
+            /// which sources may set the setting still holds. The value constraints in force here have
+            /// already admitted that value: it is the one the setting has.
+            return getSettingSourceRestrictions(setting_name).isSourceAllowed(source);
+        }
     }
 
     return getChecker(current_settings, setting_name).check(change, new_value, reaction, source);

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -162,8 +162,9 @@ private:
         }
     };
 
-    /// Common logic for `check(Settings, SettingsChanges&)` and `clamp`. Both filter out unchanged settings
-    /// (unless `compatibility` is present) and differ only in whether violations throw or get clamped to the nearest bound.
+    /// Common logic for `check(Settings, SettingsChanges&)` and `clamp`. Both filter out unchanged
+    /// settings (unless `compatibility` or `profile` is present) and differ only in whether violations
+    /// throw or get clamped to the nearest bound.
     void
     checkOrClamp(const Settings & current_settings, SettingsChanges & changes, ReactionOnViolation reaction, SettingSource source) const;
 

--- a/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.reference
+++ b/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.reference
@@ -18,6 +18,8 @@ true
 42
 -- SET in one statement is unaffected
 true	5
+-- a profile in a subquery's SETTINGS clause keeps the explicit values too
+true	5
 -- a setting a query may not set is not restored over the profile
 1
 -- and a genuine attempt to set it from a query is still rejected

--- a/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.reference
+++ b/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.reference
@@ -1,0 +1,24 @@
+-- no profile
+true	0
+-- the profile alone moves both settings
+false	5
+-- an explicit value equal to the pre-profile value survives
+true	5
+-- an explicit value different from the pre-profile value survives
+false	7
+-- both at once
+true	7
+-- a profile after the setting still wins
+false	5
+-- a profile carrying compatibility still reverts the setting on its own
+false
+-- but it does not revert a value the same request set explicitly
+true
+-- an explicit run_query_in_background=0 keeps the query in the foreground
+42
+-- SET in one statement is unaffected
+true	5
+-- a setting a query may not set is not restored over the profile
+1
+-- and a genuine attempt to set it from a query is still rejected
+READONLY

--- a/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.reference
+++ b/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.reference
@@ -1,5 +1,5 @@
 -- no profile
-true	0
+true	true
 -- the profile alone moves both settings
 false	5
 -- an explicit value equal to the pre-profile value survives

--- a/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.sh
+++ b/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.sh
@@ -21,7 +21,10 @@ ${CLICKHOUSE_CLIENT} -q "
 Q="SELECT getSetting('wait_for_async_insert'), getSetting('max_result_rows')"
 
 echo "-- no profile"
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "$Q"
+# max_result_rows is given a non-default value by the CI test configuration, so assert only what
+# the arms below need of the pre-profile value: it is neither the profile's 5 nor the explicit 7.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" \
+    -d "SELECT getSetting('wait_for_async_insert'), toBool(getSetting('max_result_rows') NOT IN (5, 7))"
 
 echo "-- the profile alone moves both settings"
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile}" -d "$Q"

--- a/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.sh
+++ b/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings
+# no-random-settings: the framework injects settings into CLICKHOUSE_URL, which would collide with the settings under test
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+profile="profile_${CLICKHOUSE_DATABASE}"
+profile_bg="profile_bg_${CLICKHOUSE_DATABASE}"
+profile_ms="profile_ms_${CLICKHOUSE_DATABASE}"
+profile_compat="profile_compat_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE SETTINGS PROFILE ${profile} SETTINGS wait_for_async_insert = 0, max_result_rows = 5;
+    CREATE SETTINGS PROFILE ${profile_bg} SETTINGS run_query_in_background = 1;
+    CREATE SETTINGS PROFILE ${profile_ms} SETTINGS max_sessions_for_user = 1;
+    CREATE SETTINGS PROFILE ${profile_compat} SETTINGS compatibility = '24.12';
+"
+
+Q="SELECT getSetting('wait_for_async_insert'), getSetting('max_result_rows')"
+
+echo "-- no profile"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "$Q"
+
+echo "-- the profile alone moves both settings"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile}" -d "$Q"
+
+echo "-- an explicit value equal to the pre-profile value survives"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile}&wait_for_async_insert=1" -d "$Q"
+
+echo "-- an explicit value different from the pre-profile value survives"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile}&max_result_rows=7" -d "$Q"
+
+echo "-- both at once"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile}&wait_for_async_insert=1&max_result_rows=7" -d "$Q"
+
+echo "-- a profile after the setting still wins"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&wait_for_async_insert=1&profile=${profile}" -d "$Q"
+
+echo "-- a profile carrying compatibility still reverts the setting on its own"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile_compat}" \
+    -d "SELECT getSetting('use_skip_indexes_if_final')"
+
+echo "-- but it does not revert a value the same request set explicitly"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&use_skip_indexes_if_final=1&profile=${profile_compat}" \
+    -d "SELECT getSetting('use_skip_indexes_if_final')"
+
+echo "-- an explicit run_query_in_background=0 keeps the query in the foreground"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile_bg}&run_query_in_background=0" -d "SELECT 42"
+
+echo "-- SET in one statement is unaffected"
+${CLICKHOUSE_CLIENT} -m -q "SET profile = '${profile}', wait_for_async_insert = 1; $Q"
+
+echo "-- a setting a query may not set is not restored over the profile"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile_ms}&max_sessions_for_user=0" \
+    -d "SELECT getSetting('max_sessions_for_user')"
+
+echo "-- and a genuine attempt to set it from a query is still rejected"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile_ms}&max_sessions_for_user=5" \
+    -d "SELECT 1" 2>&1 | grep -o -m1 "READONLY"
+
+${CLICKHOUSE_CLIENT} -q "DROP SETTINGS PROFILE ${profile}, ${profile_bg}, ${profile_ms}, ${profile_compat}"

--- a/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.sh
+++ b/tests/queries/0_stateless/05136_http_profile_keeps_explicit_settings.sh
@@ -55,6 +55,11 @@ ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile_bg}&run_query_in_bac
 echo "-- SET in one statement is unaffected"
 ${CLICKHOUSE_CLIENT} -m -q "SET profile = '${profile}', wait_for_async_insert = 1; $Q"
 
+echo "-- a profile in a subquery's SETTINGS clause keeps the explicit values too"
+# `max_result_rows` is left to the profile, so the row changes too if the clause is never applied.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" \
+    -d "SELECT * FROM ($Q SETTINGS profile = '${profile}', wait_for_async_insert = 1)"
+
 echo "-- a setting a query may not set is not restored over the profile"
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&profile=${profile_ms}&max_sessions_for_user=0" \
     -d "SELECT getSetting('max_sessions_for_user')"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118396
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a settings profile selected in an HTTP request (via `?profile=...` or the query's own `SETTINGS` clause) silently overriding a setting the same request set explicitly. Closes #118396.


### Description

Requested by @ PedroTadim in https://github.com/ClickHouse/ClickHouse/issues/118396#issuecomment-5568213637.

**What breaks.** With a profile `P` that sets `wait_for_async_insert = 0`, `curl '.../?profile=P&wait_for_async_insert=1' -d "SELECT getSetting('wait_for_async_insert')"` returns `false`. The explicit value is dropped, so a user asking for the safe value gets the unsafe one.

**Root cause.** `SettingsConstraints::checkOrClamp` drops every change whose value equals the current value, sound only if nothing later in the change set moves it. Exactly two do: `compatibility`, excluded by #99402, and `profile`, which was not. `wait_for_async_insert` defaults to `1`, so the explicit `1` is dropped as a no-op and `profile=P` then moves the value with nothing left to re-assert it.

**The change.** Two hunks in `src/Access/SettingsConstraints.cpp`. `checkOrClamp` now keeps unchanged settings when either mover is present. The unchanged-value shortcut in `checkImpl` returns the source verdict instead of `true`: a kept change becomes real once the mover shifts the value, so the source restriction must survive it, otherwise `?profile=P&max_sessions_for_user=0` would write a PROFILE-only setting from a query. Value constraints deliberately do not survive: a retained change re-asserts the value the setting already held, so a `CONST` pin stays re-assertable.

URL order still decides: `?setting=v&profile=P` still lets the profile win (`04666_run_query_in_background_http`). The same hunks cover a profile in the query's own `SETTINGS` clause, re-checked per query tree node: on master any explicit setting sharing that clause was dropped. Out of scope, identical on master: a standalone `SET profile = 'P', s = <current value>` still writes `s` (the const overload `InterpreterSetQuery` uses by design), and only the value already in effect can land.

**Validation.** New `05136_http_profile_keeps_explicit_settings` reddens on master on exactly the arms the bug reaches, passes with the fix, 50/50 randomized; reverting the second hunk alone reddens exactly the `max_sessions_for_user` arm; no other verdict change in `compatibility`, `01187`, `04666_*`, `02832`.

No `SettingsChangesHistory.cpp` entry: no new setting or default change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118581&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118581](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118581+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


