### PR TITLE
Fix `Invalid number of columns in chunk pushed to OutputPort` in a distributed quantized-codes vector search

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearchWithQuantizedCodes.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearchWithQuantizedCodes.cpp
@@ -147,8 +147,8 @@ bool optimizeVectorSearchWithQuantizedCodes(
         return false;
 
     /// The shortlist uses internal functions (`__quantizeDistance`/`__productQuantizationDistance`) that are not registered in
-    /// FunctionFactory, so a remote node could not deserialize the plan. Leave the query exact when the plan is
-    /// distributed (the vector-search-index path is skipped for the same reason above).
+    /// FunctionFactory, so a remote node could not deserialize the plan: do not rewrite the plan the initiator serializes.
+    /// Each plan fragment is re-optimized with this setting off, so the shortlist is still built inside a fragment.
     if (settings.make_distributed_plan)
         return false;
 

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearchWithQuantizedCodes.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearchWithQuantizedCodes.cpp
@@ -431,12 +431,36 @@ bool optimizeVectorSearchWithQuantizedCodes(
     inner_limit_node.step->setStepDescription("quantized shortlist limit");
     inner_limit_node.children = {&inner_sorting_node};
 
-    /// 5. Splice the shortlist above the whole filter/rename chain (between the rescore expression and the chain top).
-    /// The rescore expression keeps its output header because it ignores the extra codes/_approx columns. The general
-    /// lazy-materialization pass will later defer the heavy vector column on the inner LimitStep (descending through the
-    /// chain's Expression/Filter steps), so `vec` is read only for the k' shortlisted rows.
-    expression_node->children = {&inner_limit_node};
-    expression_node->step->updateInputHeader(inner_limit_node.step->getOutputHeader());
+    /// 5. Discard the approximate-distance column at the top of the shortlist. Nothing above consumes it, and an
+    /// unconsumed input is carried through to the block, which would widen the rescore expression's output by one
+    /// trailing column while every step above the splice keeps the width it was created with. Listing every shortlist
+    /// column as an input is what makes them consumed, so only the columns kept as outputs survive.
+    ActionsDAG discard_approx_dag;
+    SharedHeader shortlist_header = inner_limit_node.step->getOutputHeader();
+    std::vector<const ActionsDAG::Node *> shortlist_inputs;
+    shortlist_inputs.reserve(shortlist_header->columns());
+    for (const auto & shortlist_column : *shortlist_header)
+        shortlist_inputs.push_back(&discard_approx_dag.addInput(shortlist_column.name, shortlist_column.type));
+    for (size_t pos = 0; pos < shortlist_header->columns(); ++pos)
+        if (shortlist_header->getByPosition(pos).name != approx_column_name)
+            discard_approx_dag.getOutputs().push_back(shortlist_inputs[pos]);
+
+    auto discard_approx_step = std::make_unique<ExpressionStep>(shortlist_header, std::move(discard_approx_dag));
+    discard_approx_step->setStepDescription("quantized shortlist discard approximate distance");
+    /// Keep the discarded inputs, or a later pass strips them and re-exposes the column.
+    discard_approx_step->setPreventInputRemoval();
+
+    auto & discard_approx_node = nodes.emplace_back();
+    discard_approx_node.step = std::move(discard_approx_step);
+    discard_approx_node.children = {&inner_limit_node};
+
+    /// 6. Splice the shortlist above the whole filter/rename chain (between the rescore expression and the chain top).
+    /// The rescore expression keeps its output header because the extra codes columns are consumed by it and the
+    /// approximate distance was discarded above. The general lazy-materialization pass will later defer the heavy
+    /// vector column on the inner LimitStep (descending through the chain's Expression/Filter steps), so `vec` is
+    /// read only for the k' shortlisted rows.
+    expression_node->children = {&discard_approx_node};
+    expression_node->step->updateInputHeader(discard_approx_node.step->getOutputHeader());
 
     return true;
 }

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.reference
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.reference
@@ -1,5 +1,4 @@
 selects_subcolumn	5	1
 distributed_plan_subcolumn	5	1
-distributed_plan_exact	1
 collision_bails	1
 collision_exact	1

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.reference
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.reference
@@ -1,3 +1,5 @@
 selects_subcolumn	5	1
+distributed_plan_subcolumn	5	1
+distributed_plan_exact	1
 collision_bails	1
 collision_exact	1

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.sql
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.sql
@@ -34,40 +34,44 @@ SELECT 'selects_subcolumn', count(), countDistinct(length(q)) FROM
     ORDER BY cosineDistance(vec, ref) ASC LIMIT 5 SETTINGS vector_search_index_fetch_multiplier = 50
 );
 
+-- Positive oracle for the arm below, whose row-count assertions the unrewritten exact plan also satisfies.
+-- `vector_search_index_fetch_multiplier` is range-checked inside the rewrite, after it has been admitted, so this error
+-- is raised only when the rewrite really runs in the plan fragment. The initiator declines the rewrite while it is
+-- building a distributed plan, so its EXPLAIN cannot show the shortlist steps and the plan shape cannot be asserted
+-- directly. `max_rows_to_group_by` is pinned because the CI test profile sets it and `make_distributed_plan` rejects
+-- aggregation with a non-zero value.
+WITH (SELECT vec FROM quantize_edge WHERE id = 123) AS ref
+SELECT count(), countDistinct(length(q)) FROM
+(
+    SELECT id, vec.quantized AS q FROM quantize_edge
+    ORDER BY cosineDistance(vec, ref) ASC LIMIT 5
+)
+SETTINGS vector_search_index_fetch_multiplier = 0,
+    make_distributed_plan = 1,
+    distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0,
+    enable_parallel_replicas = 0,
+    max_rows_to_group_by = 0; -- { serverError INVALID_SETTING_VALUE }
+
 -- Under a distributed plan the shortlist's internal sort key must not reach the rescore expression: nothing above
 -- consumes it, so it used to be carried through as an extra trailing block column while the exchange steps above the
 -- splice kept the width they were created with, aborting with "Invalid number of columns in chunk pushed to OutputPort.
 -- Expected 2, found 3". The shortlist output needs two surviving columns for the widened block to reach an exchange,
--- which is why the subcolumn is selected here and `count()` alone would not cover the bug.
--- The plan shape is deliberately not asserted: `make_distributed_plan` runs before this rewrite, which then fires only
--- while each plan fragment is re-optimized, so the shortlist steps are absent from the initiator's EXPLAIN.
+-- which is why the subcolumn is selected here and `count()` alone would not cover the bug. The fetch multiplier goes in
+-- the outer SETTINGS: a plan fragment is built from the top-level query context, so a subquery-level value never
+-- reaches the shortlist.
 WITH (SELECT vec FROM quantize_edge WHERE id = 123) AS ref
 SELECT 'distributed_plan_subcolumn', count(), countDistinct(length(q)) FROM
 (
     SELECT id, vec.quantized AS q FROM quantize_edge
-    ORDER BY cosineDistance(vec, ref) ASC LIMIT 5 SETTINGS vector_search_index_fetch_multiplier = 50
+    ORDER BY cosineDistance(vec, ref) ASC LIMIT 5
 )
-SETTINGS make_distributed_plan = 1,
+SETTINGS vector_search_index_fetch_multiplier = 50,
+    make_distributed_plan = 1,
     distributed_plan_execute_locally = 1,
     distributed_plan_max_rows_to_broadcast = 0,
     enable_parallel_replicas = 0,
-    max_rows_to_group_by = 0; -- the test runner may randomize it, and `make_distributed_plan` rejects aggregation with it
-
--- Not aborting is not enough: the distributed shortlist must still return the exact top-k. The brute-force side runs as
--- a scalar subquery, which is planned locally, so only the shortlist above it is distributed.
-WITH (SELECT vec FROM quantize_edge WHERE id = 123) AS ref
-SELECT 'distributed_plan_exact',
-    groupArray(id) = (SELECT groupArray(id) FROM (SELECT id, cosineDistance(vec, ref) AS d FROM quantize_edge ORDER BY d, id LIMIT 10 SETTINGS vector_search_use_quantized_codes = 0))
-FROM
-(
-    SELECT id FROM quantize_edge
-    ORDER BY cosineDistance(vec, ref) ASC, id LIMIT 10 SETTINGS vector_search_index_fetch_multiplier = 50
-)
-SETTINGS make_distributed_plan = 1,
-    distributed_plan_execute_locally = 1,
-    distributed_plan_max_rows_to_broadcast = 0,
-    enable_parallel_replicas = 0,
-    max_rows_to_group_by = 0;
+    max_rows_to_group_by = 0; -- pinned: the CI test profile sets it, and make_distributed_plan rejects aggregation with a non-zero value
 
 -- A column named like the internal sort key forces the rewrite to bail to the exact path (no shortlist), and the query
 -- still returns the correct exact top-k.

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.sql
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_planner_edge_cases.sql
@@ -34,6 +34,41 @@ SELECT 'selects_subcolumn', count(), countDistinct(length(q)) FROM
     ORDER BY cosineDistance(vec, ref) ASC LIMIT 5 SETTINGS vector_search_index_fetch_multiplier = 50
 );
 
+-- Under a distributed plan the shortlist's internal sort key must not reach the rescore expression: nothing above
+-- consumes it, so it used to be carried through as an extra trailing block column while the exchange steps above the
+-- splice kept the width they were created with, aborting with "Invalid number of columns in chunk pushed to OutputPort.
+-- Expected 2, found 3". The shortlist output needs two surviving columns for the widened block to reach an exchange,
+-- which is why the subcolumn is selected here and `count()` alone would not cover the bug.
+-- The plan shape is deliberately not asserted: `make_distributed_plan` runs before this rewrite, which then fires only
+-- while each plan fragment is re-optimized, so the shortlist steps are absent from the initiator's EXPLAIN.
+WITH (SELECT vec FROM quantize_edge WHERE id = 123) AS ref
+SELECT 'distributed_plan_subcolumn', count(), countDistinct(length(q)) FROM
+(
+    SELECT id, vec.quantized AS q FROM quantize_edge
+    ORDER BY cosineDistance(vec, ref) ASC LIMIT 5 SETTINGS vector_search_index_fetch_multiplier = 50
+)
+SETTINGS make_distributed_plan = 1,
+    distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0,
+    enable_parallel_replicas = 0,
+    max_rows_to_group_by = 0; -- the test runner may randomize it, and `make_distributed_plan` rejects aggregation with it
+
+-- Not aborting is not enough: the distributed shortlist must still return the exact top-k. The brute-force side runs as
+-- a scalar subquery, which is planned locally, so only the shortlist above it is distributed.
+WITH (SELECT vec FROM quantize_edge WHERE id = 123) AS ref
+SELECT 'distributed_plan_exact',
+    groupArray(id) = (SELECT groupArray(id) FROM (SELECT id, cosineDistance(vec, ref) AS d FROM quantize_edge ORDER BY d, id LIMIT 10 SETTINGS vector_search_use_quantized_codes = 0))
+FROM
+(
+    SELECT id FROM quantize_edge
+    ORDER BY cosineDistance(vec, ref) ASC, id LIMIT 10 SETTINGS vector_search_index_fetch_multiplier = 50
+)
+SETTINGS make_distributed_plan = 1,
+    distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0,
+    enable_parallel_replicas = 0,
+    max_rows_to_group_by = 0;
+
 -- A column named like the internal sort key forces the rewrite to bail to the exact path (no shortlist), and the query
 -- still returns the correct exact top-k.
 DROP TABLE IF EXISTS quantize_collide;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110659


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` (`Invalid number of columns in chunk pushed to OutputPort`) for a vector search over a column with a `Quantized(...)` codec when `vector_search_use_quantized_codes` and the experimental `make_distributed_plan` were both enabled. The two-stage rewrite left its internal ranking column in the block handed to an exchange.


### Description

An `ORDER BY <distance>(vec, ref) LIMIT k` over a `Quantized(...)` column fails with
`Code: 49. Invalid number of columns in chunk pushed to OutputPort. Expected 2, found 3` when
`vector_search_use_quantized_codes` and `make_distributed_plan` are both on (a debug build aborts
instead):

```sql
SELECT id FROM quantize_edge
ORDER BY cosineDistance(vec, arrayMap(j -> toFloat32(j/64), range(64))) ASC LIMIT 3
SETTINGS vector_search_use_quantized_codes = 1, make_distributed_plan = 1,
         distributed_plan_execute_locally = 1, distributed_plan_max_rows_to_broadcast = 0;
```

**Root cause.** The rewrite ranks over the codes subcolumn first, appending its internal `Float32`
sort key `__quantize_approx_distance` as the last shortlist output, then splices the shortlist under
the existing rescore `ExpressionStep`. That expression does not consume the internal column, and
`ExpressionActions` carries an unconsumed input through to the block, so the step emits one extra
trailing column. Within one node this is harmless: `Sorting` and `Limit` build from the live pipeline
header. Under a distributed plan it is not: the exchange steps are created from the
pre-rewrite plan headers, each fragment is then re-optimized with `make_distributed_plan = false` so
the rewrite fires inside it and widens the block, and the consumer's `SourceFromInMemoryExchange`
pushes that wider chunk into its narrower port.

**Fix.** Discard `__quantize_approx_distance` at the top of the shortlist, so the rescore step's
input header, output header and block are all what they were before the splice. Results are
unchanged; only `vector_search_use_quantized_codes = 1` plans are affected. Same class as #114457,
which fixes the output *order* for the vector-index sibling; this is the *width*.

**Validation.** A new distributed-plan arm in `02354_vector_search_quantize_codec_planner_edge_cases`
fails without this change and passes with it, on debug and `RelWithDebInfo`; 50/50 with and without
randomized settings. Also measured, without randomization: the same abort and fix for `int8`,
`product` and `L2Distance`, and no change across the rest of the `02354_vector_search*` family.

Found by the AST fuzzer on #110659.

<details>
<summary>AST fuzzer report and CIDB occurrences (query + rows)</summary>

[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110659&sha=3f37f22f7dbd4f5652bdbadab1a2346fd131bae2&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29)

```sql
SELECT pull_request_number, commit_sha, check_name, check_start_time
FROM default.checks
WHERE test_context_raw LIKE '%Invalid number of columns in chunk pushed to OutputPort%'
  AND test_context_raw LIKE '%quantize%'
  AND check_start_time > now() - INTERVAL 120 DAY
ORDER BY check_start_time DESC FORMAT TabSeparatedWithNames
```

| pull_request_number | commit_sha | check_name | check_start_time |
|---|---|---|---|
| 110659 | 3f37f22f7dbd | AST fuzzer (amd_debug, targeted, old_compatibility) | 2026-09-03 11:03 |
| 110659 | d3eadc1e6262 | AST fuzzer (amd_debug, targeted) | 2026-09-02 21:16 |
| 110659 | fa3ee3549733 | AST fuzzer (amd_debug, targeted) | 2026-09-02 16:33 |
| 114111 | e27decbe1d9b | AST fuzzer (amd_debug) | 2026-08-11 08:21 |

Two unrelated carrier PRs, zero master runs: neither PR touches the vector-search read path, and the
defect reproduces on plain master.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118850&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118850](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118850+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1288` (included in `26.9` and later)
<!-- ch-version-info:end -->