### PR TITLE
Preserve quoting for TOP column names in metadata

### DIFF
--- a/src/IO/WriteHelpers.cpp
+++ b/src/IO/WriteHelpers.cpp
@@ -131,6 +131,7 @@ static inline void writeProbablyQuotedStringImpl(std::string_view s, WriteBuffer
         /// These keywords cause parsing ambiguity when used as function or identifier names
         /// because the parser consumes them as clause-starting keywords.
         && !isCaseInsensitiveEqual(s, "from")
+        && !isCaseInsensitiveEqual(s, "top")
         && !isCaseInsensitiveEqual(s, "values"))
     {
         writeString(s, buf);

--- a/tests/queries/0_stateless/05136_top_column_in_view_show_create.sql
+++ b/tests/queries/0_stateless/05136_top_column_in_view_show_create.sql
@@ -1,0 +1,15 @@
+CREATE TABLE top_column_source (`TOP` String) ENGINE = MergeTree() ORDER BY `TOP`;
+
+CREATE VIEW top_column_view (c String) AS
+WITH a AS
+(
+    SELECT `TOP` AS c
+    FROM top_column_source
+)
+SELECT c
+FROM a;
+
+SHOW CREATE VIEW top_column_view FORMAT Null;
+
+DROP VIEW top_column_view;
+DROP TABLE top_column_source;


### PR DESCRIPTION
There is a bug in parser when TOP is used as column name.

```SQL
create table test_3 (TOP String) engine = MergeTree() order by TOP;

create view test_4 (c String) as with A as (select `TOP` AS c from test_3)  select c from A;

show create test_4;
Output:

Received exception from server (version 26.6.1):
Code: 62. DB::Exception: Received from localhost:9000. DB::Exception: Syntax error (in file store/38e/38efbf7e-17a6-40d9-a310-d1392812ae57/test_4.sql): failed at position 116 (AS) (line 7, col 20): AS c
        FROM default.test_3
    )
SELECT c
FROM
A
. Expected one of: token, OpeningRoundBracket, number. (SYNTAX_ERROR)
(query: show create test_4;)
```
After fix:
```SQL
SHOW CREATE TABLE test_4
FORMAT Raw

Query id: 682faeb3-fa8e-48ca-a855-ee22716fd789

CREATE VIEW default.test_4
(
    `c` String
)
AS WITH
    A AS
    (
        SELECT `TOP` AS c
        FROM default.test_3
    )
SELECT c
FROM A
```

Also covers https://github.com/ClickHouse/ClickHouse/pull/106817
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYNTAX_ERROR` when loading views, materialized views, or projections whose `SELECT` list starts with a column named `TOP`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118754&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118754](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118754+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1313` (included in `26.9` and later)
<!-- ch-version-info:end -->