### PR TITLE
Fix crash in mergeTreeIndex() after ALTER of a key column between T and LowCardinality(T)

### DIFF
--- a/src/Storages/StorageMergeTreeIndex.cpp
+++ b/src/Storages/StorageMergeTreeIndex.cpp
@@ -114,7 +114,19 @@ protected:
                 /// according to setting 'primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns'.
                 if (index_position < index_ptr->size())
                 {
-                    result_columns[pos] = index_ptr->at(index_position);
+                    auto index_column = index_ptr->at(index_position);
+
+                    /// The index holds the key column in the representation the part was written with, while
+                    /// column_type is the current one. Wrapping or unwrapping LowCardinality on a key column
+                    /// is allowed and does not rewrite parts that already exist.
+                    DataTypePtr index_column_type = removeLowCardinality(column_type);
+                    if (index_column->lowCardinality())
+                        index_column_type = std::make_shared<DataTypeLowCardinality>(index_column_type);
+
+                    if (!index_column_type->equals(*column_type))
+                        index_column = recursiveLowCardinalityTypeConversion(index_column, index_column_type, column_type);
+
+                    result_columns[pos] = std::move(index_column);
                 }
                 else
                 {

--- a/tests/queries/0_stateless/05140_mergetree_index_key_type_after_alter.reference
+++ b/tests/queries/0_stateless/05140_mergetree_index_key_type_after_alter.reference
@@ -1,0 +1,27 @@
+-- String -> LowCardinality(String)
+0
+2
+4
+5
+1
+0
+2
+4
+5
+0
+2
+4
+5
+6
+8
+9
+-- LowCardinality(String) -> String
+0
+2
+4
+5
+1
+0
+2
+4
+5

--- a/tests/queries/0_stateless/05140_mergetree_index_key_type_after_alter.sql
+++ b/tests/queries/0_stateless/05140_mergetree_index_key_type_after_alter.sql
@@ -1,0 +1,50 @@
+-- Wrapping or unwrapping LowCardinality on a key column is allowed and does not rewrite existing
+-- parts, so until the mutation materializes a part's primary index holds a different representation
+-- than the current metadata declares. mergeTreeIndex must still emit the declared type.
+
+DROP TABLE IF EXISTS t_mt_index_key_type;
+
+SELECT '-- String -> LowCardinality(String)';
+
+CREATE TABLE t_mt_index_key_type (k String, v UInt64) ENGINE = MergeTree ORDER BY k
+SETTINGS index_granularity = 2, index_granularity_bytes = '10M';
+
+SYSTEM STOP MERGES t_mt_index_key_type;
+INSERT INTO t_mt_index_key_type SELECT toString(number), number FROM numbers(6);
+
+SELECT k FROM mergeTreeIndex(currentDatabase(), t_mt_index_key_type) ORDER BY k;
+
+ALTER TABLE t_mt_index_key_type MODIFY COLUMN k LowCardinality(String)
+    SETTINGS alter_sync = 0, mutations_sync = 0;
+
+-- The rewriting mutation must still be pending, otherwise the reads below cover nothing.
+SELECT count() > 0 FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_mt_index_key_type' AND NOT is_done;
+
+SELECT k FROM mergeTreeIndex(currentDatabase(), t_mt_index_key_type) ORDER BY k;
+
+-- A part written after the ALTER already carries the new representation: one read, both parts.
+INSERT INTO t_mt_index_key_type SELECT toString(number), number FROM numbers(6, 4);
+SELECT k FROM mergeTreeIndex(currentDatabase(), t_mt_index_key_type) ORDER BY k;
+
+DROP TABLE t_mt_index_key_type;
+
+SELECT '-- LowCardinality(String) -> String';
+
+CREATE TABLE t_mt_index_key_type (k LowCardinality(String), v UInt64) ENGINE = MergeTree ORDER BY k
+SETTINGS index_granularity = 2, index_granularity_bytes = '10M';
+
+SYSTEM STOP MERGES t_mt_index_key_type;
+INSERT INTO t_mt_index_key_type SELECT toString(number), number FROM numbers(6);
+
+SELECT k FROM mergeTreeIndex(currentDatabase(), t_mt_index_key_type) ORDER BY k;
+
+ALTER TABLE t_mt_index_key_type MODIFY COLUMN k String
+    SETTINGS alter_sync = 0, mutations_sync = 0;
+
+SELECT count() > 0 FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_mt_index_key_type' AND NOT is_done;
+
+SELECT k FROM mergeTreeIndex(currentDatabase(), t_mt_index_key_type) ORDER BY k;
+
+DROP TABLE t_mt_index_key_type;

--- a/tests/queries/0_stateless/05140_mergetree_index_key_type_after_alter.sql
+++ b/tests/queries/0_stateless/05140_mergetree_index_key_type_after_alter.sql
@@ -6,8 +6,10 @@ DROP TABLE IF EXISTS t_mt_index_key_type;
 
 SELECT '-- String -> LowCardinality(String)';
 
+-- use_primary_key_cache = 0 keeps the stale index in the part itself; a cache entry is evictable,
+-- and a reload rebuilds the column with the current type, which would make the reads below vacuous.
 CREATE TABLE t_mt_index_key_type (k String, v UInt64) ENGINE = MergeTree ORDER BY k
-SETTINGS index_granularity = 2, index_granularity_bytes = '10M';
+SETTINGS index_granularity = 2, index_granularity_bytes = '10M', use_primary_key_cache = 0;
 
 SYSTEM STOP MERGES t_mt_index_key_type;
 INSERT INTO t_mt_index_key_type SELECT toString(number), number FROM numbers(6);
@@ -32,7 +34,7 @@ DROP TABLE t_mt_index_key_type;
 SELECT '-- LowCardinality(String) -> String';
 
 CREATE TABLE t_mt_index_key_type (k LowCardinality(String), v UInt64) ENGINE = MergeTree ORDER BY k
-SETTINGS index_granularity = 2, index_granularity_bytes = '10M';
+SETTINGS index_granularity = 2, index_granularity_bytes = '10M', use_primary_key_cache = 0;
 
 SYSTEM STOP MERGES t_mt_index_key_type;
 INSERT INTO t_mt_index_key_type SELECT toString(number), number FROM numbers(6);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a crash and a `LOGICAL_ERROR` in the `mergeTreeIndex` table function when reading a key column whose `ALTER TABLE ... MODIFY COLUMN` between `T` and `LowCardinality(T)` has an unmaterialized mutation. The key column is now emitted in the type the current metadata declares.

### Description

Reading a key column through `mergeTreeIndex` fails while an `ALTER TABLE ... MODIFY
COLUMN` between `T` and `LowCardinality(T)` on that column has an unmaterialized mutation. Plain
`MergeTree`, no special settings. On the official master build `26.9.1.933`:

```sql
CREATE TABLE t (k String, v UInt64) ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 2;
INSERT INTO t SELECT toString(number), number FROM numbers(6);
SYSTEM STOP MERGES t;
ALTER TABLE t MODIFY COLUMN k LowCardinality(String) SETTINGS alter_sync = 0, mutations_sync = 0;
SELECT k FROM mergeTreeIndex(currentDatabase(), t) ORDER BY k;
-- Code: 49. Bad cast from type DB::ColumnString to DB::ColumnLowCardinality. (LOGICAL_ERROR)
```

The reverse ALTER (`LowCardinality(String)` to `String`) is worse: a bare segmentation fault with
empty stderr, leaving nothing for a user or log scraping to key on. Debug and sanitizer builds abort
either way.

`MergeTreeIndexSource::generate` assigned the part's primary index column straight into the output
chunk. `IndexPtr` is `shared_ptr<const Columns>`, bare columns with no types attached, while the
slot's declared type comes from current metadata, and `isSafeForKeyConversion` permits
`T <-> LowCardinality(T)` on a key column both ways without rewriting existing parts. The
stale-typed column can arrive from the write-time in-memory index, from `PrimaryIndexCache` (whose
key carries no metadata version), or from a mutated part that inherits its source part's index, so
this reconciles it with the declared slot type at the point of use. The guard is a no-op when the
representations already agree.

The new test covers both directions plus a read spanning a pre-ALTER and a post-ALTER part, and
asserts the mutation is still pending so the reads cannot pass vacuously.

Noticed and deliberately not changed: `MergeTreeDataSelectExecutor::markRangesFromPKRange`
pairs part index columns with live types for `KeyCondition`, which is harmless because
`KeyCondition` strips `LowCardinality` on the type side.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118709&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118709](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118709+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1314` (included in `26.9` and later)
<!-- ch-version-info:end -->