### PR TITLE
Return the normalized headers from HTTPHeaderFilter::checkAndNormalizeHeaders

### DIFF
--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -15,7 +15,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
-void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) const
+HTTPHeaderEntries HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries entries) const
 {
     std::lock_guard guard(mutex);
 
@@ -68,6 +68,8 @@ void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) con
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" is forbidden in configuration file, "
                                                         "see <http_forbid_headers>", reported_name);
     }
+
+    return entries;
 }
 
 void HTTPHeaderFilter::setValuesFromConfig(const Poco::Util::AbstractConfiguration & config)

--- a/src/Common/HTTPHeaderFilter.h
+++ b/src/Common/HTTPHeaderFilter.h
@@ -18,8 +18,10 @@ public:
 
     void setValuesFromConfig(const Poco::Util::AbstractConfiguration & config);
     /// Validates the headers (throws BAD_ARGUMENTS on an invalid or forbidden name/value) and
-    /// normalizes the names in place.
-    void checkAndNormalizeHeaders(HTTPHeaderEntries & entries) const;
+    /// returns the normalized entries. Returning the normalized set — rather than mutating in
+    /// place — means a caller cannot validate the headers and then accidentally send the original,
+    /// un-normalized ones; the [[nodiscard]] makes ignoring the normalized result a build error.
+    [[nodiscard]] HTTPHeaderEntries checkAndNormalizeHeaders(HTTPHeaderEntries entries) const;
 
 private:
     /// Header names are case-insensitive (RFC 7230 3.2): entries are stored

--- a/src/Common/tests/gtest_http_header_filter.cpp
+++ b/src/Common/tests/gtest_http_header_filter.cpp
@@ -29,7 +29,7 @@ bool isForbidden(const HTTPHeaderFilter & filter, const std::string & name)
     HTTPHeaderEntries entries{{name, "value"}};
     try
     {
-        filter.checkAndNormalizeHeaders(entries);
+        (void)filter.checkAndNormalizeHeaders(entries);
     }
     catch (const Exception &)
     {
@@ -206,7 +206,7 @@ TEST(HTTPHeaderFilter, RejectsCarriageReturnAndNewline)
     auto rejects = [&](const std::string & name, const std::string & value)
     {
         HTTPHeaderEntries entries{{name, value}};
-        try { filter.checkAndNormalizeHeaders(entries); }
+        try { (void)filter.checkAndNormalizeHeaders(entries); }
         catch (const Exception &) { return true; }
         return false;
     };

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -1448,7 +1448,8 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             if (pos != std::string::npos)
             {
                 DB::HTTPHeaderEntries header_entries{{auth_header_str.substr(0, pos), auth_header_str.substr(pos + 1)}};
-                args.context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_entries);
+                /// CREATE-time validation only (throws on an invalid or forbidden header); the normalized result is not stored.
+                (void)args.context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(header_entries));
             }
             else
             {

--- a/src/Databases/DataLake/HTTPBasedCatalogUtils.cpp
+++ b/src/Databases/DataLake/HTTPBasedCatalogUtils.cpp
@@ -30,7 +30,8 @@ void validateBearerToken(const DB::ContextPtr & context, const std::string & bea
         return;
 
     DB::HTTPHeaderEntries auth_header{{"Authorization", "Bearer " + bearer_token}};
-    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(auth_header);
+    /// Validation only (throws on an invalid header); the synthetic header is not sent from here.
+    (void)context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(auth_header));
 }
 
 DB::ReadWriteBufferFromHTTPPtr createReadBuffer(

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -292,8 +292,7 @@ void RestCatalog::validateAuthHeaders(const DB::HTTPHeaderEntry & header) const
     /// here, before `loadConfig` issues any request. Mirrors the CREATE-path check: a copy is
     /// validated and the original parsed header is kept.
     /// Validation only (throws on an invalid or forbidden header); the stored header is kept as-is.
-    DB::HTTPHeaderEntries header_to_check{header};
-    getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_to_check);
+    (void)getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(DB::HTTPHeaderEntries{header});
 }
 
 DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(const CatalogState & catalog_state, bool update_token) const
@@ -308,11 +307,10 @@ DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(const CatalogState & catalog_s
     if (catalog_state.auth_header.has_value())
     {
         /// Normalize the header that is actually sent to the catalog (the stored setting is kept
-        /// verbatim for compatibility): the name that reaches the wire is the validated, normalized
-        /// one, not the raw stored bytes.
-        DB::HTTPHeaderEntries header_entries{catalog_state.auth_header.value()};
-        getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_entries);
-        return header_entries;
+        /// verbatim for compatibility). Mirrors the schema-inference path in StorageURL: the name
+        /// that reaches the wire is the validated, normalized one, not the raw stored bytes.
+        return getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(
+            DB::HTTPHeaderEntries{catalog_state.auth_header.value()});
     }
 
     /// Option 2: user provided grant_type and client credentials for OAuthClientCredentialsRequest.

--- a/src/Databases/DataLake/tests/gtest_gcs_credentials.cpp
+++ b/src/Databases/DataLake/tests/gtest_gcs_credentials.cpp
@@ -42,7 +42,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsNewline)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Authorization", "Bearer token\nX-Injected: malicious"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturn)
@@ -50,7 +50,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturn)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Authorization", "Bearer token\r\nX-Injected: malicious"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationAcceptsValidToken)
@@ -58,7 +58,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationAcceptsValidToken)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Authorization", "Bearer ya29.valid-gcs-token_1234"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
+    EXPECT_NO_THROW((void)filter.checkAndNormalizeHeaders(headers));
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsColonInName)
@@ -68,7 +68,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsColonInName)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Cookie:j=\"x", "y\";session=abc"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturnInName)
@@ -76,7 +76,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturnInName)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"X-Foo\rX-Injected", "value"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsLineFeedInName)
@@ -84,7 +84,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsLineFeedInName)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"X-Foo\nX-Injected", "value"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationAcceptsColonInValue)
@@ -93,20 +93,22 @@ TEST_F(GCSCredentialsTest, HeaderValidationAcceptsColonInValue)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Host", "example.com:8080"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
+    EXPECT_NO_THROW((void)filter.checkAndNormalizeHeaders(headers));
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationNormalizesWhitespaceInName)
 {
     /// Whitespace/control in a name is still stripped rather than rejected, preserving the
     /// historical behaviour for stored objects that are re-validated on ATTACH. Assert the
-    /// in-place normalized name, so a change that stopped normalizing would be caught here.
+    /// normalized name on the returned entries (callers send what is returned), so a change that
+    /// stopped normalizing would be caught here.
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"X-A B", "value"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
-    ASSERT_EQ(headers.size(), 1u);
-    EXPECT_EQ(headers[0].name, "X-AB");
+    DB::HTTPHeaderEntries normalized;
+    EXPECT_NO_THROW(normalized = filter.checkAndNormalizeHeaders(headers));
+    ASSERT_EQ(normalized.size(), 1u);
+    EXPECT_EQ(normalized[0].name, "X-AB");
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationAcceptsNameEmptyAfterNormalization)
@@ -117,9 +119,10 @@ TEST_F(GCSCredentialsTest, HeaderValidationAcceptsNameEmptyAfterNormalization)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({" \t ", "value"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
-    ASSERT_EQ(headers.size(), 1u);
-    EXPECT_EQ(headers[0].name, "");
+    DB::HTTPHeaderEntries normalized;
+    EXPECT_NO_THROW(normalized = filter.checkAndNormalizeHeaders(headers));
+    ASSERT_EQ(normalized.size(), 1u);
+    EXPECT_EQ(normalized[0].name, "");
 }
 
 }

--- a/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/src/Dictionaries/HTTPDictionarySource.cpp
@@ -336,7 +336,7 @@ void registerDictionarySourceHTTP(DictionarySourceFactory & factory)
         if (created_from_ddl)
         {
             context->getRemoteHostFilter().checkURL(Poco::URI(uri));
-            context->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_entries);
+            header_entries = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(header_entries));
         }
 
         auto configuration = HTTPDictionarySource::Configuration

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -291,7 +291,7 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
         }
     }
 
-    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+    headers = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 
     auto shared_cache = S3::ClientCacheRegistry::instance().getOrCreateCacheForKey(url.endpoint, url.bucket);
 

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -140,7 +140,7 @@ void StorageS3Configuration::check(ContextPtr context)
 {
     validateNamespace(url.bucket);
     context->getGlobalContext()->getRemoteHostFilter().checkURL(url.uri);
-    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_from_ast);
+    headers_from_ast = context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers_from_ast));
     StorageObjectStorageConfiguration::check(context);
 }
 

--- a/src/Storages/ObjectStorage/Web/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Web/Configuration.cpp
@@ -139,7 +139,7 @@ void StorageWebConfiguration::check(ContextPtr context)
         for (const auto & url_option : url_shard)
             context->getGlobalContext()->getRemoteHostFilter().checkURL(Poco::URI(url_option.base_url + url_option.query_fragment, false));
     }
-    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_from_ast);
+    headers_from_ast = context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers_from_ast));
 }
 
 ObjectStoragePtr StorageWebConfiguration::createObjectStorage(ContextPtr context, bool, CredentialsConfigurationCallback) /// NOLINT

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1103,12 +1103,11 @@ std::pair<ColumnsDescription, String> IStorageURLBase::getTableStructureAndForma
     /// Enforce <http_forbid_headers> before any network access. This is the single funnel for
     /// schema inference (StorageURL ctor, StorageURLCluster, TableFunctionURL analysis), so the
     /// check here also covers the DESCRIBE / INSERT..SELECT / format-detection paths that never
-    /// reach the StorageURL ctor body. checkAndNormalizeHeaders normalizes in place, so validate a
-    /// copy and send that copy — the normalized names are what reach the wire. Ban "Range" on the
+    /// reach the StorageURL ctor body. checkAndNormalizeHeaders returns the normalized headers, so
+    /// send that normalized copy — the normalized names are what reach the wire. Ban "Range" on the
     /// normalized names (a padded spelling normalizes to "Range") so schema inference never reads a
     /// partial-content response.
-    HTTPHeaderEntries headers_to_check(headers);
-    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_to_check);
+    const auto headers_to_check = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
     rejectRangeHeaders(headers_to_check);
 
     Poco::Net::HTTPBasicCredentials credentials;
@@ -1621,7 +1620,7 @@ StorageURL::StorageURL(
         distributed_processing_)
 {
     context_->getRemoteHostFilter().checkURL(Poco::URI(uri));
-    context_->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+    headers = context_->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 }
 
 

--- a/src/Storages/StorageURLCluster.cpp
+++ b/src/Storages/StorageURLCluster.cpp
@@ -55,7 +55,7 @@ StorageURLCluster::StorageURLCluster(
 {
     auto headers = configuration_.headers;
     context->getRemoteHostFilter().checkURL(Poco::URI(uri));
-    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+    headers = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 
     StorageInMemoryMetadata storage_metadata;
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/117875
-->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Internal refactor of `HTTPHeaderFilter::checkAndNormalizeHeaders`; no user-facing change.


### Documentation entry for user-facing changes

**Stacked on top of #117875** (the security fix); this is the API hardening split out of it, so review/merge #117875 first.

`HTTPHeaderFilter::checkAndNormalizeHeaders` mutated its argument in place. Callers that validated a *copy* of the entries and then sent the *original* would send un-normalized headers on the wire — this was really present on the `StorageURL` schema-inference and `RestCatalog` auth paths (fixed pointwise in #117875).

This makes the function take the entries by value and **return** the normalized set (`[[nodiscard]]`), and updates every caller to use the returned value. The mistake is now impossible to write: ignoring the normalized result is a compile error, so a future caller cannot reintroduce the "validate a copy, send the original" bug. No behaviour change — the validation/normalization logic is unchanged; only how callers receive the result.
