### PR TITLE
Vector Search Stress Test Fixes

### DIFF
--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -861,6 +861,10 @@ TESTS_TO_RUN = [
 
 
 def main():
+    logger("CPU:\n" + os.popen("lscpu | grep -Ei 'model name|vendor|cpu family|^model:|stepping|^cpu.s.:|bogomips|cache|numa node.s.|implementer|^architecture|variant|^cpu part|revision'").read())
+    logger("MEM: " + os.popen("grep -E 'MemTotal|Hugepagesize' /proc/meminfo | tr -s ' ' | paste -sd'; '").read().strip())
+    logger("CPUSTAT begin: " + os.popen("head -1 /proc/stat").read().strip())
+
     test_results = install_clickhouse()
 
     if not test_results[-1].is_ok():
@@ -890,6 +894,8 @@ def main():
         test_results.append(
             Result(name="Job error", status=Result.Status.FAIL, info=str(e))
         )
+
+    logger("CPUSTAT end: " + os.popen("head -1 /proc/stat").read().strip())
 
     Result.create_from(
         results=test_results, files=[], info="Check index build time & recall"

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -81,7 +81,7 @@ dataset_hackernews_openai = {
         url           String,
         title         String,
         text          String,
-        vector        Array(Float32)
+        vector        Array(BFloat16)  CODEC(NONE)
      """,
     ID_COLUMN: "id",
     VECTOR_COLUMN: "vector",
@@ -97,7 +97,7 @@ dataset_cohere_wiki_20m = {
     ],
     SCHEMA: """
         id            UInt32,
-        vector        Array(Float32)
+        vector        Array(BFloat16)  CODEC(NONE)
      """,
     ID_COLUMN: "id",
     VECTOR_COLUMN: "vector",
@@ -141,7 +141,7 @@ dataset_laion_5b_mini_for_quick_test = {
     ],
     SCHEMA: """
         id Int32,
-        vector Array(Float32)
+        vector Array(BFloat16)  CODEC(NONE)
      """,
     ID_COLUMN: "id",
     VECTOR_COLUMN: "vector",


### PR DESCRIPTION
- Use codec NONE and BFloat16 for the vector column
- Log some CPU info and CPU stats in the test run

### Changelog category:
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118719&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118719](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118719+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1021` (included in `26.9` and later)
<!-- ch-version-info:end -->