### PR TITLE
Do not convert a column a pending mutation drops

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -502,6 +502,23 @@ void IMergeTreeReader::performRequiredConversions(Columns & res_columns) const
         {
             if (res_columns[pos] == nullptr)
                 continue;
+
+            /** A column a pending mutation drops is not read from the part: the readers skip it and the
+              * value comes from the current metadata - the column's default, in the requested type - so
+              * the type the part carries says nothing about what is in `res_columns`. Converting from
+              * that type builds the conversion for the part's type and hands it a column of another
+              * one, which raises `Illegal column ... of first argument of function ...`.
+              *
+              * That is reachable whenever the dropped name is taken by a new column of a different type
+              * before the drop's mutation has rewritten the part:
+              *
+              *     ALTER TABLE t DROP COLUMN c;               -- c UInt64 still in the part
+              *     ALTER TABLE t ADD COLUMN c UInt32;         -- new column, absent from the part
+              *     SELECT c FROM t;                           -- read as UInt32, not converted from UInt64
+              */
+            if (isColumnDroppedByPendingMutation(pos))
+                continue;
+
             const auto & column_in_part = columns_to_read[pos];
             if (column_in_part.type->equals(*name_and_type->type))
                 continue;

--- a/tests/queries/0_stateless/05117_readd_column_after_drop_conversion.reference
+++ b/tests/queries/0_stateless/05117_readd_column_after_drop_conversion.reference
@@ -1,0 +1,13 @@
+the re-added column of another type, while the part still has the old one
+5	0
+0	0	0
+the other columns of the same part
+5	10	10
+the same answer once the mutation has rewritten the part
+5	0
+re-added with the same type, with a DEFAULT expression, and as another kind of type
+[0,0,0,0,0]
+[1,2,3,4,5]
+['','','','','']
+and in a compact part
+[0,0,0,0,0]

--- a/tests/queries/0_stateless/05117_readd_column_after_drop_conversion.sql
+++ b/tests/queries/0_stateless/05117_readd_column_after_drop_conversion.sql
@@ -1,0 +1,75 @@
+-- Dropping a column and re-adding one of the same name but another type made every query touching that
+-- column fail with 44 `ILLEGAL_COLUMN` while a part still physically carried the old column, that is until
+-- the drop's mutation rewrote it. Both `ALTER` statements are metadata-only, so the part keeps the old
+-- column file while the metadata already reports the new one: the read then converted the value from the
+-- part's type, building `toUInt32` for a `UInt64` input and handing it the `UInt32` default of the new
+-- column ("Illegal column UInt32 of first argument of function toUInt32"). A column the pending mutation
+-- drops is not read from the part at all, so there is nothing to convert.
+
+DROP TABLE IF EXISTS t_readd_wide;
+CREATE TABLE t_readd_wide (id UInt64, val UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_readd_wide SELECT number, number, number + 100 FROM numbers(5);
+
+-- Keep the drop's column-removal mutation from rewriting the part; the same window exists on its own
+-- between the DDL and the background mutation.
+SYSTEM STOP MERGES t_readd_wide;
+ALTER TABLE t_readd_wide DROP COLUMN c SETTINGS alter_sync = 0;
+ALTER TABLE t_readd_wide ADD COLUMN c UInt32 SETTINGS alter_sync = 0;
+
+SELECT 'the re-added column of another type, while the part still has the old one';
+SELECT count(), sum(c) FROM t_readd_wide;
+SELECT * FROM t_readd_wide ORDER BY id LIMIT 1;
+SELECT 'the other columns of the same part';
+SELECT count(), sum(id), sum(val) FROM t_readd_wide;
+
+SELECT 'the same answer once the mutation has rewritten the part';
+SYSTEM START MERGES t_readd_wide;
+ALTER TABLE t_readd_wide DELETE WHERE 0 SETTINGS mutations_sync = 2;
+SELECT count(), sum(c) FROM t_readd_wide;
+
+SELECT 're-added with the same type, with a DEFAULT expression, and as another kind of type';
+-- One table per variant: a second `DROP COLUMN` of the same name is refused while the first one's
+-- mutation is still pending.
+DROP TABLE IF EXISTS t_readd_same_type;
+CREATE TABLE t_readd_same_type (id UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_readd_same_type SELECT number, number + 100 FROM numbers(5);
+SYSTEM STOP MERGES t_readd_same_type;
+ALTER TABLE t_readd_same_type DROP COLUMN c SETTINGS alter_sync = 0;
+ALTER TABLE t_readd_same_type ADD COLUMN c UInt64 SETTINGS alter_sync = 0;
+SELECT groupArray(c) FROM (SELECT c FROM t_readd_same_type ORDER BY id);
+
+DROP TABLE IF EXISTS t_readd_default;
+CREATE TABLE t_readd_default (id UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_readd_default SELECT number, number + 100 FROM numbers(5);
+SYSTEM STOP MERGES t_readd_default;
+ALTER TABLE t_readd_default DROP COLUMN c SETTINGS alter_sync = 0;
+ALTER TABLE t_readd_default ADD COLUMN c UInt32 DEFAULT id + 1 SETTINGS alter_sync = 0;
+SELECT groupArray(c) FROM (SELECT c FROM t_readd_default ORDER BY id);
+
+DROP TABLE IF EXISTS t_readd_string;
+CREATE TABLE t_readd_string (id UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_readd_string SELECT number, number + 100 FROM numbers(5);
+SYSTEM STOP MERGES t_readd_string;
+ALTER TABLE t_readd_string DROP COLUMN c SETTINGS alter_sync = 0;
+ALTER TABLE t_readd_string ADD COLUMN c String SETTINGS alter_sync = 0;
+SELECT groupArray(c) FROM (SELECT c FROM t_readd_string ORDER BY id);
+
+SELECT 'and in a compact part';
+DROP TABLE IF EXISTS t_readd_compact;
+CREATE TABLE t_readd_compact (id UInt64, c UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_readd_compact SELECT number, number + 100 FROM numbers(5);
+SYSTEM STOP MERGES t_readd_compact;
+ALTER TABLE t_readd_compact DROP COLUMN c SETTINGS alter_sync = 0;
+ALTER TABLE t_readd_compact ADD COLUMN c UInt32 SETTINGS alter_sync = 0;
+SELECT groupArray(c) FROM (SELECT c FROM t_readd_compact ORDER BY id);
+SYSTEM START MERGES t_readd_compact;
+
+DROP TABLE t_readd_compact;
+DROP TABLE t_readd_string;
+DROP TABLE t_readd_default;
+DROP TABLE t_readd_same_type;
+DROP TABLE t_readd_wide;


### PR DESCRIPTION
Dropping a column and re-adding one of the same name but another type made every query touching that column
fail with 44 `ILLEGAL_COLUMN` as long as a part still physically carried the old column, that is until the
drop's column-removal mutation had rewritten it:

```sql
CREATE TABLE demo (id UInt64, val UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
SETTINGS min_bytes_for_wide_part = 0;
INSERT INTO demo SELECT number, number, number FROM numbers(1000);

SYSTEM STOP MERGES demo;   -- only widens the window; it exists on its own between the DDL and the mutation
ALTER TABLE demo DROP COLUMN c SETTINGS alter_sync = 0;
ALTER TABLE demo ADD  COLUMN c UInt32 SETTINGS alter_sync = 0;

SELECT count(), sum(c) FROM demo;
-- Code: 44. DB::Exception: Illegal column UInt32 of first argument of function toUInt32:
--   while executing 'FUNCTION _CAST(c, 'UInt32')'
SELECT * FROM demo ORDER BY id LIMIT 1;         -- also raises
SELECT count(), sum(id), sum(val) FROM demo;    -- 1000, 499500, 499500: the rest of the part is readable
```

Both statements are metadata-only, so the part keeps the old column file while the metadata already reports
the new column. `IMergeTreeReader::performRequiredConversions` then saw a column whose type in the part
differs from the requested one and converted it - building the conversion for `UInt64` and handing it the
`UInt32` default of the new column.

A column that a pending mutation drops is not read from the part at all: the readers skip it and the value
comes from the current metadata, in the requested type, so there is nothing to convert. The conversion is now
skipped for such a column, which is what a read of the rewritten part already does, so the answer no longer
changes when the mutation materializes.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116416

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `ILLEGAL_COLUMN` ("Illegal column ... of first argument of function to...") raised by every query
touching a column that was dropped and re-added with a different type, for as long as a part still carried
the old column. The re-added column now reads as its default, as it does once the drop's mutation rewrites
the part.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118585&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118585](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118585+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
