### PR TITLE
Fix the `ErrorCodes` style check on the `26.6` branch

### DIFF
--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -44,6 +44,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int TOO_DEEP_RECURSION;
     extern const int SYNTAX_ERROR;
+    extern const int TOO_LARGE_STRING_SIZE;
 }
 
 template <size_t num_bytes, typename IteratorSrc, typename IteratorDst>

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -67,7 +67,6 @@ namespace ErrorCodes
     extern const int SUPPORT_IS_DISABLED;
     extern const int UNSUPPORTED_METHOD;
     extern const int OPENSSL_ERROR;
-    extern const int SYNTAX_ERROR;
     extern const int UNKNOWN_PACKET_FROM_CLIENT;
 }
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117633

The `ErrorCodes` style check (`ci/jobs/scripts/check_style/check_cpp.sh`) fails branch-wide on `26.6`, so every pull request targeting that branch is red on Style. Two backports left the per-file `ErrorCodes` declarations inconsistent:

- Backport #117011 (`Do not allocate from sizes a peer declares in the Native protocol`) added a `throw Exception(ErrorCodes::TOO_LARGE_STRING_SIZE, ...)` to `src/IO/ReadHelpers.cpp` without declaring the code in that file. It still compiles, because `ReadHelpers.h` declares it, but the check only looks at the `.cpp` — and `master` does declare it there as well.
- Backport #117003 (`Bound the MySQL handshake response`) kept the `SYNTAX_ERROR` declaration in `src/Server/MySQLHandler.cpp` but not the code that used it, so the declaration is now unused.

Reproduced and verified locally: before the change `check_cpp.sh` reports

```
ErrorCodes::SYNTAX_ERROR is defined but not used in file src/Server/MySQLHandler.cpp
ErrorCodes::TOO_LARGE_STRING_SIZE is used in file src/IO/ReadHelpers.cpp but not defined
```

and after it exits cleanly.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.5.73`
<!-- ch-version-info:end -->