### PR TITLE
Keep the JOIN instead of an IN conversion when a common subplan is referenced

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/convertJoinToIn.cpp
+++ b/src/Processors/QueryPlan/Optimizations/convertJoinToIn.cpp
@@ -9,6 +9,8 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/JoinExpressionActions.h>
 #include <Interpreters/TableJoin.h>
+#include <Processors/QueryPlan/CommonSubplanReferenceStep.h>
+#include <Processors/QueryPlan/CommonSubplanStep.h>
 #include <Processors/QueryPlan/CreatingSetsStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
@@ -130,6 +132,23 @@ static ActionsDAG cloneSubDAGWithHeader(const SharedHeader & stream_header, Acti
     return dag;
 }
 
+static bool hasCommonSubplanNodes(const QueryPlan::Node & root)
+{
+    std::vector<const QueryPlan::Node *> stack{&root};
+    while (!stack.empty())
+    {
+        const auto * node = stack.back();
+        stack.pop_back();
+
+        if (typeid_cast<const CommonSubplanStep *>(node->step.get())
+            || typeid_cast<const CommonSubplanReferenceStep *>(node->step.get()))
+            return true;
+
+        stack.insert(stack.end(), node->children.begin(), node->children.end());
+    }
+    return false;
+}
+
 size_t tryConvertJoinToIn(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes, const Optimization::ExtraSettings & settings)
 {
     auto & parent = parent_node->step;
@@ -192,6 +211,13 @@ size_t tryConvertJoinToIn(QueryPlan::Node * parent_node, QueryPlan::Nodes & node
 
     /// Check input and output type match
     if (!join->typeChangingSides().empty())
+        return 0;
+
+    /// A `CommonSubplanReferenceStep` holds a raw pointer to a node that must still hold a
+    /// `CommonSubplanStep` when the second pass resolves it. The rewrite below installs new steps at
+    /// both input node addresses and splices the right input into the IN set's own plan.
+    if (hasCommonSubplanNodes(*parent_node->children.at(0))
+        || hasCommonSubplanNodes(*parent_node->children.at(1)))
         return 0;
 
     // {

--- a/tests/queries/0_stateless/05137_convert_join_to_in_correlated_subplan_reference.reference
+++ b/tests/queries/0_stateless/05137_convert_join_to_in_correlated_subplan_reference.reference
@@ -1,0 +1,6 @@
+-- in-memory buffer
+0
+4
+-- no in-memory buffer
+0
+4

--- a/tests/queries/0_stateless/05137_convert_join_to_in_correlated_subplan_reference.sql
+++ b/tests/queries/0_stateless/05137_convert_join_to_in_correlated_subplan_reference.sql
@@ -1,17 +1,12 @@
--- Regression test for issue #118733.
--- Decorrelating a correlated scalar subquery puts a CommonSubplanStep on the outer plan's root and
--- gives the decorrelated subquery a CommonSubplanReferenceStep holding a raw pointer to that node.
--- Both become inputs of one JoinStepLogical, and the `query_plan_convert_join_to_in` rewrite
--- installed new steps at the input node addresses and spliced the right input into the IN set's own
--- plan, so the reference no longer resolved to a CommonSubplanStep:
---   Logical error: Expected CommonSubplanReferenceStep to reference CommonSubplanStep, but got Expression
--- thrown from useMemoryBufferForCommonSubplanResult with the in-memory buffer enabled, and from
--- materializeQueryPlanReferences with it disabled.
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/118733.
+-- A CommonSubplanReferenceStep holds a raw pointer to the node that must still hold the
+-- CommonSubplanStep when the second pass resolves it; the two arms cover the two consumers that do.
 
 SET enable_analyzer = 1;                             -- correlated subqueries need the analyzer
 SET allow_experimental_correlated_subqueries = 1;    -- gates decorrelation
 SET query_plan_convert_join_to_in = 1;               -- the trigger, default 0
 SET query_plan_convert_outer_join_to_inner_join = 1; -- supplies the INNER kind the rewrite requires, and the test runner randomizes it off in 5% of runs
+SET join_algorithm = 'hash';                         -- convertJoinToIn only runs for hash/parallel_hash, and the buffer=0 arm keeps the session's list
 
 DROP TABLE IF EXISTS t_05137;
 

--- a/tests/queries/0_stateless/05137_convert_join_to_in_correlated_subplan_reference.sql
+++ b/tests/queries/0_stateless/05137_convert_join_to_in_correlated_subplan_reference.sql
@@ -1,0 +1,33 @@
+-- Regression test for issue #118733.
+-- Decorrelating a correlated scalar subquery puts a CommonSubplanStep on the outer plan's root and
+-- gives the decorrelated subquery a CommonSubplanReferenceStep holding a raw pointer to that node.
+-- Both become inputs of one JoinStepLogical, and the `query_plan_convert_join_to_in` rewrite
+-- installed new steps at the input node addresses and spliced the right input into the IN set's own
+-- plan, so the reference no longer resolved to a CommonSubplanStep:
+--   Logical error: Expected CommonSubplanReferenceStep to reference CommonSubplanStep, but got Expression
+-- thrown from useMemoryBufferForCommonSubplanResult with the in-memory buffer enabled, and from
+-- materializeQueryPlanReferences with it disabled.
+
+SET enable_analyzer = 1;                             -- correlated subqueries need the analyzer
+SET allow_experimental_correlated_subqueries = 1;    -- gates decorrelation
+SET query_plan_convert_join_to_in = 1;               -- the trigger, default 0
+SET query_plan_convert_outer_join_to_inner_join = 1; -- supplies the INNER kind the rewrite requires, and the test runner randomizes it off in 5% of runs
+
+DROP TABLE IF EXISTS t_05137;
+
+CREATE TABLE t_05137 (a UInt32, b Nullable(Int64)) ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t_05137 VALUES (1, 1), (2, NULL), (3, 5), (4, 5), (5, 5);
+
+-- `max(b)` is correlated, so it is the row's own `b`: the first count is 0, and the second counts
+-- every row with a non-NULL `b`. Duplicate `b` values make the second count sensitive to a rewrite
+-- that collapsed the outer stream to its distinct correlated keys.
+SELECT '-- in-memory buffer';
+SELECT count() FROM t_05137 WHERE 1 > (SELECT max(b)) SETTINGS correlated_subqueries_use_in_memory_buffer = 1;
+SELECT count() FROM t_05137 WHERE 100 > (SELECT max(b)) SETTINGS correlated_subqueries_use_in_memory_buffer = 1;
+
+SELECT '-- no in-memory buffer';
+SELECT count() FROM t_05137 WHERE 1 > (SELECT max(b)) SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
+SELECT count() FROM t_05137 WHERE 100 > (SELECT max(b)) SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
+
+DROP TABLE t_05137;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/118733

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `LOGICAL_ERROR` ("Expected CommonSubplanReferenceStep to reference CommonSubplanStep") raised at query planning time when `query_plan_convert_join_to_in = 1` was used with a correlated aggregating scalar subquery. The `convertJoinToIn` optimization now keeps the `JOIN` instead of rewriting it when either join input carries a common subplan node.


### Description

Reproducer, with one non-default setting (correlated subqueries are enabled by default since 25.8):

```sql
CREATE TABLE t (a UInt32, b Nullable(Int64)) ENGINE = MergeTree ORDER BY a;
INSERT INTO t VALUES (1, 1), (2, NULL), (3, 5);
SELECT count() FROM t WHERE 1 > (SELECT max(b)) SETTINGS query_plan_convert_join_to_in = 1;
```

Decorrelating a correlated scalar subquery puts a `CommonSubplanStep` on the outer plan's root and gives the decorrelated subquery a `CommonSubplanReferenceStep` holding a raw `QueryPlan::Node *` to that node. The two become the inputs of one `JoinStepLogical`, so the reference is a bare pointer across subtrees of that join.

The rewrite is built on `makeExpressionNodeOnTopOf`, which relocates the existing node and installs the new step at its original address (`Optimizations/Utils.cpp:40-41`); `QueryPlan::extractSubplan` then moves the right input into the IN set's own plan. The reference therefore resolves to an `ExpressionStep`, and the second optimization pass throws from `useMemoryBufferForCommonSubplanResult` with the in-memory buffer enabled, and from `materializeQueryPlanReferences` with it disabled. `EXPLAIN PLAN` throws as well, so no rows are ever read.

`tryConvertJoinToIn` now declines when either input subtree carries a `CommonSubplanStep` or a `CommonSubplanReferenceStep`, before any plan mutation, mirroring the structural declines already in that pass (including `make_distributed_plan`). The pass cannot perform those two mutations and keep the pointer valid; remapping the reference instead is not sound here, because the producer would end up in the IN set's plan while the consumer stays in the main plan.

Validated: the new test fails on both throw sites without the change and passes with it, 50/50 under the CI randomizer, and reverting only the decline restores the failure.

Disclosed, not fixed: `limitPushDown.cpp:147`, `splitFilter.cpp:32-33` and `shortCircuitConstantFalseJoin.cpp:82-84` use the same relocate-and-reinstall or input-replacement pattern, but I could not reach any of them from SQL at this revision.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118797&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118797](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118797+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
