### PR TITLE
LIMIT BY: stop reading after a constant key reaches its limit

### DIFF
--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -114,8 +114,8 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 /// join for a small probe side. Estimates themselves are not part of the plan format, so a receiver
 /// that took either decision again would take it from an empty estimate and could decide
 /// differently from the sender.
-/// Version 16 adds the `always_read_till_end` flag to `LimitByStep`.
-static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 16;
+/// Version 17 adds the `always_read_till_end` flag to `LimitByStep`.
+static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 17;
 /// The parallel-replicas remote plan is serialized once (at DBMS_QUERY_PLAN_SERIALIZATION_VERSION) and
 /// that one blob is reused for every replica, so a replica below this version must be excluded up front
 /// rather than sent a blob it cannot parse. Tied to DBMS_QUERY_PLAN_SERIALIZATION_VERSION itself so a
@@ -148,7 +148,7 @@ static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_RANGE
 /// `JoinStepLogical`: the join order, and the runtime filter pass's small-probe decision.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_JOIN_DECISIONS = 16;
 /// First query-plan serialization version that carries the `always_read_till_end` flag on `LimitByStep`.
-static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END = 16;
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END = 17;
 /// Version 1 added the initiator's settings changes to the task.
 /// Version 2 added per-stream streaming-exchange ports to exchange_stream_sources.
 /// Version 3 added the error code of a failed task to its status reply.

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -114,6 +114,7 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 /// join for a small probe side. Estimates themselves are not part of the plan format, so a receiver
 /// that took either decision again would take it from an empty estimate and could decide
 /// differently from the sender.
+/// Version 16 adds the `always_read_till_end` flag to `LimitByStep`.
 static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 16;
 /// The parallel-replicas remote plan is serialized once (at DBMS_QUERY_PLAN_SERIALIZATION_VERSION) and
 /// that one blob is reused for every replica, so a replica below this version must be excluded up front
@@ -146,6 +147,8 @@ static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_RANGE
 /// First query-plan serialization version that carries the estimate-derived decisions of
 /// `JoinStepLogical`: the join order, and the runtime filter pass's small-probe decision.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_JOIN_DECISIONS = 16;
+/// First query-plan serialization version that carries the `always_read_till_end` flag on `LimitByStep`.
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END = 16;
 /// Version 1 added the initiator's settings changes to the task.
 /// Version 2 added per-stream streaming-exchange ports to exchange_stream_sources.
 /// Version 3 added the error code of a failed task to its status reply.

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1768,6 +1768,21 @@ static bool limitAlwaysReadsTillEnd(const ASTSelectQuery & query, const Settings
     return hasWithTotalsInAnySubqueryInFromClause(query);
 }
 
+/// LIMIT BY can be pushed into the sorted-stream pipeline before the final merge, so a direct
+/// WITH TOTALS query must drain its input even when it has ORDER BY. The final LIMIT has a weaker
+/// condition because sorting itself may already consume the full input before LIMIT runs.
+static bool limitByAlwaysReadsTillEnd(const ASTSelectQuery & query, const Settings & settings)
+{
+    if (settings[Setting::exact_rows_before_limit]
+        && (query.limitLength() || query.limitAfter() || query.limitUntil()))
+        return true;
+
+    if (query.group_by_with_totals)
+        return true;
+
+    return hasWithTotalsInAnySubqueryInFromClause(query);
+}
+
 template <size_t size>
 ALWAYS_INLINE void executeExpression(QueryPlan & query_plan, const ActionsAndProjectInputsFlagPtr & expression, const char (&description)[size])
 {
@@ -3604,10 +3619,13 @@ void InterpreterSelectQuery::executeLimitBy(QueryPlan & query_plan)
     if (fractional_limit > 0 || fractional_offset > 0)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Fractional LIMIT/OFFSET with LIMIT BY is not supported yet");
 
+    const bool always_read_till_end = limitByAlwaysReadsTillEnd(query, context->getSettingsRef());
+
     if (!is_limit_length_negative && !is_limit_offset_negative) [[likely]]
     {
         /// LIMIT N [OFFSET M] BY cols - standard positive case
-        auto limit_by = std::make_unique<LimitByStep>(query_plan.getCurrentHeader(), limit_length, limit_offset, columns);
+        auto limit_by = std::make_unique<LimitByStep>(
+            query_plan.getCurrentHeader(), limit_length, limit_offset, columns, always_read_till_end);
         query_plan.addStep(std::move(limit_by));
     }
     else if (is_limit_length_negative && is_limit_offset_negative)
@@ -3624,7 +3642,7 @@ void InterpreterSelectQuery::executeLimitBy(QueryPlan & query_plan)
         if (limit_offset > 0)
         {
             auto step1 = std::make_unique<LimitByStep>(
-                query_plan.getCurrentHeader(), std::numeric_limits<UInt64>::max(), limit_offset, columns);
+                query_plan.getCurrentHeader(), std::numeric_limits<UInt64>::max(), limit_offset, columns, always_read_till_end);
             query_plan.addStep(std::move(step1));
         }
         auto step2 = std::make_unique<NegativeLimitByStep>(query_plan.getCurrentHeader(), limit_length, 0, columns);
@@ -3639,7 +3657,8 @@ void InterpreterSelectQuery::executeLimitBy(QueryPlan & query_plan)
         auto step1 = std::make_unique<NegativeLimitByStep>(
             query_plan.getCurrentHeader(), std::numeric_limits<UInt64>::max(), limit_offset, columns);
         query_plan.addStep(std::move(step1));
-        auto step2 = std::make_unique<LimitByStep>(query_plan.getCurrentHeader(), limit_length, 0, columns);
+        auto step2 = std::make_unique<LimitByStep>(
+            query_plan.getCurrentHeader(), limit_length, 0, columns, always_read_till_end);
         query_plan.addStep(std::move(step2));
     }
 }

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1288,6 +1288,22 @@ bool limitAlwaysReadsTillEnd(
     return query_analysis_result.query_has_with_totals_in_any_subquery_in_join_tree;
 }
 
+/// LIMIT BY can be pushed into the sorted-stream pipeline before the final merge, so a direct
+/// WITH TOTALS query must drain its input even when it has ORDER BY. The final LIMIT has a weaker
+/// condition because sorting itself may already consume the full input before LIMIT runs.
+bool limitByAlwaysReadsTillEnd(
+    const QueryAnalysisResult & query_analysis_result, const Settings & settings, const QueryNode & query_node)
+{
+    if (settings[Setting::exact_rows_before_limit]
+        && (query_node.hasLimit() || query_node.hasLimitAfter() || query_node.hasLimitUntil()))
+        return true;
+
+    if (query_node.isGroupByWithTotals())
+        return true;
+
+    return query_analysis_result.query_has_with_totals_in_any_subquery_in_join_tree;
+}
+
 void addDistinctStep(QueryPlan & query_plan,
     const QueryAnalysisResult & query_analysis_result,
     const PlannerContextPtr & planner_context,
@@ -1513,8 +1529,13 @@ void addLimitByStep(
     QueryPlan & query_plan,
     const LimitByAnalysisResult & limit_by_analysis_result,
     const QueryAnalysisResult & query_analysis_result,
+    const PlannerContextPtr & planner_context,
+    const QueryNode & query_node,
     bool do_not_skip_offset)
 {
+    const Settings & settings = planner_context->getQueryContext()->getSettingsRef();
+    const bool always_read_till_end = limitByAlwaysReadsTillEnd(query_analysis_result, settings, query_node);
+
     /// Constness of LIMIT BY limit is validated during query analysis stage
     UInt64 limit_by_length = query_analysis_result.limit_by_length;
     UInt64 limit_by_offset = query_analysis_result.limit_by_offset;
@@ -1539,7 +1560,8 @@ void addLimitByStep(
     if (!is_limit_negative && !is_offset_negative) [[likely]]
     {
         /// LIMIT N [OFFSET M] BY cols - standard positive case
-        auto step = std::make_unique<LimitByStep>(query_plan.getCurrentHeader(), limit_by_length, limit_by_offset, column_names);
+        auto step = std::make_unique<LimitByStep>(
+            query_plan.getCurrentHeader(), limit_by_length, limit_by_offset, column_names, always_read_till_end);
         query_plan.addStep(std::move(step));
     }
     else if (is_limit_negative && is_offset_negative)
@@ -1556,7 +1578,7 @@ void addLimitByStep(
         if (limit_by_offset > 0)
         {
             auto step1 = std::make_unique<LimitByStep>(
-                query_plan.getCurrentHeader(), std::numeric_limits<UInt64>::max(), limit_by_offset, column_names);
+                query_plan.getCurrentHeader(), std::numeric_limits<UInt64>::max(), limit_by_offset, column_names, always_read_till_end);
             query_plan.addStep(std::move(step1));
         }
         auto step2 = std::make_unique<NegativeLimitByStep>(query_plan.getCurrentHeader(), limit_by_length, 0, column_names);
@@ -1571,7 +1593,8 @@ void addLimitByStep(
         auto step1 = std::make_unique<NegativeLimitByStep>(
             query_plan.getCurrentHeader(), std::numeric_limits<UInt64>::max(), limit_by_offset, column_names);
         query_plan.addStep(std::move(step1));
-        auto step2 = std::make_unique<LimitByStep>(query_plan.getCurrentHeader(), limit_by_length, 0, column_names);
+        auto step2 = std::make_unique<LimitByStep>(
+            query_plan.getCurrentHeader(), limit_by_length, 0, column_names, always_read_till_end);
         query_plan.addStep(std::move(step2));
     }
 }
@@ -1805,7 +1828,13 @@ void addPreliminarySortOrDistinctOrLimitStepsIfNeeded(
         /// We don't apply LIMIT BY on remote nodes at all in the old infrastructure.
         /// https://github.com/ClickHouse/ClickHouse/blob/67c1e89d90ef576e62f8b1c68269742a3c6f9b1e/src/Interpreters/InterpreterSelectQuery.cpp#L1697-L1705
         /// Let's be optimistic and only don't skip offset (it will be skipped on the initiator).
-        addLimitByStep(query_plan, limit_by_analysis_result, query_analysis_result, true /*do_not_skip_offset*/);
+        addLimitByStep(
+            query_plan,
+            limit_by_analysis_result,
+            query_analysis_result,
+            planner_context,
+            query_node,
+            true /*do_not_skip_offset*/);
     }
 
     /// Do not apply PreLimit at first stage for LIMIT BY and `exact_rows_before_limit`,
@@ -3138,7 +3167,13 @@ void Planner::buildPlanForQueryNode()
                 select_query_options,
                 "Before LIMIT BY",
                 useful_sets);
-            addLimitByStep(query_plan, limit_by_analysis_result, query_analysis_result, false /*do_not_skip_offset*/);
+            addLimitByStep(
+                query_plan,
+                limit_by_analysis_result,
+                query_analysis_result,
+                planner_context,
+                query_node,
+                false /*do_not_skip_offset*/);
         }
 
         /// WITH FILL / INTERPOLATE must run only on the finalizing node, over the merged stream,

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1837,12 +1837,14 @@ void addPreliminarySortOrDistinctOrLimitStepsIfNeeded(
             true /*do_not_skip_offset*/);
     }
 
-    /// Do not apply PreLimit at first stage for LIMIT BY and `exact_rows_before_limit`,
-    /// as it may break `rows_before_limit_at_least` value during the second stage in
-    /// case it also contains LIMIT BY
+    /// Do not apply PreLimit at first stage for LIMIT BY when the full input is required,
+    /// as it may break `rows_before_limit_at_least` during the second stage or drop totals
+    /// from a subquery.
     const Settings & settings = planner_context->getQueryContext()->getSettingsRef();
 
-    if (query_node.hasLimitBy() && settings[Setting::exact_rows_before_limit])
+    if (query_node.hasLimitBy()
+        && (settings[Setting::exact_rows_before_limit]
+            || query_analysis_result.query_has_with_totals_in_any_subquery_in_join_tree))
     {
         return;
     }

--- a/src/Processors/QueryPlan/LimitByStep.cpp
+++ b/src/Processors/QueryPlan/LimitByStep.cpp
@@ -16,7 +16,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int CORRUPTED_DATA;
-    extern const int SUPPORT_IS_DISABLED;
 }
 
 static ITransformingStep::Traits getTraits()
@@ -189,13 +188,6 @@ void LimitByStep::describeActions(JSONBuilder::JSONMap & map) const
 
 void LimitByStep::serialize(Serialization & ctx) const
 {
-    if (ctx.version < DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END && always_read_till_end)
-        throw Exception(
-            ErrorCodes::SUPPORT_IS_DISABLED,
-            "LimitByStep with always_read_till_end requires query plan serialization version >= {}, but the plan is serialized at version {}",
-            DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END,
-            ctx.version);
-
     if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END)
     {
         UInt8 flags = always_read_till_end ? 1 : 0;
@@ -213,12 +205,15 @@ void LimitByStep::serialize(Serialization & ctx) const
 
 QueryPlanStepPtr LimitByStep::deserialize(Deserialization & ctx)
 {
-    UInt8 flags = 0;
+    bool always_read_till_end = true;
     if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END)
     {
+        UInt8 flags = 0;
         readIntBinary(flags, ctx.in);
         if (flags & ~UInt8(1))
             throw Exception(ErrorCodes::CORRUPTED_DATA, "LimitByStep: unsupported flags={} in this version", static_cast<size_t>(flags));
+
+        always_read_till_end = flags & 1;
     }
 
     UInt64 group_length = 0;
@@ -234,7 +229,7 @@ QueryPlanStepPtr LimitByStep::deserialize(Deserialization & ctx)
         readStringBinary(column, ctx.in);
 
     return std::make_unique<LimitByStep>(
-        ctx.input_headers.front(), group_length, group_offset, std::move(columns), bool(flags & 1));
+        ctx.input_headers.front(), group_length, group_offset, std::move(columns), always_read_till_end);
 }
 
 void LimitByStep::applyOrder(const SortDescription & sort_description)

--- a/src/Processors/QueryPlan/LimitByStep.cpp
+++ b/src/Processors/QueryPlan/LimitByStep.cpp
@@ -4,12 +4,20 @@
 #include <Processors/QueryPlan/Serialization.h>
 #include <Processors/Transforms/LimitByTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Core/ProtocolDefines.h>
+#include <Common/Exception.h>
 #include <IO/Operators.h>
 #include <Common/JSONBuilder.h>
 #include <limits>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int CORRUPTED_DATA;
+    extern const int SUPPORT_IS_DISABLED;
+}
 
 static ITransformingStep::Traits getTraits()
 {
@@ -28,11 +36,12 @@ static ITransformingStep::Traits getTraits()
 
 LimitByStep::LimitByStep(
     const SharedHeader & input_header_,
-    size_t group_length_, size_t group_offset_, Names columns_)
+    size_t group_length_, size_t group_offset_, Names columns_, bool always_read_till_end_)
     : ITransformingStep(input_header_, input_header_, getTraits())
     , group_length(group_length_)
     , group_offset(group_offset_)
     , columns(std::move(columns_))
+    , always_read_till_end(always_read_till_end_)
 {
 }
 
@@ -61,7 +70,8 @@ void LimitByStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
                 if (stream_type != QueryPipelineBuilder::StreamType::Main)
                     return nullptr;
 
-                return std::make_shared<LimitBySortedStreamTransform>(header, group_length, group_offset, sorted_columns_descr);
+                return std::make_shared<LimitBySortedStreamTransform>(
+                    header, group_length, group_offset, sorted_columns_descr, always_read_till_end);
             });
         return;
     }
@@ -82,7 +92,8 @@ void LimitByStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
                 if (stream_type != QueryPipelineBuilder::StreamType::Main)
                     return nullptr;
 
-                return std::make_shared<LimitBySortedStreamTransform>(header, prefilter_length, 0, sorted_columns_descr);
+                return std::make_shared<LimitBySortedStreamTransform>(
+                    header, prefilter_length, 0, sorted_columns_descr, always_read_till_end);
             });
 
         /// Now we need to dedup. If LIMIT 1 BY ..., that means the same key can exist in multiple streams but in the final output that key can only appear once.
@@ -97,7 +108,7 @@ void LimitByStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
                 if (stream_type != QueryPipelineBuilder::StreamType::Main)
                     return nullptr;
 
-                return std::make_shared<LimitByTransform>(header, group_length, group_offset, columns);
+                return std::make_shared<LimitByTransform>(header, group_length, group_offset, columns, always_read_till_end);
             });
         return;
     }
@@ -125,9 +136,10 @@ void LimitByStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
                 return nullptr;
 
             if (!sorted_columns_descr.empty())
-                return std::make_shared<LimitBySortedStreamTransform>(header, group_length, group_offset, sorted_columns_descr);
+                return std::make_shared<LimitBySortedStreamTransform>(
+                    header, group_length, group_offset, sorted_columns_descr, always_read_till_end);
 
-            return std::make_shared<LimitByTransform>(header, group_length, group_offset, columns);
+            return std::make_shared<LimitByTransform>(header, group_length, group_offset, columns, always_read_till_end);
         });
 }
 
@@ -155,6 +167,8 @@ void LimitByStep::describeActions(FormatSettings & settings) const
 
     settings.out << prefix << "Length " << group_length << '\n';
     settings.out << prefix << "Offset " << group_offset << '\n';
+    if (always_read_till_end)
+        settings.out << prefix << "Reads all data\n";
     if (skip_stream_merging)
         settings.out << prefix << "Skip stream merging: 1\n";
 }
@@ -168,12 +182,26 @@ void LimitByStep::describeActions(JSONBuilder::JSONMap & map) const
     map.add("Columns", std::move(columns_array));
     map.add("Length", group_length);
     map.add("Offset", group_offset);
+    map.add("Reads All Data", always_read_till_end);
     if (skip_stream_merging)
         map.add("Skip stream merging", true);
 }
 
 void LimitByStep::serialize(Serialization & ctx) const
 {
+    if (ctx.version < DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END && always_read_till_end)
+        throw Exception(
+            ErrorCodes::SUPPORT_IS_DISABLED,
+            "LimitByStep with always_read_till_end requires query plan serialization version >= {}, but the plan is serialized at version {}",
+            DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END,
+            ctx.version);
+
+    if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END)
+    {
+        UInt8 flags = always_read_till_end ? 1 : 0;
+        writeIntBinary(flags, ctx.out);
+    }
+
     writeVarUInt(group_length, ctx.out);
     writeVarUInt(group_offset, ctx.out);
 
@@ -185,6 +213,14 @@ void LimitByStep::serialize(Serialization & ctx) const
 
 QueryPlanStepPtr LimitByStep::deserialize(Deserialization & ctx)
 {
+    UInt8 flags = 0;
+    if (ctx.version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END)
+    {
+        readIntBinary(flags, ctx.in);
+        if (flags & ~UInt8(1))
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "LimitByStep: unsupported flags={} in this version", static_cast<size_t>(flags));
+    }
+
     UInt64 group_length = 0;
     UInt64 group_offset = 0;
 
@@ -197,7 +233,8 @@ QueryPlanStepPtr LimitByStep::deserialize(Deserialization & ctx)
     for (auto & column : columns)
         readStringBinary(column, ctx.in);
 
-    return std::make_unique<LimitByStep>(ctx.input_headers.front(), group_length, group_offset, std::move(columns));
+    return std::make_unique<LimitByStep>(
+        ctx.input_headers.front(), group_length, group_offset, std::move(columns), bool(flags & 1));
 }
 
 void LimitByStep::applyOrder(const SortDescription & sort_description)

--- a/src/Processors/QueryPlan/LimitByStep.h
+++ b/src/Processors/QueryPlan/LimitByStep.h
@@ -11,7 +11,7 @@ class LimitByStep : public ITransformingStep
 public:
     explicit LimitByStep(
             const SharedHeader & input_header_,
-            size_t group_length_, size_t group_offset_, Names columns_);
+            size_t group_length_, size_t group_offset_, Names columns_, bool always_read_till_end_ = false);
 
     String getName() const override { return "LimitBy"; }
 
@@ -30,6 +30,7 @@ public:
     size_t getGroupLength() const { return group_length; }
     size_t getGroupOffset() const { return group_offset; }
     const Names & getColumns() const { return columns; }
+    bool alwaysReadTillEnd() const { return always_read_till_end; }
 
     void applyOrder(const SortDescription & sort_description);
 
@@ -48,6 +49,8 @@ private:
     size_t group_offset;
 
     Names columns;
+
+    bool always_read_till_end = false;
 
     SortDescription sorted_columns_descr;
 

--- a/src/Processors/QueryPlan/Optimizations/limitPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/limitPushDown.cpp
@@ -199,7 +199,7 @@ void pushLimitByIntoSort(QueryPlan::Node & node)
     if (length == 0 || length > std::numeric_limits<UInt64>::max() - offset)
         return;
 
-    sort->updateLimitByHint(limit_by->getColumns(), length + offset);
+    sort->updateLimitByHint(limit_by->getColumns(), length + offset, limit_by->alwaysReadTillEnd());
 }
 
 }

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -280,10 +280,11 @@ void SortingStep::updateOutputHeader()
     output_header = input_headers.front();
 }
 
-void SortingStep::updateLimitByHint(Names limit_by_columns_, UInt64 limit_by_group_length_)
+void SortingStep::updateLimitByHint(Names limit_by_columns_, UInt64 limit_by_group_length_, bool limit_by_always_read_till_end_)
 {
     limit_by_columns = std::move(limit_by_columns_);
     limit_by_group_length = limit_by_group_length_;
+    limit_by_always_read_till_end = limit_by_always_read_till_end_;
 }
 
 void SortingStep::addPerStreamLimitByIfNeeded(QueryPipelineBuilder & pipeline, const SortDescription & stream_sort_desc)
@@ -300,7 +301,8 @@ void SortingStep::addPerStreamLimitByIfNeeded(QueryPipelineBuilder & pipeline, c
         {
             if (stream_type != QueryPipelineBuilder::StreamType::Main)
                 return nullptr;
-            return std::make_shared<LimitBySortedStreamTransform>(header, limit_by_group_length, 0, sort_prefix);
+            return std::make_shared<LimitBySortedStreamTransform>(
+                header, limit_by_group_length, 0, sort_prefix, limit_by_always_read_till_end);
         });
 }
 
@@ -848,6 +850,7 @@ QueryPlanStepPtr SortingStep::clone() const
     cloned->threshold_tracker = threshold_tracker;
     cloned->limit_by_columns = limit_by_columns;
     cloned->limit_by_group_length = limit_by_group_length;
+    cloned->limit_by_always_read_till_end = limit_by_always_read_till_end;
     return cloned;
 }
 

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -175,7 +175,7 @@ public:
     bool supportsDataflowStatisticsCollection() const override { return true; }
     void setTopKThresholdTracker(TopKThresholdTrackerPtr threshold_tracker_) { threshold_tracker = threshold_tracker_; }
 
-    void updateLimitByHint(Names limit_by_columns_, UInt64 limit_by_group_length_);
+    void updateLimitByHint(Names limit_by_columns_, UInt64 limit_by_group_length_, bool limit_by_always_read_till_end_);
 
     std::vector<size_t> getStepGroups() const override;
     String getStepGroupName(size_t group) const override;
@@ -245,6 +245,7 @@ private:
     /// See `pushLimitByIntoSort`. Empty means no hint.
     Names limit_by_columns;
     UInt64 limit_by_group_length = 0;
+    bool limit_by_always_read_till_end = false;
 
     Processors scatter_stage;
     Processors sorting_stage;

--- a/src/Processors/QueryPlan/tests/gtest_limit_by_step_serialization.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_limit_by_step_serialization.cpp
@@ -90,5 +90,3 @@ TEST(LimitByStepSerialization, FlagRoundTripsAtCurrentVersion)
         EXPECT_EQ(bytes, serializeStep(*restored, current_version));
     }
 }
-
-}

--- a/src/Processors/QueryPlan/tests/gtest_limit_by_step_serialization.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_limit_by_step_serialization.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include <Core/Block.h>
+#include <Core/ProtocolDefines.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/SetSerialization.h>
+#include <Processors/QueryPlan/LimitByStep.h>
+#include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
+#include <Processors/QueryPlan/Serialization.h>
+#include <Common/tests/gtest_global_context.h>
+
+using namespace DB;
+
+namespace
+{
+
+constexpr UInt64 legacy_version = DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_LIMIT_BY_ALWAYS_READ_TILL_END - 1;
+constexpr UInt64 current_version = DBMS_QUERY_PLAN_SERIALIZATION_VERSION;
+
+SharedHeader makeHeader()
+{
+    auto type = std::make_shared<DataTypeUInt64>();
+    return std::make_shared<const Block>(Block({ColumnWithTypeAndName(type->createColumn(), type, "number")}));
+}
+
+std::unique_ptr<LimitByStep> makeStep(const SharedHeader & header, bool always_read_till_end)
+{
+    return std::make_unique<LimitByStep>(header, 2, 1, Names{"number"}, always_read_till_end);
+}
+
+String serializeStep(const IQueryPlanStep & step, UInt64 version)
+{
+    WriteBufferFromOwnString out;
+    SerializedSetsRegistry registry;
+    IQueryPlanStep::Serialization ctx{out, registry};
+    ctx.version = version;
+    step.serialize(ctx);
+    return out.str();
+}
+
+std::unique_ptr<LimitByStep> deserializeStep(const String & bytes, const SharedHeader & header, UInt64 version)
+{
+    ReadBufferFromString in(bytes);
+    DeserializedSetsRegistry registry;
+    QueryPlanSerializationSettings settings;
+    ContextPtr context = getContext().context;
+
+    IQueryPlanStep::Deserialization ctx{
+        in, registry, {}, context, SharedHeaders{header}, header, settings, 0, version, false};
+
+    auto step = LimitByStep::deserialize(ctx);
+    EXPECT_TRUE(in.eof());
+
+    return std::unique_ptr<LimitByStep>(static_cast<LimitByStep *>(step.release()));
+}
+
+}
+
+TEST(LimitByStepSerialization, LegacyFormatPreservesReadAllBehavior)
+{
+    auto header = makeHeader();
+    auto early_stop_step = makeStep(header, false);
+    auto read_all_step = makeStep(header, true);
+
+    const String early_stop_bytes = serializeStep(*early_stop_step, legacy_version);
+    const String read_all_bytes = serializeStep(*read_all_step, legacy_version);
+
+    /// The legacy format has no flag, so both values must produce the same bytes.
+    EXPECT_EQ(early_stop_bytes, read_all_bytes);
+
+    auto restored = deserializeStep(early_stop_bytes, header, legacy_version);
+    EXPECT_TRUE(restored->alwaysReadTillEnd());
+    EXPECT_EQ(early_stop_bytes, serializeStep(*restored, legacy_version));
+}
+
+TEST(LimitByStepSerialization, FlagRoundTripsAtCurrentVersion)
+{
+    auto header = makeHeader();
+
+    for (bool always_read_till_end : {false, true})
+    {
+        auto step = makeStep(header, always_read_till_end);
+        const String bytes = serializeStep(*step, current_version);
+        auto restored = deserializeStep(bytes, header, current_version);
+
+        EXPECT_EQ(restored->alwaysReadTillEnd(), always_read_till_end);
+        EXPECT_EQ(bytes, serializeStep(*restored, current_version));
+    }
+}
+
+}

--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -110,10 +110,16 @@ ChunkRowRange shrinkRunToLimitWindow(
 }
 
 
-LimitByTransform::LimitByTransform(SharedHeader header, UInt64 group_length_, UInt64 group_offset_, const Names & column_names)
+LimitByTransform::LimitByTransform(
+    SharedHeader header,
+    UInt64 group_length_,
+    UInt64 group_offset_,
+    const Names & column_names,
+    bool always_read_till_end_)
     : ISimpleTransform(header, header, true)
     , group_offset(group_offset_)
     , group_limit_end(computeGroupLimitEnd(group_length_, group_offset_))
+    , always_read_till_end(always_read_till_end_)
 {
     auto grouping_keys = filterNonConstKeys(header, column_names);
     grouping_key_positions = std::move(grouping_keys.positions);
@@ -232,7 +238,7 @@ void LimitByTransform::transform(Chunk & chunk)
         if (group_counts.empty())
             group_counts.push_back(0);
         processRun(0, row_count, 0);
-        if (group_counts[0] >= group_limit_end)
+        if (!always_read_till_end && group_counts[0] >= group_limit_end)
             stopReading();
     }
     else
@@ -284,10 +290,15 @@ void LimitByTransform::transform(Chunk & chunk)
 
 
 LimitBySortedStreamTransform::LimitBySortedStreamTransform(
-    SharedHeader header, UInt64 group_length_, UInt64 group_offset_, const SortDescription & sorted_columns_descr)
+    SharedHeader header,
+    UInt64 group_length_,
+    UInt64 group_offset_,
+    const SortDescription & sorted_columns_descr,
+    bool always_read_till_end_)
     : ISimpleTransform(header, header, true)
     , group_offset(group_offset_)
     , group_limit_end(computeGroupLimitEnd(group_length_, group_offset_))
+    , always_read_till_end(always_read_till_end_)
 {
     Names key_names;
     key_names.reserve(sorted_columns_descr.size());
@@ -398,7 +409,7 @@ void LimitBySortedStreamTransform::transform(Chunk & chunk)
 
     /// `filterNonConstKeys` removed all grouping keys, so every row in this stream
     /// belongs to one logical group and no later input can produce another output row.
-    if (grouping_key_positions.empty() && current_group_rows_seen >= group_limit_end)
+    if (!always_read_till_end && grouping_key_positions.empty() && current_group_rows_seen >= group_limit_end)
         stopReading();
 
     /// Save the last grouping key so the next chunk can detect whether its first

--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -396,6 +396,11 @@ void LimitBySortedStreamTransform::transform(Chunk & chunk)
         ++run_count;
     }
 
+    /// `filterNonConstKeys` removed all grouping keys, so every row in this stream
+    /// belongs to one logical group and no later input can produce another output row.
+    if (grouping_key_positions.empty() && current_group_rows_seen >= group_limit_end)
+        stopReading();
+
     /// Save the last grouping key so the next chunk can detect whether its first
     /// row continues the same group or starts a new one. With no non-constant grouping
     /// keys this is a no-op (nothing to remember).

--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -232,6 +232,8 @@ void LimitByTransform::transform(Chunk & chunk)
         if (group_counts.empty())
             group_counts.push_back(0);
         processRun(0, row_count, 0);
+        if (group_counts[0] >= group_limit_end)
+            stopReading();
     }
     else
     {

--- a/src/Processors/Transforms/LimitByTransform.h
+++ b/src/Processors/Transforms/LimitByTransform.h
@@ -31,7 +31,12 @@ namespace DB
 class LimitByTransform final : public ISimpleTransform
 {
 public:
-    LimitByTransform(SharedHeader header, UInt64 group_length_, UInt64 group_offset_, const Names & column_names);
+    LimitByTransform(
+        SharedHeader header,
+        UInt64 group_length_,
+        UInt64 group_offset_,
+        const Names & column_names,
+        bool always_read_till_end_ = false);
 
     String getName() const override { return "LimitByTransform"; }
 
@@ -60,6 +65,7 @@ private:
     /// Kept per-group interval is `[group_offset, group_limit_end)`.
     const UInt64 group_offset;
     const UInt64 group_limit_end;
+    const bool always_read_till_end;
 
     AggregatedDataVariants data;
     ColumnsHashing::HashMethodContextPtr hash_method_context;
@@ -95,7 +101,12 @@ private:
 class LimitBySortedStreamTransform final : public ISimpleTransform
 {
 public:
-    LimitBySortedStreamTransform(SharedHeader header, UInt64 group_length_, UInt64 group_offset_, const SortDescription & sorted_columns_descr);
+    LimitBySortedStreamTransform(
+        SharedHeader header,
+        UInt64 group_length_,
+        UInt64 group_offset_,
+        const SortDescription & sorted_columns_descr,
+        bool always_read_till_end_ = false);
 
     String getName() const override { return "LimitBySortedStreamTransform"; }
 
@@ -120,6 +131,7 @@ private:
     /// Kept per-group interval is `[group_offset, group_limit_end)`.
     const UInt64 group_offset;
     const UInt64 group_limit_end;
+    const bool always_read_till_end;
 
     MutableColumns previous_chunk_last_grouping_key_columns;
 

--- a/tests/performance/limit_by_const_early_stop.xml
+++ b/tests/performance/limit_by_const_early_stop.xml
@@ -1,0 +1,26 @@
+<test>
+    <settings>
+        <max_threads>1</max_threads>
+        <max_block_size>8192</max_block_size>
+        <enable_analyzer>1</enable_analyzer>
+    </settings>
+
+    <!-- The generic LimitByTransform should stop after the first block once the constant group is full. -->
+    <query>
+        SELECT number, 'fixed-key' AS k
+        FROM numbers(65536)
+        WHERE sleepEachRow(0.0000125) = 0
+        LIMIT 2 BY k
+        FORMAT Null
+    </query>
+
+    <!-- The sorted-stream transform should stop after the first block for the same constant group. -->
+    <query>
+        SELECT number, identity(1) AS k
+        FROM numbers(65536)
+        WHERE sleepEachRow(0.0000125) = 0
+        ORDER BY k
+        LIMIT 2 BY k
+        FORMAT Null
+    </query>
+</test>

--- a/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.reference
+++ b/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.reference
@@ -19,3 +19,5 @@ UInt16
 0	grp
 1	grp
 OK
+1
+OK

--- a/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.reference
+++ b/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.reference
@@ -16,3 +16,6 @@ new
 new
 1	0
 UInt16
+0	grp
+1	grp
+OK

--- a/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
+++ b/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
@@ -53,3 +53,21 @@ SELECT DISTINCT 'new' AS my_field FROM (SELECT 'old' AS my_field, number FROM nu
 -- the redefined type.
 SELECT toUInt16(1) AS x, number FROM (SELECT toUInt8(1) AS x, number FROM numbers(3)) ORDER BY number LIMIT 1 BY x SETTINGS enable_analyzer=1;
 SELECT toTypeName(x) FROM (SELECT toUInt16(1) AS x FROM (SELECT toUInt8(1) AS x, number FROM numbers(3)) ORDER BY number LIMIT 1 BY x) SETTINGS enable_analyzer=1;
+
+SELECT number, 'grp' AS grp
+FROM numbers(5)
+LIMIT 2 BY grp;
+
+SELECT number, 'grp' AS grp
+FROM numbers(100000)
+LIMIT 2 BY grp
+FORMAT Null
+SETTINGS max_threads = 1, max_block_size = 10, log_comment = '03779_limit_by_const_early_stop';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT if(count() > 0 AND max(read_rows) < 1000, 'OK', 'FAIL')
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND log_comment = '03779_limit_by_const_early_stop'
+  AND type = 'QueryFinish';

--- a/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
+++ b/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
@@ -72,6 +72,8 @@ WHERE current_database = currentDatabase()
   AND log_comment = '03779_limit_by_const_early_stop'
   AND type = 'QueryFinish';
 
+SET enable_analyzer = 1;
+
 SELECT count() > 0
 FROM (EXPLAIN PIPELINE
       SELECT number, 1 AS k
@@ -92,6 +94,6 @@ SYSTEM FLUSH LOGS query_log;
 
 SELECT if(count() > 0 AND max(read_rows) < 1000, 'OK', 'FAIL')
 FROM system.query_log
-WHERE current_database() = currentDatabase()
+WHERE current_database = currentDatabase()
   AND log_comment = '03779_limit_by_const_early_stop_sorted'
   AND type = 'QueryFinish';

--- a/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
+++ b/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
@@ -74,21 +74,23 @@ WHERE current_database = currentDatabase()
 
 SET enable_analyzer = 1;
 
+-- Keep the constant as a ColumnConst, but prevent the analyzer from folding the
+-- ORDER BY key away, so this checks the final sorted-stream LIMIT BY transform.
 SELECT count() > 0
 FROM (EXPLAIN PIPELINE
-      SELECT number, 1 AS k
-      FROM numbers_mt(100000)
+      SELECT number, identity(1) AS k
+      FROM numbers(100000)
       ORDER BY k
       LIMIT 2 BY k
-      SETTINGS max_threads = 4, max_block_size = 10)
+      SETTINGS max_threads = 1, max_block_size = 10)
 WHERE explain LIKE '%LimitBySortedStreamTransform%';
 
-SELECT number, 1 AS k
-FROM numbers_mt(100000)
+SELECT number, identity(1) AS k
+FROM numbers(100000)
 ORDER BY k
 LIMIT 2 BY k
 FORMAT Null
-SETTINGS max_threads = 4, max_block_size = 10, log_comment = '03779_limit_by_const_early_stop_sorted';
+SETTINGS max_threads = 1, max_block_size = 10, log_comment = '03779_limit_by_const_early_stop_sorted';
 
 SYSTEM FLUSH LOGS query_log;
 

--- a/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
+++ b/tests/queries/0_stateless/03779_distinct_order_by_limit_by_const_column.sql
@@ -71,3 +71,27 @@ FROM system.query_log
 WHERE current_database = currentDatabase()
   AND log_comment = '03779_limit_by_const_early_stop'
   AND type = 'QueryFinish';
+
+SELECT count() > 0
+FROM (EXPLAIN PIPELINE
+      SELECT number, 1 AS k
+      FROM numbers_mt(100000)
+      ORDER BY k
+      LIMIT 2 BY k
+      SETTINGS max_threads = 4, max_block_size = 10)
+WHERE explain LIKE '%LimitBySortedStreamTransform%';
+
+SELECT number, 1 AS k
+FROM numbers_mt(100000)
+ORDER BY k
+LIMIT 2 BY k
+FORMAT Null
+SETTINGS max_threads = 4, max_block_size = 10, log_comment = '03779_limit_by_const_early_stop_sorted';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT if(count() > 0 AND max(read_rows) < 1000, 'OK', 'FAIL')
+FROM system.query_log
+WHERE current_database() = currentDatabase()
+  AND log_comment = '03779_limit_by_const_early_stop_sorted'
+  AND type = 'QueryFinish';

--- a/tests/queries/0_stateless/05153_limit_by_const_with_totals.reference
+++ b/tests/queries/0_stateless/05153_limit_by_const_with_totals.reference
@@ -59,7 +59,7 @@
 	[
 		{
 			"name": "g",
-			"type": "UInt64"
+			"type": "UInt8"
 		},
 		{
 			"name": "c",

--- a/tests/queries/0_stateless/05153_limit_by_const_with_totals.reference
+++ b/tests/queries/0_stateless/05153_limit_by_const_with_totals.reference
@@ -1,0 +1,56 @@
+{
+	"meta":
+	[
+		{
+			"name": "ignore(number)",
+			"type": "UInt8"
+		},
+		{
+			"name": "count()",
+			"type": "UInt64"
+		},
+		{
+			"name": "k",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, 1, "grp"]
+	],
+
+	"totals": [0, 1000, "grp"],
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 1
+}
+{
+	"meta":
+	[
+		{
+			"name": "number",
+			"type": "UInt64"
+		},
+		{
+			"name": "count()",
+			"type": "UInt64"
+		},
+		{
+			"name": "k",
+			"type": "UInt8"
+		}
+	],
+
+	"data":
+	[
+		[0, 1, 1]
+	],
+
+	"totals": [0, 1000, 1],
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 1
+}

--- a/tests/queries/0_stateless/05153_limit_by_const_with_totals.reference
+++ b/tests/queries/0_stateless/05153_limit_by_const_with_totals.reference
@@ -54,3 +54,31 @@
 
 	"rows_before_limit_at_least": 1
 }
+{
+	"meta":
+	[
+		{
+			"name": "g",
+			"type": "UInt64"
+		},
+		{
+			"name": "c",
+			"type": "UInt64"
+		},
+		{
+			"name": "k",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, 4, "grp"]
+	],
+
+	"totals": [0, 12, "grp"],
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 1
+}

--- a/tests/queries/0_stateless/05153_limit_by_const_with_totals.sql
+++ b/tests/queries/0_stateless/05153_limit_by_const_with_totals.sql
@@ -1,0 +1,21 @@
+-- A constant LIMIT BY key must not cancel aggregation before the totals row is complete.
+SET output_format_write_statistics = 0;
+SET group_by_two_level_threshold = 1;
+
+SELECT ignore(number), count(), 'grp' AS k
+FROM numbers_mt(1000)
+GROUP BY number WITH TOTALS
+LIMIT 1 BY k
+LIMIT 1
+FORMAT JSONCompact
+SETTINGS max_threads = 1, max_block_size = 10, enable_analyzer = 0;
+
+-- Cover the sorted-stream path and the per-stream LIMIT BY sort pushdown.
+SELECT number, count(), identity(1) AS k
+FROM numbers_mt(1000)
+GROUP BY number WITH TOTALS
+ORDER BY k, number
+LIMIT 1 BY k
+LIMIT 1
+FORMAT JSONCompact
+SETTINGS max_threads = 4, max_block_size = 10, query_plan_push_limit_by_into_sort = 1, enable_analyzer = 1;

--- a/tests/queries/0_stateless/05153_limit_by_const_with_totals.sql
+++ b/tests/queries/0_stateless/05153_limit_by_const_with_totals.sql
@@ -19,3 +19,17 @@ LIMIT 1 BY k
 LIMIT 1
 FORMAT JSONCompact
 SETTINGS max_threads = 4, max_block_size = 10, query_plan_push_limit_by_into_sort = 1, enable_analyzer = 1;
+
+-- Cover the first-stage preliminary LIMIT guard when a FROM subquery has WITH TOTALS.
+SELECT g, c, 'grp' AS k
+FROM
+(
+    SELECT number % 3 AS g, count() AS c
+    FROM numbers(12)
+    GROUP BY g WITH TOTALS
+    ORDER BY g
+)
+LIMIT 1 BY k
+LIMIT 1
+FORMAT JSONCompact
+SETTINGS max_threads = 1, max_block_size = 10, enable_analyzer = 1;

--- a/tests/queries/0_stateless/05166_limit_by_const_with_totals_joined_subquery.reference
+++ b/tests/queries/0_stateless/05166_limit_by_const_with_totals_joined_subquery.reference
@@ -1,0 +1,28 @@
+{
+	"meta":
+	[
+		{
+			"name": "n",
+			"type": "UInt64"
+		},
+		{
+			"name": "s",
+			"type": "UInt64"
+		},
+		{
+			"name": "k",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, 3, "grp"]
+	],
+
+	"totals": [0, 15, "grp"],
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 1
+}

--- a/tests/queries/0_stateless/05166_limit_by_const_with_totals_joined_subquery.sql
+++ b/tests/queries/0_stateless/05166_limit_by_const_with_totals_joined_subquery.sql
@@ -1,0 +1,20 @@
+SET output_format_write_statistics = 0;
+
+-- A `WITH TOTALS` subquery on the right side of a JOIN is fully read while the join is built.
+-- LIMIT BY's constant-key early stop must not drop its totals block in the old analyzer.
+SELECT l.n, r.s, 'grp' AS k
+FROM
+(
+    SELECT number AS n
+    FROM numbers(6)
+) AS l
+INNER JOIN
+(
+    SELECT number % 3 AS n, sum(number) AS s
+    FROM numbers(6)
+    GROUP BY n WITH TOTALS
+) AS r ON l.n = r.n
+LIMIT 1 BY k
+LIMIT 1
+FORMAT JSONCompact
+SETTINGS max_threads = 1, max_block_size = 1, enable_analyzer = 0, join_algorithm = 'hash';


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improve `LIMIT BY` performance by stopping input reads after a constant grouping key reaches its limit.

## What does this PR do?

- Uses the existing physical `ColumnConst` detection in `filterNonConstKeys`.
- Stops reading input when the single constant-key group reaches `offset + length` in both the generic and sorted-stream paths.
- Keeps the current chunk filtering and output accounting unchanged.
- Adds regressions for the direct result, sorted pipeline shape, and `system.query_log.read_rows`.

## Repro

```sql
SELECT number, 'grp' AS grp
FROM numbers(5)
LIMIT 2 BY grp
FORMAT TSV;
```

The result is unchanged:

```text
0\tgrp
1\tgrp
```

The wasted read is visible with a larger input and a small block size:

```sql
SELECT number, 'grp' AS grp
FROM numbers(100000)
LIMIT 2 BY grp
FORMAT Null
SETTINGS max_threads = 1, max_block_size = 10;
```

Before the change, this reads all 100,000 rows. After the change, it stops after the first input block.

The sorted-stream case is also covered by the regression query:

```sql
SELECT number, 1 AS k
FROM numbers_mt(100000)
ORDER BY k
LIMIT 2 BY k
FORMAT Null
SETTINGS max_threads = 4, max_block_size = 10;
```

## Why?

When all `LIMIT BY` keys are physical constant columns, `filterNonConstKeys` removes them. The generic transform uses `AggregatedDataVariants::Type::without_key`, so every row belongs to the same logical group. The sorted-stream transform has the same one-group invariant when `grouping_key_positions` is empty.

`processRun()` and the sorted-stream row accounting already apply the existing offset and length rules. Once the current group reaches `group_limit_end`, no later input can produce another output row, so the upstream source can be stopped safely.

The change is limited to this physical constant-key path. Non-constant keys keep the existing behavior.

## History

This follows the existing `LIMIT BY` design from [#103349](https://github.com/ClickHouse/ClickHouse/pull/103349):

- The old transform already ignored physical `ColumnConst` keys.
- The large rewrite preserved that behavior in `filterNonConstKeys`.
- The same PR added the `processRun()` short-circuit once `group_limit_end` was reached.

This PR applies the next step for the one-group case: after the current chunk fills that group, stop requesting more input.

## Benchmark

I ran the performance script with two local native-protocol servers and 5 measured runs per side.

```sql
SELECT number, 'fixed-key' AS k
FROM numbers(1000000000)
LIMIT 2 BY k
FORMAT Null
```

Settings: `max_threads = 1`, `max_block_size = 8192`.

| Version | Median time | `read_rows` | `read_bytes` |
| --- | ---: | ---: | ---: |
| Before | 0.454215 s | 1,000,000,000 | 8,000,000,000 |
| After | 0.0014789 s | 8,192 | 65,536 |

This is about **307x faster** and reads about **122,070x fewer rows** in this intentionally extreme fixed-key case. This benchmark is a sensitivity check for the physical `ColumnConst` path, not a general `LIMIT BY` workload.

## Tests

- `git diff --check`
- `cmake --build build-local --target clickhouse -- -j8`
- The direct result regression returned the expected two rows.
- The sorted `EXPLAIN PIPELINE` regression confirms `LimitBySortedStreamTransform` is present, with `enable_analyzer = 1` pinned in the test.
- The query-log assertions returned `OK` and require at least one matching query.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118770&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118770](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118770+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1311` (included in `26.9` and later)
<!-- ch-version-info:end -->