### PR TITLE
Docs: Add Cloud changelog for JWT authentication and MySQL CDC GA

### DIFF
--- a/docs/concepts/features/security/external-authenticators/jwt.mdx
+++ b/docs/concepts/features/security/external-authenticators/jwt.mdx
@@ -7,7 +7,6 @@ doc_type: 'reference'
 ---
 
 import { CloudOnlyBadge } from "/snippets/components/CloudOnlyBadge/CloudOnlyBadge.jsx";
-import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 import { VersionBadge } from "/snippets/components/VersionBadge/VersionBadge.jsx";
 import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanFeatureBadge/EnterprisePlanFeatureBadge.jsx";
 
@@ -213,11 +212,10 @@ You do not need to configure anything to use this authenticator. It is provision
 
 ## Enabling JWT authentication for your service {#enabling-jwt-authentication-for-your-service}
 
-<BetaBadge/>
 <VersionBadge minVersion="26.4" />
 <EnterprisePlanFeatureBadge feature="JWT authentication with a custom identity provider"/>
 
-In addition to the built-in authenticator, you can configure your ClickHouse Cloud service to accept JWTs issued by your own identity provider (for example, Microsoft Entra or Okta). This is a beta feature, available in the Enterprise plan for services running ClickHouse version 26.4 or later. You can configure it yourself from the Cloud console under **Settings → Security → JWT authentication** — see [JWT authentication setup](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup) for step-by-step instructions. Each provider is defined by the following:
+In addition to the built-in authenticator, you can configure your ClickHouse Cloud service to accept JWTs issued by your own identity provider (for example, Microsoft Entra or Okta). This feature is available on the Enterprise plan for services running ClickHouse version 26.4 or later. You can configure it yourself from the Cloud console under **Settings → Security → JWT authentication** — see [JWT authentication setup](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup) for step-by-step instructions. Each provider is defined by the following:
 
 | Parameter | Description |
 |---|---|

--- a/docs/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup.mdx
@@ -13,9 +13,6 @@ import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanF
 
 import { VersionBadge } from "/snippets/components/VersionBadge/VersionBadge.jsx";
 
-import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
-
-<BetaBadge/>
 <VersionBadge minVersion="26.4" />
 <EnterprisePlanFeatureBadge feature="JWT authentication with a custom identity provider"/>
 

--- a/docs/resources/changelogs/cloud/2026.mdx
+++ b/docs/resources/changelogs/cloud/2026.mdx
@@ -13,6 +13,21 @@ import { Image } from "/snippets/components/Image.jsx";
 In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibility](/products/cloud/guides/cloud-compatibility) page.
 
 
+<Update label="2026-09-08">
+
+This week brings production-ready security and data integration improvements to ClickHouse Cloud. JWT authentication is now generally available for Enterprise services, and the MySQL CDC connector for ClickPipes has graduated to GA with faster snapshots, safer defaults, and better observability.
+
+### JWT authentication for ClickHouse services is now generally available {#jwt-authentication-for-clickhouse-services-is-now-generally-available}
+
+You can now authenticate to your ClickHouse service using JWTs issued by your own identity provider, including Okta, Auth0, Microsoft Entra ID, Keycloak, or any provider that publishes a JWKS endpoint. JWT authentication lets you govern access through your existing identity provider, with policy-enforced token expiry—eliminating separate ClickHouse passwords and shared secrets to rotate. This feature is available on the Enterprise plan for services running ClickHouse 26.4 or later. Configure it from **Service → Settings → Security → JWT authentication**. See the [JWT authentication setup guide](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup).
+
+### MySQL CDC connector for ClickPipes is now generally available {#mysql-cdc-connector-for-clickpipes-is-now-generally-available}
+
+The MySQL CDC connector for ClickPipes is now production-ready. This release adds automatic parallel snapshotting, delivering up to 27× faster initial loads, along with safer defaults for production deployments, including GTID-based replication and a minimum 72-hour binlog retention period. New resource-utilization and lag metrics also make it easier to monitor pipelines. The connector is available to all ClickHouse Cloud customers through the ClickPipes UI, OpenAPI, and Terraform. See the [MySQL ClickPipes documentation](/integrations/clickpipes/mysql) and the [GA release announcement](https://clickhouse.com/blog/mysql-cdc-connector-for-clickpipes-is-now-generally-available).
+
+</Update>
+
+
 <Update label="2026-08-31">
 
 This week expands ClickHouse Cloud's global reach with new AWS regions in Taipei and Malaysia, adds Global Access support for Private Service Connect, and makes it easier for SAML users to move between organizations.


### PR DESCRIPTION
Adds the 2026-09-08 Cloud changelog entry covering the general availability of JWT authentication and the MySQL CDC connector for ClickPipes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118818&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118818](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118818+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.977` (included in `26.9` and later)
<!-- ch-version-info:end -->