### PR TITLE
Assign `query_kind` before the checks that read it in `TCPHandler`

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2795,6 +2795,11 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
     /// Settings
     ///
 
+    /// Must be set before the version-gated compatibility decisions below read it: `query_kind` is a
+    /// handler member that lives as long as the connection, so until it is assigned it still holds
+    /// the *previous* query's kind on this connection (and `NO_QUERY` for the first one).
+    query_kind = state->query_context->getClientInfo().query_kind;
+
     /// FIXME: Remove when allow_experimental_analyzer will become obsolete.
     /// Analyzer became Beta in 24.3 and started to be enabled by default.
     /// We have to disable it for ourselves to make sure we don't have different settings on
@@ -2812,7 +2817,6 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
         passed_settings.set("optimize_const_name_size", -1);
 
     auto settings_changes = passed_settings.changes();
-    query_kind = state->query_context->getClientInfo().query_kind;
     if (query_kind == ClientInfo::QueryKind::INITIAL_QUERY)
     {
         /// Throw an exception if the passed settings violate the constraints.


### PR DESCRIPTION
`TCPHandler::query_kind` is a handler member, so it lives as long as the connection. `processQuery` assigned it only *after* the version-gated compatibility block that reads it:

```cpp
    if (query_kind == ClientInfo::QueryKind::SECONDARY_QUERY          // <-- reads it here
        && VersionNumber(client_info.client_version_major, ...) < VersionNumber(23, 3, 0)
        && !passed_settings[Setting::allow_experimental_analyzer].changed)
        passed_settings.set("allow_experimental_analyzer", false);
    ...
    auto settings_changes = passed_settings.changes();
    query_kind = state->query_context->getClientInfo().query_kind;    // <-- assigned only here
```

So that block saw the **previous** query's kind on the same connection, and `NO_QUERY` for the first query of a connection — never the kind of the query actually being processed. This PR assigns `query_kind` before its first reader instead; `state->query_context` is already built at that point, so the statement simply moves up.

The affected check is the pre-23.3 `allow_experimental_analyzer` downgrade, whose stated purpose is "to make sure we don't have different settings on different servers". With the stale read it was skipped for the first query on every connection and then keyed off a leftover value, so for a genuinely pre-23.3 initiator the setting was *not* forced off consistently — the opposite of the guarantee the check exists to provide.

**This is latent on current master.** Since the query context of a server-initiated query is filled with this server's own version (#109408), no ClickHouse initiator can report a version below 23.3 any more, so the downgrade cannot fire at all. I found this while investigating #86667, where that downgrade was still reachable and did split the analyzer between initiator and shard. I am deliberately not claiming this ordering bug explains the every-other-reload pattern in #86667: I looked, and found a counterexample (12 consecutive queries over one reused inter-server connection all succeeded), so the intermittency there is gated by something I did not pin down. This PR is the ordering defect on its own terms.

No test: the behaviour is only observable from an initiator that reports a version below 23.3 with `query_kind = SECONDARY_QUERY`, which no supported ClickHouse and no current client can produce, and the logic is inline in `TCPHandler::processQuery` rather than in anything a functional test can reach. Adding a test would mean faking an ancient client version over the native protocol, which is not worth the machinery for a statement move.

Not built locally — this working tree is three weeks behind `master` and its build directory predates `Common/saturatedDuration.h`, so a single-TU syntax check of a `master`-based file is not possible here without a fresh worktree and rebuild. The change moves one existing statement within one function and introduces no new names; letting CI compile it.

Related: https://github.com/ClickHouse/ClickHouse/issues/86667
Related: https://github.com/ClickHouse/ClickHouse/pull/109408

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118624&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118624](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118624+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1115` (included in `26.9` and later)
<!-- ch-version-info:end -->