### PR TITLE
ci: switch user for build profile diff

### DIFF
--- a/ci/jobs/build_profile_diff_job.py
+++ b/ci/jobs/build_profile_diff_job.py
@@ -69,7 +69,7 @@ import subprocess
 import traceback
 from typing import Dict, List, Optional
 
-from ci.jobs.scripts.log_cluster import LogCluster
+from ci.jobs.scripts.log_cluster import BUILD_PROFILE_USER, LogCluster
 from ci.praktika.gh import GH
 from ci.praktika.info import Info
 from ci.praktika.result import Result
@@ -206,6 +206,8 @@ class Section:
 
 class Db:
     def __init__(self):
+        # CI_LOGS_USER only for local runs
+        user = os.environ.get("CI_LOGS_USER", BUILD_PROFILE_USER)
         # This job only reads, so it goes to the read-only sub-service of the
         # CI logs cluster (LogCluster.READONLY_URL) rather than to the endpoint
         # that ingests the logs and profiles of the whole CI fleet.
@@ -215,15 +217,15 @@ class Db:
         if url:
             if not url.startswith("http"):
                 url = f"https://{url}:8443"
-            password = os.environ.get("CI_LOGS_PASSWORD", os.environ.get("CI_LOGS_PASWORD", ""))
+            password = os.environ.get("CI_LOGS_PASSWORD", "")
             self._cluster = LogCluster(
                 url=url,
-                user=os.environ.get("CI_LOGS_USER", "default"),
+                user=user,
                 password=password,
                 readonly=True,
             )
         else:
-            self._cluster = LogCluster(readonly=True)
+            self._cluster = LogCluster(readonly=True, user=user)
 
     def query(self, query: str) -> List[dict]:
         """Run a SELECT and return rows as dicts. Raises on failure."""

--- a/ci/jobs/scripts/job_hooks/build_profile_hook.py
+++ b/ci/jobs/scripts/job_hooks/build_profile_hook.py
@@ -3,7 +3,10 @@ import sys
 import traceback
 from pathlib import Path
 
-from ci.jobs.scripts.log_cluster import LogClusterBuildProfileQueries
+from ci.jobs.scripts.log_cluster import (
+    BUILD_PROFILE_USER,
+    LogClusterBuildProfileQueries,
+)
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
@@ -275,7 +278,7 @@ def check():
         check_start_time = Utils.timestamp_to_str(
             Result.from_fs(Info().job_name).start_time
         )
-        queries = LogClusterBuildProfileQueries()
+        queries = LogClusterBuildProfileQueries(user=BUILD_PROFILE_USER)
 
         def insert_profile_data(build_name, start_time, file):
             # On PRs and for the warmup build the time trace is uploaded

--- a/ci/jobs/scripts/log_cluster.py
+++ b/ci/jobs/scripts/log_cluster.py
@@ -8,6 +8,9 @@ from ci.praktika.info import Info
 from ci.praktika.secret import Secret
 from ci.praktika.utils import Utils
 
+# The build profile collect and diff jobs
+BUILD_PROFILE_USER = "ci_build_profiler"
+
 
 @dataclass(frozen=True)
 class MetaColumn:
@@ -34,7 +37,6 @@ class LogCluster:
     # profile uploads of the whole CI fleet do not compete for one endpoint.
     # Not a secret, unlike the writer endpoint, hence no AWS SSM parameter.
     READONLY_URL = "https://t6h0zvqlgy.us-east-2.aws.clickhouse-staging.com"
-    USER = "ci"
 
     # The CI metadata every export to this cluster carries, defined once so
     # that the DDL of the destination table, the INSERT column list and the
@@ -155,10 +157,10 @@ class LogCluster:
         values = cls.meta_values(check_start_time, check_name)
         return [c.literal.format(values[c.name]) for c in cls.meta_columns()]
 
-    def __init__(self, url="", user="", password=None, readonly=False):
+    def __init__(self, user, url="", password=None, readonly=False):
         # Explicit url/user/password skip the AWS SSM secret lookup - used for
         # running the consumers locally against the cluster.
-        self.user = user or self.USER
+        self.user = user
         self.readonly = readonly
         self.url = url or (self.READONLY_URL if readonly else "")
         self._session = None
@@ -385,9 +387,9 @@ class LogClusterBuildProfileQueries:
         "PerformPendingInstantiations",
     )
 
-    def __init__(self):
+    def __init__(self, user):
         self._info = Info()
-        self._log_cluster = LogCluster()
+        self._log_cluster = LogCluster(user=user)
 
     def _columns(self, table_columns):
         names = LogCluster.meta_column_names() + list(table_columns)
@@ -486,8 +488,3 @@ class LogClusterBuildProfileQueries:
     FROM input('file String, address String, size String, type String, symbol String')
     SETTINGS format_regexp = '^([^ ]+) ([0-9a-fA-F]+)(?: ([0-9a-fA-F]+))? (.) (.+)$'
     FORMAT Regexp"""
-
-
-if __name__ == "__main__":
-    LogCluster = LogCluster()
-    assert LogCluster.is_ready()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118618&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118618](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118618+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.932` (included in `26.9` and later)
<!-- ch-version-info:end -->