### PR TITLE
Apply signed integer settings sent in the legacy binary format, and validate non-zero settings there

### DIFF
--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -679,6 +679,12 @@ void SettingFieldNonZeroUInt64::parseFromString(const String & str)
     checkValueNonZero();
 }
 
+void SettingFieldNonZeroUInt64::readBinary(ReadBuffer & in)
+{
+    SettingFieldUInt64::readBinary(in);
+    checkValueNonZero();
+}
+
 void SettingFieldNonZeroUInt64::checkValueNonZero() const
 {
     if (value == 0)

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -260,7 +260,7 @@ void SettingFieldNumber<T>::readBinary(ReadBuffer & in)
     {
         Int64 x = 0;
         readVarInt(x, in);
-        *this = static_cast<T>(value);
+        *this = static_cast<T>(x);
     }
     else
     {

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -636,6 +636,7 @@ public:
     SettingFieldNonZeroUInt64 & operator=(const Field & f);
 
     void parseFromString(const String & str);
+    void readBinary(ReadBuffer & in);
 
 private:
     void checkValueNonZero() const;

--- a/src/Core/tests/gtest_settings.cpp
+++ b/src/Core/tests/gtest_settings.cpp
@@ -8,12 +8,14 @@
 #include <Core/Field.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
+#include <IO/VarInt.h>
 
 #include <limits>
 
 namespace DB::ErrorCodes
 {
     extern const int INCORRECT_DATA;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -209,6 +211,46 @@ GTEST_TEST(Settings, KnownSettingFlaggedCustomOnTheWireIsReadIntoItsTypedField)
     /// A name that is not a setting here stays a custom setting.
     ASSERT_TRUE(settings.isChanged("custom_unknown_here"));
     ASSERT_EQ(settings.get("custom_unknown_here"), Field(String("kept")));
+}
+
+GTEST_TEST(Settings, LegacyBinaryFormatRejectsZeroForANonZeroSetting)
+{
+    /// The legacy binary format decodes each value through the setting's own readBinary. A query
+    /// arriving over TCP is additionally passed through the settings constraints, which re-validate,
+    /// but a persisted distributed batch header and a deserialized query plan read this format with
+    /// nothing after it, so readBinary is where a non-zero setting's restriction has to hold.
+    auto wire = [](UInt64 value)
+    {
+        WriteBufferFromOwnString out;
+        BaseSettingsHelpers::writeString("grace_hash_join_initial_buckets", out);
+        writeVarUInt(value, out);
+        BaseSettingsHelpers::writeString("", out); /// end of settings
+        return out.str();
+    };
+
+    /// Each buffer of wire bytes is named: ReadBufferFromString does not copy, so a temporary would
+    /// leave it reading freed memory, where an empty name reads as the end-of-settings marker.
+    const String zero_bytes = wire(0);
+    Settings rejected;
+    ReadBufferFromString zero(zero_bytes);
+    try
+    {
+        rejected.read(zero, SettingsWriteFormat::BINARY);
+        FAIL() << "zero was accepted for a non-zero setting";
+    }
+    catch (const Exception & e)
+    {
+        /// Pinned, so that a misspelled setting name failing as SETTING_NOT_FOUND cannot pass here.
+        ASSERT_EQ(e.code(), ErrorCodes::BAD_ARGUMENTS);
+    }
+
+    /// A permitted value must still be decoded and applied through the same path.
+    const String two_bytes = wire(2);
+    Settings accepted;
+    ReadBufferFromString two(two_bytes);
+    accepted.read(two, SettingsWriteFormat::BINARY);
+    ASSERT_TRUE(accepted.isChanged("grace_hash_join_initial_buckets"));
+    ASSERT_EQ(accepted.get("grace_hash_join_initial_buckets"), Field(UInt64(2)));
 }
 
 GTEST_TEST(SettingFieldTimespan, ValueAlwaysFitsInt64Microseconds)

--- a/tests/queries/0_stateless/05136_legacy_binary_settings_signed_integer.python
+++ b/tests/queries/0_stateless/05136_legacy_binary_settings_signed_integer.python
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# A peer declaring a revision below DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS
+# (54429) sends per-query settings in the legacy binary format: the setting name followed by
+# the raw typed value, with no flags byte and no string conversion. REVISION is pinned one
+# below that constant so the set of exchanged, revision-gated fields is fixed and cannot drift.
+#
+# Exchange 1 asserts that a signed integral setting sent that way is applied:
+# `max_partitions_to_read = 1` against a two-partition table must raise TOO_MANY_PARTITIONS.
+# Exchange 2 sends the same query with no settings at all, so a Data packet there proves the
+# exception comes from the transported setting and not from the hand-rolled handshake.
+
+import os
+import socket
+import struct
+import uuid
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "127.0.0.1")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT_TCP", "9000"))
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "default")
+CLIENT_NAME = "legacy binary settings"
+
+REVISION = 54428
+
+
+def writeVarUInt(x, ba):
+    for _ in range(0, 9):
+        byte = x & 0x7F
+        if x > 0x7F:
+            byte |= 0x80
+        ba.append(byte)
+        x >>= 7
+        if x == 0:
+            return
+
+
+def writeVarInt(x, ba):
+    # DB::encodeZigZag, src/IO/VarInt.h
+    writeVarUInt(((x << 1) ^ (x >> 63)) & 0xFFFFFFFFFFFFFFFF, ba)
+
+
+def writeStringBinary(s, ba):
+    b = bytes(s, "utf-8") if isinstance(s, str) else s
+    writeVarUInt(len(b), ba)
+    ba.extend(b)
+
+
+def readStrict(s, size=1):
+    res = bytearray()
+    while size:
+        cur = s.recv(size)
+        if not cur:
+            raise EOFError("Connection closed by server")
+        size -= len(cur)
+        res.extend(cur)
+    return res
+
+
+def readUInt(s, size=1):
+    res = readStrict(s, size)
+    val = 0
+    for i in range(len(res)):
+        val += res[i] << (i * 8)
+    return val
+
+
+def readUInt8(s):
+    return readUInt(s)
+
+
+def readUInt32(s):
+    return readUInt(s, 4)
+
+
+def readVarUInt(s):
+    x = 0
+    for i in range(9):
+        byte = readStrict(s)[0]
+        x |= (byte & 0x7F) << (7 * i)
+        if not byte & 0x80:
+            return x
+    return x
+
+
+def readStringBinary(s):
+    size = readVarUInt(s)
+    return readStrict(s, size).decode("utf-8")
+
+
+def sendHello(s):
+    ba = bytearray()
+    writeVarUInt(0, ba)  # Hello
+    writeStringBinary(CLIENT_NAME, ba)
+    writeVarUInt(24, ba)  # major
+    writeVarUInt(9, ba)  # minor
+    writeVarUInt(REVISION, ba)
+    writeStringBinary(CLICKHOUSE_DATABASE, ba)  # database
+    writeStringBinary("default", ba)  # user
+    writeStringBinary("", ba)  # password
+    s.sendall(ba)
+
+
+def receiveHello(s):
+    assert readVarUInt(s) == 0  # Hello
+    readStringBinary(s)  # server name
+    readVarUInt(s)  # major
+    readVarUInt(s)  # minor
+    readVarUInt(s)  # revision
+    readStringBinary(s)  # timezone (>= 54058)
+    readStringBinary(s)  # display name (>= 54372)
+    readVarUInt(s)  # version patch (>= 54401)
+    # No addendum is exchanged below DBMS_MIN_PROTOCOL_VERSION_WITH_ADDENDUM (54458).
+
+
+def serializeClientInfo(ba, query_id):
+    ba.append(1)  # INITIAL_QUERY
+    writeStringBinary("default", ba)  # initial_user
+    writeStringBinary(query_id, ba)  # initial_query_id
+    writeStringBinary("127.0.0.1:9000", ba)  # initial_address
+    ba.append(1)  # interface = TCP
+    writeStringBinary("os_user", ba)
+    writeStringBinary("client_hostname", ba)
+    writeStringBinary(CLIENT_NAME, ba)
+    writeVarUInt(24, ba)  # client major
+    writeVarUInt(9, ba)  # client minor
+    writeVarUInt(REVISION, ba)  # client tcp protocol version
+    writeStringBinary("", ba)  # quota key (>= 54060)
+    writeVarUInt(1, ba)  # client version patch (>= 54401)
+
+
+def sendQuery(s, query, settings):
+    ba = bytearray()
+    query_id = uuid.uuid4().hex
+    writeVarUInt(1, ba)  # Query
+    writeStringBinary(query_id, ba)
+    serializeClientInfo(ba, query_id)
+    for name, value in settings:
+        writeStringBinary(name, ba)
+        writeVarInt(value, ba)
+    writeStringBinary("", ba)  # end of settings
+    writeVarUInt(2, ba)  # stage = Complete
+    ba.append(0)  # no compression
+    writeStringBinary(query, ba)
+    s.sendall(ba)
+
+
+def serializeBlockInfo(ba):
+    writeVarUInt(1, ba)  # field 1
+    ba.append(0)  # is_overflows = false
+    writeVarUInt(2, ba)  # field 2
+    ba.extend(struct.pack("<i", -1))  # bucket_num = -1
+    writeVarUInt(0, ba)  # end of block info
+
+
+def sendEmptyBlock(s):
+    ba = bytearray()
+    writeVarUInt(2, ba)  # Data
+    writeStringBinary("", ba)
+    serializeBlockInfo(ba)
+    writeVarUInt(0, ba)  # columns
+    writeVarUInt(0, ba)  # rows
+    s.sendall(ba)
+
+
+def readException(s):
+    code = readUInt32(s)
+    readStringBinary(s)  # name
+    text = readStringBinary(s)
+    readStringBinary(s)  # trace
+    readUInt8(s)  # has_nested
+    return code, text
+
+
+def runQuery(query, settings):
+    """Return (packet_type, error_code) of the first Data or Exception packet."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(60)
+        s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+        sendHello(s)
+        receiveHello(s)
+        sendQuery(s, query, settings)
+        sendEmptyBlock(s)  # no external tables
+        while True:
+            packet = readVarUInt(s)
+            if packet == 1:  # Data
+                return packet, None
+            if packet == 2:  # Exception
+                return packet, readException(s)[0]
+            if packet == 3:  # Progress
+                raise RuntimeError("Progress packet before the first Data packet")
+            if packet == 10:  # Log
+                raise RuntimeError("Log packet before the first Data packet")
+            raise RuntimeError("Unexpected packet {}".format(packet))
+
+
+def main():
+    query = "SELECT i FROM t_legacy_binary_settings ORDER BY i"
+
+    packet, code = runQuery(query, [("max_partitions_to_read", 1)])
+    assert packet == 2, "expected an Exception packet, got packet {}".format(packet)
+    print("code", code)
+
+    packet, _code = runQuery(query, [])
+    assert packet == 1, "expected a Data packet, got packet {}".format(packet)
+    print("control packet", packet)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/queries/0_stateless/05136_legacy_binary_settings_signed_integer.reference
+++ b/tests/queries/0_stateless/05136_legacy_binary_settings_signed_integer.reference
@@ -1,0 +1,2 @@
+code 565
+control packet 1

--- a/tests/queries/0_stateless/05136_legacy_binary_settings_signed_integer.sh
+++ b/tests/queries/0_stateless/05136_legacy_binary_settings_signed_integer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# NOTE: this sh wrapper is required because of shell_config
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_legacy_binary_settings"
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE t_legacy_binary_settings (d Date, i Int32)
+    ENGINE = MergeTree PARTITION BY d ORDER BY i
+"
+$CLICKHOUSE_CLIENT -q "
+    INSERT INTO t_legacy_binary_settings VALUES ('2021-01-01', 1), ('2021-01-02', 2)
+"
+
+python3 "$CURDIR"/05136_legacy_binary_settings_signed_integer.python
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_legacy_binary_settings"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed two defects in the legacy binary settings format, used for native-protocol clients declaring a revision below 54429. Signed integer settings (for example `max_partitions_to_read` or `iceberg_snapshot_id`) were silently ignored, and were reported as changed while holding their default, so they overrode the table-level value with that default. Settings required to be greater than zero (for example `max_block_size`) were not validated when read from that format.

### Description

Two defects in the legacy binary settings format, which `TCPHandler` selects for any native-protocol peer declaring a revision below `DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS` (54429); no minimum revision is enforced.

**1. Signed integral settings were discarded.** `SettingFieldNumber<T>::readBinary` decoded into a local, then assigned from `value`, its own data member. `BaseSettings::read` resets to defaults first and `operator=` sets `changed`, so the setting was flagged as a user override while holding its default, and `ReadFromMergeTree` then prefers that default over the table-level value. 22 signed query settings are affected, six of them snapshot selectors for Iceberg, DeltaLake and Paimon. Introduced in `300727afa316a01c` (2020-07-27).

**2. A non-zero setting was not validated.** `SettingFieldNonZeroUInt64` re-runs `checkValueNonZero()` from every mutating entry point it overrides, but not `readBinary`, whose base `*this = static_cast<T>(x)` binds statically to `SettingFieldUInt64::operator=`. Of the twelve operations in `SettingFieldOps`, `read_binary` was the only mutating one that could store a forbidden value. Requested by @ Algunenano in review.

Both writers were already correct, so the wire format is unchanged.

On (2), a TCP query's outcome is unchanged: `SettingsConstraints::checkOrClamp` already rejects the zero with the same `BAD_ARGUMENTS`, now raised at the decode step. The override matters where nothing runs after the decode: `QueryPlanSerializationSettings::readBinary` and the old-format branch of `DistributedAsyncInsertHeader`. The modern header format already rejects zero there, so this makes the legacy branch consistent; the one behaviour change is that a pre-2024-03 old-format batch carrying an explicit `0` would stop draining.

Tests. A raw native-protocol client pinned to revision 54428 requires `TOO_MANY_PARTITIONS` for `max_partitions_to_read = 1`. A gtest drives `Settings::read` with `SettingsWriteFormat::BINARY`, because the constraints check masks (2) on every SQL-reachable path. Both fail without this change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118610&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118610](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118610+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

