### PR TITLE
Add missing links to chdb docs, format warning

### DIFF
--- a/docs/products/managed-postgres/extensions/chdb/chdb_hook.mdx
+++ b/docs/products/managed-postgres/extensions/chdb/chdb_hook.mdx
@@ -342,11 +342,12 @@ higher to have chdb_hook send the query and parameters to the Postgres log
 2026-08-08 09:41:06.842 EDT [59940] STATEMENT:  COPY "users" FROM 'file:///tmp/users.data' (format 'Parquet');
 ```
 
-> [!WARNING]
-> Do not leave [log_min_messages] set to a debugging level beyond a single
-> debugging session so as to avoid logging sensitive information such as
-> credentials, and because PostgreSQL itself also logs debugging information
-> and can quickly fill the log.
+<Warning>
+Do not leave [log_min_messages] set to a debugging level beyond a single
+debugging session so as to avoid logging sensitive information such as
+credentials, and because PostgreSQL itself also logs debugging information and
+can quickly fill the log.
+</Warning>
 
 ## CREATE TABLE Overloading {#create-table-overloading}
 
@@ -734,6 +735,7 @@ Copyright (c) 2026, ClickHouse
     "Azure: Manage storage account access keys"
   [row-level security]: https://www.postgresql.org/docs/current/ddl-rowsecurity.html
     "Postgres Docs: Row Security Policies"
+  [JSON type]: /reference/data-types/newjson "ClickHouse Docs: JSON Data Type"
   [LOAD]: https://www.postgresql.org/docs/current/sql-load.html "Postgres Docs: LOAD"
   [session_preload_libraries]:https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-SESSION-PRELOAD-LIBRARIES
     "Postgres Docs: `session_preload_libraries`"

--- a/docs/products/managed-postgres/extensions/chdb/introduction.mdx
+++ b/docs/products/managed-postgres/extensions/chdb/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-sidebarTitle: 'chdb Extensions'
+sidebarTitle: 'Introduction'
 description: 'Import and export data from Postgres to a wide variety of data formats and object stores.'
 slug: '/cloud/managed-postgres/extensions/chdb'
 title: 'chdb Extension reference documentation'
@@ -288,3 +288,6 @@ Copyright (c) 2026, ClickHouse
     "ClickHouse Docs: Advanced tutorial"
   [benchmark]: https://github.com/ClickHouse/pg_chdb/tree/main/dev/benchmark
     "Postgres Lake Copy Benchmark"
+  [JSONCompact]: /reference/formats/JSON/JSONCompact "ClickHouse Docs: JSONCompact"
+  [JSONCompactEachRow]: /reference/formats/JSON/JSONCompactEachRow "ClickHouse Docs: JSONCompactEachRow"
+  [DuckDB]: https://duckdb.org "DuckDB: Your universal data wrangling tool"


### PR DESCRIPTION
And also change the default page name in the sidebar to "Introduction".

### Changelog category (leave one):

- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118587&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118587](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118587+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118587&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118587](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118587+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.964` (included in `26.9` and later)
<!-- ch-version-info:end -->