### PR TITLE
Remove a duplicate include from the text index condition

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -33,7 +33,6 @@
 #include <absl/container/inlined_vector.h>
 #include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnSet.h>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117314

`MergeTreeIndexConditionText.cpp` includes `DataTypeLowCardinality.h` twice since https://github.com/ClickHouse/ClickHouse/pull/117314. clang-tidy reports it as `readability-duplicate-include`, which fails the `Build (arm_tidy)` job on master and on every pull request that merges the current master, for example https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118336&sha=529d408ec7857c13d50a02630c0afa98c71f6444&name_0=PR&name_1=Build%20(arm_tidy). This removes the second include.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118661&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118661](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118661+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.942` (included in `26.9` and later)
<!-- ch-version-info:end -->