### PR TITLE
Prepare `filesystem_caches` directories in the server entrypoint

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -3,14 +3,13 @@ import atexit
 import json
 import logging
 import os
-import shlex
 import tempfile
-import traceback
 from pathlib import Path
 from typing import Dict, List
 
 from ci.defs.job_configs import JobConfigs
 from ci.jobs.scripts.clickhouse_version import CHVersion
+from ci.jobs.scripts.docker_server.docker_library import test_docker_library
 from ci.praktika import Secret
 from ci.praktika.info import Info
 from ci.praktika.result import Result
@@ -20,7 +19,6 @@ ARCH = ("amd64", "arm64")
 
 temp_path = Path(f"{Utils.cwd()}/ci/tmp")
 
-GITHUB_SERVER_URL = os.getenv("GITHUB_SERVER_URL", "https://github.com")
 with tempfile.NamedTemporaryFile("w", delete=False) as f:
     GIT_KNOWN_HOSTS_FILE = f.name
     GIT_PREFIX = (  # All commits to remote are done as robot-clickhouse
@@ -46,62 +44,6 @@ class DockerImageData:
         self.name = name
         assert not path.startswith("/")
         self.path = path
-
-
-def is_distroless_image(docker_image: str) -> bool:
-    _, tag = docker_image.rsplit(":", 1)
-    return "distroless" in tag.split("-")
-
-
-def get_official_images_variant(docker_image: str) -> str:
-    # The official-images test runner derives its lookup variant from the final
-    # tag suffix. For example, head-distroless-amd64 is looked up as repo:amd64.
-    _, tag = docker_image.rsplit(":", 1)
-    return tag.rsplit("-", 1)[-1]
-
-
-def write_distroless_docker_library_config(docker_image: str, config_dir: Path) -> Path:
-    """Map arch-suffixed distroless tags to the distroless-safe config tests."""
-    # Generate a short config fragment for local arch-suffixed distroless CI tags.
-    # The runner derives tags like head-distroless-amd64 as repo:amd64; map that
-    # derived key to the distroless-safe tests because this helper is only used
-    # for images already identified as distroless.
-    repo, _ = docker_image.rsplit(":", 1)
-    variant = get_official_images_variant(docker_image)
-    image_variant = shlex.quote(f"{repo}:{variant}")
-    tests_var = (
-        "keeperDistrolessSafeTests"
-        if "clickhouse-keeper" in repo
-        else "clickhouseDistrolessSafeTests"
-    )
-
-    generated_config = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            prefix="docker-library-distroless-",
-            suffix=".sh",
-            dir=config_dir,
-            delete=False,
-            encoding="utf-8",
-        ) as f:
-            generated_config = Path(f.name)
-            f.write(
-                "#!/usr/bin/env bash\n"
-                "\n"
-                "explicitTests+=(\n"
-                f"\t[{image_variant}]=1\n"
-                ")\n"
-                "\n"
-                "imageTests+=(\n"
-                f"\t[{image_variant}]=\"${{{tests_var}}}\"\n"
-                ")\n"
-            )
-            return generated_config
-    except Exception:
-        if generated_config:
-            generated_config.unlink(missing_ok=True)
-        raise
 
 
 class DelOS(argparse.Action):
@@ -699,63 +641,6 @@ def build_and_push_image(
             f"{image.name}:{tag}-$arch",
         )
     return result
-
-
-def test_docker_library(test_results) -> None:
-    """we test our images vs the official docker library repository to track integrity"""
-    arch = "amd64" if Utils.is_amd() else "arm64"
-    check_images = [tr.name for tr in test_results if tr.name.endswith(f"-{arch}")]
-    if not check_images:
-        return
-    test_name = "docker library image test"
-    try:
-        repo = "docker-library/official-images"
-        logging.info("Cloning %s repository to run tests for 'clickhouse' image", repo)
-        repo_path = temp_path / repo
-        config_override = (
-            Path(Utils.cwd()) / "ci/jobs/scripts/docker_server/config.sh"
-        ).absolute()
-        if not Shell.check(
-            f"git clone --depth 1 {GITHUB_SERVER_URL}/{repo} {repo_path}",
-            verbose=True,
-            retries=3,
-        ):
-            raise RuntimeError(f"Failed to clone {repo}")
-        run_sh = (repo_path / "test/run.sh").absolute()
-        for image in check_images:
-            generated_config = None
-            try:
-                configs = [repo_path / "test/config.sh", config_override]
-                if is_distroless_image(image):
-                    generated_config = write_distroless_docker_library_config(
-                        image, config_override.parent
-                    )
-                    configs.append(generated_config)
-                config_args = " ".join(
-                    f"-c {shlex.quote(config.as_posix())}" for config in configs
-                )
-                cmd = (
-                    f"{shlex.quote(run_sh.as_posix())} "
-                    f"{shlex.quote(image)} {config_args}"
-                )
-                test_results.append(
-                    Result.from_commands_run(
-                        name=f"{test_name} ({image})", command=cmd
-                    )
-                )
-            finally:
-                if generated_config:
-                    generated_config.unlink(missing_ok=True)
-
-    except Exception as e:
-        logging.error("Failed while testing the docker library image: %s", e)
-        test_results.append(
-            Result(
-                name=test_name,
-                status=Result.Status.FAIL,
-                info=f"Exception while testing docker library: {traceback.format_exc()}",
-            )
-        )
 
 
 def check_server_readme(image_path: str) -> Result:

--- a/ci/jobs/scripts/docker_server/docker_library.py
+++ b/ci/jobs/scripts/docker_server/docker_library.py
@@ -117,7 +117,9 @@ def test_docker_library(test_results, check_images=None) -> None:
                 )
                 cmd = f"{shlex.quote(run_sh.as_posix())} {shlex.quote(image)} {config_args}"
                 test_results.append(
-                    Result.from_commands_run(name=f"{test_name} ({image})", command=cmd)
+                    Result.from_commands_run(
+                        name=f"{test_name} ({image})", command=cmd, with_info=True
+                    )
                 )
             finally:
                 if generated_config:

--- a/ci/jobs/scripts/docker_server/docker_library.py
+++ b/ci/jobs/scripts/docker_server/docker_library.py
@@ -1,0 +1,134 @@
+"""The docker-library test runner, shared by the docker job scripts.
+
+Kept out of `docker_server.py` so that a caller can reuse it without importing a job entry point,
+which would pull in `ci.defs.job_configs` and the rest of that script's module scope.
+"""
+
+import logging
+import os
+import shlex
+import tempfile
+import traceback
+from pathlib import Path
+
+from ci.praktika.result import Result
+from ci.praktika.utils import Shell, Utils
+
+GITHUB_SERVER_URL = os.getenv("GITHUB_SERVER_URL", "https://github.com")
+
+# Derived from this file, not the working directory: a caller in another directory would otherwise
+# get a clone path outside `ci/tmp` and a `config.sh` that does not exist.
+SCRIPT_DIR = Path(__file__).resolve().parent  # ci/jobs/scripts/docker_server
+CONFIG_OVERRIDE = SCRIPT_DIR / "config.sh"
+TEMP_PATH = SCRIPT_DIR.parents[2] / "tmp"  # parents[2] is `ci`
+
+
+def is_distroless_image(docker_image: str) -> bool:
+    _, tag = docker_image.rsplit(":", 1)
+    return "distroless" in tag.split("-")
+
+
+def get_official_images_variant(docker_image: str) -> str:
+    # The official-images test runner derives its lookup variant from the final
+    # tag suffix. For example, head-distroless-amd64 is looked up as repo:amd64.
+    _, tag = docker_image.rsplit(":", 1)
+    return tag.rsplit("-", 1)[-1]
+
+
+def write_distroless_docker_library_config(docker_image: str, config_dir: Path) -> Path:
+    """Map arch-suffixed distroless tags to the distroless-safe config tests."""
+    # Generate a short config fragment for local arch-suffixed distroless CI tags.
+    # The runner derives tags like head-distroless-amd64 as repo:amd64; map that
+    # derived key to the distroless-safe tests because this helper is only used
+    # for images already identified as distroless.
+    repo, _ = docker_image.rsplit(":", 1)
+    variant = get_official_images_variant(docker_image)
+    image_variant = shlex.quote(f"{repo}:{variant}")
+    tests_var = (
+        "keeperDistrolessSafeTests"
+        if "clickhouse-keeper" in repo
+        else "clickhouseDistrolessSafeTests"
+    )
+
+    generated_config = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            prefix="docker-library-distroless-",
+            suffix=".sh",
+            dir=config_dir,
+            delete=False,
+            encoding="utf-8",
+        ) as f:
+            generated_config = Path(f.name)
+            f.write(
+                "#!/usr/bin/env bash\n"
+                "\n"
+                "explicitTests+=(\n"
+                f"\t[{image_variant}]=1\n"
+                ")\n"
+                "\n"
+                "imageTests+=(\n"
+                f'\t[{image_variant}]="${{{tests_var}}}"\n'
+                ")\n"
+            )
+            return generated_config
+    except Exception:
+        if generated_config:
+            generated_config.unlink(missing_ok=True)
+        raise
+
+
+def test_docker_library(test_results, check_images=None) -> None:
+    """we test our images vs the official docker library repository to track integrity
+
+    `check_images` names the images to run the suite against. Without it they are taken from the
+    `-<arch>`-suffixed `test_results` names, which is how this job labels them; a caller using
+    another naming convention passes its own tags, so a mismatch cannot silently test nothing.
+    """
+    arch = "amd64" if Utils.is_amd() else "arm64"
+    if check_images is None:
+        check_images = [tr.name for tr in test_results if tr.name.endswith(f"-{arch}")]
+    if not check_images:
+        return
+    test_name = "docker library image test"
+    try:
+        repo = "docker-library/official-images"
+        logging.info("Cloning %s repository to run tests for 'clickhouse' image", repo)
+        repo_path = TEMP_PATH / repo
+        if not Shell.check(
+            f"git clone --depth 1 {GITHUB_SERVER_URL}/{repo} {repo_path}",
+            verbose=True,
+            retries=3,
+        ):
+            raise RuntimeError(f"Failed to clone {repo}")
+        run_sh = repo_path / "test/run.sh"
+        for image in check_images:
+            generated_config = None
+            try:
+                configs = [repo_path / "test/config.sh", CONFIG_OVERRIDE]
+                if is_distroless_image(image):
+                    generated_config = write_distroless_docker_library_config(
+                        image, CONFIG_OVERRIDE.parent
+                    )
+                    configs.append(generated_config)
+                config_args = " ".join(
+                    f"-c {shlex.quote(config.as_posix())}" for config in configs
+                )
+                cmd = f"{shlex.quote(run_sh.as_posix())} {shlex.quote(image)} {config_args}"
+                test_results.append(
+                    Result.from_commands_run(name=f"{test_name} ({image})", command=cmd)
+                )
+            finally:
+                if generated_config:
+                    generated_config.unlink(missing_ok=True)
+
+    except Exception as e:
+        logging.error("Failed while testing the docker library image: %s", e)
+        test_results.append(
+            Result(
+                name=test_name,
+                status=Result.Status.FAIL,
+                info=f"Exception while testing docker library: {traceback.format_exc()}",
+            )
+        )

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-caches-path/cache.xml
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-caches-path/cache.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <filesystem_caches_path>/mnt/clickhouse-cache/</filesystem_caches_path>
+    <filesystem_caches>
+        <docker_relative_cache>
+            <max_size>10000000</max_size>
+            <path>docker_relative_cache</path>
+        </docker_relative_cache>
+    </filesystem_caches>
+</clickhouse>

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-caches-path/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-caches-path/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# A relative `filesystem_caches` path with an explicit `filesystem_caches_path`.
+# Check successful startup and ownership of the path chosen by the server.
+# Do not assert a location: this must also pass when the server's initialization
+# ordering is corrected together with any required directory preparation.
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+source "$dir/../lib.sh"
+
+image="$1"
+
+# Docker creates a fresh anonymous volume owned by `root:root` with mode `0755`.
+# Without `CAP_DAC_OVERRIDE`, the server cannot create a cache there until the
+# entrypoint has prepared its directory or a writable parent.
+cid="$(
+  docker run -d \
+    -v /mnt/clickhouse-cache \
+    -v "$dir/cache.xml":/etc/clickhouse-server/config.d/cache.xml:ro \
+    --cap-drop=DAC_OVERRIDE \
+    --name "$(cname)" \
+    "$image"
+)"
+trap 'docker rm -vf "$cid" > /dev/null' EXIT
+
+chCli() {
+  docker exec "$cid" clickhouse-client --query "$*"
+}
+
+# shellcheck source=../../../../../tmp/docker-library/official-images/test/retry.sh
+. "$TESTS_LIB_DIR/retry.sh" \
+  --cid "$cid" \
+  --image "$image" \
+  --tries "$CLICKHOUSE_TEST_TRIES" \
+  --sleep "$CLICKHOUSE_TEST_SLEEP" \
+  chCli SELECT 1
+
+cache_path="$(chCli "SELECT path FROM system.filesystem_cache_settings WHERE cache_name = 'docker_relative_cache'")"
+[ -n "$cache_path" ]
+
+server_uid="$(docker exec "$cid" sed -n 's/^Uid:[[:space:]]*\([0-9][0-9]*\).*/\1/p' /proc/1/status)"
+[ -n "$server_uid" ]
+[ "$server_uid" != 0 ]
+
+# Inspected as the server's own uid, not as root: the server creates `<path>/caches` as
+# `drwxr-x---`, so with `CAP_DAC_OVERRIDE` dropped root cannot traverse into it and a directory
+# that exists would read as missing.
+docker exec -u "$server_uid" "$cid" test -d "$cache_path"
+[ "$(docker exec -u "$server_uid" "$cid" stat -c '%u' "$cache_path")" = "$server_uid" ]

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-dir/cache.xml
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-dir/cache.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <filesystem_caches>
+        <docker_test_cache>
+            <max_size>10000000</max_size>
+            <path>/mnt/clickhouse-cache/docker_test_cache</path>
+        </docker_test_cache>
+    </filesystem_caches>
+</clickhouse>

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-dir/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-dir/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# An absolute `filesystem_caches` path below a directory the server does not own. The entrypoint
+# prepares it, because the server cannot: `FileCache::initialize` calls `fs::create_directories` as
+# the server's own uid, which has no capability to write into a `root:root` mount.
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+source "$dir/../lib.sh"
+
+image="$1"
+
+# A destination-only `-v` gets an anonymous volume, which docker creates `root:root 0755` and
+# `docker rm -v` reclaims. Dropping `CAP_DAC_OVERRIDE` is what makes this exercise the real failure
+# mode, rather than passing because the process may write into that mount regardless of ownership.
+cid="$(
+  docker run -d \
+    -v /mnt/clickhouse-cache \
+    -v "$dir/cache.xml":/etc/clickhouse-server/config.d/cache.xml:ro \
+    --cap-drop=DAC_OVERRIDE \
+    --name "$(cname)" \
+    "$image"
+)"
+trap 'docker rm -vf $cid > /dev/null' EXIT
+
+chCli() {
+  docker exec "$cid" clickhouse-client --query "$*"
+}
+
+# shellcheck source=../../../../../tmp/docker-library/official-images/test/retry.sh
+. "$TESTS_LIB_DIR/retry.sh" \
+  --cid "$cid" \
+  --image "$image" \
+  --tries "$CLICKHOUSE_TEST_TRIES" \
+  --sleep "$CLICKHOUSE_TEST_SLEEP" \
+  chCli SELECT 1
+
+[ "$(chCli "SELECT path FROM system.filesystem_cache_settings WHERE cache_name = 'docker_test_cache'")" = /mnt/clickhouse-cache/docker_test_cache ]
+
+# The uid comes from the server's own process, so a `chmod` in place of the `chown` would not pass.
+server_uid="$(docker exec "$cid" sed -n 's/^Uid:[[:space:]]*\([0-9][0-9]*\).*/\1/p' /proc/1/status)"
+[ -n "$server_uid" ]
+[ "$(docker exec "$cid" stat -c '%u' /mnt/clickhouse-cache/docker_test_cache)" = "$server_uid" ]

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-dir/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-dir/run.sh
@@ -39,4 +39,6 @@ chCli() {
 # The uid comes from the server's own process, so a `chmod` in place of the `chown` would not pass.
 server_uid="$(docker exec "$cid" sed -n 's/^Uid:[[:space:]]*\([0-9][0-9]*\).*/\1/p' /proc/1/status)"
 [ -n "$server_uid" ]
-[ "$(docker exec "$cid" stat -c '%u' /mnt/clickhouse-cache/docker_test_cache)" = "$server_uid" ]
+[ "$server_uid" != 0 ]
+docker exec -u "$server_uid" "$cid" test -d /mnt/clickhouse-cache/docker_test_cache
+[ "$(docker exec -u "$server_uid" "$cid" stat -c '%u' /mnt/clickhouse-cache/docker_test_cache)" = "$server_uid" ]

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/cache.xml
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/cache.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <filesystem_caches>
+        <docker_relative_cache>
+            <max_size>10000000</max_size>
+            <path>docker_relative_cache</path>
+        </docker_relative_cache>
+    </filesystem_caches>
+</clickhouse>

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# A relative `filesystem_caches` path, with `filesystem_caches_path` unset as in the shipped image,
+# so the server resolves it under `<path>/caches`. The prefix is the server's to choose either way,
+# so the entrypoint must leave the entry alone: preparing the value as written would make a
+# directory beside the one the server actually opens.
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+source "$dir/../lib.sh"
+
+image="$1"
+
+cid="$(
+  docker run -d \
+    -v "$dir/cache.xml":/etc/clickhouse-server/config.d/cache.xml:ro \
+    --name "$(cname)" \
+    "$image"
+)"
+trap 'docker rm -vf $cid > /dev/null' EXIT
+
+chCli() {
+  docker exec "$cid" clickhouse-client --query "$*"
+}
+
+# shellcheck source=../../../../../tmp/docker-library/official-images/test/retry.sh
+. "$TESTS_LIB_DIR/retry.sh" \
+  --cid "$cid" \
+  --image "$image" \
+  --tries "$CLICKHOUSE_TEST_TRIES" \
+  --sleep "$CLICKHOUSE_TEST_SLEEP" \
+  chCli SELECT 1
+
+data_dir="$(chCli "SELECT value FROM system.server_settings WHERE name = 'path'")"
+[ "$(chCli "SELECT path FROM system.filesystem_cache_settings WHERE cache_name = 'docker_relative_cache'")" = "${data_dir}caches/docker_relative_cache" ]
+
+# Pins the `grep '^/'` filter: dropping it reddens here, by preparing the value as written.
+! docker exec "$cid" test -e "${data_dir}docker_relative_cache"

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/run.sh
@@ -33,5 +33,7 @@ chCli() {
 data_dir="$(chCli "SELECT value FROM system.server_settings WHERE name = 'path'")"
 [ "$(chCli "SELECT path FROM system.filesystem_cache_settings WHERE cache_name = 'docker_relative_cache'")" = "${data_dir}caches/docker_relative_cache" ]
 
-# Pins the `grep '^/'` filter: dropping it reddens here, by preparing the value as written.
-! docker exec "$cid" test -e "${data_dir}docker_relative_cache"
+# The entrypoint runs `cd "$DATA_DIR"` before `manage_clickhouse_directories`, regardless of
+# the image's `WORKDIR`. Without `grep '^/'`, it creates the raw relative path here,
+# beside `caches`, so this assertion must fail when that filter is removed.
+docker exec "$cid" test ! -e "${data_dir}docker_relative_cache"

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -42,6 +42,13 @@ FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_
 readarray -t DISKS_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.path' || true)
 readarray -t DISKS_METADATA_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.metadata_path' || true)
 
+# A `filesystem_caches` entry is not a `storage_configuration` disk, so the paths above do not cover
+# it, and `FileCache::initialize` cannot create one under a directory the server does not own.
+# Absolute entries only: those are used verbatim, while a relative one is resolved by the server
+# against a prefix (`filesystem_caches_path`, or `<path>/caches` when unset) that this script cannot
+# reconstruct, so preparing it as written would create a directory nothing opens.
+readarray -t FILESYSTEM_CACHES_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='filesystem_caches.*.path' | grep '^/' || true)
+
 CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
 CLICKHOUSE_PASSWORD_FILE="${CLICKHOUSE_PASSWORD_FILE:-}"
 if [[ -n "${CLICKHOUSE_PASSWORD_FILE}" && -f "${CLICKHOUSE_PASSWORD_FILE}" ]]; then
@@ -86,7 +93,8 @@ function manage_clickhouse_directories() {
       "$USER_PATH" \
       "$FORMAT_SCHEMA_PATH" \
       "${DISKS_PATHS[@]}" \
-      "${DISKS_METADATA_PATHS[@]}"
+      "${DISKS_METADATA_PATHS[@]}" \
+      "${FILESYSTEM_CACHES_PATHS[@]}"
     do
         create_directory_and_do_chown "$dir"
     done
@@ -100,11 +108,11 @@ function manage_clickhouse_user() {
     case $USERS_XML in
         /* ) # absolute path
             cp "$USERS_XML" /tmp
-            USERS_CONFIG="/tmp/$(basename $USERS_XML)"
+            USERS_CONFIG="/tmp/$(basename "$USERS_XML")"
             ;;
         * ) # relative path to the $CLICKHOUSE_CONFIG
             cp "$(dirname "$CLICKHOUSE_CONFIG")/${USERS_XML}" /tmp
-            USERS_CONFIG="/tmp/$(basename $USERS_XML)"
+            USERS_CONFIG="/tmp/$(basename "$USERS_XML")"
             ;;
     esac
 


### PR DESCRIPTION
The shell server entrypoint prepares `storage_configuration` disk directories before dropping privileges, but does not read `filesystem_caches.*.path`. An absolute cache path below a root-owned mount can therefore fail in `FileCache::initialize` with `create_directories: Permission denied`.

Read those paths beside the disk paths and pass absolute entries through the existing `create_directory_and_do_chown` loop. Cache directories inherit the same ownership handling, including `CLICKHOUSE_DO_NOT_CHOWN` and non-root container execution. Relative entries remain the server's responsibility because `FileCacheSettings::loadFromConfig` resolves them beneath a server-selected prefix.

Three docker-library cases cover an absolute cache beneath a `root:root 0755` mount, a relative cache, and a relative cache with `filesystem_caches_path` configured. The mount cases drop `CAP_DAC_OVERRIDE` so startup depends on directory permissions. The explicit-prefix case checks startup and ownership of the server-selected cache directory without freezing the current server initialization order.

The relative-path assertion intentionally checks `${data_dir}docker_relative_cache`: the entrypoint executes `cd "$DATA_DIR"` before `manage_clickhouse_directories`, so removing `grep '^/'` creates the unused directory beside `caches`. The image's initial `WORKDIR` does not determine that location. Verified on the existing PR head: the unchanged relative test passes with the filter and exits 1 when only that filter is removed.

Local validation uses the official docker-library harness and the PR entrypoint on ARM64 Ubuntu and Alpine images. The full suite passes 9/9 on each. Removing cache-directory preparation makes the absolute case fail on both; the captured Ubuntu server error is `BAD_ARGUMENTS` with `create_directories: Permission denied`. Removing the absolute-only filter makes the relative case fail on both.

The docker-library runner moves into `ci/jobs/scripts/docker_server/docker_library.py` so other Docker jobs can reuse it without importing a job entry point. It resolves paths from `__file__` and accepts an optional image list; the existing caller continues to derive images from result names. Local checks cover calls from another directory, implicit and explicit image selection, distroless configuration cleanup, and failure reporting. Also quotes the `basename` arguments flagged by ShellCheck.

Scope is limited to absolute `filesystem_caches.*.path` entries in shell images. Preparing `filesystem_caches_path`, resolving cached disks' named-collection `cache_name` paths, and the distroless `docker-init` entrypoint remain separate follow-ups. Named collections may also be stored in server metadata by `CREATE NAMED COLLECTION`, outside the configuration visible to `extract-from-config`.

### Changelog category (leave one):

- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed startup of the shell-based Docker server images when an absolute `filesystem_caches` path is a missing directory below a directory the server does not own. The entrypoint now prepares these cache directories with the same ownership handling as `storage_configuration` disk paths.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118842&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118842](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118842+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1057` (included in `26.9` and later)
<!-- ch-version-info:end -->