### PR TITLE
Validate the argument list of an optimization of `mergeTreeAnalyzeIndexes`

### DIFF
--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -80,6 +80,41 @@ static Strings extractParts(const ASTPtr & argument, const ContextPtr & context)
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parts must be an array of strings, got: {}", argument->formatForLogging());
 }
 
+/// The arguments of an optimization, in the same shapes as `extractParts` above accepts: an array
+/// literal wrapped in a `_CAST` with the analyzer, a bare `array(...)` call without it. Every element
+/// is evaluated on its own, so that a list of mixed types - which is what `buildAnalyzeIndexQuery`
+/// sends - keeps the type of each element instead of being coerced to one common type.
+static Array extractOptimizationArguments(const ASTPtr & argument, const ContextPtr & context)
+{
+    ASTPtr array = argument;
+    if (const auto * func = array->as<ASTFunction>())
+    {
+        if (func->name == "_CAST" && func->arguments && !func->arguments->children.empty()) /// _CAST([...], 'Array(String)')
+            array = func->arguments->children.at(0);
+        else if (func->name == "array" && func->arguments) /// array(ExpressionList)
+            array = func->arguments;
+        else
+            array = ASTPtr();
+    }
+
+    if (array)
+    {
+        if (const auto * literal = array->as<ASTLiteral>(); literal && literal->value.getType() == Field::Types::Array)
+            return literal->value.safeGet<Array>();
+
+        if (const auto * expr_list = array->as<ASTExpressionList>())
+        {
+            Array result;
+            for (const auto & element : expr_list->children)
+                result.push_back(evaluateConstantExpressionAsLiteral(element, context)->as<ASTLiteral &>().value);
+            return result;
+        }
+    }
+
+    throw Exception(ErrorCodes::BAD_ARGUMENTS,
+        "Arguments of an optimization must be an array of its parameters, got: {}", argument->formatForLogging());
+}
+
 class TableFunctionMergeTreeAnalyzeIndexes : public ITableFunction
 {
 public:
@@ -205,8 +240,7 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations(const 
     auto optimization = checkAndGetLiteralArgument<String>(args[start_index++], "extra_optimization");
     if (optimization == "vector_search_index_analysis")
     {
-        auto cast_node = args[start_index++]->children.at(0);
-        auto vector_search_args = evaluateConstantExpressionAsLiteral(cast_node->children.at(0), context)->as<ASTLiteral &>().value.safeGet<Array>();
+        auto vector_search_args = extractOptimizationArguments(args[start_index++], context);
         if (vector_search_args.size() != 6)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
                 "vector_search_index_analysis requires 6 arguments");

--- a/tests/queries/0_stateless/05142_analyze_indexes_malformed_optimization_args.sql
+++ b/tests/queries/0_stateless/05142_analyze_indexes_malformed_optimization_args.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS t_analyze_optimization_args;
+CREATE TABLE t_analyze_optimization_args (key Int, v Array(Float32)) ENGINE = MergeTree ORDER BY key;
+
+-- A malformed argument list of an optimization is rejected instead of being navigated into.
+
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', 42); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', 'not an array'); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', NULL); -- { serverError BAD_ARGUMENTS }
+
+SET enable_analyzer = 0;
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', 42); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
+SET enable_analyzer = 1;
+
+-- A well-formed argument list is accepted; the table has no vector similarity index, so the
+-- analysis returns no ranges.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', array('v', 'L2Distance', 3, [1.5, 2.5, 3.5], 1, 0));
+
+DROP TABLE t_analyze_optimization_args;

--- a/tests/queries/0_stateless/05142_analyze_indexes_malformed_optimization_args.sql
+++ b/tests/queries/0_stateless/05142_analyze_indexes_malformed_optimization_args.sql
@@ -10,6 +10,10 @@ SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_
 SET enable_analyzer = 0;
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', 42); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
+
+-- The argument list `buildAnalyzeIndexQuery` sends is accepted on the old interpreter as well, where
+-- each element keeps its own type instead of the whole array being coerced to one.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_analyze_optimization_args, 1, [], 'vector_search_index_analysis', array('v', 'L2Distance', 3, [1.5, 2.5, 3.5], 1, 0));
 SET enable_analyzer = 1;
 
 -- A well-formed argument list is accepted; the table has no vector similarity index, so the


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117610

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

A malformed argument list of an optimization of the `mergeTreeAnalyzeIndexes` table function is now reported as `BAD_ARGUMENTS` instead of a logical error or a raw `std::exception`.


### Description

`parseArgumentsForOptimizations` navigated two levels of raw AST children of its `args_array` argument without validating its shape, so

- a subquery there raised `Logical error: Trying to get name of not a column: ExpressionList` (which aborts a debug build, and the AST fuzzer generates exactly this shape), and
- a bare literal escaped as `boost::container::out_of_range: vector::at out of range` (`STD_EXCEPTION`).

The argument is now extracted the same way `extractParts` extracts the neighbouring `parts_array` - accepting an array literal wrapped in a `_CAST`, or a bare `array(...)` call, which is what an argument list of mixed types (the shape `buildAnalyzeIndexQuery` sends) stays as - and reporting `BAD_ARGUMENTS` for anything else. Each element is evaluated on its own, so it keeps its own type.

The six parameters of `vector_search_index_analysis` are then checked explicitly, one by one: a wrong element type - `['v', 'L2Distance', 3, 1, 1, 0]`, `[1, 'L2Distance', 3, [1.0], 1, 0]`, a negative limit, a flag other than `true` / `false` / `0` / `1` - is reported as `BAD_ARGUMENTS` naming the offending parameter and its position, instead of escaping as an internal `BAD_GET`. A wrong number of parameters lists the expected ones.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118644&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118644](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118644+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

