### PR TITLE
Fix unquoted heredoc in stress_tests.lib executing backticked words from XML comments

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -181,8 +181,22 @@ EOL
     max_users_mem=$((total_mem*30/100)) # 30%
     # Similar to docker/test/fuzzer/query-fuzzer-tweaks-users.xml
     echo "Setting max_memory_usage_for_user=$max_users_mem and max_memory_usage for queries to 10G"
-    # The heredoc delimiter is unquoted so that ${max_users_mem} expands. That also means backticks
-    # and $(...) would be evaluated, so keep them out of the XML comments below.
+    # The heredoc delimiter is unquoted so that ${max_users_mem} expands, which also means the shell
+    # evaluates backticks and $(...) in the body. The body's comments are XML comments too, where a
+    # double hyphen is not allowed. Rationale needing any of those goes in a shell comment, like this
+    # one for the `allow_experimental_window_view` constraint below:
+    #
+    # `WINDOW VIEW` is removed, and the setting is an obsolete no-op here, but the upgrade
+    # check runs the *previous release's* test suite under the *previous release's* binary,
+    # which still accepts `CREATE WINDOW VIEW`. `clickhouse-test --upgrade-check` runs the
+    # client with `--fake-drop`, so those tests' `DROP TABLE` is ignored and the window view
+    # is left in the metadata, which the new binary then cannot load on the post-upgrade
+    # restart. Keep the setting unchangeable until the previous release no longer contains
+    # tests that create window views. The constraint alone is enough: it rejects any change
+    # with `SETTING_CONSTRAINT_VIOLATION`, and both binaries default the setting to `false`.
+    # Assigning the value in the profile instead would mark an obsolete setting as changed on
+    # the new binary, which adds an `Obsolete setting` entry to `system.warnings` that
+    # `01945_system_warnings` asserts is absent.
     cat > /etc/clickhouse-server/users.d/stress_test_tweaks-users.xml <<EOL
 <clickhouse>
     <profiles>
@@ -227,19 +241,6 @@ EOL
                     <readonly/>
                 </max_ast_depth>
 
-                <!--
-                 `WINDOW VIEW` is removed, and the setting is an obsolete no-op here, but the upgrade
-                 check runs the *previous release's* test suite under the *previous release's* binary,
-                 which still accepts `CREATE WINDOW VIEW`. `clickhouse-test --upgrade-check` runs the
-                 client with `--fake-drop`, so those tests' `DROP TABLE` is ignored and the window view
-                 is left in the metadata, which the new binary then cannot load on the post-upgrade
-                 restart. Keep the setting unchangeable until the previous release no longer contains
-                 tests that create window views. The constraint alone is enough: it rejects any change
-                 with `SETTING_CONSTRAINT_VIOLATION`, and both binaries default the setting to `false`.
-                 Assigning the value in the profile instead would mark an obsolete setting as changed on
-                 the new binary, which adds an `Obsolete setting` entry to `system.warnings` that
-                 `01945_system_warnings` asserts is absent.
-                -->
                 <allow_experimental_window_view>
                     <readonly/>
                 </allow_experimental_window_view>

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -181,22 +181,13 @@ EOL
     max_users_mem=$((total_mem*30/100)) # 30%
     # Similar to docker/test/fuzzer/query-fuzzer-tweaks-users.xml
     echo "Setting max_memory_usage_for_user=$max_users_mem and max_memory_usage for queries to 10G"
-    # The heredoc delimiter is unquoted so that ${max_users_mem} expands, which also means the shell
-    # evaluates backticks and $(...) in the body. The body's comments are XML comments too, where a
-    # double hyphen is not allowed. Rationale needing any of those goes in a shell comment, like this
-    # one for the `allow_experimental_window_view` constraint below:
-    #
-    # `WINDOW VIEW` is removed, and the setting is an obsolete no-op here, but the upgrade
-    # check runs the *previous release's* test suite under the *previous release's* binary,
-    # which still accepts `CREATE WINDOW VIEW`. `clickhouse-test --upgrade-check` runs the
-    # client with `--fake-drop`, so those tests' `DROP TABLE` is ignored and the window view
-    # is left in the metadata, which the new binary then cannot load on the post-upgrade
-    # restart. Keep the setting unchangeable until the previous release no longer contains
-    # tests that create window views. The constraint alone is enough: it rejects any change
-    # with `SETTING_CONSTRAINT_VIOLATION`, and both binaries default the setting to `false`.
-    # Assigning the value in the profile instead would mark an obsolete setting as changed on
-    # the new binary, which adds an `Obsolete setting` entry to `system.warnings` that
-    # `01945_system_warnings` asserts is absent.
+    # The heredoc delimiter is unquoted so that ${max_users_mem} expands. That also means backticks
+    # and $(...) would be evaluated, and its XML comments cannot hold a double hyphen, so the
+    # rationale for the `allow_experimental_window_view` constraint below lives here: the upgrade
+    # check replays the previous release's test suite under its own binary, which still creates
+    # window views, and `clickhouse-test --upgrade-check` passes `--fake-drop`, so they stay in the
+    # metadata for the new binary to fail on. Keep it readonly, rather than set to `false`, until
+    # that suite stops creating them: assigning an obsolete setting makes the new binary warn.
     cat > /etc/clickhouse-server/users.d/stress_test_tweaks-users.xml <<EOL
 <clickhouse>
     <profiles>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114747


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Stop the stress-test harness from wasting ~28.5 minutes of every `Stress test` job on a `clickhouse-test --upgrade-check` run that an unquoted heredoc was executing out of an XML comment.

### Description

`configure_limits` writes `users.d/stress_test_tweaks-users.xml` with an **unquoted** heredoc
delimiter. That is deliberate, since the body interpolates `${max_users_mem}`, but it also means the
shell expands the body, including its XML comments. One comment documents the
`allow_experimental_window_view` constraint in markdown style, and its 20 backticks pair into 10
command substitutions that bash runs. Nine are harmless: eight print `command not found`, and one is
the builtin `false`. The tenth, `` `clickhouse-test --upgrade-check` ``, is a real executable: it runs
against the server `stop_server` just halted, retries 180 times at 9.5 s each, and gives up after
**28.5 minutes**.

Measured on public master, `Stress test (amd_debug)` @ `396ec56e0c14`: `++ clickhouse-test
--upgrade-check` at 01:57:11, `TestException: Server is not responding` at 02:25:42. The double `+`
is bash tracing a substitution; the log has no genuine invocation and `stress_runner.sh` never
mentions one. Across 32,170 `Stress test` jobs since 2026-08-30 that is about 15,000 machine-hours,
41% of the average 69-minute job. It never reddens a job, since the exit status of `cat > f <<EOL` is
`cat`'s: this is latency only.

Quoting the delimiter, or just deleting the backticks, does not work: the prose also contains
`--upgrade-check` and `--fake-drop`, and a double hyphen is illegal inside an XML comment. I measured
that arm: the server then refuses to start with `Code: 347 ... SAXParseException: Invalid token`. So I
moved the rationale into a shell comment above the heredoc, condensed to seven lines on review,
since a `#` comment is not expanded. That cures both hazards, keeps `${max_users_mem}` interpolating, and leaves the emitted
settings byte-identical. The file's three other comment blocks stay put, written free of both hazards
on purpose.

`configure_limits` has one call site (`stress_runner.sh:268`), so `Upgrade check (*)` lanes are not
affected. The block arrived with PR #114747; job log:
`https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/396ec56e0c141bdfb0c290b50c1528a5e5c6b08d/masterci/stress_test_amd_debug/job.log`

<details>
<summary>Validation: build-free 3-arm A/B probe of the generated config</summary>

Each arm sources the real `configure_limits` heredoc region with a recording stub named
`clickhouse-test` first on `PATH`, then checks the emitted XML.

| arm | stub invocations | `command not found` | `xmllint` | `${max_users_mem}` |
|---|---|---|---|---|
| master today | **1** | **8** | OK | 1 |
| negative control: backticks deleted, block left in the body | 0 | 0 | **BAD x2** | 1 |
| this PR | **0** | **0** | **OK** | **1** |

The middle row is why the obvious fixes were rejected: `Double hyphen within comment` at
`--upgrade-check` and at `--fake-drop`. A fifth oracle diffs the emitted settings with comments
stripped and reads IDENTICAL across all three arms, which is what proves the change is comment-only.

Also: `shellcheck` findings on the file drop from 12 to 1 (10x SC2006 plus SC2215 "This flag is used
as a command name", pointing straight at `--fake-drop`, all gone); `bash -n` clean;
`ci/jobs/check_style.py` 14/15, the one failure being `settings_changes_history`, which fails
identically on an unmodified tree because local runs have no `changed_files` from the workflow hook.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118710&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118710](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118710+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.967` (included in `26.9` and later)
<!-- ch-version-info:end -->