### PR TITLE
Clear the part check queue when `SYSTEM RESTORE REPLICA` reissues block numbers

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
@@ -88,6 +88,20 @@ void ReplicatedMergeTreePartCheckThread::enqueuePart(const String & name, time_t
     getTask()->schedule();
 }
 
+void ReplicatedMergeTreePartCheckThread::clearQueue()
+{
+    /// Lock order matches enqueuePart: cancel_removed_parts_mutex before parts_mutex.
+    std::lock_guard cancel_lock(cancel_removed_parts_mutex);
+    std::lock_guard lock(parts_mutex);
+
+    if (parts_queue.empty())
+        return;
+
+    LOG_TRACE(log, "Dropping {} queued part checks", parts_queue.size());
+    parts_queue.clear();
+    parts_set.clear();
+}
+
 BackgroundSchedulePoolTaskHolder & ReplicatedMergeTreePartCheckThread::getTask()
 {
     return pausable_task.getTask();

--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.h
@@ -59,6 +59,10 @@ public:
     /// delay_to_check_seconds - check no sooner than the specified number of seconds.
     void enqueuePart(const String & name, time_t delay_to_check_seconds = 0);
 
+    /// Drop every queued check, for when block numbers were reissued and the names denote nothing.
+    /// Does not affect a check already running - pause the task for that.
+    void clearQueue();
+
     /// Get the number of parts in the queue for check.
     size_t size() const;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7433,6 +7433,9 @@ void StorageReplicatedMergeTree::restoreMetadataInZooKeeper(
     /// We need to bump the ZK version to match so parts don't appear "from the future".
     int32_t max_parts_metadata_version = 0;
 
+    /// No check may run while block numbers are reissued below.
+    auto pause_checking_parts = part_check_thread.temporaryPause();
+
     /// Why all parts (not only Active) are moved to detached/:
     /// After ZK metadata restoration ZK resets sequential counters (including block number counters), so one may
     /// potentially encounter a situation that a part we want to attach already exists.
@@ -7454,6 +7457,9 @@ void StorageReplicatedMergeTree::restoreMetadataInZooKeeper(
     }
 
     LOG_INFO(log, "Moved all parts to detached/");
+
+    /// Parts come back under freshly allocated block numbers, so queued names are now stale.
+    part_check_thread.clearQueue();
 
     const bool is_first_replica = createTableIfNotExists(metadata_snapshot, zookeeper_retries_info);
 
@@ -11604,9 +11610,9 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
     {
         MergeTreeData::Transaction transaction(*this, NO_TRANSACTION_RAW);
         auto replaced_parts = renameTempPartAndReplace(new_data_part, transaction, /*rename_in_transaction=*/ true);
-        new_data_part->getDataPartStorage().commitTransaction();
-        transaction.renameParts();
 
+        /// Checked before the rename below: rollback only moves the part to Outdated, so past
+        /// that point its directory survives under the final name as an unexpected part.
         if (!replaced_parts.empty())
         {
             Strings part_names;
@@ -11625,6 +11631,9 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
                             "Tried to create empty part {}, but it replaces existing parts {}.",
                             lost_part_name, fmt::join(part_names, ", "));
         }
+
+        new_data_part->getDataPartStorage().commitTransaction();
+        transaction.renameParts();
 
         lockSharedData(*new_data_part, false, {});
 

--- a/tests/queries/0_stateless/05111_restore_replica_clears_part_check_queue.reference
+++ b/tests/queries/0_stateless/05111_restore_replica_clears_part_check_queue.reference
@@ -1,0 +1,4 @@
+parts before	1
+queued before restore	1
+queued after restore	0
+rows	10

--- a/tests/queries/0_stateless/05111_restore_replica_clears_part_check_queue.sh
+++ b/tests/queries/0_stateless/05111_restore_replica_clears_part_check_queue.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-replicated-database, no-ordinary-database, no-shared-merge-tree, no-parallel
+
+# `SYSTEM RESTORE REPLICA` reattaches every part under a freshly allocated block number, so any
+# name queued for check beforehand stops denoting anything. Left queued, such a name is read as a
+# lost part and `createEmptyPartInsteadOfLost` recreates it over a block range that now holds
+# unrelated data; the rejected write leaves a zero-row part behind that breaks the next attach.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t (k UInt64) ENGINE = MergeTree ORDER BY k;
+    INSERT INTO t SELECT number FROM numbers(5);
+    INSERT INTO t SELECT number FROM numbers(5, 5);
+    OPTIMIZE TABLE t FINAL;
+"
+
+# A part spanning several blocks, so a stale name would cover the blocks reissued after the restore.
+${CLICKHOUSE_CLIENT} -q "SELECT 'parts before', count() FROM system.parts WHERE database = currentDatabase() AND table = 't' AND active"
+
+${CLICKHOUSE_CLIENT} -q "
+    DETACH TABLE t;
+    ATTACH TABLE t AS REPLICATED;
+"
+
+# The part is on disk but absent from Keeper, so the check is deferred rather than resolved.
+${CLICKHOUSE_CLIENT} -q "CHECK TABLE t FORMAT Null"
+${CLICKHOUSE_CLIENT} -q "SELECT 'queued before restore', parts_to_check > 0 FROM system.replicas WHERE database = currentDatabase() AND table = 't'"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM RESTORE REPLICA t"
+${CLICKHOUSE_CLIENT} -q "SELECT 'queued after restore', parts_to_check FROM system.replicas WHERE database = currentDatabase() AND table = 't'"
+
+${CLICKHOUSE_CLIENT} -q "SELECT 'rows', count() FROM t"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/103537

`SYSTEM RESTORE REPLICA` reattaches every part under a freshly allocated block number, but leaves the part check queue untouched. A part name is its block range, so a queued name then denotes nothing: the check reads the renamed part as lost, and `createEmptyPartInsteadOfLost` recreates it over a range the reissued counter has since given to unrelated inserts. The write is rejected, but only after the part got its final on-disk name, leaving a zero-row part that the next load reports as unexpected. Paired with the empty part `DROP PARTITION` leaves for the same range, `checkPartsImpl` ends up with two zero-row parts that neither contain nor are disjoint from each other - the `LOGICAL_ERROR` "Part A intersects previous part B" that #103537 tolerates.

Seen on BuzzHouse for #100943, where `all_2_11_3` came back as `all_0_0_0` while blocks 2, 3 and 5 were reissued: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100943&sha=3308ce056bdfd5672c3c300ccae03968beac9846&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29

The restore now drops the stale names and pauses the check task for the whole renumbering, since clearing the queue cannot stop a check that already started. `createEmptyPartInsteadOfLost` also tests `replaced_parts` before committing to disk, so a rejected empty part leaves only its `tmp_empty_` directory - that path is reachable without a restore.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SYSTEM RESTORE REPLICA` leaving stale entries in the part check queue. Because the restore reassigns block numbers, such an entry made a renamed part look lost and caused an empty part to be written over a block range holding unrelated data, leaving a zero-row part on disk that broke the next attach with `Part ... intersects previous part ...`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118704&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118704](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118704+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
