### PR TITLE
Fix flaky 01660_system_parts_smoke by pinning `old_parts_lifetime`

### DIFF
--- a/tests/queries/0_stateless/01660_system_parts_smoke.sql
+++ b/tests/queries/0_stateless/01660_system_parts_smoke.sql
@@ -8,7 +8,9 @@ SELECT _state FROM system.parts FORMAT Null;
 
 -- Create one table and see some columns in system.parts
 DROP TABLE IF EXISTS data_01660;
-CREATE TABLE data_01660 (key Int) Engine=MergeTree() ORDER BY key;
+-- `old_parts_lifetime` is pinned because the assertions below observe Outdated parts: both the
+-- default and the values CI randomizes over can elapse within a single test's time budget.
+CREATE TABLE data_01660 (key Int) Engine=MergeTree() ORDER BY key SETTINGS old_parts_lifetime = 100500;
 SYSTEM STOP MERGES data_01660;
 
 -- Empty
@@ -30,9 +32,8 @@ SYSTEM START MERGES data_01660;
 OPTIMIZE TABLE data_01660 FINAL;
 SELECT count(), _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660' GROUP BY _state ORDER BY _state;
 
--- TRUNCATE does not remove parts instantly
--- Empty active parts are clearing by async process
--- Inactive parts are clearing by async process also
+-- TRUNCATE covers the active parts with empty ones and clears what it can before returning.
+-- The parts OPTIMIZE outdated stay for `old_parts_lifetime`, so they are still listed here.
 SELECT '# truncate';
 TRUNCATE data_01660;
 SELECT if (count() > 0, 'HAVE PARTS', 'NO PARTS'), _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660' GROUP BY _state ORDER BY _state;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (test-only change).

### Description

`01660_system_parts_smoke` asserts that parts are still listed after `TRUNCATE`, and the comment
above that step claimed the opposite of what the code does ("clearing by async process").
`StorageMergeTree::truncate()` calls `clearOldMutations`, `clearOldPartsFromFilesystem` and
`clearEmptyParts` itself before returning (`StorageMergeTree.cpp:2977-2979`); the part it covers
gets `remove_time = 0` and always goes, and the new empty part is outdated in-query. The only rows
left to satisfy the reference are the two `OPTIMIZE FINAL` outdated, and those survive only while
`now - remove_time < old_parts_lifetime` (`MergeTreeData.cpp:4126-4127`). The test pinned nothing;
`old_parts_lifetime` defaults to 480 s and CI randomizes it down to 10 s, while the per-test budget
is 600 s. Once the window elapses the table has zero parts and `GROUP BY _state` emits nothing, so
the reference line goes **missing** rather than printing `NO PARTS` (under `GROUP BY`, `count()` is
never 0, so that branch is unreachable).

Fix: pin `old_parts_lifetime` on the test's own table and correct the comment. A per-DDL `SETTINGS`
value beats the runner's injection (`ClientBase.cpp:3944-3956`), so every other setting stays
randomized; a `-- Random settings limits:` clamp cannot express this: it only bounds the randomizer's
own value, whose maximum is the 480 s default, and not `--merge-tree-settings`. The assertion, the
query and `.reference` are untouched, and the same line repairs the identical weakness in the
`# optimize` step. No product default changes.

The oracle is unchanged and stays presence-only: the empty covering part is `Outdated` too and
satisfies it. So this removes a spurious failure rather than tightening what the assertion
distinguishes.

Validated: base fails / fixed passes under `--merge-tree-settings "--old_parts_lifetime 0"`; 50/50
under default randomization; green at the randomizer floor (10) and with randomization off.

No related open issue found. `04089_merge_tree_refresh_after_merge.sh` and
`01173_transaction_control_queries.sql` share the same unpinned oracle shape; not folded in here.

<details>
<summary>Reproducer and both-directions result</summary>

```bash
mkdir -p ci/tmp
tests/clickhouse-test --merge-tree-settings "--old_parts_lifetime 0" \
    01660_system_parts_smoke < /dev/null
```

`--merge-tree-settings` replaces the randomized MergeTree dict entirely, so `old_parts_lifetime` is
the only injected setting. On master the test fails deterministically, with the reference line
simply absent and the `# optimize` step intact:

```
 # optimize
 1	Active
 2	Outdated
 # truncate
-HAVE PARTS	Outdated
 # drop
```

With this change it passes. Every removal is logged inside the single `TRUNCATE` query, which is
what shows the cleanup is synchronous rather than deferred:

```
Truncated table with 1 parts by replacing them with new empty 1 parts.
Skipped 0 old parts, found 3 old parts to remove. Parts: [all_1_1_0, all_1_2_1, all_2_2_0]
Removed 3 old parts
Will drop empty part all_1_2_2
Skipped 0 old parts, found 1 old parts to remove. Parts: [all_1_2_2]
Removed 1 old parts
```

`100500` is the value already used for `old_parts_lifetime` in
`02482_load_parts_refcounts.sh`; any value well above the per-test budget is equivalent.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118711&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118711](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118711+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.947` (included in `26.9` and later)
<!-- ch-version-info:end -->