### PR TITLE
backfill_distroless: move off the retired release-maker pool

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -65,11 +65,19 @@ jobs:
         # out-of-band, so this job never authenticated explicitly. Generic
         # runners are not, so the `--push` below would fail on auth. Same
         # credentials and mechanism as ci/jobs/docker_server.py::docker_login.
-        # Skipped on dry-run, which never pushes.
-        if: ${{ !inputs.dry-run }}
+        #
+        # Deliberately unconditional. `inputs.dry-run` arrives as the string
+        # "false" when dispatched through the API (which is how
+        # DistrolessAutoRebuild triggers this), so an `if: !inputs.dry-run`
+        # guard evaluates a non-empty string and skips the login on exactly
+        # the runs that need it. The build step below string-compares
+        # INPUT_DRY_RUN for the same reason. Logging in on a dry-run is
+        # harmless, so skip the guard rather than the credentials.
         shell: bash
         run: |
-          set -e
+          set -eo pipefail
+          # pipefail matters: without it a failed SSM fetch pipes an empty
+          # password into docker login and the step fails on the wrong error.
           aws ssm get-parameter --name dockerhub_robot_password \
             --with-decryption --output text --query Parameter.Value \
             | docker login --username 'robotclickhouse' --password-stdin

--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -21,7 +21,13 @@ env:
 
 jobs:
   BackfillDistroless:
-    runs-on: [self-hosted, release-maker]
+    # Generic CI pool. The dedicated `release-maker` pool is retired; between
+    # 2026-08-03 and 2026-09-03 every dispatch sat unclaimed and was killed by
+    # GitHub's 24h queue timeout (8 consecutive runs, `runner_name` empty,
+    # `steps: []`), so no distroless rebuild reached Docker Hub for a month.
+    # This job only downloads prebuilt release debs and assembles layers, so it
+    # does not need release-grade hardware.
+    runs-on: [self-hosted, arm-small]
     steps:
       - name: Check out repository code
         uses: ClickHouse/checkout@v1
@@ -29,8 +35,44 @@ jobs:
           clear-repository: true
       - name: Debug Info
         uses: ./.github/actions/debug
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx (multi-arch)
+        shell: bash
+        run: |
+          set -e
+          # The generic runner is not pre-provisioned for multi-arch docker
+          # builds (the legacy `release-maker` host was). Mirrors the same
+          # migration in ci/jobs/release_job.py. Two things are needed:
+          #
+          # 1. QEMU/binfmt registration. Both linux/amd64 and linux/arm64 are
+          #    built in one buildx invocation; this pool is aarch64, so amd64
+          #    is the emulated arch. binfmt is pinned by digest (not `latest`)
+          #    because it runs --privileged.
+          # 2. A `docker-container` builder with host networking. The default
+          #    sandbox network has no working egress for RUN steps, and the
+          #    ch-builder stage does apt-get plus wget against
+          #    packages.clickhouse.com. Use a dedicated builder name and
+          #    recreate it unconditionally so a pre-provisioned shared builder
+          #    is never clobbered.
+          docker run --privileged --rm \
+            tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 \
+            --install all
+          docker buildx rm distroless-backfill-builder >/dev/null 2>&1 || true
+          docker buildx create --name distroless-backfill-builder \
+            --driver docker-container --driver-opt network=host --use
+          docker buildx inspect --bootstrap
+      - name: Docker Hub login
+        # The legacy `release-maker` host was logged in to Docker Hub
+        # out-of-band, so this job never authenticated explicitly. Generic
+        # runners are not, so the `--push` below would fail on auth. Same
+        # credentials and mechanism as ci/jobs/docker_server.py::docker_login.
+        # Skipped on dry-run, which never pushes.
+        if: ${{ !inputs.dry-run }}
+        shell: bash
+        run: |
+          set -e
+          aws ssm get-parameter --name dockerhub_robot_password \
+            --with-decryption --output text --query Parameter.Value \
+            | docker login --username 'robotclickhouse' --password-stdin
       - name: Build and push distroless images
         shell: bash
         env:

--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -265,6 +265,8 @@ jobs:
                 --label="com.clickhouse.build.version=${VERSION}-distroless" \
                 ${TAG_ARGS} \
                 --build-arg=VERSION="${VERSION}" \
+                --build-arg=apt_archive=http://us-east-1.ec2.archive.ubuntu.com \
+                --build-arg=apt_ports_archive=http://us-east-1.ec2.ports.ubuntu.com \
                 --progress=plain \
                 --file="${DOCKERFILE}" \
                 "${CONTEXT}"


### PR DESCRIPTION
The dedicated `release-maker` pool is retired, so `BackfillDistroless` has had nowhere to run. Every dispatch between 2026-08-03 and 2026-09-03 sat unclaimed and was killed by GitHub's 24h queue timeout, 8 consecutive runs, `runner_name` empty and `steps: []` on all of them:

```
2026-09-02  cancelled  33651211829
2026-09-01  cancelled  33488286129
2026-08-31  cancelled  33443502485 -> 33443522275
2026-08-30  cancelled  33315142988
2026-08-21  cancelled  32497696333
2026-08-19  cancelled  32236723225
2026-08-06  cancelled  31096799133
2026-08-03  cancelled  30835296642
```

So no distroless rebuild has reached Docker Hub in a month. Concretely: `clickhouse-{server,keeper}:{25.8,26.3,26.4}-distroless` are still built on `cc-debian13`, still carry `libssl3t64 3.5.6-1~deb13u2`, and still show CVE-2026-14456 (fixable HIGH) even though #116929 fixed the base pin on master. `release-maker` had exactly one consumer left in the repo, this workflow.

This moves the job to the generic `arm-small` pool. It only downloads prebuilt release debs and assembles layers, so it doesn't need release-grade hardware.

Two things the old host provided out-of-band that a generic runner doesn't. Both were already solved the same way for the release job in `ci/jobs/release_job.py` when it moved to ephemeral runners, so this follows that precedent rather than inventing anything:

- **Multi-arch.** The build is one `--platform=linux/amd64,linux/arm64` buildx call. Register QEMU/binfmt, pinned by digest rather than `latest` since it runs `--privileged`, and create a `docker-container` builder with `network=host`. The network option is load-bearing: the default sandbox network has no working egress for `RUN` steps, and the `ch-builder` stage does `apt-get` and `wget` against `packages.clickhouse.com`.
- **Docker Hub credentials.** There was no login step at all, `--push` relied on the old host's ambient login. Now authenticates explicitly with the `robotclickhouse` robot password from SSM, matching `ci/jobs/docker_server.py::docker_login`. Skipped on dry-run.

Worth a reviewer's eye on two things I couldn't settle without running it. `arm-small` makes amd64 the emulated arch, the inverse of the release job which runs on x86 and emulates arm64, so the emulated `apt-get`/`dpkg` path in `ch-builder` is slower and `small` may be tight on disk for 2 arches x 2 images x N versions; `arm-medium` or an amd pool is the fallback. And I'm assuming the generic pool's instance role can read the `dockerhub_robot_password` SSM parameter, which the first real dispatch will confirm.

Suggest verifying with `dry-run=true` first, which exercises pickup, binfmt and the multi-arch build without pushing.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118804&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118804](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118804+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.985` (included in `26.9` and later)
<!-- ch-version-info:end -->