### PR TITLE
Keep the `Filesystem` database's directory in the file-rename grant test

### DIFF
--- a/tests/queries/0_stateless/05057_file_rename_after_processing_write_grant.sh
+++ b/tests/queries/0_stateless/05057_file_rename_after_processing_write_grant.sh
@@ -225,4 +225,10 @@ DROP DATABASE IF EXISTS ${FS_DB};
 DROP DATABASE IF EXISTS ${URL_DB};
 DROP USER IF EXISTS ${READER};
 "
-rm -rf "${FILES_DIR}"
+# Only the files, never the directory: `${FS_DB}` is a `Filesystem` database over it, and the two
+# cleanups above and below cannot be made atomic. The `DROP DATABASE` is a call into the server and
+# fails whenever the server is gone - which is routine under a stress run, where it is killed and
+# restarted while the tests run - while the removal here is local and always succeeds. Removing the
+# directory would then leave a `Filesystem` database pointing at a path that no longer exists, and
+# `loadMetadata` aborts every subsequent server start over it, so the server never comes back.
+rm -f "${FILES_DIR}"/*.csv


### PR DESCRIPTION
`05057_file_rename_after_processing_write_grant` creates a `Filesystem` database over its `user_files` directory and, on its last two lines, drops the database and then removes the directory. The two cannot be made atomic: the `DROP DATABASE` is a call into the server and fails whenever the server is gone — routine under a stress run, where the server is killed and restarted while the tests run — while the `rm -rf` is local and always succeeds.

What that leaves behind is a `Filesystem` database whose path no longer exists, and `loadMetadata` aborts on it:

```
Application: Caught exception while loading metadata: Code: 36. DB::Exception:
Path does not exist: /var/lib/clickhouse/user_files/05057_file_rename_after_processing_write_grant_test_...:
while loading database `fsdb_...` from file metadata/fsdb_....sql. (BAD_ARGUMENTS)
```

Every subsequent start of that server hits the same exception, so the job dies with `Cannot start clickhouse-server: server process is not running after 11 start attempts` and loses everything the stress run had left to check.

Since the test was added on 2026-09-04 this has been failing stress jobs across the fleet — on `master` and on more than 20 unrelated pull requests over two days, across `arm_tsan`, `amd_tsan`, `arm_msan`, `amd_msan` and `arm_asan_ubsan, s3`:

```sql
SELECT check_start_time, check_name, pull_request_number
FROM checks
WHERE test_context_raw LIKE '%fsdb_05057_file_rename_after_processing%'
  AND check_start_time > now() - INTERVAL 10 DAY
ORDER BY check_start_time DESC
```

Removing only the files keeps the directory the database points at, so a database that survives the cleanup still resolves and the server starts.

This does not address the second half of the issue — that a `Filesystem` database with a missing directory prevents the whole server from starting, rather than making one database unavailable. A `Filesystem` database is a view over a directory, and losing that directory bricking the server looks like a robustness defect in its own right; that is left for a separate decision.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118772
Related: https://github.com/ClickHouse/ClickHouse/pull/115798

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118773&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118773](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118773+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
