### PR TITLE
Return the normalized headers from HTTPHeaderFilter::checkAndNormalizeHeaders

### DIFF
--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -15,7 +15,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
-void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) const
+HTTPHeaderEntries HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries entries) const
 {
     std::lock_guard guard(mutex);
 
@@ -68,6 +68,8 @@ void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) con
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" is forbidden in configuration file, "
                                                         "see <http_forbid_headers>", reported_name);
     }
+
+    return entries;
 }
 
 void HTTPHeaderFilter::setValuesFromConfig(const Poco::Util::AbstractConfiguration & config)

--- a/src/Common/HTTPHeaderFilter.h
+++ b/src/Common/HTTPHeaderFilter.h
@@ -18,8 +18,10 @@ public:
 
     void setValuesFromConfig(const Poco::Util::AbstractConfiguration & config);
     /// Validates the headers (throws BAD_ARGUMENTS on an invalid or forbidden name/value) and
-    /// normalizes the names in place.
-    void checkAndNormalizeHeaders(HTTPHeaderEntries & entries) const;
+    /// returns the normalized entries. Returning the normalized set — rather than mutating in
+    /// place — means a caller cannot validate the headers and then accidentally send the original,
+    /// un-normalized ones; the [[nodiscard]] makes ignoring the normalized result a build error.
+    [[nodiscard]] HTTPHeaderEntries checkAndNormalizeHeaders(HTTPHeaderEntries entries) const;
 
 private:
     /// Header names are case-insensitive (RFC 7230 3.2): entries are stored

--- a/src/Common/tests/gtest_http_header_filter.cpp
+++ b/src/Common/tests/gtest_http_header_filter.cpp
@@ -29,7 +29,7 @@ bool isForbidden(const HTTPHeaderFilter & filter, const std::string & name)
     HTTPHeaderEntries entries{{name, "value"}};
     try
     {
-        filter.checkAndNormalizeHeaders(entries);
+        (void)filter.checkAndNormalizeHeaders(entries);
     }
     catch (const Exception &)
     {
@@ -206,7 +206,7 @@ TEST(HTTPHeaderFilter, RejectsCarriageReturnAndNewline)
     auto rejects = [&](const std::string & name, const std::string & value)
     {
         HTTPHeaderEntries entries{{name, value}};
-        try { filter.checkAndNormalizeHeaders(entries); }
+        try { (void)filter.checkAndNormalizeHeaders(entries); }
         catch (const Exception &) { return true; }
         return false;
     };

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -1448,7 +1448,8 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             if (pos != std::string::npos)
             {
                 DB::HTTPHeaderEntries header_entries{{auth_header_str.substr(0, pos), auth_header_str.substr(pos + 1)}};
-                args.context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_entries);
+                /// CREATE-time validation only (throws on an invalid or forbidden header); the normalized result is not stored.
+                (void)args.context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(header_entries));
             }
             else
             {

--- a/src/Databases/DataLake/HTTPBasedCatalogUtils.cpp
+++ b/src/Databases/DataLake/HTTPBasedCatalogUtils.cpp
@@ -30,7 +30,8 @@ void validateBearerToken(const DB::ContextPtr & context, const std::string & bea
         return;
 
     DB::HTTPHeaderEntries auth_header{{"Authorization", "Bearer " + bearer_token}};
-    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(auth_header);
+    /// Validation only (throws on an invalid header); the synthetic header is not sent from here.
+    (void)context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(auth_header));
 }
 
 DB::ReadWriteBufferFromHTTPPtr createReadBuffer(

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -292,8 +292,7 @@ void RestCatalog::validateAuthHeaders(const DB::HTTPHeaderEntry & header) const
     /// here, before `loadConfig` issues any request. Mirrors the CREATE-path check: a copy is
     /// validated and the original parsed header is kept.
     /// Validation only (throws on an invalid or forbidden header); the stored header is kept as-is.
-    DB::HTTPHeaderEntries header_to_check{header};
-    getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_to_check);
+    (void)getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(DB::HTTPHeaderEntries{header});
 }
 
 DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(const CatalogState & catalog_state, bool update_token) const
@@ -308,11 +307,10 @@ DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(const CatalogState & catalog_s
     if (catalog_state.auth_header.has_value())
     {
         /// Normalize the header that is actually sent to the catalog (the stored setting is kept
-        /// verbatim for compatibility): the name that reaches the wire is the validated, normalized
-        /// one, not the raw stored bytes.
-        DB::HTTPHeaderEntries header_entries{catalog_state.auth_header.value()};
-        getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_entries);
-        return header_entries;
+        /// verbatim for compatibility). Mirrors the schema-inference path in StorageURL: the name
+        /// that reaches the wire is the validated, normalized one, not the raw stored bytes.
+        return getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(
+            DB::HTTPHeaderEntries{catalog_state.auth_header.value()});
     }
 
     /// Option 2: user provided grant_type and client credentials for OAuthClientCredentialsRequest.

--- a/src/Databases/DataLake/tests/gtest_gcs_credentials.cpp
+++ b/src/Databases/DataLake/tests/gtest_gcs_credentials.cpp
@@ -42,7 +42,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsNewline)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Authorization", "Bearer token\nX-Injected: malicious"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturn)
@@ -50,7 +50,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturn)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Authorization", "Bearer token\r\nX-Injected: malicious"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationAcceptsValidToken)
@@ -58,7 +58,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationAcceptsValidToken)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Authorization", "Bearer ya29.valid-gcs-token_1234"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
+    EXPECT_NO_THROW((void)filter.checkAndNormalizeHeaders(headers));
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsColonInName)
@@ -68,7 +68,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsColonInName)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Cookie:j=\"x", "y\";session=abc"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturnInName)
@@ -76,7 +76,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsCarriageReturnInName)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"X-Foo\rX-Injected", "value"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationRejectsLineFeedInName)
@@ -84,7 +84,7 @@ TEST_F(GCSCredentialsTest, HeaderValidationRejectsLineFeedInName)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"X-Foo\nX-Injected", "value"});
-    EXPECT_THROW(filter.checkAndNormalizeHeaders(headers), DB::Exception);
+    EXPECT_THROW((void)filter.checkAndNormalizeHeaders(headers), DB::Exception);
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationAcceptsColonInValue)
@@ -93,20 +93,22 @@ TEST_F(GCSCredentialsTest, HeaderValidationAcceptsColonInValue)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"Host", "example.com:8080"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
+    EXPECT_NO_THROW((void)filter.checkAndNormalizeHeaders(headers));
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationNormalizesWhitespaceInName)
 {
     /// Whitespace/control in a name is still stripped rather than rejected, preserving the
     /// historical behaviour for stored objects that are re-validated on ATTACH. Assert the
-    /// in-place normalized name, so a change that stopped normalizing would be caught here.
+    /// normalized name on the returned entries (callers send what is returned), so a change that
+    /// stopped normalizing would be caught here.
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({"X-A B", "value"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
-    ASSERT_EQ(headers.size(), 1u);
-    EXPECT_EQ(headers[0].name, "X-AB");
+    DB::HTTPHeaderEntries normalized;
+    EXPECT_NO_THROW(normalized = filter.checkAndNormalizeHeaders(headers));
+    ASSERT_EQ(normalized.size(), 1u);
+    EXPECT_EQ(normalized[0].name, "X-AB");
 }
 
 TEST_F(GCSCredentialsTest, HeaderValidationAcceptsNameEmptyAfterNormalization)
@@ -117,9 +119,10 @@ TEST_F(GCSCredentialsTest, HeaderValidationAcceptsNameEmptyAfterNormalization)
     DB::HTTPHeaderFilter filter;
     DB::HTTPHeaderEntries headers;
     headers.push_back({" \t ", "value"});
-    EXPECT_NO_THROW(filter.checkAndNormalizeHeaders(headers));
-    ASSERT_EQ(headers.size(), 1u);
-    EXPECT_EQ(headers[0].name, "");
+    DB::HTTPHeaderEntries normalized;
+    EXPECT_NO_THROW(normalized = filter.checkAndNormalizeHeaders(headers));
+    ASSERT_EQ(normalized.size(), 1u);
+    EXPECT_EQ(normalized[0].name, "");
 }
 
 }

--- a/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/src/Dictionaries/HTTPDictionarySource.cpp
@@ -336,7 +336,7 @@ void registerDictionarySourceHTTP(DictionarySourceFactory & factory)
         if (created_from_ddl)
         {
             context->getRemoteHostFilter().checkURL(Poco::URI(uri));
-            context->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_entries);
+            header_entries = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(header_entries));
         }
 
         auto configuration = HTTPDictionarySource::Configuration

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -291,7 +291,7 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
         }
     }
 
-    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+    headers = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 
     auto shared_cache = S3::ClientCacheRegistry::instance().getOrCreateCacheForKey(url.endpoint, url.bucket);
 

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -145,7 +145,7 @@ void StorageS3Configuration::check(ContextPtr context)
 {
     validateNamespace(url.bucket);
     context->getGlobalContext()->getRemoteHostFilter().checkURL(url.uri);
-    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_from_ast);
+    headers_from_ast = context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers_from_ast));
     StorageObjectStorageConfiguration::check(context);
 }
 

--- a/src/Storages/ObjectStorage/Web/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Web/Configuration.cpp
@@ -139,7 +139,7 @@ void StorageWebConfiguration::check(ContextPtr context)
         for (const auto & url_option : url_shard)
             context->getGlobalContext()->getRemoteHostFilter().checkURL(Poco::URI(url_option.base_url + url_option.query_fragment, false));
     }
-    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_from_ast);
+    headers_from_ast = context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers_from_ast));
 }
 
 ObjectStoragePtr StorageWebConfiguration::createObjectStorage(ContextPtr context, bool, CredentialsConfigurationCallback) /// NOLINT

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1615,7 +1615,8 @@ StorageURL::StorageURL(
     const HTTPHeaderEntries & headers_,
     const String & http_method_,
     ASTPtr partition_by_,
-    bool distributed_processing_)
+    bool distributed_processing_,
+    bool validate_headers_)
     : IStorageURLBase(
         uri_,
         context_,
@@ -1632,7 +1633,12 @@ StorageURL::StorageURL(
         distributed_processing_)
 {
     context_->getRemoteHostFilter().checkURL(Poco::URI(uri));
-    headers = context_->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
+    /// Only validate/normalize freshly supplied headers (CREATE / url()); skip on ATTACH replay of
+    /// existing metadata so a table persisted by an older release keeps attaching. The injection-char
+    /// and forbidden-header rejections still apply to every fresh request (including the url() table
+    /// function); a query against a pre-existing table sends its stored headers unchanged.
+    if (validate_headers_)
+        headers = context_->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 }
 
 
@@ -2629,7 +2635,8 @@ void registerStorageURL(StorageFactory & factory)
                     config.headers,
                     config.http_method,
                     partition_by,
-                    /* distributed_processing */ false);
+                    /* distributed_processing */ false,
+                    /* validate_headers */ isFreshTableDefinition(args.mode, args.query.attach_short_syntax));
             }
 
             if (args.mode <= LoadingStrictnessLevel::CREATE)

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1111,18 +1111,6 @@ namespace
         Poco::Net::HTTPBasicCredentials credentials;
         const std::optional<FormatSettings> & format_settings;
     };
-
-/// A "Range" header must not reach the wire during schema inference: it would make inference read a
-/// partial-content response. Applied on the already-normalized names (case-insensitive), so a
-/// padded/mixed-case spelling that normalizes to "Range" is caught too. Only the fresh-request
-/// inference path uses this; the read/ATTACH paths keep their existing behaviour so that attaching
-/// a table stored with such a header does not start failing.
-void rejectRangeHeaders(const HTTPHeaderEntries & headers)
-{
-    for (const auto & entry : headers)
-        if (boost::to_lower_copy(entry.name) == "range")
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Range headers are not allowed");
-}
 }
 
 std::pair<ColumnsDescription, String> IStorageURLBase::getTableStructureAndFormatFromDataImpl(
@@ -1138,11 +1126,8 @@ std::pair<ColumnsDescription, String> IStorageURLBase::getTableStructureAndForma
     /// schema inference (StorageURL ctor, StorageURLCluster, TableFunctionURL analysis), so the
     /// check here also covers the DESCRIBE / INSERT..SELECT / format-detection paths that never
     /// reach the StorageURL ctor body. checkAndNormalizeHeaders returns the normalized headers, so
-    /// send that normalized copy — the normalized names are what reach the wire. Ban "Range" on the
-    /// normalized names (a padded spelling normalizes to "Range") so schema inference never reads a
-    /// partial-content response.
+    /// send that normalized copy — the normalized names are what reach the wire.
     const auto headers_to_check = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
-    rejectRangeHeaders(headers_to_check);
 
     Poco::Net::HTTPBasicCredentials credentials;
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1137,12 +1137,11 @@ std::pair<ColumnsDescription, String> IStorageURLBase::getTableStructureAndForma
     /// Enforce <http_forbid_headers> before any network access. This is the single funnel for
     /// schema inference (StorageURL ctor, StorageURLCluster, TableFunctionURL analysis), so the
     /// check here also covers the DESCRIBE / INSERT..SELECT / format-detection paths that never
-    /// reach the StorageURL ctor body. checkAndNormalizeHeaders normalizes in place, so validate a
-    /// copy and send that copy — the normalized names are what reach the wire. Ban "Range" on the
+    /// reach the StorageURL ctor body. checkAndNormalizeHeaders returns the normalized headers, so
+    /// send that normalized copy — the normalized names are what reach the wire. Ban "Range" on the
     /// normalized names (a padded spelling normalizes to "Range") so schema inference never reads a
     /// partial-content response.
-    HTTPHeaderEntries headers_to_check(headers);
-    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_to_check);
+    const auto headers_to_check = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
     rejectRangeHeaders(headers_to_check);
 
     Poco::Net::HTTPBasicCredentials credentials;
@@ -1648,7 +1647,7 @@ StorageURL::StorageURL(
         distributed_processing_)
 {
     context_->getRemoteHostFilter().checkURL(Poco::URI(uri));
-    context_->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+    headers = context_->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 }
 
 

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -357,7 +357,11 @@ public:
         const HTTPHeaderEntries & headers_ = {},
         const String & method_ = "",
         ASTPtr partition_by_ = nullptr,
-        bool distributed_processing_ = false);
+        bool distributed_processing_ = false,
+        /// Validate/normalize headers in the ctor. Pass false when replaying existing metadata
+        /// (server-startup ATTACH) so a table persisted by an older release keeps attaching;
+        /// fresh CREATE / url() keep validating (see the URL storage factory).
+        bool validate_headers_ = true);
 
     String getName() const override
     {

--- a/src/Storages/StorageURLCluster.cpp
+++ b/src/Storages/StorageURLCluster.cpp
@@ -55,7 +55,7 @@ StorageURLCluster::StorageURLCluster(
 {
     auto headers = configuration_.headers;
     context->getRemoteHostFilter().checkURL(Poco::URI(uri));
-    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers);
+    headers = context->getHTTPHeaderFilter().checkAndNormalizeHeaders(std::move(headers));
 
     StorageInMemoryMetadata storage_metadata;
 

--- a/tests/queries/0_stateless/03623_header_filtering.sql
+++ b/tests/queries/0_stateless/03623_header_filtering.sql
@@ -11,11 +11,3 @@ SELECT * FROM url(
     'data String',
     headers('exact_header	' = 'true', 'exact_header	' = 'true')
 ); -- {serverError BAD_ARGUMENTS}
-
--- Schema inference must not send a 'Range' header (it would read a partial-content response). A
--- whitespace-padded 'R ange' normalizes to 'Range', so it is rejected during inference, before any
--- request. (The read/ATTACH paths keep their existing behaviour, so this ban is inference-only.)
-DESCRIBE url(
-    'http://google.com',
-    headers('R ange' = 'bytes=0-1')
-); -- {serverError BAD_ARGUMENTS}


### PR DESCRIPTION
<!-- Stacked on #118830 (base branch reject-colon-in-http-header-names). Merge #118830 first. -->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes


### Description

Internal API hardening, split out of the security fix in #118830 and stacked on top of it.

`HTTPHeaderFilter::checkAndNormalizeHeaders` now takes the entries by value and **returns** the normalized set (`[[nodiscard]]`) instead of mutating in place. This makes the "validate a copy, then send the original un-normalized headers" mistake impossible to write — the compiler flags any caller that ignores the result. All callers are updated to use the returned value.

No behaviour change; this is a refactor. Merge #118830 first (this PR is stacked on its branch).
