### PR TITLE
Fix wrong result for `SELECT * APPLY (x -> f(x))` over `JOIN ... USING`

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -2609,6 +2609,9 @@ ProjectionNames QueryAnalyzer::resolveMatcher(QueryTreeNodePtr & matcher_node, I
 
                 if (apply_transformer->getApplyTransformerType() == ApplyColumnTransformerType::LAMBDA)
                 {
+                    /// A lambda body can only learn a matched column's name from this map; the FUNCTION branch below also reads its alias.
+                    node_to_projection_name.emplace(node, result_projection_names.back());
+
                     auto lambda_expression_to_resolve = expression_node->clone();
                     auto & lambda_scope = createIdentifierResolveScope(lambda_expression_to_resolve, /*parent_scope=*/&scope);
                     node_projection_names = resolveLambda(expression_node, lambda_expression_to_resolve, {node}, lambda_scope);

--- a/tests/queries/0_stateless/05142_apply_lambda_join_using_projection_name.reference
+++ b/tests/queries/0_stateless/05142_apply_lambda_join_using_projection_name.reference
@@ -1,0 +1,43 @@
+-- unqualified * over JOIN USING: every USING column keeps its own name
+toString(id)	toString(g)	toString(v)	toString(w)
+100	1	10	a
+-- wrapping in a passthrough SELECT * must not swap values between USING columns
+toString(id)	toString(g)	toString(v)	toString(w)
+100	1	10	a
+-- USING columns of different types must not collide into one name
+toTypeName(id)	toTypeName(g)	toTypeName(v)	toTypeName(w)
+UInt64	UInt16	Int64	String
+-- COLUMNS list form
+toString(id)	toString(g)
+100	1
+-- ARRAY JOIN columns are a third producer of an unregistered matched node
+toString(id)	toString(a1)	toString(a2)
+1	10	20
+toString(id)	toString(a1)	toString(a2)
+1	10	20
+-- FULL JOIN promotes the USING column to a function of both sides
+toString(id)	toString(g)	toString(v)	toString(w)
+100	1	10	a
+-- join_use_nulls
+toString(id)	toString(g)	toString(v)	toString(w)
+100	1	10	a
+-- a single USING column cannot collide, but was still named after the parameter
+toString(id)	toString(g)	toString(v)	toString(ar.g)	toString(w)
+100	1	10	1	a
+-- subcolumn USING key
+toString(t.a)	toString(t)	toString(v)	toString(sr.t)	toString(w)
+100	(100)	10	(100)	a
+-- chained lambda APPLY transformers
+length(toString(id))	length(toString(g))	length(toString(v))	length(toString(w))
+3	1	2	1
+-- the function form of APPLY was already correct and must not change
+toString(id)	toString(g)	toString(v)	toString(w)
+100	1	10	a
+-- a qualified column selected next to the matcher keeps its own name, in either order
+id	toString(id)	toString(g)	toString(v)	toString(w)
+100	100	1	10	a
+toString(id)	toString(g)	toString(v)	toString(w)	id
+100	1	10	a	100
+-- an ordinary higher-order lambda still shows its parameter name
+arrayMap(lambda(tuple(x), plus(x, 1)), [1, 2])
+[2,3]

--- a/tests/queries/0_stateless/05142_apply_lambda_join_using_projection_name.sql
+++ b/tests/queries/0_stateless/05142_apply_lambda_join_using_projection_name.sql
@@ -1,0 +1,70 @@
+-- A lambda APPLY transformer over JOIN ... USING must name each result after the matched column,
+-- not after the lambda parameter. Identical names made the outer `*` shadow one column with another.
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS al;
+DROP TABLE IF EXISTS ar;
+DROP TABLE IF EXISTS sl;
+DROP TABLE IF EXISTS sr;
+DROP TABLE IF EXISTS aj;
+
+CREATE TABLE al (id UInt64, g UInt16, v Int64)  ENGINE = MergeTree ORDER BY id;
+CREATE TABLE ar (id UInt64, g UInt16, w String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO al VALUES (100, 1, 10);
+INSERT INTO ar VALUES (100, 1, 'a');
+
+CREATE TABLE sl (t Tuple(a UInt64), v Int64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE sr (t Tuple(a UInt64), w String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO sl VALUES ((100), 10);
+INSERT INTO sr VALUES ((100), 'a');
+
+CREATE TABLE aj (id UInt64, a1 Array(UInt8), a2 Array(UInt8)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO aj VALUES (1, [10], [20]);
+
+SELECT '-- unqualified * over JOIN USING: every USING column keeps its own name';
+SELECT * APPLY (x -> toString(x)) FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+SELECT '-- wrapping in a passthrough SELECT * must not swap values between USING columns';
+SELECT * FROM (SELECT * APPLY (x -> toString(x)) FROM al JOIN ar USING (id, g)) FORMAT TSVWithNames;
+
+SELECT '-- USING columns of different types must not collide into one name';
+SELECT * APPLY (x -> toTypeName(x)) FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+SELECT '-- COLUMNS list form';
+SELECT COLUMNS(id, g) APPLY (x -> toString(x)) FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+SELECT '-- ARRAY JOIN columns are a third producer of an unregistered matched node';
+SELECT * APPLY (x -> toString(x)) FROM aj ARRAY JOIN a1, a2 FORMAT TSVWithNames;
+SELECT * FROM (SELECT * APPLY (x -> toString(x)) FROM aj ARRAY JOIN a1, a2) FORMAT TSVWithNames;
+
+SELECT '-- FULL JOIN promotes the USING column to a function of both sides';
+SELECT * APPLY (x -> toString(x)) FROM al FULL JOIN ar USING (id, g) ORDER BY 1 FORMAT TSVWithNames;
+
+SELECT '-- join_use_nulls';
+SELECT * APPLY (x -> toString(x)) FROM al LEFT JOIN ar USING (id, g) SETTINGS join_use_nulls = 1 FORMAT TSVWithNames;
+
+SELECT '-- a single USING column cannot collide, but was still named after the parameter';
+SELECT * APPLY (x -> toString(x)) FROM al JOIN ar USING (id) FORMAT TSVWithNames;
+
+SELECT '-- subcolumn USING key';
+SELECT * APPLY (x -> toString(x)) FROM sl JOIN sr USING (t.a) FORMAT TSVWithNames;
+
+SELECT '-- chained lambda APPLY transformers';
+SELECT * APPLY (x -> toString(x)) APPLY (y -> length(y)) FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+SELECT '-- the function form of APPLY was already correct and must not change';
+SELECT * APPLY toString FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+SELECT '-- a qualified column selected next to the matcher keeps its own name, in either order';
+SELECT al.id, * APPLY (x -> toString(x)) FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+SELECT * APPLY (x -> toString(x)), al.id FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+SELECT '-- an ordinary higher-order lambda still shows its parameter name';
+SELECT arrayMap(x -> x + 1, [1, 2]) FROM al JOIN ar USING (id, g) FORMAT TSVWithNames;
+
+DROP TABLE al;
+DROP TABLE ar;
+DROP TABLE sl;
+DROP TABLE sr;
+DROP TABLE aj;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/118739


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a wrong result for `SELECT * APPLY (x -> f(x))` over `JOIN ... USING (a, b)`: every `USING` column was named after the lambda parameter (`f(x)`) instead of the matched column, so two output columns shared one name, and wrapping the query in `SELECT * FROM (...)` returned one `USING` column's values under the other column's position; a type-returning lambda such as `toTypeName` failed with `Code: 352 AMBIGUOUS_COLUMN_NAME` instead. The same happened for `COLUMNS(a, b) APPLY (x -> f(x))`, and for two or more `ARRAY JOIN` columns, which needs no join at all. The lambda form of `APPLY` now names these columns like `APPLY f` and a plain `*` already did.


### Description

Reported by @ qoega from a fuzzer run. No error is raised:

```sql
CREATE TABLE al (id UInt64, g UInt16, v Int64)  ENGINE = MergeTree ORDER BY id;
CREATE TABLE ar (id UInt64, g UInt16, w String) ENGINE = MergeTree ORDER BY id;
INSERT INTO al VALUES (100, 1, 10);  INSERT INTO ar VALUES (100, 1, 'a');

SELECT * FROM (SELECT * APPLY (x -> toString(x)) FROM al JOIN ar USING (id, g));
-- 100  100  10  a     <- g's column carries id's value; expected 100  1  10  a
```

`resolveMatcher` keeps each matched column's visible name in `node_to_projection_name`. `APPLY f`
also reads the matched node's alias, so it is unaffected; `APPLY (x -> f(x))` binds the node to the
lambda parameter, so that map is its only channel. Three matcher paths never register the node:
the unqualified `*` over `JOIN ... USING`, the `COLUMNS(a, b)` list form (registered only under a
two-or-more-join compatibility setting), and an unaliased `ARRAY JOIN` column. The name then falls
back to the identifier as written, so every column becomes `f(x)`.

The lambda branch now seeds that map with the name the matcher already computed. `emplace` does
not overwrite, so it is a no-op for an already-registered column, and one site covers all three.

Against a pre-fix binary, 18 cases go from wrong to correct (3 wrong values, 1 `Code: 352`, 14
duplicate names) across all three paths, `FULL JOIN`, `join_use_nulls`, a subcolumn key, chained
transformers and `EXCEPT`/`REPLACE`; 6 stay byte-identical, including `APPLY f`, `arrayMap`,
`JOIN ... ON` and a single table. No reference changed across 138 related matcher and join tests;
150/150 randomized runs pass.

Column names change from `f(x)` to `f(<column>)`, matching `APPLY f` and a plain `*`. Out of
scope: `COLUMNS(id) ... FULL JOIN ... USING (id)` still fails with `Code: 47`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118825&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118825](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118825+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1289` (included in `26.9` and later)
<!-- ch-version-info:end -->