### PR TITLE
ci: move tables for sending data to ci-logs to a separate database

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -14,6 +14,8 @@ set -e
 # Pre-configured destination cluster, where to export the data
 CLICKHOUSE_CI_LOGS_CLUSTER=${CLICKHOUSE_CI_LOGS_CLUSTER:-system_logs_export}
 
+LOG_EXPORT_DATABASE=${LOG_EXPORT_DATABASE:-ci_logs_export}
+
 # The server to export the logs from. The performance comparison runs two
 # servers side by side (see ci/jobs/performance_tests.py), so every query to the
 # exporting server must be able to target one of them; empty means the default
@@ -118,6 +120,8 @@ function setup_logs_replication()
     debug_or_sanitizer_build=$(clickhouse-client "${LOCAL_ARGS[@]}" -q "WITH ((SELECT value FROM system.build_options WHERE name='BUILD_TYPE') AS build, (SELECT value FROM system.build_options WHERE name='CXX_FLAGS') as flags) SELECT build='Debug' OR flags LIKE '%fsanitize%'")
     echo "Build is debug or sanitizer: $debug_or_sanitizer_build"
 
+    clickhouse-client "${LOCAL_ARGS[@]}" --query "CREATE DATABASE IF NOT EXISTS ${LOG_EXPORT_DATABASE}"
+
     # For each system log table:
     echo 'Create %_log tables'
     # Filter by engine to exclude virtual system tables that merely match the
@@ -170,11 +174,11 @@ function setup_logs_replication()
             --distributed_ddl_task_timeout=30 --distributed_ddl_output_mode=throw_only_active \
             "${CONNECTION_ARGS[@]:?}" || continue
 
-        echo "Creating table system.${table}_sender" >&2
+        echo "Creating table ${LOG_EXPORT_DATABASE}.${table}_sender" >&2
 
         # Create Distributed table and materialized view to watch on the original table:
         clickhouse-client "${LOCAL_ARGS[@]}" --query "
-            CREATE TABLE system.${table}_sender
+            CREATE TABLE ${LOG_EXPORT_DATABASE}.${table}_sender
             ENGINE = Distributed(${CLICKHOUSE_CI_LOGS_CLUSTER}, default, ${table}_${hash})
             SETTINGS flush_on_detach=0
             EMPTY AS
@@ -182,11 +186,11 @@ function setup_logs_replication()
             FROM system.${table}
         " || continue
 
-        echo "Creating materialized view system.${table}_watcher" >&2
+        echo "Creating materialized view ${LOG_EXPORT_DATABASE}.${table}_watcher" >&2
 
         clickhouse-client "${LOCAL_ARGS[@]}" --query "
-            CREATE MATERIALIZED VIEW system.${table}_watcher
-            TO system.${table}_sender
+            CREATE MATERIALIZED VIEW ${LOG_EXPORT_DATABASE}.${table}_watcher
+            TO ${LOG_EXPORT_DATABASE}.${table}_sender
             DEFINER = ci_logs_sender
             AS
             SELECT ${EXTRA_COLUMNS_EXPRESSION_FOR_TABLE}, * FROM system.${table}
@@ -206,18 +210,23 @@ function stop_logs_replication()
     # same `timeout` pattern as the drop step so an unreachable cluster cannot
     # block teardown indefinitely.
     echo "Flush pending log records to the remote cluster"
-    ( clickhouse-client "${LOCAL_ARGS[@]}" --query "select database||'.'||table from system.tables where database = 'system' and table like '%_sender'" | {
+    ( clickhouse-client "${LOCAL_ARGS[@]}" --query "select database||'.'||table from system.tables where database = '${LOG_EXPORT_DATABASE}' and table like '%_sender'" | {
         tee /dev/stderr
     } | {
         timeout --verbose --preserve-status --signal TERM --kill-after 1m 5m xargs -n1 -P10 -r -i clickhouse-client ${LOG_EXPORT_SERVER_PORT:+--port $LOG_EXPORT_SERVER_PORT} --query "SYSTEM FLUSH DISTRIBUTED {}"
     } ) || echo "WARNING: failed to flush pending log records, some rows may be lost"
 
     echo "Detach all logs replication"
-    clickhouse-client "${LOCAL_ARGS[@]}" --query "select database||'.'||table from system.tables where database = 'system' and (table like '%_sender' or table like '%_watcher')" | {
+    clickhouse-client "${LOCAL_ARGS[@]}" --query "select database||'.'||table from system.tables where database = '${LOG_EXPORT_DATABASE}' and (table like '%_sender' or table like '%_watcher')" | {
         tee /dev/stderr
     } | {
         timeout --verbose --preserve-status --signal TERM --kill-after 5m 15m xargs -n1 -P10 -r -i clickhouse-client ${LOG_EXPORT_SERVER_PORT:+--port $LOG_EXPORT_SERVER_PORT} --query "drop table {}"
     }
+
+    echo "Drop the ${LOG_EXPORT_DATABASE} database"
+    timeout --verbose --preserve-status --signal TERM --kill-after 1m 5m \
+        clickhouse-client "${LOCAL_ARGS[@]}" --query "DROP DATABASE IF EXISTS ${LOG_EXPORT_DATABASE}" \
+        || echo "WARNING: failed to drop the ${LOG_EXPORT_DATABASE} database"
 }
 
 

--- a/ci/jobs/scripts/log_export.py
+++ b/ci/jobs/scripts/log_export.py
@@ -1,8 +1,8 @@
 """Export of the `system.*_log` tables of a local server to the CI Logs cluster.
 
 Every check exports its system logs the same way: for each system log table a
-`Distributed` table (`system.<table>_sender`) is created next to it, fed by a
-materialized view (`system.<table>_watcher`) that adds the columns identifying
+`Distributed` table (`<export database>.<table>_sender`) is created, fed by a
+materialized view (`<export database>.<table>_watcher`) that adds the columns identifying
 the CI run. The rows are then sent to the CI Logs cluster in the background, by
 the server itself. The tables and the views are created by
 `ci/jobs/scripts/functional_tests/setup_log_cluster.sh`; this module holds what
@@ -50,13 +50,15 @@ CI_LOGS_SENDER_USER_CONFIG = "./tests/config/users.d/ci_logs_sender.yaml"
 # The port of the local server to export from, for `setup_log_cluster.sh`.
 SERVER_PORT_ENV = "LOG_EXPORT_SERVER_PORT"
 
+# The local database of the export tables; must match the default of
+# `LOG_EXPORT_DATABASE` in `setup_log_cluster.sh`, which creates them.
+LOG_EXPORT_DATABASE = "ci_logs_export"
+
 # The `Distributed` tables the export sends through, created by `start` as
-# `system.<log table>_sender`. `endsWith` rather than `LIKE '%\_sender'`, to
-# keep the escape of the underscore out of a query that goes through a shell
-# command line.
+# `<LOG_EXPORT_DATABASE>.<log table>_sender`
 SENDER_TABLES_QUERY = (
     "SELECT database || '.' || name FROM system.tables "
-    "WHERE database = 'system' AND endsWith(name, '_sender') AND engine = 'Distributed'"
+    f"WHERE database = '{LOG_EXPORT_DATABASE}' AND endsWith(name, '_sender') AND engine = 'Distributed'"
 )
 
 _credentials = None

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -19,6 +19,13 @@ from typing import List, Optional
 # Failpoint that delays every background mutation by a bounded random amount.
 MUTATION_DELAY_FAILPOINT = "mutate_task_random_sleep_in_prepare"
 
+# Databases the hung check keeps attached. The log export sends the system logs
+# of the run from the `Distributed` tables of `ci_logs_export` (the default of
+# `LOG_EXPORT_DATABASE` in `ci/jobs/scripts/functional_tests/setup_log_cluster.sh`),
+# and they are created with `flush_on_detach=0`, so detaching that database
+# drops whatever is still queued and exports nothing for the rest of the run.
+KEEP_DATABASES = ("system", "ci_logs_export")
+
 # GNU `tar` exit statuses: 0 - success, 1 - some files differ (a file changed
 # or shrank while it was being read), 2 and above - a fatal error.
 TAR_EXIT_DIFFERS = 1
@@ -894,7 +901,7 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
                     .split()
                 )
                 for db in databases:
-                    if db == "system":
+                    if db in KEEP_DATABASES:
                         continue
                     command = make_query_command(f"DETACH DATABASE {db}")
                     # we don't wait for drop

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -102,8 +102,8 @@ mkdir -p $DEST_CLIENT_PATH
 # Patching configs which are symbolic links can affect source files,
 # need to delete links created by previous script versions
 # Also this is generally good (least astonishment principle) not to retain any old configs
-# `system_logs_export.yaml` is the exception: it is not a config of the test suite. A
-# `system.*_sender` `Distributed` table stays in the server metadata, and restoring a queued
+# `system_logs_export.yaml` is the exception: it is not a config of the test suite. The
+# `Distributed` tables of the log export stay in the server metadata, and restoring a queued
 # insert of one resolves the cluster, so a start without the definition aborts (`Code: 701`).
 LOG_EXPORT_CONFIG=system_logs_export.yaml
 if [ -f "$DEST_SERVER_PATH/config.d/$LOG_EXPORT_CONFIG" ]; then

--- a/tests/queries/0_stateless/01563_distributed_query_finish.sh
+++ b/tests/queries/0_stateless/01563_distributed_query_finish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Tags: distributed, no-parallel, no-fasttest
-# Tag no-fasttest: Checks system.errors
+# Tags: distributed, no-fasttest
+# Tag no-fasttest: checks system.text_log
 
 # query finish should not produce any NETWORK_ERROR
 # (NETWORK_ERROR will be in case of connection reset)
@@ -19,33 +19,35 @@ create table dist_01247 as data_01247 engine=Distributed(test_cluster_two_shards
 select * from dist_01247 format Null;
 EOL
 
-# Silence the CI log export sender pool so its NETWORK_ERRORs
-# (when the cloud destination is unreachable) don't contaminate system.errors.
-# This only blocks the async insert sender; SELECT from dist_01247 is unaffected.
-$CLICKHOUSE_CLIENT -q "SYSTEM STOP DISTRIBUTED SENDS"
-trap '$CLICKHOUSE_CLIENT -q "SYSTEM START DISTRIBUTED SENDS"' EXIT
-
+# NETWORK_ERROR of our own query via system.text_log (append-only, keyed by query_id):
+# noise-immune both ways vs last-writer-wins system.errors. Per-run salt skips stale rerun
+# rows; the event_date/event_time lower bound prunes text_log by its sort key so the retry
+# loop cannot degrade into repeated full scans; enable_parallel_replicas=0 keeps read local.
+salt=$(random_str 10)
+run_start=$($CLICKHOUSE_CLIENT -q "SELECT now()")
+network_errors=0
 for ((i = 0; i < 100; ++i)); do
-    network_errors_before=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.errors WHERE name = 'NETWORK_ERROR'")
+    query_id="01563_distributed_query_finish-$CLICKHOUSE_DATABASE-$salt-$i"
 
     opts=(
         "--max_distributed_connections=1"
         "--optimize_skip_unused_shards=1"
         "--optimize_distributed_group_by_sharding_key=1"
         "--prefer_localhost_replica=0"
+        "--query_id=$query_id"
     )
     # The query uses `FORMAT Null` to discard the output (we only care about NETWORK_ERROR side effects).
     # Do not pass `--format`: the `format` setting now takes precedence over the query `FORMAT` clause and would un-discard the output.
     $CLICKHOUSE_CLIENT "${opts[@]}" -m -q "select count(), * from dist_01247 group by number order by number limit 1 format Null"
 
-    # expect zero new network errors
-    network_errors_after=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.errors WHERE name = 'NETWORK_ERROR'")
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS text_log"
+    network_errors=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.text_log WHERE event_date >= toDate('$run_start') AND event_time >= '$run_start' AND query_id = '$query_id' AND message LIKE '%NETWORK_ERROR%' SETTINGS enable_parallel_replicas = 0")
 
-    if [[ $((network_errors_after-network_errors_before)) -eq 0 ]]; then
+    if [[ $network_errors -eq 0 ]]; then
         break
     fi
 done
-echo NETWORK_ERROR=$(( network_errors_after-network_errors_before ))
+echo NETWORK_ERROR=$network_errors
 
 $CLICKHOUSE_CLIENT -q "drop table data_01247"
 $CLICKHOUSE_CLIENT -q "drop table dist_01247"

--- a/tests/queries/0_stateless/01563_distributed_query_finish.sh
+++ b/tests/queries/0_stateless/01563_distributed_query_finish.sh
@@ -19,7 +19,7 @@ create table dist_01247 as data_01247 engine=Distributed(test_cluster_two_shards
 select * from dist_01247 format Null;
 EOL
 
-# Silence the CI system.*_log_sender background pool so its NETWORK_ERRORs
+# Silence the CI log export sender pool so its NETWORK_ERRORs
 # (when the cloud destination is unreachable) don't contaminate system.errors.
 # This only blocks the async insert sender; SELECT from dist_01247 is unaffected.
 $CLICKHOUSE_CLIENT -q "SYSTEM STOP DISTRIBUTED SENDS"


### PR DESCRIPTION
Otherwise we may end up trying to SELECT them after new fuzzer has been added in https://github.com/ClickHouse/ClickHouse/pull/111406/commits/b4287a85cc80beec7f75573442568b1a4c74f646

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118619&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118619](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118619+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.958` (included in `26.9` and later)
<!-- ch-version-info:end -->