### PR TITLE
Remove a duplicate include that breaks the clang-tidy build

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -33,7 +33,6 @@
 #include <absl/container/inlined_vector.h>
 #include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnSet.h>


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/117314

`MergeTreeIndexConditionText.cpp` includes `DataTypes/DataTypeLowCardinality.h` twice, at lines 11 and 36. `Build (arm_tidy)` therefore fails for every pull request based on master since #117314 was merged on 2026-09-07:

```
src/Storages/MergeTree/MergeTreeIndexConditionText.cpp:36:1: error: duplicate include [readability-duplicate-include,-warnings-as-errors]
   35 | #include <DataTypes/DataTypeArray.h>
   36 | #include <DataTypes/DataTypeLowCardinality.h>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning treated as error
ninja: build stopped: cannot make progress due to previous errors.
```

Seen on https://github.com/ClickHouse/ClickHouse/actions/runs/34181230141/job/101920870844 (from https://github.com/ClickHouse/ClickHouse/pull/118699, which does not touch this file).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118701&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118701](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118701+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
