### PR TITLE
Reload the plain-rewritable filesystem when a rollback does not complete

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -219,6 +219,7 @@ static struct InitFiu
     REGULAR(zero_copy_lock_zk_fail_after_op) \
     REGULAR(plain_object_storage_write_fail_on_directory_create) \
     REGULAR(plain_object_storage_write_fail_on_directory_move) \
+    REGULAR(plain_object_storage_fail_on_directory_move_undo) \
     REGULAR(zero_copy_unlock_zk_fail_before_op) \
     REGULAR(zero_copy_unlock_zk_fail_after_op) \
     REGULAR(plain_rewritable_object_storage_azure_not_found_on_init) \

--- a/src/Disks/DiskObjectStorage/MetadataStorages/MetadataOperationsHolder.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/MetadataOperationsHolder.cpp
@@ -44,6 +44,11 @@ void MetadataOperationsHolder::prependOperation(MetadataOperationPtr && operatio
     operations.emplace_front(std::move(operation));
 }
 
+bool MetadataOperationsHolder::isPartiallyRolledBack() const
+{
+    return state == MetadataStorageTransactionState::PARTIALLY_ROLLED_BACK;
+}
+
 void MetadataOperationsHolder::addOperation(MetadataOperationPtr && operation)
 {
     if (state != MetadataStorageTransactionState::PREPARING)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/MetadataOperationsHolder.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/MetadataOperationsHolder.h
@@ -24,6 +24,10 @@ public:
     void commit();
     void finalize() noexcept;
 
+    /// True when rolling back a failed commit did not run to completion, so the operations that
+    /// were already applied to object storage are still in place.
+    bool isPartiallyRolledBack() const;
+
 private:
     std::deque<MetadataOperationPtr> operations;
     MetadataStorageTransactionState state{MetadataStorageTransactionState::PREPARING};

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -404,6 +404,7 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::commit(const Tr
     /// 0. Add preconditions for transaction commit.
     operations.prependOperation(std::make_unique<MetadataStorageFromPlainObjectStorageValidatePreconditionsOperation>(uncommitted_state.getTxPreconditions(), commit_snapshot));
 
+    try
     {
         std::unique_lock lock(metadata_storage.metadata_mutex);
 
@@ -415,6 +416,38 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::commit(const Tr
 
         /// 3. Exchange metadata with updated fs.
         metadata_storage.fs.applySnapshot(commit_snapshot);
+    }
+    catch (...)
+    {
+        /// A commit that fails normally changes nothing: the snapshot is published only once every
+        /// operation has succeeded, and rolling back restores what object storage held before.
+        /// A rollback that stops halfway is different - the operations it never reached keep the
+        /// writes they already made, so object storage now describes a filesystem this process
+        /// does not have, and the disagreement survives until something rebuilds the filesystem.
+        /// Serving a filesystem that is known to be wrong is worse than listing the disk again.
+        /// The lock above is released while unwinding, so reloading here cannot deadlock.
+        if (operations.isPartiallyRolledBack())
+        {
+            LOG_ERROR(
+                getLogger("MetadataStorageFromPlainRewritableObjectStorage"),
+                "Rolling back the metadata transaction did not complete, so object storage may no "
+                "longer agree with the in-memory filesystem. Reloading it from object storage.");
+
+            try
+            {
+                metadata_storage.dropCache();
+            }
+            catch (...)
+            {
+                /// Reported separately: the caller has to see the error that failed the
+                /// transaction, not the one that failed the recovery.
+                tryLogCurrentException(
+                    getLogger("MetadataStorageFromPlainRewritableObjectStorage"),
+                    "Could not reload the filesystem after a partial rollback");
+            }
+        }
+
+        throw;
     }
 
     operations.finalize();

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorageOperations.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorageOperations.cpp
@@ -40,6 +40,7 @@ namespace FailPoints
 {
     extern const char plain_object_storage_write_fail_on_directory_create[];
     extern const char plain_object_storage_write_fail_on_directory_move[];
+    extern const char plain_object_storage_fail_on_directory_move_undo[];
     extern const char plain_object_storage_copy_fail_on_file_move[];
     extern const char plain_object_storage_copy_temp_source_file_fail_on_file_move[];
     extern const char plain_object_storage_copy_temp_target_file_fail_on_file_move[];
@@ -256,6 +257,17 @@ void MetadataStorageFromPlainObjectStorageMoveDirectoryOperation::undo()
 
         if (!changed_paths.contains(sub_path_from))
             continue;
+
+        /// Injected only here, unlike plain_object_storage_write_fail_on_directory_move, which
+        /// sits in rewriteSingleDirectory and therefore fires on the forward pass first. Failing
+        /// the undo is the only way to reach the state where object storage kept the new path
+        /// while the transaction reported failure.
+        fiu_do_on(FailPoints::plain_object_storage_fail_on_directory_move_undo,
+        {
+            throw Exception(
+                ErrorCodes::FAULT_INJECTED,
+                "Injecting fault when reversing the move from '{}' to '{}'", sub_path_to, sub_path_from);
+        });
 
         auto write_buf = createWriteBuf(remote_info.value(), /*expected_content*/std::nullopt);
         rewriteSingleDirectory(sub_path_to, sub_path_from, *write_buf);

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -14,6 +14,8 @@
 #include <Common/thread_local_rng.h>
 #include <Common/FailPoint.h>
 
+#include <base/scope_guard.h>
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -2233,4 +2235,54 @@ TEST_F(MetadataPlainRewritableDiskTest, ConcurrentCreateDirectory)
     metadata = restartMetadataStorage("ConcurrentCreateDirectory");
     EXPECT_TRUE(metadata->existsDirectory("A"));
     EXPECT_EQ(generateObjectKeyPrefixForDirectoryPath(metadata, "A/"), remote_prefix);
+}
+
+/// Reversing a directory move is not atomic: it rewrites one `prefix.path` marker per directory,
+/// and each of those is a separate object storage write. When one of them fails the rollback
+/// stops there, so the markers it never reached keep describing the move, while the in-memory
+/// filesystem still describes the state before it - a failed transaction never publishes its
+/// snapshot. The two only have to agree again the next time the filesystem is rebuilt from object
+/// storage, which for a MergeTree part means a directory turning up under a name the server never
+/// committed.
+TEST_F(MetadataPlainRewritableDiskTest, MoveUndoFailureDoesNotOutliveTheTransaction)
+{
+    auto metadata = getMetadataStorage("MoveUndoFailure");
+    auto object_storage = getObjectStorage("MoveUndoFailure");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectory("A");
+        tx->createDirectory("A/B");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    const auto a_path = createMetadataObjectPath(metadata, "A");
+    const auto ab_path = createMetadataObjectPath(metadata, "A/B");
+
+    {
+        FailPointInjection::enableFailPoint("plain_object_storage_fail_on_directory_move_undo");
+        SCOPE_EXIT(FailPointInjection::disableFailPoint("plain_object_storage_fail_on_directory_move_undo"));
+
+        /// The move executes and rewrites both markers; the failing file move is what makes the
+        /// transaction roll back afterwards, and the rollback is what cannot finish.
+        auto tx = metadata->createTransaction();
+        tx->moveDirectory("A", "MOVED");
+        tx->moveFile("non-existing", "other-place");
+        EXPECT_ANY_THROW(tx->commit(DB::NoCommitOptions{}));
+    }
+
+    /// The rollback never restored them, so object storage still describes the moved tree.
+    EXPECT_EQ(readObject(object_storage, a_path), "MOVED/");
+    EXPECT_EQ(readObject(object_storage, ab_path), "MOVED/B/");
+
+    /// Whichever state object storage was left in, the live filesystem has to describe the same
+    /// one. Reloading must not change what this disk reports.
+    const bool exists_a = metadata->existsDirectory("A");
+    const bool exists_moved = metadata->existsDirectory("MOVED");
+
+    metadata = restartMetadataStorage("MoveUndoFailure");
+    EXPECT_EQ(metadata->existsDirectory("A"), exists_a);
+    EXPECT_EQ(metadata->existsDirectory("A/B"), exists_a);
+    EXPECT_EQ(metadata->existsDirectory("MOVED"), exists_moved);
+    EXPECT_EQ(metadata->existsDirectory("MOVED/B"), exists_moved);
 }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118615

Reversing a directory move rewrites one `prefix.path` marker per directory, and each of those is a separate object storage write. `MetadataOperationsHolder::rollback` stops at the first `undo()` that throws, so the operations it never reached keep the writes they already made. The in-memory filesystem is unaffected, because a failed commit never publishes its snapshot — and the result is that object storage describes a filesystem this process does not have.

Nothing reconciled the two. `PARTIALLY_ROLLED_BACK` was recorded and then never read, so the only trace was a sentence appended to the exception, and the disagreement survived until the filesystem was next rebuilt from object storage. For a MergeTree part rename that means the merge reports failure while the directory is left under its committed name, and a later restart loads a part the server never committed.

This reloads the filesystem from object storage when the rollback did not complete. Note it does not undo the move: once the rollback has failed, the pre-move state is gone from object storage, so the guarantee is that the in-memory filesystem matches what is actually there. The reload runs only after a transaction has already failed, and serving a filesystem known to disagree with object storage is worse than listing the disk again.

The test needs a fault that fires only while undoing, hence the new failpoint: the existing `plain_object_storage_write_fail_on_directory_move` sits in `rewriteSingleDirectory`, which the forward pass calls first, so it can never leave a move half reversed.

**Open question for reviewers.** The recovery is a full disk relist (`dropCache`). It only fires after a rollback has already failed, so it should be rare, but on a large `plain_rewritable` disk it is a LIST storm at an already-bad moment. The cheaper alternative is a "needs reload" flag consumed by the next `refresh()`, but `refresh()` is not guaranteed to run, so the stale window would be unbounded. I chose correctness; happy to switch if you prefer bounded cost.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `plain_rewritable` disks continuing to serve a filesystem that disagrees with object storage after a metadata transaction failed to roll back completely. The disagreement previously surfaced only after a restart, when a directory could appear under a name the server never committed.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118623&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118623](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118623+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
