### PR TITLE
Remove a duplicate include in `MergeTreeIndexConditionText`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -33,7 +33,6 @@
 #include <absl/container/inlined_vector.h>
 #include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnSet.h>


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...


### Description

`DataTypes/DataTypeLowCardinality.h` is included twice in `MergeTreeIndexConditionText.cpp`, so `Build (arm_tidy)` fails on every pull request:

```
/ClickHouse/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp:36:1: error: duplicate include [readability-duplicate-include,-warnings-as-errors]
```

The second occurrence is removed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118680&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118680](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118680+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
