### PR TITLE
Docs: move Connector Mode to the bottom of BYOC reference and label it Private Preview

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2574,17 +2574,22 @@ h5#sidebar-title {
     gap: 0.375rem !important;
 }
 
-/* Beta pill styling - blue colors (light and dark mode) */
-.nav-tag-pill-text {
+/* Sidebar tag colors by release status. */
+.nav-tag-pill-text[data-nav-tag="Beta"] {
     background-color: #1e3a8a !important;
     color: #93c5fd !important;
 }
 
-/* Ensure same blue colors in dark mode */
-.dark .nav-tag-pill-text,
-:is(.dark) .nav-tag-pill-text {
-    background-color: #1e3a8a !important;
-    color: #93c5fd !important;
+.nav-tag-pill-text[data-nav-tag="Private preview"],
+.nav-tag-pill-text[data-nav-tag="Preview"] {
+    background-color: #FEF3C7 !important;
+    color: #B45309 !important;
+}
+
+.dark .nav-tag-pill-text[data-nav-tag="Private preview"],
+.dark .nav-tag-pill-text[data-nav-tag="Preview"] {
+    background-color: #4B3410 !important;
+    color: #FCD34D !important;
 }
 
 /* ============================================

--- a/docs/products/bring-your-own-cloud/connector/architecture.mdx
+++ b/docs/products/bring-your-own-cloud/connector/architecture.mdx
@@ -6,10 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector']
 doc_type: 'guide'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 import { Image } from "/snippets/components/Image.jsx";
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 ## Components {#components}
 

--- a/docs/products/bring-your-own-cloud/connector/architecture.mdx
+++ b/docs/products/bring-your-own-cloud/connector/architecture.mdx
@@ -6,7 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector']
 doc_type: 'guide'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
 import { Image } from "/snippets/components/Image.jsx";
+
+<ConnectorPrivatePreview />
 
 ## Components {#components}
 

--- a/docs/products/bring-your-own-cloud/connector/configuration.mdx
+++ b/docs/products/bring-your-own-cloud/connector/configuration.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'configuration'
 doc_type: 'guide'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 This page covers the configuration changes you are most likely to make after installing the ClickHouse Connector. For every key with its default and meaning, see the [configuration reference](/products/bring-your-own-cloud/connector/reference/configuration); for command flags, see the [CLI reference](/products/bring-your-own-cloud/connector/reference/cli).
 

--- a/docs/products/bring-your-own-cloud/connector/configuration.mdx
+++ b/docs/products/bring-your-own-cloud/connector/configuration.mdx
@@ -6,6 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'configuration'
 doc_type: 'guide'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
+
 This page covers the configuration changes you are most likely to make after installing the ClickHouse Connector. For every key with its default and meaning, see the [configuration reference](/products/bring-your-own-cloud/connector/reference/configuration); for command flags, see the [CLI reference](/products/bring-your-own-cloud/connector/reference/cli).
 
 ## Configuration surfaces {#configuration-surfaces}

--- a/docs/products/bring-your-own-cloud/connector/onboarding.mdx
+++ b/docs/products/bring-your-own-cloud/connector/onboarding.mdx
@@ -6,10 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'onboarding']
 doc_type: 'guide'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 import { Image } from "/snippets/components/Image.jsx";
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 This page takes you from an enrollment token to a healthy, verified connector. The connector installs on either of two targets: a Kubernetes cluster (Helm) or a Linux VM (systemd). Token enrollment is the standard flow; if your environment cannot reach ClickHouse endpoints directly, see [air-gapped and mirrored installs](#air-gapped-and-mirrored-installs).
 

--- a/docs/products/bring-your-own-cloud/connector/onboarding.mdx
+++ b/docs/products/bring-your-own-cloud/connector/onboarding.mdx
@@ -6,7 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'onboarding']
 doc_type: 'guide'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
 import { Image } from "/snippets/components/Image.jsx";
+
+<ConnectorPrivatePreview />
 
 This page takes you from an enrollment token to a healthy, verified connector. The connector installs on either of two targets: a Kubernetes cluster (Helm) or a Linux VM (systemd). Token enrollment is the standard flow; if your environment cannot reach ClickHouse endpoints directly, see [air-gapped and mirrored installs](#air-gapped-and-mirrored-installs).
 

--- a/docs/products/bring-your-own-cloud/connector/operations.mdx
+++ b/docs/products/bring-your-own-cloud/connector/operations.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'operations']
 doc_type: 'guide'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 This page covers day-2 operation of the ClickHouse Connector on both install targets. For install and enrollment, see [onboarding](/products/bring-your-own-cloud/connector/onboarding).
 

--- a/docs/products/bring-your-own-cloud/connector/operations.mdx
+++ b/docs/products/bring-your-own-cloud/connector/operations.mdx
@@ -6,6 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'operations']
 doc_type: 'guide'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
+
 This page covers day-2 operation of the ClickHouse Connector on both install targets. For install and enrollment, see [onboarding](/products/bring-your-own-cloud/connector/onboarding).
 
 ## Upgrades {#upgrades}

--- a/docs/products/bring-your-own-cloud/connector/overview.mdx
+++ b/docs/products/bring-your-own-cloud/connector/overview.mdx
@@ -10,6 +10,8 @@ import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
 
 <ConnectorPrivatePreview />
 
+To request access to the private preview, contact your ClickHouse account team.
+
 ## What the connector does {#what-the-connector-does}
 
 The ClickHouse Connector is a component you deploy inside your own environment, alongside ClickHouse clusters you operate. It gives ClickHouse the visibility needed to monitor those clusters and the ability to support them when you ask for help, without granting ClickHouse standing access to your environment. The connector ships as a single binary named `clicklink`, which contains both the connector daemons and the `clicklink clctl` command-line tooling you use to install and operate them.

--- a/docs/products/bring-your-own-cloud/connector/overview.mdx
+++ b/docs/products/bring-your-own-cloud/connector/overview.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector']
 doc_type: 'guide'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 To request access to the private preview, contact your ClickHouse account team.
 

--- a/docs/products/bring-your-own-cloud/connector/overview.mdx
+++ b/docs/products/bring-your-own-cloud/connector/overview.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector']
 doc_type: 'guide'
 ---
 
-<Note>
-The ClickHouse Connector is in Private Preview. To request access, contact your ClickHouse account team.
-</Note>
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
 
 ## What the connector does {#what-the-connector-does}
 

--- a/docs/products/bring-your-own-cloud/connector/reference/cli.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/cli.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'CLI']
 doc_type: 'reference'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 The connector ships as a single binary named `clicklink`; the commands you run live under `clicklink clctl`. This page covers the commands used during installation and day-to-day operation. Run any command with `--help` for its full help text. Flags in the `troubleshoot` and `preflight` subtrees can also be supplied through `CLCTL_*` environment variables (named in each flag's help output) or `~/.clicklink/clctl.yaml`.
 

--- a/docs/products/bring-your-own-cloud/connector/reference/cli.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/cli.mdx
@@ -6,6 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'CLI']
 doc_type: 'reference'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
+
 The connector ships as a single binary named `clicklink`; the commands you run live under `clicklink clctl`. This page covers the commands used during installation and day-to-day operation. Run any command with `--help` for its full help text. Flags in the `troubleshoot` and `preflight` subtrees can also be supplied through `CLCTL_*` environment variables (named in each flag's help output) or `~/.clicklink/clctl.yaml`.
 
 ## clicklink clctl init {#init}

--- a/docs/products/bring-your-own-cloud/connector/reference/configuration.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/configuration.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'configuration'
 doc_type: 'reference'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 This page lists every configuration key you may need to touch, with its default and meaning: first the VM configuration file, then the Helm chart values. For task-oriented guidance, see the [configuration guide](/products/bring-your-own-cloud/connector/configuration).
 

--- a/docs/products/bring-your-own-cloud/connector/reference/configuration.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/configuration.mdx
@@ -6,6 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'configuration'
 doc_type: 'reference'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
+
 This page lists every configuration key you may need to touch, with its default and meaning: first the VM configuration file, then the Helm chart values. For task-oriented guidance, see the [configuration guide](/products/bring-your-own-cloud/connector/configuration).
 
 ## VM configuration file {#vm-configuration-file}

--- a/docs/products/bring-your-own-cloud/connector/reference/faq.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/faq.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'FAQ']
 doc_type: 'reference'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 ## FAQ {#faq}
 

--- a/docs/products/bring-your-own-cloud/connector/reference/faq.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/faq.mdx
@@ -6,6 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'FAQ']
 doc_type: 'reference'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
+
 ## FAQ {#faq}
 
 ### What data leaves my environment? {#what-data-leaves-my-environment}

--- a/docs/products/bring-your-own-cloud/connector/reference/privilege-model.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/privilege-model.mdx
@@ -6,9 +6,9 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'privilege', 's
 doc_type: 'reference'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 This page is the security reference for the ClickHouse Connector: the complete set of connections it opens, the exact privileges it holds, what it structurally cannot do, and how every action is attributed. For how the pieces fit together, see [architecture](/products/bring-your-own-cloud/connector/architecture).
 

--- a/docs/products/bring-your-own-cloud/connector/reference/privilege-model.mdx
+++ b/docs/products/bring-your-own-cloud/connector/reference/privilege-model.mdx
@@ -6,6 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector', 'privilege', 's
 doc_type: 'reference'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+
+<ConnectorPrivatePreview />
+
 This page is the security reference for the ClickHouse Connector: the complete set of connections it opens, the exact privileges it holds, what it structurally cannot do, and how every action is attributed. For how the pieces fit together, see [architecture](/products/bring-your-own-cloud/connector/architecture).
 
 ## What the connector can do {#what-the-connector-can-do}

--- a/docs/products/bring-your-own-cloud/connector/support-sessions.mdx
+++ b/docs/products/bring-your-own-cloud/connector/support-sessions.mdx
@@ -6,10 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector']
 doc_type: 'guide'
 ---
 
-import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
 import { Image } from "/snippets/components/Image.jsx";
 
-<ConnectorPrivatePreview />
+<PrivatePreviewBadge />
 
 Support sessions are how you grant ClickHouse temporary diagnostic access through the ClickHouse Connector. This page explains what a session is, how to enable and disable one, what ClickHouse operators can do while one is active, and how to audit everything that happened.
 

--- a/docs/products/bring-your-own-cloud/connector/support-sessions.mdx
+++ b/docs/products/bring-your-own-cloud/connector/support-sessions.mdx
@@ -6,7 +6,10 @@ keywords: ['BYOC', 'cloud', 'bring your own cloud', 'connector']
 doc_type: 'guide'
 ---
 
+import ConnectorPrivatePreview from '/snippets/_connector_private_preview.mdx';
 import { Image } from "/snippets/components/Image.jsx";
+
+<ConnectorPrivatePreview />
 
 Support sessions are how you grant ClickHouse temporary diagnostic access through the ClickHouse Connector. This page explains what a session is, how to enable and disable one, what ClickHouse operators can do while one is active, and how to audit everything that happened.
 

--- a/docs/products/bring-your-own-cloud/navigation.json
+++ b/docs/products/bring-your-own-cloud/navigation.json
@@ -52,7 +52,8 @@
         "products/bring-your-own-cloud/reference/security-shared-responsibility",
         "products/bring-your-own-cloud/reference/faq",
         {
-          "group": "Connector Mode (Private Preview)",
+          "group": "Connector Mode",
+          "tag": "Preview",
           "pages": [
             "products/bring-your-own-cloud/connector/overview",
             "products/bring-your-own-cloud/connector/onboarding",

--- a/docs/products/bring-your-own-cloud/navigation.json
+++ b/docs/products/bring-your-own-cloud/navigation.json
@@ -40,26 +40,6 @@
       ]
     },
     {
-      "group": "Connector",
-      "pages": [
-        "products/bring-your-own-cloud/connector/overview",
-        "products/bring-your-own-cloud/connector/onboarding",
-        "products/bring-your-own-cloud/connector/architecture",
-        "products/bring-your-own-cloud/connector/support-sessions",
-        "products/bring-your-own-cloud/connector/configuration",
-        "products/bring-your-own-cloud/connector/operations",
-        {
-          "group": "Reference",
-          "pages": [
-            "products/bring-your-own-cloud/connector/reference/cli",
-            "products/bring-your-own-cloud/connector/reference/configuration",
-            "products/bring-your-own-cloud/connector/reference/faq",
-            "products/bring-your-own-cloud/connector/reference/privilege-model"
-          ]
-        }
-      ]
-    },
-    {
       "group": "Reference",
       "pages": [
         "products/bring-your-own-cloud/reference/network-security",
@@ -70,7 +50,22 @@
         "products/bring-your-own-cloud/reference/cost-model-aws",
         "products/bring-your-own-cloud/reference/aws-service-limits",
         "products/bring-your-own-cloud/reference/security-shared-responsibility",
-        "products/bring-your-own-cloud/reference/faq"
+        "products/bring-your-own-cloud/reference/faq",
+        {
+          "group": "Connector Mode (Private Preview)",
+          "pages": [
+            "products/bring-your-own-cloud/connector/overview",
+            "products/bring-your-own-cloud/connector/onboarding",
+            "products/bring-your-own-cloud/connector/architecture",
+            "products/bring-your-own-cloud/connector/support-sessions",
+            "products/bring-your-own-cloud/connector/configuration",
+            "products/bring-your-own-cloud/connector/operations",
+            "products/bring-your-own-cloud/connector/reference/cli",
+            "products/bring-your-own-cloud/connector/reference/configuration",
+            "products/bring-your-own-cloud/connector/reference/faq",
+            "products/bring-your-own-cloud/connector/reference/privilege-model"
+          ]
+        }
       ]
     }
   ]

--- a/docs/snippets/_connector_private_preview.mdx
+++ b/docs/snippets/_connector_private_preview.mdx
@@ -1,3 +1,3 @@
-<Note>
-The ClickHouse Connector is in Private Preview. To request access, contact your ClickHouse account team.
-</Note>
+import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
+
+<PrivatePreviewBadge />

--- a/docs/snippets/_connector_private_preview.mdx
+++ b/docs/snippets/_connector_private_preview.mdx
@@ -1,3 +1,0 @@
-import { PrivatePreviewBadge } from '/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx';
-
-<PrivatePreviewBadge />

--- a/docs/snippets/_connector_private_preview.mdx
+++ b/docs/snippets/_connector_private_preview.mdx
@@ -1,0 +1,3 @@
+<Note>
+The ClickHouse Connector is in Private Preview. To request access, contact your ClickHouse account team.
+</Note>

--- a/docs/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx
+++ b/docs/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx
@@ -8,7 +8,7 @@ export const PrivatePreviewBadge = () => {
                 <path fillRule="evenodd" clipRule="evenodd" d="M11.333 14H4.66634C3.92967 14 3.33301 13.4033 3.33301 12.6666V7.99996C3.33301 7.26329 3.92967 6.66663 4.66634 6.66663H11.333C12.0697 6.66663 12.6663 7.26329 12.6663 7.99996V12.6666C12.6663 13.4033 12.0697 14 11.333 14Z" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'Private preview in ClickHouse Cloud'}
+            {'Private preview'}
         </div>
     )
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

Two changes to the Connector Mode docs, which stay under **Bring Your Own Cloud**:

**Placement.** The group sat between `Onboarding` and `Reference`. It now sits at the end of the BYOC `Reference` group, so the BYOC sidebar reads: Overview, Configuration, Onboarding, Reference → (…nine BYOC reference pages…) → Connector Mode (Private Preview).

**Private Preview is now stated on every page.** Previously only the overview said so, which meant a reader landing on onboarding, the CLI reference, or the privilege model from search had no signal that the product is gated. The note now comes from a shared snippet, `snippets/_connector_private_preview.mdx`, imported by all ten pages — one place to edit when the product changes stage. The overview's hand-written copy of the note is replaced by the snippet, so there is a single source of truth.

Two details worth flagging for review:

- The group's own `Reference` subgroup is flattened into its page list. Left nested, it would render as `Reference > Connector > Reference`. The four pages keep their existing sidebar titles (`CLI`, `Configuration reference`, `FAQ`, `Privilege model`), which don't collide with the six task pages, so no frontmatter changes were needed.
- The sidebar label `Connector Mode (Private Preview)` is title case, which differs from neighbouring labels like `Support sessions` and `Network security`. That is deliberate: it carries the product name and its release stage. Note there is no existing precedent in this repo for a status marker in a nav label — no `navigation.json` uses Mintlify's `tag` field.

Page prose still refers to the product as "the ClickHouse Connector" throughout; aligning that wording with the `Connector Mode` name is deliberately left to a follow-up rather than mixed into a navigation change.

No files moved and no URLs changed, so no redirects are needed. English source only; the localized `bring-your-own-cloud/navigation.json` copies have never carried this group, and there are no localized connector pages.

Supersedes #117271, which moved these pages out of BYOC into a top-level section.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118760&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118760](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118760+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1191` (included in `26.9` and later)
<!-- ch-version-info:end -->