### PR TITLE
Avoid undefined behavior in ctype calls on signed characters

### DIFF
--- a/src/Client/LineReader.cpp
+++ b/src/Client/LineReader.cpp
@@ -17,7 +17,7 @@ namespace
 /// Trim ending whitespace inplace
 void trim(String & s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
 struct NoCaseCompare
@@ -26,7 +26,7 @@ struct NoCaseCompare
     {
         return std::lexicographical_compare(begin(str1), end(str1), begin(str2), end(str2), [](const char c1, const char c2)
         {
-            return std::tolower(c1) < std::tolower(c2);
+            return std::tolower(static_cast<unsigned char>(c1)) < std::tolower(static_cast<unsigned char>(c2));
         });
     }
 };

--- a/src/Common/levenshteinDistance.cpp
+++ b/src/Common/levenshteinDistance.cpp
@@ -21,7 +21,8 @@ size_t levenshteinDistanceCaseInsensitive(const String & lhs, const String & rhs
         for (size_t i = 1; i <= n; ++i)
         {
             size_t old = row[i];
-            row[i] = std::min(prev + (std::tolower(lhs[j - 1]) != std::tolower(rhs[i - 1])),
+            row[i] = std::min(prev + (std::tolower(static_cast<unsigned char>(lhs[j - 1]))
+                                      != std::tolower(static_cast<unsigned char>(rhs[i - 1]))),
                               std::min(row[i - 1], row[i]) + 1);
             prev = old;
         }

--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -1459,7 +1459,7 @@ public:
 
         for (size_t i = 0; i < query.size() && prefix.size() < max_len; ++i)
         {
-            if (std::isspace(query[i]))
+            if (std::isspace(static_cast<unsigned char>(query[i])))
             {
                 if (!prev_was_space)
                 {
@@ -1469,7 +1469,7 @@ public:
             }
             else
             {
-                prefix.push_back(static_cast<char>(std::toupper(query[i])));
+                prefix.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(query[i]))));
                 prev_was_space = false;
             }
         }


### PR DESCRIPTION
This fixes undefined behavior caused by passing potentially negative `char` values directly to `<cctype>` functions.

The affected code paths process client input, string values, and raw bytes from `String` objects. On platforms where `char` is signed, non-ASCII bytes can become negative, while `std::isspace`, `std::tolower`, and `std::toupper` require either `EOF` or a value representable as `unsigned char`.

Convert the input bytes to `unsigned char` before calling the classification and case-conversion functions in:

- `src/Client/LineReader.cpp`
- `src/Common/levenshteinDistance.cpp`
- `src/Core/PostgreSQLProtocol.h`

The existing behavior is otherwise unchanged.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

