### PR TITLE
Disable the fail points a stateless test enables once it is over

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2591,10 +2591,14 @@ class TestCase:
     # failed together, fleet-wide, for three days.
     #
     # So disable what the test names, once it is over, whatever its outcome. `SYSTEM DISABLE
-    # FAILPOINT` is idempotent and accepts a name that is not armed - or that no build knows
-    # at all - so a name picked up from a comment or from an `EXPLAIN` is harmless. Only
-    # literal names are matched: a test that builds the name at runtime (`$FP`) still has to
-    # disable it itself, for which a `trap` is the usual way.
+    # FAILPOINT` is idempotent for a registered name, so disabling one that was never armed is
+    # a no-op. Only literal names are matched: a test that builds the name at runtime (`$FP`)
+    # still has to disable it itself, for which a `trap` is the usual way.
+    #
+    # This scrapes names out of the test file, so it also picks up a name that only occurs in
+    # prose or inside an `EXPLAIN`, which the server rejects as unregistered. That is expected
+    # here and stays quiet. Once `SYSTEM DISABLE ALL FAILPOINTS` (#118877) is in, this whole
+    # function becomes that one statement and the scraping goes away.
     FAILPOINT_ENABLE_RE = re.compile(
         r"SYSTEM\s+ENABLE\s+FAILPOINT\s+([A-Za-z_][A-Za-z_0-9]*)", re.IGNORECASE
     )
@@ -2629,6 +2633,10 @@ class TestCase:
                 # armed there to begin with.
                 if "compiled without FIU" in str(e):
                     return
+                # A name that is not a registered fail point came from prose or from an
+                # `EXPLAIN`, not from a statement that armed anything.
+                if "Cannot find fail point" in str(e):
+                    continue
                 # Otherwise best-effort: a server that stopped answering is reported by the
                 # test result and by the hung check, not from here.
                 print(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2580,6 +2580,63 @@ class TestCase:
         os.environ["CLICKHOUSE_URL_PARAMS"] = self.base_url_params
         os.environ["CLICKHOUSE_CLIENT_OPT"] = self.base_client_options
 
+    # A fail point armed with `SYSTEM ENABLE FAILPOINT` is server-wide: it is scoped
+    # neither to the session nor to the database that armed it. A test that never reaches
+    # its own `SYSTEM DISABLE FAILPOINT` therefore leaves it armed for every test that runs
+    # after it against the same server - a `.sql` test stops at its first unexpected error,
+    # and a `.sh` test can exit early or be killed on timeout. Whichever test next walks
+    # that code path then fails for a reason that is not its own, which is the hardest kind
+    # of CI failure to attribute: in #118831 / #118832 a racy `.sql` test aborted before its
+    # own `DISABLE`, and the test that ran eight minutes later took the blame - the two
+    # failed together, fleet-wide, for three days.
+    #
+    # So disable what the test names, once it is over, whatever its outcome. `SYSTEM DISABLE
+    # FAILPOINT` is idempotent and accepts a name that is not armed - or that no build knows
+    # at all - so a name picked up from a comment or from an `EXPLAIN` is harmless. Only
+    # literal names are matched: a test that builds the name at runtime (`$FP`) still has to
+    # disable it itself, for which a `trap` is the usual way.
+    FAILPOINT_ENABLE_RE = re.compile(
+        r"SYSTEM\s+ENABLE\s+FAILPOINT\s+([A-Za-z_][A-Za-z_0-9]*)", re.IGNORECASE
+    )
+
+    def disable_failpoints(self):
+        # `testcase_args` is set only once the test starts running, so a skipped test
+        # sends nothing.
+        if self.testcase_args is None:
+            return
+
+        try:
+            with open(self.case_file, "r", encoding="utf-8", errors="replace") as f:
+                names = sorted(set(self.FAILPOINT_ENABLE_RE.findall(f.read())))
+        except OSError:
+            return
+
+        for name in names:
+            try:
+                clickhouse_execute(
+                    self.testcase_args,
+                    f"SYSTEM DISABLE FAILPOINT {name}",
+                    timeout=30,
+                    # Best-effort teardown: do not spend the HTTP retry budget here, the
+                    # test result already reports a server that stopped answering.
+                    max_http_retries=1,
+                    settings={
+                        "log_comment": f"{self.testcase_args.testcase_basename}-{self.testcase_args.testcase_database}",
+                    },
+                )
+            except Exception as e:
+                # A build without FIU rejects the statement itself, and there is nothing
+                # armed there to begin with.
+                if "compiled without FIU" in str(e):
+                    return
+                # Otherwise best-effort: a server that stopped answering is reported by the
+                # test result and by the hung check, not from here.
+                print(
+                    f"WARNING: could not disable fail point {name} after {self.name}: "
+                    f"{type(e).__name__}: {e}",
+                    file=sys.stderr,
+                )
+
     def add_info_about_settings(self, description):
         if self.effective_settings:
             description += f"\nSettings used in the test: {self.cli_format_settings(self.effective_settings)}"
@@ -4231,6 +4288,7 @@ class TestCase:
                 self.get_description_from_exception_info(sys.exc_info()),
             )
         finally:
+            self.disable_failpoints()
             self.remove_settings_from_env()
 
     def _cleanup(self, passed):


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118877
Related: https://github.com/ClickHouse/ClickHouse/issues/118831
Related: https://github.com/ClickHouse/ClickHouse/issues/118832
Related: https://github.com/ClickHouse/ClickHouse/pull/118417

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

A fail point armed with `SYSTEM ENABLE FAILPOINT` is server-wide: it is scoped neither to the session nor to the database that armed it. A test that never reaches its own `SYSTEM DISABLE FAILPOINT` leaves it armed for every test that runs after it against the same server. A `.sql` test stops at its first unexpected error, so an unexpected error anywhere before the `DISABLE` is enough; a `.sh` test can exit early or be killed on timeout.

The test that then fails is not the test that is broken, which makes this the hardest kind of CI failure to attribute. `master` spent 2026-09-06 to 2026-09-08 demonstrating it:

- `04648_distributed_plan_task_error_propagation` lost a race (fix: #118417) and got `POCO_EXCEPTION` where it expected `CANNOT_SCHEDULE_TASK`. Being a `.sql` test, it aborted there - before `SYSTEM DISABLE FAILPOINT distributed_plan_record_failure_while_starting_tasks`.
- Every distributed-plan query for the rest of that job then failed at task start with `Injected task failure while starting tasks`.
- `04340_distributed_plan_status_reenqueue_fault`, eight minutes later in the same job, therefore never started a task, never reached a status re-enqueue, and reported `reenqueue fault handled: 0`.

Both tests failed together in every failing run of `Stateless tests (arm_asan_ubsan, azure, sequential)`, about 25 times a day each, and each got its own "flaky test" issue. Only `04340` looked like a flake; nothing about it was.

So `clickhouse-test` now disarms, once a test that mentions a fail point is over and whatever its outcome, the fail points it left armed, in the `finally` that already resets the per-test environment. The source of truth is the server: `system.fail_points` reports which fail points are armed right now, and only those are ever disabled. The test file is not trusted to say what the test armed - a name in prose, in an `EXPLAIN`, or in a `clickhouse-local` invocation never touched the shared server, and a name built at runtime (`$FP`) is invisible to any scraping.

Which of the armed fail points belong to the finished test depends on how it ran:

- A sequential test (`no-parallel`, or the whole run with `--jobs 1`) owns the server for its duration, so every fail point still armed when it finishes is its own leftover. This covers both tests from #118831 / #118832 and also the 27 of the 170 fail-point tests that build the name at runtime.
- A concurrent test shares the server with the tests running next to it, and a fail point armed by one of them must stay armed. So only the names this test arms with a literal `SYSTEM ENABLE FAILPOINT <name>` statement are disabled, and only if the server reports them armed. Comments are skipped, and a shell test that runs `clickhouse-local` anywhere contributes no names, since a query string spanning several lines or a shell wrapper around the invocation defeats any line-by-line attribution. A concurrent test that builds the name at runtime still has to disable it itself, for which a `trap` is the usual way.

Nothing is sent for a name the server does not report armed, so a build without FIU (no registered fail points) and a name that is not a fail point never produce a statement or a warning. #118877 adds `SYSTEM DISABLE ALL FAILPOINTS`; once it is in, the sequential branch can become that one statement.

Verified against a local server:

- a `no-parallel` test that aborts right after `SYSTEM ENABLE FAILPOINT dummy_failpoint` leaves nothing armed, including a second fail point armed before it ran;
- the same test run concurrently disarms `dummy_failpoint` and leaves the second fail point armed;
- a concurrent test that only mentions `dummy_failpoint` in a comment disarms nothing;
- over the whole `0_stateless` suite the concurrent-mode scraping drops exactly the comment words (`is`, `toggles`, `fails`, `already`) and the two `clickhouse-local`-only tests (`04654`, `04658`), and loses no name that a test really arms on the server.

Example of the leak - `04648`'s abort at 18:57:20 and `04340`'s three poisoned queries at 19:05:50 are both in that job's server log: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=1dd29f83596b117a895338eabb68bcec75042885&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20sequential%29

Found from the `master` failed-checks dashboard: https://play.clickhouse.com/play?run=1&color_modes=%7B%22ppm%22%3A%22none%22%2C%22test_name%22%3A%22categorical%22%7D&tab=Failed%20checks


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118863&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118863](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118863+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

