### PR TITLE
[Iceberg spec fix part 1]: Compute the Iceberg date partition transforms in UTC

### DIFF
--- a/src/Functions/icebergDateTransforms.cpp
+++ b/src/Functions/icebergDateTransforms.cpp
@@ -1,0 +1,242 @@
+#include <Columns/ColumnsDateTime.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/DecimalFunctions.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <Common/DateLUT.h>
+#include <Common/DateLUTImpl.h>
+#include <Common/assert_cast.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
+}
+
+namespace
+{
+
+enum class IcebergDateTransform : uint8_t
+{
+    Year,
+    Month,
+    Day,
+    Hour,
+};
+
+Int64 floorDivide(Int64 numerator, Int64 denominator)
+{
+    Int64 quotient = numerator / denominator;
+    if (numerator % denominator != 0 && (numerator < 0) != (denominator < 0))
+        --quotient;
+    return quotient;
+}
+
+Int32 narrowToInt32(Int64 value, const char * function_name)
+{
+    if (value < std::numeric_limits<Int32>::min() || value > std::numeric_limits<Int32>::max())
+        throw Exception(
+            ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE,
+            "Result {} of function {} does not fit into the Iceberg `int` partition value type",
+            value,
+            function_name);
+    return static_cast<Int32>(value);
+}
+
+template <IcebergDateTransform transform>
+class FunctionIcebergDateTransform final : public IFunction
+{
+public:
+    static constexpr const char * name = []
+    {
+        if constexpr (transform == IcebergDateTransform::Year)
+            return "icebergYear";
+        else if constexpr (transform == IcebergDateTransform::Month)
+            return "icebergMonth";
+        else if constexpr (transform == IcebergDateTransform::Day)
+            return "icebergDay";
+        else
+            return "icebergHour";
+    }();
+
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionIcebergDateTransform>(); }
+
+    String getName() const override { return name; }
+
+    size_t getNumberOfArguments() const override { return 1; }
+
+    bool useDefaultImplementationForConstants() const override { return true; }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+
+    bool hasInformationAboutMonotonicity() const override { return true; }
+    Monotonicity getMonotonicityForRange(const IDataType &, const Field &, const Field &) const override
+    {
+        return {.is_monotonic = true, .is_always_monotonic = true};
+    }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        if (arguments.size() != 1)
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Incorrect number of arguments of function {}: expected 1", name);
+
+        WhichDataType which(arguments[0]);
+        if constexpr (transform == IcebergDateTransform::Hour)
+        {
+            if (!which.isDateTime() && !which.isDateTime64())
+                throw Exception(
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                    "Argument of function {} must be DateTime or DateTime64, got {}",
+                    name,
+                    arguments[0]->getName());
+        }
+        else if (!which.isDateTime() && !which.isDateTime64() && !which.isDate() && !which.isDate32())
+        {
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Argument of function {} must be Date, Date32, DateTime or DateTime64, got {}",
+                name,
+                arguments[0]->getName());
+        }
+
+        return std::make_shared<DataTypeInt32>();
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    {
+        auto result_column = ColumnInt32::create(input_rows_count);
+        auto & result_data = result_column->getData();
+
+        const auto & argument = arguments[0];
+        WhichDataType which(argument.type);
+
+        if (which.isDateTime())
+        {
+            const auto & data = assert_cast<const ColumnDateTime &>(*argument.column).getData();
+            fillFromTicks(result_data, input_rows_count, [&](size_t i) { return static_cast<Int64>(data[i]); }, 1);
+        }
+        else if (which.isDateTime64())
+        {
+            const auto & column = assert_cast<const ColumnDateTime64 &>(*argument.column);
+            const Int64 ticks_per_second = DecimalUtils::scaleMultiplier<Int64>(column.getScale());
+            const auto & data = column.getData();
+            fillFromTicks(
+                result_data, input_rows_count, [&](size_t i) { return static_cast<Int64>(data[i].value); }, ticks_per_second);
+        }
+        else if constexpr (transform != IcebergDateTransform::Hour)
+        {
+            if (which.isDate())
+            {
+                const auto & data = assert_cast<const ColumnDate &>(*argument.column).getData();
+                for (size_t i = 0; i < input_rows_count; ++i)
+                    result_data[i] = fromDayNum(static_cast<Int64>(data[i]));
+            }
+            else if (which.isDate32())
+            {
+                const auto & data = assert_cast<const ColumnDate32 &>(*argument.column).getData();
+                for (size_t i = 0; i < input_rows_count; ++i)
+                    result_data[i] = fromDayNum(static_cast<Int64>(data[i]));
+            }
+            else
+                throw Exception(
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {}", argument.type->getName(), name);
+        }
+        else
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {}", argument.type->getName(), name);
+
+        return result_column;
+    }
+
+private:
+    template <typename GetTicks>
+    static void fillFromTicks(
+        ColumnInt32::Container & result_data, size_t input_rows_count, GetTicks && get_ticks, Int64 ticks_per_second)
+    {
+        if constexpr (transform == IcebergDateTransform::Hour)
+        {
+            for (size_t i = 0; i < input_rows_count; ++i)
+                result_data[i] = narrowToInt32(floorDivide(get_ticks(i), ticks_per_second * 3600), name);
+        }
+        else
+        {
+            for (size_t i = 0; i < input_rows_count; ++i)
+                result_data[i] = fromDayNum(floorDivide(get_ticks(i), ticks_per_second * 86400));
+        }
+    }
+
+    static Int32 fromDayNum(Int64 day)
+    {
+        if constexpr (transform == IcebergDateTransform::Day)
+            return narrowToInt32(day, name);
+        else
+        {
+            const auto & utc = DateLUT::instance("UTC");
+            const auto day_num = ExtendedDayNum(narrowToInt32(day, name));
+            if constexpr (transform == IcebergDateTransform::Year)
+                return utc.toYearSinceEpoch(day_num);
+            else
+                return utc.toMonthNumSinceEpoch(day_num);
+        }
+    }
+};
+
+}
+
+REGISTER_FUNCTION(IcebergDateTransforms)
+{
+    const FunctionDocumentation::IntroducedIn introduced_in = {26, 9};
+    const auto category = FunctionDocumentation::Category::Other;
+    const FunctionDocumentation::Arguments date_or_timestamp
+        = {{"value", "The value to transform.", {"Date", "Date32", "DateTime", "DateTime64"}}};
+    const FunctionDocumentation::Arguments timestamp = {{"value", "The value to transform.", {"DateTime", "DateTime64"}}};
+
+    factory.registerFunction<FunctionIcebergDateTransform<IcebergDateTransform::Year>>(FunctionDocumentation{
+        .description = R"(Implements the Iceberg `year` partition transform: the number of years from 1970, computed in UTC.
+See https://iceberg.apache.org/spec/#partition-transforms.)",
+        .syntax = "icebergYear(value)",
+        .arguments = date_or_timestamp,
+        .returned_value = {"Years from 1970, negative for values before 1970", {"Int32"}},
+        .examples = {{"Example", "SELECT icebergYear(toDate32('1969-05-05'))", "-1"}},
+        .introduced_in = introduced_in,
+        .category = category});
+
+    factory.registerFunction<FunctionIcebergDateTransform<IcebergDateTransform::Month>>(FunctionDocumentation{
+        .description = R"(Implements the Iceberg `month` partition transform: the number of months from 1970-01-01, computed in UTC.
+See https://iceberg.apache.org/spec/#partition-transforms.)",
+        .syntax = "icebergMonth(value)",
+        .arguments = date_or_timestamp,
+        .returned_value = {"Months from 1970-01-01, negative for values before 1970", {"Int32"}},
+        .examples = {{"Example", "SELECT icebergMonth(toDate32('1969-01-01'))", "-12"}},
+        .introduced_in = introduced_in,
+        .category = category});
+
+    factory.registerFunction<FunctionIcebergDateTransform<IcebergDateTransform::Day>>(FunctionDocumentation{
+        .description = R"(Implements the Iceberg `day` partition transform: the number of days from 1970-01-01, computed in UTC.
+See https://iceberg.apache.org/spec/#partition-transforms.)",
+        .syntax = "icebergDay(value)",
+        .arguments = date_or_timestamp,
+        .returned_value = {"Days from 1970-01-01, negative for values before 1970", {"Int32"}},
+        .examples = {{"Example", "SELECT icebergDay(toDate32('1969-12-31'))", "-1"}},
+        .introduced_in = introduced_in,
+        .category = category});
+
+    factory.registerFunction<FunctionIcebergDateTransform<IcebergDateTransform::Hour>>(FunctionDocumentation{
+        .description
+        = R"(Implements the Iceberg `hour` partition transform: the number of hours from 1970-01-01 00:00:00, computed in UTC.
+See https://iceberg.apache.org/spec/#partition-transforms.)",
+        .syntax = "icebergHour(value)",
+        .arguments = timestamp,
+        .returned_value = {"Hours from 1970-01-01 00:00:00, negative for values before 1970", {"Int32"}},
+        .examples = {{"Example", "SELECT icebergHour(toDateTime64('1970-01-01 01:30:00', 6, 'UTC'))", "1"}},
+        .introduced_in = introduced_in,
+        .category = category});
+}
+
+}

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -437,16 +437,16 @@ std::optional<TransformAndArgument> parseTransformAndArgument(const String & tra
     std::string transform_name = Poco::toLower(transform_name_src);
 
     if (transform_name == "year" || transform_name == "years")
-        return TransformAndArgument{"toYearNumSinceEpoch", std::nullopt};
+        return TransformAndArgument{"icebergYear", std::nullopt};
 
     if (transform_name == "month" || transform_name == "months")
-        return TransformAndArgument{"toMonthNumSinceEpoch", std::nullopt};
+        return TransformAndArgument{"icebergMonth", std::nullopt};
 
     if (transform_name == "day" || transform_name == "date" || transform_name == "days" || transform_name == "dates")
-        return TransformAndArgument{"toRelativeDayNum", std::nullopt};
+        return TransformAndArgument{"icebergDay", std::nullopt};
 
     if (transform_name == "hour" || transform_name == "hours")
-        return TransformAndArgument{"toRelativeHourNum", std::nullopt};
+        return TransformAndArgument{"icebergHour", std::nullopt};
 
     if (transform_name == "identity")
         return TransformAndArgument{"identity", std::nullopt};
@@ -811,22 +811,22 @@ static Poco::JSON::Object::Ptr getPartitionField(
         result->set(Iceberg::f_transform, "identity");
         return result;
     }
-    else if (partition_function->name == "toYearNumSinceEpoch")
+    else if (partition_function->name == "icebergYear" || partition_function->name == "toYearNumSinceEpoch")
     {
         result->set(Iceberg::f_transform, "year");
         return result;
     }
-    else if (partition_function->name == "toMonthNumSinceEpoch")
+    else if (partition_function->name == "icebergMonth" || partition_function->name == "toMonthNumSinceEpoch")
     {
         result->set(Iceberg::f_transform, "month");
         return result;
     }
-    else if (partition_function->name == "toRelativeDayNum")
+    else if (partition_function->name == "icebergDay" || partition_function->name == "toRelativeDayNum")
     {
         result->set(Iceberg::f_transform, "day");
         return result;
     }
-    else if (partition_function->name == "toRelativeHourNum")
+    else if (partition_function->name == "icebergHour" || partition_function->name == "toRelativeHourNum")
     {
         result->set(Iceberg::f_transform, "hour");
         return result;
@@ -902,6 +902,10 @@ static std::pair<String, String> parseFunction(const ASTPtr & func_object)
             {"identity", "identity"},
             {"icebergBucket", "bucket"},
             {"icebergTruncate", "truncate"},
+            {"icebergYear", "year"},
+            {"icebergMonth", "month"},
+            {"icebergDay", "day"},
+            {"icebergHour", "hour"},
             {"toYearNumSinceEpoch", "year"},
             {"toMonthNumSinceEpoch", "month"},
             {"toRelativeDayNum", "day"},
@@ -1555,10 +1559,6 @@ DataTypePtr getFunctionResultType(const String & iceberg_transform_name, DataTyp
 {
     if (iceberg_transform_name.starts_with("identity") || iceberg_transform_name.starts_with("truncate"))
         return source_type;
-    if (iceberg_transform_name.starts_with("year"))
-        return std::make_shared<DataTypeUInt16>();
-    if (iceberg_transform_name.starts_with("month") || iceberg_transform_name.starts_with("day") || iceberg_transform_name.starts_with("hour"))
-        return std::make_shared<DataTypeUInt32>();
     return std::make_shared<DataTypeInt32>();
 }
 

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_partition_transforms_utc.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_partition_transforms_utc.py
@@ -1,0 +1,95 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    create_iceberg_table,
+    default_download_directory,
+    get_uuid_str,
+)
+
+# 2023-12-31 22:00:00.000001 UTC, which is already 2024-01-01 in Asia/Kolkata.
+MODERN_MICROS = 1704060000000001
+MODERN_LOCAL = "2023-12-31 22:00:00.000001"
+# 1969-12-31 00:00:00.000001 UTC, before the epoch every date transform counts from.
+PRE_EPOCH_MICROS = -86399999999
+PRE_EPOCH_LOCAL = "1969-12-31 00:00:00.000001"
+
+EXPECTED_PARTITION_VALUES = {
+    "icebergYear": ["53", "-1"],
+    "icebergMonth": ["647", "-1"],
+    "icebergDay": ["2023-12-31", "1969-12-31"],
+    "icebergHour": ["473350", "-24"],
+}
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+@pytest.mark.parametrize("transform", ["icebergYear", "icebergMonth", "icebergDay", "icebergHour"])
+def test_writes_date_transform_partition_values_are_utc(
+    started_cluster_iceberg_with_spark, storage_type, transform
+):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    table_name = (
+        "test_writes_date_transform_" + transform.lower() + "_" + storage_type + "_" + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_with_spark,
+        "(ts DateTime64(6), i Int64)",
+        2,
+        f"({transform}(ts))",
+    )
+
+    instance.query(
+        f"""
+        INSERT INTO {table_name} VALUES
+            (fromUnixTimestamp64Micro({MODERN_MICROS}), 1), (fromUnixTimestamp64Micro({PRE_EPOCH_MICROS}), 2)
+        """,
+        settings={"allow_insert_into_iceberg": 1, "session_timezone": "Asia/Kolkata"},
+    )
+
+    path = f"/var/lib/clickhouse/user_files/iceberg_data/default/{table_name}"
+    default_download_directory(started_cluster_iceberg_with_spark, storage_type, f"{path}/", f"{path}/")
+
+    table = spark.read.format("iceberg").load(path)
+    assert table.count() == 2
+
+    for expected_i, local in ((1, MODERN_LOCAL), (2, PRE_EPOCH_LOCAL)):
+        rows = table.filter(f"ts = to_timestamp_ntz('{local}')").collect()
+        assert [row["i"] for row in rows] == [expected_i], f"Spark cannot find the row for {local}"
+
+    partitions = spark.read.format("iceberg").load(f"{path}#partitions")
+    written = sorted(str(row["partition"]["ts"]) for row in partitions.collect())
+    assert written == sorted(EXPECTED_PARTITION_VALUES[transform])
+
+
+def test_iceberg_date_transform_functions(started_cluster_iceberg_with_spark):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+
+    assert instance.query(
+        """
+        SELECT
+            icebergYear(toDate32('1969-05-05')), icebergMonth(toDate32('1969-01-01')),
+            icebergDay(toDate32('1969-12-31')), icebergHour(toDateTime64('1969-12-31 23:00:00', 6, 'UTC'))
+        """
+    ) == "-1\t-12\t-1\t-1\n"
+
+    assert instance.query(
+        f"""
+        SELECT icebergYear(ts), icebergMonth(ts), icebergDay(ts), icebergHour(ts)
+        FROM (SELECT CAST(fromUnixTimestamp64Micro({MODERN_MICROS}) AS DateTime64(6)) AS ts)
+        """,
+        settings={"session_timezone": "Asia/Kolkata"},
+    ) == "53\t647\t19722\t473350\n"
+
+    assert instance.query(
+        """
+        SELECT toTypeName(icebergDay(toDate('2024-01-01'))), icebergYear(CAST(NULL AS Nullable(Date32)))
+        """
+    ) == "Int32\t\\N\n"
+
+    assert "ILLEGAL_TYPE_OF_ARGUMENT" in instance.query_and_get_error(
+        "SELECT icebergHour(toDate('2024-01-01'))"
+    )


### PR DESCRIPTION
The `year`, `month`, `day` and `hour` partition transforms were computed with `toYearNumSinceEpoch`, `toMonthNumSinceEpoch`, `toRelativeDayNum` and `toRelativeHourNum`. Those interpret the value in the column's timezone, or in the server's when the column has none, and return an unsigned type.

The specification counts the units from 1970 on the stored value itself: a `timestamp` is a date and time of day whose value is independent of zone adjustments, and a `timestamptz` is already stored in UTC, so no zone may enter the transform. The result type is a signed `int`, which is negative for a value before 1970. ClickHouse instead put the same stored value in partition `19722` under `UTC` and `19723` under `Asia/Kolkata`, and clamped a value from 1969 to `0`, both when writing the partition value and when pruning by it.

New functions `icebergYear`, `icebergMonth`, `icebergDay` and `icebergHour` compute the units from the stored value in UTC and return `Int32`. `PARTITION BY` keeps accepting the old spellings so existing DDL still works, and maps them to the same Iceberg transform.

Note that a table written before this change by a server in a non-UTC timezone holds shifted partition values, and pruning now derives the correct ones, so such files can be pruned away.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Compute the Iceberg date partition transforms in UTC

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118583&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118583](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118583+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.290` (included in `26.10` and later)
<!-- ch-version-info:end -->