### PR TITLE
Fix the SQLancer job losing its tail to SIGPIPE, and bound the finding flood

### DIFF
--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -414,21 +414,39 @@ echo "(console shows one progress line per ~5 min; full output goes to sqlancer.
 # failures to fill a triage session; everything found so far is kept and
 # reported.
 MAX_DISTINCT_FAILURES="${SQLANCER_MAX_DISTINCT_FAILURES:-50}"
+# The distinct cap alone does not bound the run. A broken interaction between
+# the fuzzer and the server - e.g. a client that cannot decode the responses,
+# so every statement fails and every expected-error allowlist stops matching -
+# turns almost every generated statement into a finding while producing only a
+# handful of families. The 2026-09-07 run reported 193,987 findings in 25
+# families, never reached the 50-family cap, and spent the full 5h budget on a
+# single setup error. Bound the raw finding count too: a night that has already
+# produced this many reproducers has nothing left to learn, and stopping keeps
+# the reporting cheap enough to survive (see `prepare_attachment`).
+MAX_TOTAL_FINDINGS="${SQLANCER_MAX_TOTAL_FINDINGS:-2000}"
 ABORT_FLAG="$OUTPUT_PATH/aborted-on-finding-flood"
 watch_finding_flood() {
-    local counts distinct
+    local counts total distinct
     while sleep 60; do
         pgrep -f 'target/sqlancer-.*\.jar' > /dev/null || return 0
         counts="$(python3 "$REPO_DIR/ci/jobs/scripts/sqlancer_failures.py" \
             --logs-dir "$SQLANCER_DIR/logs/clickhouse" --out-dir "$FAILURES_PATH" --dry-run 2>/dev/null || true)"
+        total="$(printf '%s' "$counts" | cut -f1)"
         distinct="$(printf '%s' "$counts" | cut -f2)"
         case "$distinct" in ''|*[!0-9]*) continue ;; esac
+        case "$total" in ''|*[!0-9]*) total=0 ;; esac
+        # `$ABORT_FLAG` holds the reason as a phrase, ready to be quoted in the
+        # report row further down.
         if [ "$distinct" -ge "$MAX_DISTINCT_FAILURES" ]; then
-            echo "$distinct" > "$ABORT_FLAG"
-            echo "=== Stopping SQLancer: $distinct distinct failures reached (cap $MAX_DISTINCT_FAILURES) ==="
-            pkill -f 'target/sqlancer-.*\.jar' || true
-            return 0
+            echo "$distinct distinct failures (cap $MAX_DISTINCT_FAILURES)" > "$ABORT_FLAG"
+        elif [ "$total" -ge "$MAX_TOTAL_FINDINGS" ]; then
+            echo "$total findings in $distinct distinct failure(s) (cap $MAX_TOTAL_FINDINGS findings)" > "$ABORT_FLAG"
+        else
+            continue
         fi
+        echo "=== Stopping SQLancer: $(cat "$ABORT_FLAG") ==="
+        pkill -f 'target/sqlancer-.*\.jar' || true
+        return 0
     done
 }
 watch_finding_flood &
@@ -498,12 +516,34 @@ fi
 echo "$FAILURE_SUMMARY"
 if [ -f "$ABORT_FLAG" ]; then
     add_test_result "SQLancer stopped early" FAIL \
-        "stopped after $(cat "$ABORT_FLAG") distinct failures (cap $MAX_DISTINCT_FAILURES) - the remaining budget would only have re-found them"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY; stopped early at the distinct-failure cap"
+        "stopped after $(cat "$ABORT_FLAG") - the remaining budget would only have re-found them"
+    FAILURE_SUMMARY="$FAILURE_SUMMARY; stopped early: $(cat "$ABORT_FLAG")"
 fi
 if [ "$FAILURE_COUNT" -gt 0 ] && [ -f "$FAILURES_PATH/analysis.txt" ]; then
     ATTACHED_FILES_ARRAY+=("$FAILURES_PATH/analysis.txt" "$FAILURES_PATH/findings.json")
-    sed -n '/^x[0-9]/,/^Per-finding index/{/^Per-finding index/!p}' "$FAILURES_PATH/analysis.txt" | head -n 60
+    # Print the family section of the analysis, bounded to 60 lines. Deliberately
+    # one `awk` and no pipe: `... | head -n 60` kills the producer with SIGPIPE as
+    # soon as `head` has its 60 lines, and under `set -o pipefail` that made the
+    # whole job exit 141 right here whenever the summary was big enough to fill
+    # the pipe buffer, skipping the sanitizer scan, the run summary, the Slack
+    # notification and the clean shutdown (2026-09-07).
+    awk '/^Per-finding index/ { exit } /^x[0-9]/ { inside = 1 } inside && shown < 60 { print; shown++ }' \
+        "$FAILURES_PATH/analysis.txt"
+    # `prepare_attachment` compresses in place once a file passes its size
+    # threshold, but `subresults.json` was written before that and references the
+    # uncompressed path, so the `Failure analysis` row would link a file that no
+    # longer exists and praktika would leave the runner-local path in the report.
+    # Resolve the attachment now and point the fragment at the surviving path.
+    ANALYSIS_ATTACHMENT="$(prepare_attachment "$FAILURES_PATH/analysis.txt" || true)"
+    if [ -n "$ANALYSIS_ATTACHMENT" ] \
+        && [ "$ANALYSIS_ATTACHMENT" != "$FAILURES_PATH/analysis.txt" ] \
+        && [ -s "${SUBRESULTS_FRAGMENT:-}" ]; then
+        python3 -c 'import json,sys
+path, old, new = sys.argv[1:4]
+text = open(path, encoding="utf-8").read()
+open(path, "w", encoding="utf-8").write(text.replace(json.dumps(old)[1:-1], json.dumps(new)[1:-1]))' \
+            "$SUBRESULTS_FRAGMENT" "$FAILURES_PATH/analysis.txt" "$ANALYSIS_ATTACHMENT"
+    fi
 fi
 
 # Sanitizer reports and `<Fatal>` messages are a finding on their own, even when


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/actions/runs/34092338702
Related: https://github.com/ClickHouse/ClickHouse/pull/118541

Three reporting and flood-control problems in `ci/jobs/sqlancer_job.sh`, all visible in the `NightlySQLancer` run of 2026-09-07, where one setup error (the server started answering `compress=1` with ZSTD frames that the Java client cannot decode, after https://github.com/ClickHouse/ClickHouse/pull/108786) turned nearly every generated statement into a finding.

**1. The job lost its whole tail to `SIGPIPE`.** The family section of the analysis was printed with `sed -n '...' analysis.txt | head -n 60`. Once that section exceeds the pipe buffer, `head` closes the pipe after 60 lines, `sed` dies of `SIGPIPE`, and under the script's `set -eu` plus `set -o pipefail` the job exits 141 at that line. Skipped as a result: the sanitizer and `<Fatal>` scan of the server logs, the run summary and provenance block, the Slack notification, and the clean shutdown. The report showed `Job got terminated with an error, exit code [141]` and hid the real Java exit code, 255. Reproduced 3 out of 3 times with a 200k-line summary. The extraction is now a single `awk` with no pipe, byte-identical to the old output on a real `analysis.txt`.

**2. The `Failure analysis` row linked a dead file.** `prepare_attachment` compresses in place above 10 MB, but `subresults.json` is written by `sqlancer_failures.py` before that and references the uncompressed path. On 2026-09-07 the job-level link was `analysis.txt.gz` while the sub-result linked `file:///home/ubuntu/actions-runner/.../failures/analysis.txt`, which praktika could not upload, so the report kept the runner-local path. On 2026-09-01 and 2026-09-04, where the file stayed under the threshold, both links are S3 URLs. The attachment is now resolved before the fragment is consumed, and the fragment is rewritten to the surviving path.

**3. Flood control counted only families.** The watchdog stopped at 50 distinct failure families. A broken fuzzer-to-server interaction produces very many findings in very few families: 193,987 findings in 25 families, which never approached the cap and burned the full 5h budget re-finding the same setup error. The watchdog now also stops on the raw finding count (default 2000, `SQLANCER_MAX_TOTAL_FINDINGS`), and `$ABORT_FLAG` carries the reason as a phrase so the report row says which bound tripped.

Verification, since none of this is exercised by a normal green run: `bash -n` on the script; the old and new extraction compared line by line on the `analysis.txt` of the 2026-09-04 run (identical, 37 lines) and on a synthetic 200k-line summary (identical first 60 lines, old exits 141, new exits 0, 3 runs each); and the `subresults.json` rewrite applied to a fragment of the same shape the script produces, checking that every row still parses and only the analysis path changed.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118725&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118725](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118725+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.951` (included in `26.9` and later)
<!-- ch-version-info:end -->