### PR TITLE
Fix linker error after #117540

### DIFF
--- a/src/Functions/equals.cpp
+++ b/src/Functions/equals.cpp
@@ -8,12 +8,9 @@ namespace DB
 {
 
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
-/// Used through `FunctionIsNotDistinctFrom` in `executeArrayLexicographic`; instantiated in isNotDistinctFrom.cpp.
-extern template class FunctionComparison<EqualsOp, NameEquals, true>;
 
 REGISTER_FUNCTION(Equals)
 {
-    // Documentation for equals
     FunctionDocumentation::Description description = "Compares two values for equality.";
     FunctionDocumentation::Syntax syntax = R"(
         equals(a, b)

--- a/src/Functions/equals.cpp
+++ b/src/Functions/equals.cpp
@@ -9,6 +9,9 @@ namespace DB
 
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
+/// Used through `FunctionIsNotDistinctFrom` in `executeArrayLexicographic`; instantiated in isNotDistinctFrom.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals, true>;
+
 REGISTER_FUNCTION(Equals)
 {
     FunctionDocumentation::Description description = "Compares two values for equality.";
@@ -68,5 +71,12 @@ ColumnPtr FunctionComparison<EqualsOp, NameEquals>::executeArrayLexicographic(
         column_type_name1,
         input_rows_count);
 }
+
+/// Explicit instantiation definition, paired with the `extern template class` declarations in the other comparison
+/// functions. An implicit instantiation emits only the base-object constructor (`C2`), and at `-O0` clang does not
+/// emit `available_externally` members, so a translation unit that relies on `extern template` would reference the
+/// complete-object constructor (`C1`) by name and fail to link. This must come after the explicit member
+/// specializations above.
+template class FunctionComparison<EqualsOp, NameEquals>;
 
 }

--- a/src/Functions/greater.cpp
+++ b/src/Functions/greater.cpp
@@ -7,6 +7,8 @@ namespace DB
 
 using FunctionGreater = FunctionComparison<GreaterOp, NameGreater>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
+
+/// Avoid second instantiation
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Greater)

--- a/src/Functions/greater.cpp
+++ b/src/Functions/greater.cpp
@@ -8,7 +8,7 @@ namespace DB
 using FunctionGreater = FunctionComparison<GreaterOp, NameGreater>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
-/// Avoid second instantiation
+/// Instantiated in equals.cpp.
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Greater)
@@ -80,5 +80,8 @@ ColumnPtr FunctionComparison<GreaterOp, NameGreater>::executeArrayLexicographic(
         column_type_name1,
         input_rows_count);
 }
+
+/// Explicit instantiation definition, see the comment in equals.cpp. Must come after the member specializations above.
+template class FunctionComparison<GreaterOp, NameGreater>;
 
 }

--- a/src/Functions/greaterOrEquals.cpp
+++ b/src/Functions/greaterOrEquals.cpp
@@ -9,7 +9,7 @@ using FunctionGreaterOrEquals = FunctionComparison<GreaterOrEqualsOp, NameGreate
 using FunctionGreater = FunctionComparison<GreaterOp, NameGreater>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
-/// Avoid second instantiation
+/// Instantiated in greater.cpp and equals.cpp.
 extern template class FunctionComparison<GreaterOp, NameGreater>;
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 

--- a/src/Functions/greaterOrEquals.cpp
+++ b/src/Functions/greaterOrEquals.cpp
@@ -7,8 +7,10 @@ namespace DB
 
 using FunctionGreaterOrEquals = FunctionComparison<GreaterOrEqualsOp, NameGreaterOrEquals>;
 using FunctionGreater = FunctionComparison<GreaterOp, NameGreater>;
-extern template class FunctionComparison<GreaterOp, NameGreater>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
+
+/// Avoid second instantiation
+extern template class FunctionComparison<GreaterOp, NameGreater>;
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(GreaterOrEquals)

--- a/src/Functions/isDistinctFrom.cpp
+++ b/src/Functions/isDistinctFrom.cpp
@@ -7,11 +7,6 @@
 namespace DB
 {
 
-/// avoid second copy
-extern template class FunctionComparison<EqualsOp, NameEquals, true>;
-/// The null-safe comparison falls back to the plain one for tuples; instantiated in notEquals.cpp.
-extern template class FunctionComparison<NotEqualsOp, NameNotEquals>;
-
 REGISTER_FUNCTION(IsDistinctFrom)
 {
     FunctionDocumentation::Description description = R"(

--- a/src/Functions/isDistinctFrom.cpp
+++ b/src/Functions/isDistinctFrom.cpp
@@ -7,6 +7,11 @@
 namespace DB
 {
 
+/// Instantiated in isNotDistinctFrom.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals, true>;
+/// The null-safe comparison falls back to the plain one for tuples; instantiated in notEquals.cpp.
+extern template class FunctionComparison<NotEqualsOp, NameNotEquals>;
+
 REGISTER_FUNCTION(IsDistinctFrom)
 {
     FunctionDocumentation::Description description = R"(

--- a/src/Functions/isNotDistinctFrom.cpp
+++ b/src/Functions/isNotDistinctFrom.cpp
@@ -5,7 +5,7 @@
 namespace DB
 {
 
-/// Avoid second instantiation
+/// The null-safe comparison falls back to the plain one for tuples; instantiated in equals.cpp.
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(IsNotDistinctFrom)
@@ -86,5 +86,8 @@ ColumnPtr FunctionComparison<EqualsOp, NameEquals, true /* is null safe cmp*/>::
         column_type_name1,
         input_rows_count);
 }
+
+/// Explicit instantiation definition, see the comment in equals.cpp. Must come after the member specializations above.
+template class FunctionComparison<EqualsOp, NameEquals, true>;
 
 }

--- a/src/Functions/isNotDistinctFrom.cpp
+++ b/src/Functions/isNotDistinctFrom.cpp
@@ -5,7 +5,7 @@
 namespace DB
 {
 
-/// The null-safe comparison falls back to the plain one for tuples; instantiated in equals.cpp.
+/// Avoid second instantiation
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(IsNotDistinctFrom)

--- a/src/Functions/less.cpp
+++ b/src/Functions/less.cpp
@@ -8,6 +8,8 @@ namespace DB
 
 using FunctionLess = FunctionComparison<LessOp, NameLess>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
+
+/// Avoid second instantiation
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Less)

--- a/src/Functions/less.cpp
+++ b/src/Functions/less.cpp
@@ -9,7 +9,7 @@ namespace DB
 using FunctionLess = FunctionComparison<LessOp, NameLess>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
-/// Avoid second instantiation
+/// Instantiated in equals.cpp.
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(Less)
@@ -81,5 +81,8 @@ ColumnPtr FunctionComparison<LessOp, NameLess>::executeArrayLexicographic(
         column_type_name1,
         input_rows_count);
 }
+
+/// Explicit instantiation definition, see the comment in equals.cpp. Must come after the member specializations above.
+template class FunctionComparison<LessOp, NameLess>;
 
 }

--- a/src/Functions/lessOrEquals.cpp
+++ b/src/Functions/lessOrEquals.cpp
@@ -8,8 +8,10 @@ namespace DB
 
 using FunctionLessOrEquals = FunctionComparison<LessOrEqualsOp, NameLessOrEquals>;
 using FunctionLess = FunctionComparison<LessOp, NameLess>;
-extern template class FunctionComparison<LessOp, NameLess>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
+
+/// Avoid second instantiation
+extern template class FunctionComparison<LessOp, NameLess>;
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 
 REGISTER_FUNCTION(LessOrEquals)

--- a/src/Functions/lessOrEquals.cpp
+++ b/src/Functions/lessOrEquals.cpp
@@ -10,7 +10,7 @@ using FunctionLessOrEquals = FunctionComparison<LessOrEqualsOp, NameLessOrEquals
 using FunctionLess = FunctionComparison<LessOp, NameLess>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 
-/// Avoid second instantiation
+/// Instantiated in less.cpp and equals.cpp.
 extern template class FunctionComparison<LessOp, NameLess>;
 extern template class FunctionComparison<EqualsOp, NameEquals>;
 

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -8,6 +8,11 @@ namespace DB
 
 using FunctionNotEquals = FunctionComparison<NotEqualsOp, NameNotEquals>;
 
+/// Instantiated in equals.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals>;
+/// Used through `FunctionIsNotDistinctFrom` in `executeArrayLexicographic`; instantiated in isNotDistinctFrom.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals, true>;
+
 REGISTER_FUNCTION(NotEquals)
 {
     FunctionDocumentation::Description description = "Compares two values for inequality.";
@@ -67,5 +72,8 @@ ColumnPtr FunctionComparison<NotEqualsOp, NameNotEquals>::executeArrayLexicograp
         column_type_name1,
         input_rows_count);
 }
+
+/// Explicit instantiation definition, see the comment in equals.cpp. Must come after the member specializations above.
+template class FunctionComparison<NotEqualsOp, NameNotEquals>;
 
 }

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -7,14 +7,9 @@ namespace DB
 {
 
 using FunctionNotEquals = FunctionComparison<NotEqualsOp, NameNotEquals>;
-using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
-extern template class FunctionComparison<EqualsOp, NameEquals>;
-/// Used through `FunctionIsNotDistinctFrom` in `executeArrayLexicographic`; instantiated in isNotDistinctFrom.cpp.
-extern template class FunctionComparison<EqualsOp, NameEquals, true>;
 
 REGISTER_FUNCTION(NotEquals)
 {
-    // Documentation for notEquals
     FunctionDocumentation::Description description = "Compares two values for inequality.";
     FunctionDocumentation::Syntax syntax = R"(
     notEquals(a, b)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117540

Resolves local errors

```
ld.lld-22: error: undefined symbol: DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals, false>::FunctionComparison(DB::ComparisonParams)
>>> referenced by construct_at.h:37 (/data/ch1/contrib/llvm-project/libcxx/include/__memory/construct_at.h:37)
>>>               src/Functions/CMakeFiles/clickhouse_functions_obj.dir/./isDistinctFrom.cpp.o:(DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals, false>* std::__1::construct_at[abi:sqe220101]<DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals, false>, DB::ComparisonParams const&, DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals, false>*>(DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals, false>*, DB::ComparisonParams const&))
>>> did you mean: DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals, false>::FunctionComparison(DB::ComparisonParams)
>>> defined in: src/Functions/CMakeFiles/clickhouse_functions_obj.dir/./notEquals.cpp.o

ld.lld-22: error: undefined symbol: DB::FunctionComparison<DB::EqualsOp, DB::NameEquals, true>::FunctionComparison(DB::ComparisonParams)
>>> referenced by construct_at.h:37 (/data/ch1/contrib/llvm-project/libcxx/include/__memory/construct_at.h:37)
>>>               src/Functions/CMakeFiles/clickhouse_functions_obj.dir/./equals.cpp.o:(DB::FunctionComparison<DB::EqualsOp, DB::NameEquals, true>* std::__1::construct_at[abi:sqe220101]<DB::FunctionComparison<DB::EqualsOp, DB::NameEquals, true>, DB::ComparisonParams const&, DB::FunctionComparison<DB::EqualsOp, DB::NameEquals, true>*>(DB::FunctionComparison<DB::EqualsOp, DB::NameEquals, true>*, DB::ComparisonParams const&))
clang++-22: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118800&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118800](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118800+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1029` (included in `26.9` and later)
<!-- ch-version-info:end -->