### PR TITLE
Replace the proxy of a lazily loaded table with the table itself

### DIFF
--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -5,6 +5,7 @@
 #include <Backups/RestorerFromBackup.h>
 #include <Core/Settings.h>
 #include <Core/UUID.h>
+#include <Interpreters/ActionLocksManager.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InterpreterCreateQuery.h>
@@ -553,7 +554,7 @@ bool DatabaseWithOwnTablesBase::isTableExist(const String & table_name, ContextP
     return tables.contains(table_name);
 }
 
-StoragePtr DatabaseWithOwnTablesBase::replaceLoadedLazyTableUnlocked(const Tables::iterator & it) const
+StoragePtr DatabaseWithOwnTablesBase::replaceLoadedLazyTableUnlocked(Tables::iterator it) const
 {
     /// By value: the map slot is overwritten below, and the proxy is still needed after that.
     StoragePtr proxy = it->second;
@@ -582,6 +583,12 @@ StoragePtr DatabaseWithOwnTablesBase::replaceLoadedLazyTableUnlocked(const Table
     }
 
     it->second = real_table;
+
+    /// `ActionLocksManager` keys the locks it holds by the storage they were taken on, so a
+    /// `SYSTEM STOP MERGES` issued while the table was still a proxy has to be re-keyed: the
+    /// matching `SYSTEM START MERGES` addresses the storage that just took the proxy's place, and
+    /// would otherwise not find the lock and never lift it.
+    getContext()->getActionLocksManager()->transfer(proxy.get(), real_table);
 
     LOG_TRACE(log, "Replaced the proxy of lazily loaded table {} with the loaded {}",
               table_id.getNameForLogs(), real_table->getName());

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -553,6 +553,42 @@ bool DatabaseWithOwnTablesBase::isTableExist(const String & table_name, ContextP
     return tables.contains(table_name);
 }
 
+StoragePtr DatabaseWithOwnTablesBase::replaceLoadedLazyTableUnlocked(const Tables::iterator & it) const
+{
+    /// By value: the map slot is overwritten below, and the proxy is still needed after that.
+    StoragePtr proxy = it->second;
+    StoragePtr real_table = proxy->getLoadedLazyTable();
+    if (!real_table)
+        return proxy;
+
+    auto table_id = proxy->getStorageID();
+    /// A rename updates the proxy and the storage it stands for together, under this same mutex.
+    chassert(real_table->getStorageID() == table_id);
+
+    /// The UUID mapping has to be updated as well: `DatabaseCatalog::getTableImpl` answers a
+    /// StorageID that already carries a UUID straight from it, without asking the database.
+    if (table_id.hasUUID())
+        DatabaseCatalog::instance().updateUUIDMapping(
+            table_id.uuid, std::const_pointer_cast<IDatabase>(shared_from_this()), real_table);
+
+    /// A proxy and the storage it stands for are not counted the same way: `AttachedReplicatedTable`
+    /// is only counted for `StorageReplicatedMergeTree`.
+    if (!real_table->isSystemStorage() && !DatabaseCatalog::isPredefinedDatabase(database_name))
+    {
+        for (auto metric : getAttachedCountersForStorage(proxy))
+            CurrentMetrics::sub(metric);
+        for (auto metric : getAttachedCountersForStorage(real_table))
+            CurrentMetrics::add(metric);
+    }
+
+    it->second = real_table;
+
+    LOG_TRACE(log, "Replaced the proxy of lazily loaded table {} with the loaded {}",
+              table_id.getNameForLogs(), real_table->getName());
+
+    return real_table;
+}
+
 StoragePtr DatabaseWithOwnTablesBase::tryGetTable(const String & table_name, ContextPtr) const
 {
     waitTableStarted(table_name);
@@ -563,13 +599,18 @@ DatabaseTablesIteratorPtr DatabaseWithOwnTablesBase::getTablesIterator(ContextPt
 {
     ensurePopulated();
     std::lock_guard lock(mutex);
+
     if (!filter_by_table_name)
+    {
+        for (auto it = tables.begin(); it != tables.end(); ++it)
+            replaceLoadedLazyTableUnlocked(it);
         return std::make_unique<DatabaseTablesSnapshotIterator>(tables, database_name);
+    }
 
     Tables filtered_tables;
-    for (const auto & [table_name, storage] : tables)
-        if (filter_by_table_name(table_name))
-            filtered_tables.emplace(table_name, storage);
+    for (auto it = tables.begin(); it != tables.end(); ++it)
+        if (filter_by_table_name(it->first))
+            filtered_tables.emplace(it->first, replaceLoadedLazyTableUnlocked(it));
 
     return std::make_unique<DatabaseTablesSnapshotIterator>(std::move(filtered_tables), database_name);
 }
@@ -874,7 +915,7 @@ StoragePtr DatabaseWithOwnTablesBase::getTableUnlocked(const String & table_name
 {
     auto it = tables.find(table_name);
     if (it != tables.end())
-        return it->second;
+        return replaceLoadedLazyTableUnlocked(it);
     throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table {}.{} doesn't exist",
                     backQuote(database_name), backQuote(table_name));
 }
@@ -931,14 +972,14 @@ StoragePtr DatabaseWithOwnTablesBase::tryGetTableNoWait(const String & table_nam
         std::lock_guard lock(mutex);
         auto it = tables.find(table_name);
         if (it != tables.end())
-            return it->second;
+            return replaceLoadedLazyTableUnlocked(it);
     }
 
     ensurePopulated();
     std::lock_guard lock(mutex);
     auto it = tables.find(table_name);
     if (it != tables.end())
-        return it->second;
+        return replaceLoadedLazyTableUnlocked(it);
     return {};
 }
 

--- a/src/Databases/DatabasesCommon.h
+++ b/src/Databases/DatabasesCommon.h
@@ -101,7 +101,7 @@ protected:
     /// real storage instead of the proxy. It has to happen here rather than in the proxy itself,
     /// because the proxy loads the table from under this mutex (`DatabaseAtomic::renameTable` does,
     /// through `tryCreateSymlink`), so it cannot take it.
-    StoragePtr replaceLoadedLazyTableUnlocked(const Tables::iterator & it) const TSA_REQUIRES(mutex);
+    StoragePtr replaceLoadedLazyTableUnlocked(Tables::iterator it) const TSA_REQUIRES(mutex);
 
 private:
     mutable std::atomic<bool> has_deferred_population{false};

--- a/src/Databases/DatabasesCommon.h
+++ b/src/Databases/DatabasesCommon.h
@@ -79,7 +79,9 @@ public:
 protected:
     bool mayShadowDeferredTable(const String & table_name) const;
 
-    Tables tables TSA_GUARDED_BY(mutex);
+    /// Mutable because a lazily loaded table replaces itself with the storage it stands for as soon
+    /// as the load is noticed, which happens on the (const) lookup paths.
+    mutable Tables tables TSA_GUARDED_BY(mutex);
     SnapshotDetachedTables snapshot_detached_tables TSA_GUARDED_BY(mutex);
     LoggerPtr log;
 
@@ -89,6 +91,17 @@ protected:
     virtual StoragePtr detachTableUnlocked(const String & table_name) TSA_REQUIRES(mutex);
     StoragePtr getTableUnlocked(const String & table_name) const TSA_REQUIRES(mutex);
     StoragePtr tryGetTableNoWait(const String & table_name) const;
+
+    /// If `it` holds a lazily loaded table (see the `lazy_load_tables` database setting) that has
+    /// already been loaded, put the storage it stands for in its place and return that storage;
+    /// otherwise return what is already there.
+    ///
+    /// Doing this makes everything that resolves the table from now on - including everything that
+    /// only recognizes a table by its concrete type, such as `system.parts` or mutations - see the
+    /// real storage instead of the proxy. It has to happen here rather than in the proxy itself,
+    /// because the proxy loads the table from under this mutex (`DatabaseAtomic::renameTable` does,
+    /// through `tryCreateSymlink`), so it cannot take it.
+    StoragePtr replaceLoadedLazyTableUnlocked(const Tables::iterator & it) const TSA_REQUIRES(mutex);
 
 private:
     mutable std::atomic<bool> has_deferred_population{false};

--- a/src/Interpreters/ActionLocksManager.cpp
+++ b/src/Interpreters/ActionLocksManager.cpp
@@ -62,6 +62,24 @@ void ActionLocksManager::remove(const StoragePtr & table, StorageActionBlockType
         storage_locks[table.get()].erase(action_type);
 }
 
+void ActionLocksManager::transfer(const IStorage * from, const StoragePtr & to)
+{
+    std::lock_guard lock(mutex);
+
+    auto it = storage_locks.find(from);
+    if (it == storage_locks.end())
+        return;
+
+    auto moved_locks = std::move(it->second);
+    storage_locks.erase(it);
+
+    /// The locks themselves already belong to `to`: a proxy forwards `getActionLock` to the storage
+    /// it stands for. Only the key has to change. Anything `to` already holds stays as it is.
+    auto & locks = storage_locks[to.get()];
+    for (auto & [action_type, action_lock] : moved_locks)
+        locks.try_emplace(action_type, std::move(action_lock));
+}
+
 void ActionLocksManager::cleanExpired()
 {
     std::lock_guard lock(mutex);

--- a/src/Interpreters/ActionLocksManager.h
+++ b/src/Interpreters/ActionLocksManager.h
@@ -28,6 +28,11 @@ public:
     void remove(const StorageID & table_id, StorageActionBlockType action_type);
     void remove(const StoragePtr & table, StorageActionBlockType action_type);
 
+    /// Re-key every lock held for `from` onto `to`. Used when a lazily loaded table replaces the
+    /// proxy that stood for it: a `SYSTEM STOP ...` issued before the replacement was keyed by the
+    /// proxy, while the matching `SYSTEM START ...` addresses the storage that took its place.
+    void transfer(const IStorage * from, const StoragePtr & to);
+
     /// Removes all locks of non-existing tables
     void cleanExpired();
 

--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -96,7 +96,7 @@ TableLockHolder IStorage::tryLockForShare(const String & query_id, const Poco::T
 
 std::optional<IStorage::AlterLockHolder> IStorage::tryLockForAlter(const Poco::Timespan & acquire_timeout)
 {
-    AlterLockHolder lock{alter_lock, std::defer_lock};
+    AlterLockHolder lock{*alter_lock, std::defer_lock};
 
     if (!lock.try_lock_for(saturatedMilliseconds(acquire_timeout.totalMilliseconds())))
         return {};
@@ -118,6 +118,12 @@ IStorage::AlterLockHolder IStorage::lockForAlter(const Poco::Timespan & acquire_
     return std::move(*lock);
 }
 
+
+void IStorage::takeTableLocksFrom(const IStorage & other)
+{
+    alter_lock = other.alter_lock;
+    drop_lock = other.drop_lock;
+}
 
 TableExclusiveLockHolder IStorage::lockExclusively(const String & query_id, const Poco::Timespan & acquire_timeout)
 {

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -365,6 +365,24 @@ public:
     /// heavyweight and makes table irresponsive.
     TableExclusiveLockHolder lockExclusively(const String & query_id, const Poco::Timespan & acquire_timeout);
 
+    /// For a lazily loaded table (see the `lazy_load_tables` database setting), the storage this one
+    /// stands for, once it has been loaded, and nullptr before that. Never triggers the load.
+    /// Any other storage returns nullptr: it already is the storage it stands for.
+    virtual StoragePtr getLoadedLazyTable() const { return nullptr; }
+
+    /// Make this storage use the very same table-level locks as `other` instead of its own, so that
+    /// the two objects form a single lock domain for lockForShare, lockForAlter and lockExclusively.
+    ///
+    /// This exists for lazily loaded tables. A `StorageTableProxy` is published in the database
+    /// before the real storage exists, and is replaced by the real storage once it has been loaded.
+    /// Queries that resolved the table before the replacement keep a reference to the proxy and lock
+    /// it, while queries that resolve it afterwards lock the real storage. Unless both objects lock
+    /// the same primitives, a DROP or an ALTER would not wait for a SELECT that is still running.
+    ///
+    /// Must be called on a freshly created storage that has not been published anywhere yet, and
+    /// both storages must stand for the same table.
+    void takeTableLocksFrom(const IStorage & other);
+
     /** Returns stage to which query is going to be processed in read() function.
       * (Normally, the function only reads the columns from the list, but in other cases,
       *  for example, the request can be partially processed on a remote server, or an aggregate projection.)
@@ -837,7 +855,8 @@ public:
 private:
     /// Lock required for alter queries (lockForAlter).
     /// Allows to execute only one simultaneous alter query.
-    mutable std::timed_mutex alter_lock;
+    /// Held behind a shared_ptr so that it can be shared with another storage, see takeTableLocksFrom.
+    mutable std::shared_ptr<std::timed_mutex> alter_lock = std::make_shared<std::timed_mutex>();
 
     /// Lock required for drop queries. Every thread that want to ensure, that
     /// table is not dropped have to table this lock for read (lockForShare).

--- a/src/Storages/StorageTableProxy.h
+++ b/src/Storages/StorageTableProxy.h
@@ -75,7 +75,13 @@ public:
 
     StoragePtr getLoadedLazyTable() const override
     {
-        std::lock_guard lock{nested_mutex};
+        /// Never wait for the load to finish. This is called by the database with its own mutex
+        /// held, while `getNested` keeps `nested_mutex` for as long as the table takes to load, so
+        /// waiting here would hold the whole database up. Reporting "not loaded yet" is harmless:
+        /// the next lookup replaces the proxy instead.
+        std::unique_lock lock{nested_mutex, std::try_to_lock};
+        if (!lock.owns_lock())
+            return nullptr;
         return nested;
     }
 

--- a/src/Storages/StorageTableProxy.h
+++ b/src/Storages/StorageTableProxy.h
@@ -61,11 +61,40 @@ public:
         LOG_TRACE(log, "Loading lazy table on first access");
 
         auto nested_storage = get_nested();
+        /// The database replaces this proxy with the loaded storage as soon as it notices the load
+        /// (see `DatabaseWithOwnTablesBase::replaceLoadedLazyTableUnlocked`), after which the two
+        /// objects are both around and both reachable as this table. Hand over the table-level
+        /// locks, so that they keep excluding each other across the replacement.
+        nested_storage->takeTableLocksFrom(*this);
         nested_storage->startup();
         nested_storage->renameInMemory(getStorageID());
         nested = nested_storage;
         get_nested = {};
         return nested;
+    }
+
+    StoragePtr getLoadedLazyTable() const override
+    {
+        std::lock_guard lock{nested_mutex};
+        return nested;
+    }
+
+    /// `StorageProxy` forwards `mutate`, but not the checks that gate a mutation, an UPDATE or a
+    /// DELETE. Without these, the first such statement addressed to a table that has not been loaded
+    /// yet is answered by the `IStorage` defaults and rejected, e.g. with
+    /// `Table engine MergeTree doesn't support mutations`. They all mean the table is about to be
+    /// written to, so materializing it here costs nothing.
+    void checkMutationIsPossible(const MutationCommands & commands, const Settings & settings) const override
+    {
+        getNested()->checkMutationIsPossible(commands, settings);
+    }
+
+    bool supportsDelete() const override { return getNested()->supportsDelete(); }
+    bool supportsLightweightDelete() const override { return getNested()->supportsLightweightDelete(); }
+    std::expected<void, PreformattedMessage> supportsLightweightUpdate() const override { return getNested()->supportsLightweightUpdate(); }
+    QueryPipeline updateLightweight(const MutationCommands & commands, ContextPtr context) override
+    {
+        return getNested()->updateLightweight(commands, context);
     }
 
     bool storesDataOnDisk() const override { return true; }

--- a/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.reference
+++ b/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.reference
@@ -1,0 +1,9 @@
+cold engine	TableProxy
+select	4
+engine	MergeTree
+parts	1
+parts_columns	1
+after alter delete	3
+after lightweight delete	2
+cold lightweight delete	1
+cold alter delete	0

--- a/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.reference
+++ b/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.reference
@@ -7,3 +7,5 @@ after alter delete	3
 after lightweight delete	2
 cold lightweight delete	1
 cold alter delete	0
+stopped merges parts	2
+started merges parts	1

--- a/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.sql
+++ b/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.sql
@@ -46,4 +46,26 @@ ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 ALTER TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t DELETE WHERE id = 4 SETTINGS mutations_sync = 2;
 SELECT 'cold alter delete', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
 
+-- An action lock (`SYSTEM STOP MERGES` and friends) is keyed by the storage it was taken on, so one
+-- taken while the table was still a proxy has to survive the replacement: the matching
+-- `SYSTEM START MERGES` addresses the storage that took the proxy's place.
+-- `max_bytes_to_merge_at_max_space_in_pool` keeps background merges away, so the two parts stay two
+-- until the explicit `OPTIMIZE`, which ignores that limit for `FINAL`.
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t2 (id UInt64) ENGINE = MergeTree ORDER BY id
+    SETTINGS max_bytes_to_merge_at_max_space_in_pool = 1;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t2 VALUES (1);
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t2 VALUES (2);
+
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+
+SYSTEM STOP MERGES {CLICKHOUSE_DATABASE_1:Identifier}.t2;
+-- Reading `system.parts` replaces the proxy, so the `SYSTEM START MERGES` below no longer addresses
+-- the storage the lock was taken on.
+SELECT 'stopped merges parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't2' AND active;
+SYSTEM START MERGES {CLICKHOUSE_DATABASE_1:Identifier}.t2;
+OPTIMIZE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t2 FINAL;
+SELECT 'started merges parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't2' AND active;
+
 DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};

--- a/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.sql
+++ b/tests/queries/0_stateless/05137_lazy_load_tables_replace_proxy_after_load.sql
@@ -1,0 +1,49 @@
+-- Tags: no-replicated-database
+-- A database with `lazy_load_tables` stands every table in for a `StorageTableProxy` until it is
+-- first accessed. Once the table is loaded, the database hands out the storage itself, so everything
+-- that recognizes a table by its concrete type works again.
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+
+-- `USE` only so that the queries below can say `currentDatabase()`.
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+
+-- Nothing has touched the table yet, so it is still only a proxy.
+SELECT 'cold engine', engine FROM system.tables WHERE database = currentDatabase() AND name = 't';
+
+-- Reading the table loads it, and the database then replaces the proxy with the loaded storage.
+SELECT 'select', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
+
+SELECT 'engine', engine FROM system.tables WHERE database = currentDatabase() AND name = 't';
+SELECT 'parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't' AND active;
+SELECT 'parts_columns', count() > 0 FROM system.parts_columns WHERE database = currentDatabase() AND table = 't' AND active;
+
+-- A mutation and a lightweight delete both need the real storage.
+ALTER TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t DELETE WHERE id = 1 SETTINGS mutations_sync = 2;
+SELECT 'after alter delete', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
+
+DELETE FROM {CLICKHOUSE_DATABASE_1:Identifier}.t WHERE id = 2;
+SELECT 'after lightweight delete', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
+
+-- The same statements must also work as the very first thing addressed to a table that has not been
+-- accessed at all since the database was attached.
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+
+DELETE FROM {CLICKHOUSE_DATABASE_1:Identifier}.t WHERE id = 3;
+SELECT 'cold lightweight delete', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
+
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+
+ALTER TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t DELETE WHERE id = 4 SETTINGS mutations_sync = 2;
+SELECT 'cold alter delete', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.t;
+
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};


### PR DESCRIPTION
A database with the `lazy_load_tables` setting attaches every table as a `StorageTableProxy` and keeps it behind that proxy forever, even after the table has been loaded. `StorageProxy` forwards a subset of `IStorage`; everything that recognizes a table by its concrete type instead never sees the table. That is about thirty `IStorage` virtuals that `MergeTree` overrides, plus every `dynamic_cast<MergeTreeData *>`.

Reproduced on 26.8:

```sql
CREATE DATABASE lz ENGINE = Atomic SETTINGS lazy_load_tables = 1;
CREATE TABLE lz.t (id UInt64) ENGINE = MergeTree ORDER BY id;
INSERT INTO lz.t VALUES (1);
-- restart, then:
SELECT count() FROM lz.t;                       -- 1, the table is loaded now
SELECT count() FROM system.parts WHERE database = 'lz';   -- 0
ALTER TABLE lz.t DELETE WHERE id = 999;         -- Table engine MergeTree doesn't support mutations
DELETE FROM lz.t WHERE id = 999;                -- DELETE query is not supported for table lz.t
```

`system.parts`, `system.parts_columns`, `system.detached_parts`, `system.mutations`, `system.replicas` and `system.replication_queue` stay empty for such a table, `AttachedReplicatedTable` is never counted, and mutations and `DELETE` are rejected outright.

Once the table has been loaded there is no reason to keep the proxy in front of it. The database now notices the load on its lookup paths and puts the loaded storage into the table map and into the `DatabaseCatalog` UUID mapping in its place, so from then on the table is indistinguishable from an eagerly loaded one. Both maps have to be updated, because `DatabaseCatalog::getTableImpl` answers a `StorageID` that already carries a UUID straight from the UUID mapping, without asking the database.

The replacement has to happen in the database rather than in the proxy: the proxy loads the table from under the database mutex, through `DatabaseAtomic::renameTable` calling `tryCreateSymlink`, so it cannot take that mutex itself.

### Locking

The two objects are both alive and both reachable as the same table across the replacement: a query that resolved the table before it keeps a reference to the proxy and locks that, while a query that resolves it afterwards locks the loaded storage. `lockForShare`, `lockForAlter` and `lockExclusively` are not virtual, so the proxy never forwarded them, and the two objects would have formed two independent lock domains - a `DROP` would not have waited for a `SELECT` that is still running. This is not hypothetical: `TableNode` takes the share lock on the storage the resolver returned and only then runs `read`, which is what triggers the load.

The loaded storage therefore adopts the proxy's `drop_lock` and `alter_lock` at load time, through the new `IStorage::takeTableLocksFrom`, so that the two objects keep excluding each other. `drop_lock` is already a `std::shared_ptr<RWLockImpl>`; `alter_lock` becomes a `std::shared_ptr<std::timed_mutex>` for the same reason. `is_dropped` and `is_detached` stay per-object: `lockForShare` only consults them for a table without a UUID, and `lazy_load_tables` is an `Atomic` database setting, so every such table has one.

### Action locks

`ActionLocksManager` keys the locks it holds by the storage they were taken on, and the same table is a proxy before the load and the loaded storage after the replacement. `add` and `remove` therefore canonicalize a lazily loaded table to the storage it stands for at call time, through the blocking `IStorage::loadLazyTable`, so that a `SYSTEM STOP MERGES` addressed to the proxy is lifted by a `SYSTEM START MERGES` addressed to the loaded storage, and a database-wide `SYSTEM STOP/START ...` that still holds the proxy from its snapshot of the tables ends up under the same key. `DELETE` loads the table the same way before it decides anything, so its projections check sees the real metadata and the real `MergeTree` settings.

### Scope

A table that has never been accessed is still a proxy, so this does not make `system.parts` complete for a database that has just started up - that is what lazy loading is. What it does is bound the exposure to the window before the first access, instead of forever.

Within that window, the checks that gate a mutation, an `UPDATE` and a `DELETE` are now forwarded as well, so those work as the very first statement addressed to a table that has not been loaded yet. The remaining unforwarded `IStorage` virtuals are only reachable in that same window and are left alone.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed tables in a database with the `lazy_load_tables` setting staying hidden behind a lightweight proxy after they have been loaded. They were missing from `system.parts`, `system.parts_columns`, `system.detached_parts`, `system.mutations` and `system.replicas`, were not counted in the `AttachedReplicatedTable` metric, and rejected mutations and `DELETE` queries with `Table engine MergeTree doesn't support mutations`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118699&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118699](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118699+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

