### PR TITLE
Add Beekeeper Studio to GUI tools

### DIFF
--- a/docs/integrations/connectors/tools/gui.mdx
+++ b/docs/integrations/connectors/tools/gui.mdx
@@ -496,6 +496,21 @@ Features:
 
 </Accordion>
 
+<Accordion title="Beekeeper Studio">
+
+[Beekeeper Studio](https://www.beekeeperstudio.io/) is a free, open-source SQL editor and database manager with support for ClickHouse.
+
+Features:
+
+- Modern SQL editor with autocomplete and multi-tab query execution.
+- Schema browser for tables, views, and columns.
+- Save and organize favorite queries.
+- Cross-platform desktop app (Windows, macOS, Linux), plus a self-hosted/web edition.
+
+[Beekeeper Studio and ClickHouse guide](https://docs.beekeeperstudio.io/user_guide/connecting/clickhouse/) · [GitHub](https://github.com/beekeeper-studio/beekeeper-studio)
+
+</Accordion>
+
 ## Commercial {#commercial}
 
 <Accordion title="ProbeDeck">


### PR DESCRIPTION
Adds Beekeeper Studio, a free and open-source SQL editor and database manager, to the Open-source section of the Visual Interfaces (third-party GUI tools) page.

### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118600&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118600](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118600+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
