### PR TITLE
Remove duplicate include in MergeTreeIndexConditionText.cpp

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -33,7 +33,6 @@
 #include <absl/container/inlined_vector.h>
 #include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnSet.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Description

`DataTypeLowCardinality.h` is included twice in `MergeTreeIndexConditionText.cpp`, which fails `readability-duplicate-include` in the `Build (arm_tidy)` check (master's own `Build (arm_tidy)` is currently red on it, blocking the merge-build of open PRs). Remove the duplicate occurrence. No behavior change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118664&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118664](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118664+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
