### PR TITLE
Fix S3 listObjects dropping objects on an empty page with a continuation token

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -401,9 +401,10 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
         auto result = outcome.GetResult();
         auto objects = result.GetContents();
 
-        if (objects.empty())
-            break;
-
+        /// A page can carry no objects while objects still remain: the scan may stop early
+        /// inside a partition and report `IsTruncated` together with a continuation token.
+        /// `IsTruncated` is the only thing that ends the listing - stopping on an empty page
+        /// would silently drop every object after it.
         for (const auto & object : objects)
             children.emplace_back(std::make_shared<RelativePathWithMetadata>(
                 object.GetKey(),

--- a/tests/integration/test_s3_list_objects_empty_page/s3_mocks/empty_list_page.py
+++ b/tests/integration/test_s3_list_objects_empty_page/s3_mocks/empty_list_page.py
@@ -1,0 +1,178 @@
+"""A MinIO proxy that injects an empty `ListObjectsV2` page carrying a continuation token.
+
+Amazon S3 may answer a listing request with no keys at all while still reporting
+`IsTruncated=true` and a `NextContinuationToken`, because the scan can stop early inside a
+partition. A client that treats "no keys" as "end of listing" then silently loses every object
+that lives on a later page.
+
+Once armed, the first listing of each distinct prefix is answered with such an empty page. The
+real upstream answer is fetched at that moment and held back, then replayed when the client
+returns with the token. Replaying instead of forwarding matters: the token is synthetic, and a
+request rewritten to remove it would no longer match its AWS v4 signature.
+"""
+
+import http.client
+import http.server
+import socketserver
+import sys
+import threading
+import urllib.parse
+
+UPSTREAM_HOST = "minio1:9001"
+
+# Marks a token as ours, so it is unambiguous when the client sends it back.
+TOKEN_PREFIX = "injected-empty-page-"
+
+state_lock = threading.Lock()
+armed = False
+injected_prefixes = set()
+held_responses = {}
+token_counter = 0
+
+
+def request(command, url, headers={}, data=None):
+    """Mini-requests."""
+
+    class Dummy:
+        pass
+
+    parts = urllib.parse.urlparse(url)
+    c = http.client.HTTPConnection(parts.hostname, parts.port)
+    c.request(
+        command,
+        urllib.parse.urlunparse(parts._replace(scheme="", netloc="")),
+        headers=headers,
+        body=data,
+    )
+    r = c.getresponse()
+    result = Dummy()
+    result.status_code = r.status
+    result.headers = r.headers
+    result.content = r.read()
+    return result
+
+
+class RequestHandler(http.server.BaseHTTPRequestHandler):
+    def reply(self, code, body, content_type="text/plain"):
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def relay(self, r):
+        self.send_response(r.status_code)
+        for k, v in r.headers.items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(r.content)
+
+    def forward(self):
+        content_length = self.headers.get("Content-Length")
+        data = self.rfile.read(int(content_length)) if content_length else None
+        return request(
+            self.command,
+            f"http://{UPSTREAM_HOST}{self.path}",
+            headers=self.headers,
+            data=data,
+        )
+
+    def empty_truncated_page(self, params, token):
+        bucket = urllib.parse.urlparse(self.path).path.lstrip("/").split("/")[0]
+        prefix = params.get("prefix", [""])[0]
+        max_keys = params.get("max-keys", ["1000"])[0]
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+            f"<Name>{bucket}</Name>"
+            f"<Prefix>{prefix}</Prefix>"
+            "<KeyCount>0</KeyCount>"
+            f"<MaxKeys>{max_keys}</MaxKeys>"
+            "<IsTruncated>true</IsTruncated>"
+            f"<NextContinuationToken>{token}</NextContinuationToken>"
+            "</ListBucketResult>"
+        ).encode()
+
+    def handle_list_request(self, params):
+        global armed
+        global token_counter
+
+        token = params.get("continuation-token", [""])[0]
+
+        if token.startswith(TOKEN_PREFIX):
+            with state_lock:
+                held = held_responses.pop(token, None)
+            if held is not None:
+                self.relay(held)
+                return
+            # Unknown token of ours: the client is following a page we no longer hold.
+            self.reply(500, b"unknown injected continuation token")
+            return
+
+        prefix = params.get("prefix", [""])[0]
+        with state_lock:
+            inject = armed and prefix not in injected_prefixes
+            if inject:
+                injected_prefixes.add(prefix)
+
+        if not inject:
+            self.relay(self.forward())
+            return
+
+        upstream = self.forward()
+        if upstream.status_code != 200:
+            self.relay(upstream)
+            return
+
+        with state_lock:
+            token_counter += 1
+            token = f"{TOKEN_PREFIX}{token_counter}"
+            held_responses[token] = upstream
+
+        self.reply(200, self.empty_truncated_page(params, token), "application/xml")
+
+    def do_GET(self):
+        global armed
+        global injected_prefixes
+        global held_responses
+
+        if self.path == "/":
+            self.reply(200, b"OK")
+            return
+
+        if self.path.startswith("/arm") or self.path.startswith("/disarm"):
+            with state_lock:
+                armed = self.path.startswith("/arm")
+                injected_prefixes = set()
+                held_responses = {}
+            self.reply(200, b"OK")
+            return
+
+        params = urllib.parse.parse_qs(
+            urllib.parse.urlparse(self.path).query, keep_blank_values=True
+        )
+        if "list-type" in params:
+            self.handle_list_request(params)
+            return
+
+        self.do_HEAD()
+
+    def do_PUT(self):
+        self.do_HEAD()
+
+    def do_DELETE(self):
+        self.do_HEAD()
+
+    def do_POST(self):
+        self.do_HEAD()
+
+    def do_HEAD(self):
+        self.relay(self.forward())
+
+
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    """Handle requests in a separate thread."""
+
+
+httpd = ThreadedHTTPServer(("0.0.0.0", int(sys.argv[1])), RequestHandler)
+httpd.serve_forever()

--- a/tests/integration/test_s3_list_objects_empty_page/test.py
+++ b/tests/integration/test_s3_list_objects_empty_page/test.py
@@ -1,0 +1,89 @@
+import os
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.mock_servers import start_mock_servers
+
+MOCK_PORT = 8083
+NUM_ROWS = 100
+
+cluster = ClickHouseCluster(__file__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    cluster.add_instance("node", with_minio=True, stay_alive=True)
+    try:
+        cluster.start()
+        start_mock_servers(
+            cluster,
+            os.path.join(os.path.dirname(__file__), "s3_mocks"),
+            [("empty_list_page.py", "resolver", str(MOCK_PORT))],
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def control_mock(command):
+    response = cluster.exec_in_container(
+        cluster.get_container_id("resolver"),
+        ["curl", "-s", f"http://localhost:{MOCK_PORT}/{command}"],
+    )
+    assert response == "OK", f"unexpected reply from the mock: {response}"
+
+
+def test_empty_listing_page_does_not_hide_parts(start_cluster):
+    """An empty `ListObjectsV2` page must not make a `plain_rewritable` disk look empty.
+
+    `MetadataStorageFromPlainRewritableObjectStorage::load` decides whether the disk holds
+    anything with `existsOrHasAnyChild`, which lists with `max-keys=1`. If that listing stops at
+    an empty page instead of following the continuation token, the disk comes up with no
+    directories at all and the table silently loses every part it has.
+
+    The disk is defined on the table rather than in the server config so that it is created
+    after the mock proxy is listening; it is then recreated on every subsequent startup.
+    """
+    node = cluster.instances["node"]
+
+    node.query("DROP TABLE IF EXISTS test_empty_page SYNC")
+    node.query(
+        f"""
+        CREATE TABLE test_empty_page (key Int32, value String)
+        ENGINE = MergeTree()
+        ORDER BY key
+        SETTINGS disk = disk(
+            name = disk_empty_page,
+            type = s3_plain_rewritable,
+            endpoint = 'http://resolver:{MOCK_PORT}/root/data/',
+            access_key_id = minio,
+            secret_access_key = 'ClickHouse_Minio_P@ssw0rd')
+        """
+    )
+    node.query(
+        f"INSERT INTO test_empty_page SELECT number, toString(number) FROM numbers({NUM_ROWS})"
+    )
+
+    assert int(node.query("SELECT count() FROM test_empty_page")) == NUM_ROWS
+
+    # Arm while the server is down, so the disk load during startup is what consumes the injected
+    # page rather than some background listing that happens to run first. From now on the first
+    # listing of each prefix answers with no keys, `IsTruncated=true` and a continuation token.
+    node.stop_clickhouse()
+    control_mock("arm")
+    node.start_clickhouse()
+
+    assert int(node.query("SELECT count() FROM test_empty_page")) == NUM_ROWS
+    assert (
+        int(
+            node.query(
+                "SELECT count() FROM system.parts "
+                "WHERE database = 'default' AND table = 'test_empty_page' AND active"
+            )
+        )
+        > 0
+    )
+
+    control_mock("disarm")
+    node.query("DROP TABLE test_empty_page SYNC")

--- a/tests/integration/test_s3_list_objects_empty_page/test.py
+++ b/tests/integration/test_s3_list_objects_empty_page/test.py
@@ -87,3 +87,69 @@ def test_empty_listing_page_does_not_hide_parts(start_cluster):
 
     control_mock("disarm")
     node.query("DROP TABLE test_empty_page SYNC")
+
+
+def test_empty_listing_page_does_not_create_intersecting_parts(start_cluster):
+    """A disk that comes up empty makes the table renumber its blocks and collide with itself.
+
+    This is the damage the previous test stops one step short of. If a restart hides the existing
+    parts, the block counter restarts from 1, so parts written afterwards reuse block numbers that
+    are already on the disk. Each generation merges into a level 1 part sharing the same left
+    edge - `all_1_2_1` and `all_1_3_1` - and `MergeTreePartInfo::contains` rejects that pair,
+    because a containing part may only have an equal level when the block range is identical.
+    Once both generations are visible the table cannot be loaded at all:
+    `Part ... intersects previous part ...`.
+
+    The merges matter: without them both generations would only produce level 0 parts whose names
+    collide outright, which is not an intersection.
+    """
+    node = cluster.instances["node"]
+
+    node.query("DROP TABLE IF EXISTS test_intersecting SYNC")
+    node.query(
+        f"""
+        CREATE TABLE test_intersecting (key Int32, value String)
+        ENGINE = MergeTree()
+        ORDER BY key
+        SETTINGS disk = disk(
+            name = disk_intersecting,
+            type = s3_plain_rewritable,
+            endpoint = 'http://resolver:{MOCK_PORT}/root/intersecting/',
+            access_key_id = minio,
+            secret_access_key = 'ClickHouse_Minio_P@ssw0rd')
+        """
+    )
+
+    def insert(count, offset):
+        node.query(
+            f"INSERT INTO test_intersecting "
+            f"SELECT number + {offset}, toString(number) FROM numbers({count})"
+        )
+
+    # First generation: two parts merged into all_1_2_1.
+    insert(50, 0)
+    insert(50, 50)
+    node.query("OPTIMIZE TABLE test_intersecting FINAL")
+    assert int(node.query("SELECT count() FROM test_intersecting")) == 100
+
+    node.stop_clickhouse()
+    control_mock("arm")
+    node.start_clickhouse()
+
+    # Second generation. Without the fix the table is empty here, so these blocks are numbered
+    # from 1 again and the merge below produces all_1_3_1 next to the surviving all_1_2_1.
+    insert(50, 100)
+    insert(50, 150)
+    insert(50, 200)
+    node.query("OPTIMIZE TABLE test_intersecting FINAL")
+
+    # Restore normal listings, so the next startup sees every directory on the disk.
+    node.stop_clickhouse()
+    control_mock("disarm")
+    node.start_clickhouse()
+
+    assert int(node.query("SELECT count() FROM test_intersecting")) == 250
+    assert not node.contains_in_log("intersects previous part")
+    assert not node.contains_in_log("intersects next part")
+
+    node.query("DROP TABLE test_intersecting SYNC")


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109761
Related: https://github.com/ClickHouse/ClickHouse/issues/109751

`S3ObjectStorage::listObjects` stopped paginating as soon as a response carried no keys, ignoring `IsTruncated`. A listing may legitimately return an empty page while more keys remain, and every object after that page was then silently lost.

The most exposed caller is `IObjectStorage::existsOrHasAnyChild`, which lists with `max-keys=1`, so one such response makes it report that a path does not exist. That is how `MetadataStorageFromPlainRewritableObjectStorage::load` decides whether the disk holds anything, so the disk comes up with no directories at all and a MergeTree table on it loses every part. The same listing also backs directory lookups on `plain` disks and data lake metadata discovery for Iceberg, Delta Lake, Hudi and Paimon, where dropping the tail can mean reading an older snapshot.

`IObjectStorageIteratorAsync::nextBatch` had the same defect and was fixed in #109761. That fix does not cover this path: on a `plain_rewritable` disk the `existsOrHasAnyChild` probes run before the iterator is used and can short-circuit the whole load.

Added `tests/integration/test_s3_list_objects_empty_page`, which proxies MinIO and answers the first listing of each prefix with no keys plus `IsTruncated=true` and a continuation token.

`test_empty_listing_page_does_not_hide_parts` covers the immediate effect: without the fix the table reports 0 of 100 rows after a restart.

`test_empty_listing_page_does_not_create_intersecting_parts` carries it through to the lasting damage. With the parts hidden the block counter restarts from 1, so the next generation of parts reuses block numbers already on the disk. Each generation merges into a level 1 part with the same left edge, and once both are listed the table cannot be attached at all:

```
Code: 49. DB::Exception: Part all_1_2_1 intersects next part all_1_3_1.
It is a bug or a result of manual intervention:
Cannot attach table `default`.`test_intersecting`
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed object storage listing silently skipping objects when S3 returns an empty page together with a continuation token. This could make a `plain_rewritable` disk appear empty and hide table parts, and could make data lake tables read a stale snapshot.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.940` (included in `26.9` and later)
- Backported to: `26.8.3.60`, `26.7.7.48`, `26.6.5.74`, `26.3.33.19`
<!-- ch-version-info:end -->