### PR TITLE
Prune Hive-style partitioned directories during object storage listing

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1193,6 +1193,8 @@ The server successfully detected this situation and will download merged part fr
     M(ObjectStorageGlobFilteredObjects, "Objects that did not match the glob or regex pattern and were skipped during listing.", ValueType::Number) \
     M(ObjectStoragePredicateFilteredObjects, "Objects removed by virtual column predicate filtering on _path/_file.", ValueType::Number) \
     M(ObjectStorageReadObjects, "Objects actually opened for reading by the object storage source.", ValueType::Number) \
+    M(ObjectStorageListedCommonPrefixes, "Partition directories returned by delimiter-based object storage listing while pruning Hive-style partitioned paths.", ValueType::Number) \
+    M(ObjectStorageHivePartitionPrunedPrefixes, "Partition directories skipped during listing because the query condition on Hive partition columns cannot be satisfied beneath them.", ValueType::Number) \
     \
     M(ServerStartupMilliseconds, "Time elapsed from starting server to listening to sockets in milliseconds", ValueType::Milliseconds) \
     M(IOUringSQEsSubmitted, "Total number of io_uring SQEs submitted", ValueType::Number) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8770,6 +8770,14 @@ Serialize String values during aggregation with zero byte at the end. Enable to 
 Maximum number of `_path` values that can be extracted from query filters to use for file iteration
 instead of glob listing. 0 means disabled.
 )", 0) \
+    DECLARE(Bool, use_hive_partition_pruning_during_listing, true, R"(
+Prune Hive-style partitioned directories (`/name=value/`) while listing a globbed path in object storage table engines and functions (`s3`, `azureBlobStorage` and their cluster variants), instead of listing every object under the common prefix and filtering the keys afterwards.
+
+The directory levels covered by the glob are enumerated one by one with the delimiter form of the listing API (`ListObjectsV2` with a delimiter for S3, `ListBlobsByHierarchy` for Azure Blob Storage). A `name=value` directory is skipped together with everything beneath it when the `WHERE` condition on the partition columns known at that level cannot be satisfied. Only applies when the condition restricts a partition column that appears in a directory-level glob segment and the storage supports delimiter listing, otherwise the common prefix is listed as before. See also `hive_partition_pruning_during_listing_max_prefixes`.
+)", 0) \
+    DECLARE(UInt64, hive_partition_pruning_during_listing_max_prefixes, 1000, R"(
+Maximum number of partition directories that may remain after pruning at any directory level when `use_hive_partition_pruning_during_listing` is enabled. When exceeded, ClickHouse gives up the level-by-level enumeration and lists the whole common prefix at once, so that the number of listing requests stays bounded for paths where the condition prunes little.
+)", 0) \
     DECLARE(Bool, ignore_on_cluster_for_replicated_database, false, R"(
 Always ignore ON CLUSTER clause for DDL queries with replicated databases.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,6 +43,8 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.9",
         {
+            {"use_hive_partition_pruning_during_listing", false, true, "New setting to prune Hive-style partitioned directories during object storage listing (S3, Azure) using the delimiter form of the listing API, instead of listing every object under the common prefix and filtering afterwards."},
+            {"hive_partition_pruning_during_listing_max_prefixes", 1000, 1000, "New setting bounding the number of partition directories kept while pruning during listing; above it the whole common prefix is listed at once."},
             {"reader_executor_window_size", 4194304, 8388608, "Raised the default read window of the experimental `ReaderExecutor` from 4 MiB to 8 MiB. Under memory pressure the window is reduced from this base, floored at 128 KiB."},
             {"webassembly_udf_input_split_memory_ratio", 0.0, 0.5, "New setting controlling the fraction of a WebAssembly UDF instance's linear memory that one call's serialized input may occupy, which also enables the dynamic splitting of that input by its serialized size; `compatibility` below 26.9 sets it to 0 and restores the previous behavior, where `webassembly_udf_max_input_block_size = 0` meant one call per pipeline block."},
             {"query_plan_optimize_join_order_use_cd_a_conflict_detector", false, false, "New setting to use the CD-A conflict detector for join reordering validity in the DPsub join order algorithm."},

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -179,6 +179,33 @@ ListBlobsPagedResponse ContainerClientWrapper::ListBlobs(const ListBlobsOptions 
     return response;
 }
 
+ListBlobsByHierarchyPagedResponse ContainerClientWrapper::ListBlobsByHierarchy(
+    const String & delimiter, const ListBlobsOptions & options) const
+{
+    auto new_options = options;
+    new_options.Prefix = blob_prefix + options.Prefix.ValueOr("");
+
+    auto response = client.ListBlobsByHierarchy(delimiter, new_options);
+
+    for (auto & blob : response.Blobs)
+    {
+        if (!blob.Name.starts_with(blob_prefix))
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected prefix '{}' in blob name '{}'", blob_prefix, blob.Name);
+
+        blob.Name = blob.Name.substr(blob_prefix.size());
+    }
+
+    for (auto & blob_prefix_name : response.BlobPrefixes)
+    {
+        if (!blob_prefix_name.starts_with(blob_prefix))
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected prefix '{}' in blob prefix '{}'", blob_prefix, blob_prefix_name);
+
+        blob_prefix_name = blob_prefix_name.substr(blob_prefix.size());
+    }
+
+    return response;
+}
+
 bool ContainerClientWrapper::IsClientForDisk() const
 {
     return client.GetClickhouseOptions().IsClientForDisk;

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h
@@ -117,6 +117,7 @@ using RawContainerClient = Azure::Storage::Blobs::BlobContainerClient;
 
 using Azure::Storage::Blobs::ListBlobsOptions;
 using Azure::Storage::Blobs::ListBlobsPagedResponse;
+using Azure::Storage::Blobs::ListBlobsByHierarchyPagedResponse;
 using Azure::Storage::Blobs::BlobContainerBatch;
 using BlobContainerPropertiesRespones = Azure::Response<Azure::Storage::Blobs::Models::BlobContainerProperties>;
 using BlobBatchResultResponse = Azure::Response<Azure::Storage::Blobs::Models::SubmitBlobBatchResult>;
@@ -134,6 +135,9 @@ public:
     BlockBlobClient GetBlockBlobClient(const String & blob_name) const;
     BlobContainerPropertiesRespones GetProperties() const;
     ListBlobsPagedResponse ListBlobs(const ListBlobsOptions & options) const;
+    /// Lists one page of blobs and blob prefixes ("directories") under `options.Prefix`, using `delimiter`
+    /// as the hierarchy separator. Blob names and prefixes are returned relative to the endpoint prefix.
+    ListBlobsByHierarchyPagedResponse ListBlobsByHierarchy(const String & delimiter, const ListBlobsOptions & options) const;
 
     BlobContainerBatch CreateBatch() const;
     BlobBatchResultResponse SubmitBatch(const BlobContainerBatch & batch) const;

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -232,6 +232,41 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
     }
 }
 
+std::vector<std::string> AzureObjectStorage::listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const
+{
+    auto client_ptr = client.get();
+
+    Azure::Storage::Blobs::ListBlobsOptions options;
+    options.Prefix = path_prefix;
+    if (max_keys)
+        options.PageSizeHint = max_keys;
+    else
+        options.PageSizeHint = settings.get()->list_object_keys_size;
+
+    std::vector<std::string> common_prefixes;
+
+    /// Re-issue the request per page through the client wrapper for the same reason as in `listObjects`.
+    while (true)
+    {
+        auto response = client_ptr->ListBlobsByHierarchy("/", options);
+
+        ProfileEvents::increment(ProfileEvents::AzureListObjects);
+        if (client_ptr->IsClientForDisk())
+            ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
+
+        /// Blobs located directly under the prefix are intentionally ignored: the caller is interested
+        /// in the directory structure only, the blobs are listed separately once the directories are chosen.
+        common_prefixes.insert(common_prefixes.end(), response.BlobPrefixes.begin(), response.BlobPrefixes.end());
+
+        if (!response.NextPageToken.HasValue() || response.NextPageToken.Value().empty())
+            break;
+
+        options.ContinuationToken = response.NextPageToken;
+    }
+
+    return common_prefixes;
+}
+
 std::unique_ptr<ReadBufferFromFileBase> AzureObjectStorage::readObject( /// NOLINT
     const StoredObject & object,
     const ReadSettings & read_settings,

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -45,6 +45,10 @@ public:
         bool with_tags,
         const std::optional<std::string> & start_after) const override;
 
+    bool supportsListingCommonPrefixes() const override { return true; }
+
+    std::vector<std::string> listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const override;
+
     std::string getName() const override { return "Azure"; }
 
     std::string getDiskName() const override { return name; }

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -199,6 +199,11 @@ void CachedObjectStorage::listObjects(const std::string & path, RelativePathsWit
     object_storage->listObjects(path, children, max_keys);
 }
 
+std::vector<std::string> CachedObjectStorage::listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const
+{
+    return object_storage->listCommonPrefixes(path_prefix, max_keys);
+}
+
 ObjectMetadata CachedObjectStorage::getObjectMetadata(const std::string & path, bool with_tags) const
 {
     return object_storage->getObjectMetadata(path, with_tags);

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.h
@@ -80,6 +80,10 @@ public:
 
     void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
 
+    bool supportsListingCommonPrefixes() const override { return object_storage->supportsListingCommonPrefixes(); }
+
+    std::vector<std::string> listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const override;
+
     ObjectMetadata getObjectMetadata(const std::string & path, bool with_tags) const override;
 
     std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string & path, bool with_tags) const override;

--- a/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.cpp
@@ -63,6 +63,11 @@ ObjectStorageIteratorPtr IObjectStorage::iterate(
     return std::make_shared<ObjectStorageIteratorFromList>(std::move(files));
 }
 
+std::vector<std::string> IObjectStorage::listCommonPrefixes(const std::string &, size_t) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "listCommonPrefixes() is not supported by {}", getName());
+}
+
 ThreadPool & IObjectStorage::getThreadPoolWriter()
 {
     auto context = Context::getGlobalContextInstance();

--- a/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
@@ -273,6 +273,16 @@ public:
         bool with_tags,
         const std::optional<std::string> & start_after) const;
 
+    /// Whether `listCommonPrefixes` is supported by this storage.
+    virtual bool supportsListingCommonPrefixes() const { return false; }
+
+    /// List the "directories" directly under `path_prefix`: the distinct prefixes that extend `path_prefix`
+    /// up to and including the next '/', without listing the objects beneath them. This uses the delimiter
+    /// form of the listing API (S3 `ListObjectsV2` with `Delimiter`, Azure `ListBlobsByHierarchy`).
+    /// `path_prefix` may be a partial prefix, i.e. it does not have to end with '/'. Returned prefixes end with '/'.
+    /// `max_keys` is the page size of the underlying requests, 0 means the storage default.
+    virtual std::vector<std::string> listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const;
+
     /// Get object metadata if supported. It should be possible to receive at least size of object
     virtual ObjectMetadata getObjectMetadata(const std::string & path, bool with_tags) const = 0;
     virtual ObjectMetadata getObjectMetadata(const RelativePathWithMetadata & object, bool with_tags) const

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -428,6 +428,41 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
     } while (outcome.GetResult().GetIsTruncated());
 }
 
+std::vector<std::string> S3ObjectStorage::listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const
+{
+    auto settings_ptr = s3_settings.get();
+
+    S3::ListObjectsV2Request request;
+    request.SetBucket(uri.bucket);
+    request.SetPrefix(path_prefix);
+    request.SetDelimiter("/");
+    if (max_keys)
+        request.SetMaxKeys(static_cast<int>(max_keys));
+    else
+        request.SetMaxKeys(static_cast<int>(settings_ptr->request_settings[S3RequestSetting::list_object_keys_size]));
+
+    std::vector<std::string> common_prefixes;
+    Aws::S3::Model::ListObjectsV2Outcome outcome;
+    do
+    {
+        ProfileEvents::increment(ProfileEvents::S3ListObjects);
+        ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
+
+        outcome = client.get()->ListObjectsV2(request);
+        throwIfError(
+            outcome, "while listing common prefixes in bucket '{}' with prefix '{}' on disk '{}'", uri.bucket, path_prefix, disk_name);
+
+        /// Objects located directly under the prefix are intentionally ignored: the caller is interested
+        /// in the directory structure only, the objects are listed separately once the directories are chosen.
+        for (const auto & common_prefix : outcome.GetResult().GetCommonPrefixes())
+            common_prefixes.push_back(common_prefix.GetPrefix());
+
+        request.SetContinuationToken(outcome.GetResult().GetNextContinuationToken());
+    } while (outcome.GetResult().GetIsTruncated());
+
+    return common_prefixes;
+}
+
 void S3ObjectStorage::removeObjectImpl(const StoredObject & object, bool if_exists)
 {
     auto blob_storage_log = BlobStorageLogWriter::create(disk_name);

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -102,6 +102,10 @@ public:
         bool with_tags,
         const std::optional<std::string> & start_after) const override;
 
+    bool supportsListingCommonPrefixes() const override { return true; }
+
+    std::vector<std::string> listCommonPrefixes(const std::string & path_prefix, size_t max_keys) const override;
+
     /// Uses `DeleteObjectRequest`.
     void removeObjectIfExists(const StoredObject & object) override;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -87,6 +87,8 @@ namespace ProfileEvents
     extern const Event ObjectStorageGlobFilteredObjects;
     extern const Event ObjectStoragePredicateFilteredObjects;
     extern const Event ObjectStorageReadObjects;
+    extern const Event ObjectStorageListedCommonPrefixes;
+    extern const Event ObjectStorageHivePartitionPrunedPrefixes;
 }
 
 namespace CurrentMetrics
@@ -208,6 +210,8 @@ namespace Setting
     extern const SettingsUInt64 s3_path_filter_limit;
     extern const SettingsBool use_parquet_metadata_cache;
     extern const SettingsBool s3_validate_etag_on_read;
+    extern const SettingsBool use_hive_partition_pruning_during_listing;
+    extern const SettingsUInt64 hive_partition_pruning_during_listing_max_prefixes;
 }
 
 static void logIcebergFileStats(const ObjectInfoPtr & object_info, const LoggerPtr & log)
@@ -1945,9 +1949,9 @@ StorageObjectStorageSource::GlobIterator::GlobIterator(
     const NamesAndTypesList & hive_columns_,
     ContextPtr context_,
     ObjectInfos * read_keys_,
-    size_t list_object_keys_size,
+    size_t list_object_keys_size_,
     bool throw_on_zero_files_match_,
-    bool with_tags,
+    bool with_tags_,
     std::function<void(FileProgress)> file_progress_callback_)
     : WithContext(context_)
     , object_storage(object_storage_)
@@ -1955,6 +1959,8 @@ StorageObjectStorageSource::GlobIterator::GlobIterator(
     , virtual_columns(virtual_columns_)
     , hive_columns(hive_columns_)
     , throw_on_zero_files_match(throw_on_zero_files_match_)
+    , list_object_keys_size(list_object_keys_size_)
+    , with_tags(with_tags_)
     , log(getLogger("GlobIterator"))
     , read_keys(read_keys_)
     , local_context(context_)
@@ -1966,8 +1972,6 @@ StorageObjectStorageSource::GlobIterator::GlobIterator(
         match_web_paths_only = configuration->getType() == ObjectStorageType::Web;
         const auto & key_with_globs = reading_path;
         const auto key_prefix = reading_path.cutGlobs(configuration->supportsPartialPathPrefix());
-
-        object_storage_iterator = object_storage->iterate(key_prefix, list_object_keys_size, with_tags, std::nullopt);
 
         matcher = std::make_unique<re2::RE2>(makeRegexpPatternFromGlobs(key_with_globs.path));
         if (!matcher->ok())
@@ -1981,6 +1985,10 @@ StorageObjectStorageSource::GlobIterator::GlobIterator(
             VirtualColumnUtils::buildSetsForDAG(*filter_dag, getContext());
             filter_expr = std::make_shared<ExpressionActions>(std::move(*filter_dag));
         }
+
+        prefixes_to_list = resolveListingPrefixes(predicate, key_prefix);
+        if (!startListingNextPrefix())
+            is_finished = true;
     }
     else
     {
@@ -1991,8 +1999,220 @@ StorageObjectStorageSource::GlobIterator::GlobIterator(
     }
 }
 
+namespace
+{
+
+/// A directory level of a globbed path: one path segment that is followed by at least one more segment.
+struct HivePartitionListingLevel
+{
+    /// The literal start of the segment before its first glob character. It narrows the listing of the level.
+    String literal_prefix;
+    /// Matches the partial path up to and including this segment, with the trailing '/'.
+    std::unique_ptr<re2::RE2> matcher;
+    /// Hive partition columns whose values are known once the path is resolved up to this segment.
+    NamesAndTypesList known_hive_columns;
+    /// The part of the query condition that depends only on `known_hive_columns`, if there is any.
+    ExpressionActionsPtr filter;
+};
+
+std::vector<std::string_view> splitPathIntoSegments(const String & path)
+{
+    std::vector<std::string_view> segments;
+    size_t start = 0;
+    while (true)
+    {
+        const auto pos = path.find('/', start);
+        if (pos == String::npos)
+        {
+            segments.emplace_back(path.data() + start, path.size() - start);
+            return segments;
+        }
+        segments.emplace_back(path.data() + start, pos - start);
+        start = pos + 1;
+    }
+}
+
+bool hasGlobs(std::string_view segment)
+{
+    return segment.find_first_of("*?{") != std::string_view::npos;
+}
+
+String literalPrefixOfSegment(std::string_view segment)
+{
+    return String(segment.substr(0, segment.find_first_of("*?{")));
+}
+
+/// The partition key of a `key=value` segment when the key itself is literal, e.g. `year` for `year=*` or `year=2024`.
+std::optional<String> hivePartitionKeyOfSegment(std::string_view segment)
+{
+    const auto key_value_delimiter = segment.find('=');
+    if (key_value_delimiter == std::string_view::npos || key_value_delimiter == 0)
+        return std::nullopt;
+
+    const auto first_glob = segment.find_first_of("*?{");
+    if (first_glob != std::string_view::npos && first_glob < key_value_delimiter)
+        return std::nullopt;
+
+    return String(segment.substr(0, key_value_delimiter));
+}
+
+}
+
+std::vector<String> StorageObjectStorageSource::GlobIterator::resolveListingPrefixes(
+    const ActionsDAG::Node * predicate, const String & common_prefix)
+{
+    const auto & settings = getContext()->getSettingsRef();
+    if (!predicate || hive_columns.empty() || match_web_paths_only || configuration->isArchive()
+        || !settings[Setting::use_hive_partition_pruning_during_listing]
+        || !configuration->supportsPartialPathPrefix()
+        || !object_storage->supportsListingCommonPrefixes())
+        return {common_prefix};
+
+    const auto & path = configuration->getPathForRead().path;
+    const auto segments = splitPathIntoSegments(path);
+    const size_t file_name_segment = segments.size() - 1;
+
+    size_t first_glob_segment = 0;
+    while (first_glob_segment < segments.size() && !hasGlobs(segments[first_glob_segment]))
+        ++first_glob_segment;
+
+    /// The directory levels that can be enumerated one by one: from the first globbed segment up to (excluding)
+    /// the file name segment or a segment with `**`, which spans an arbitrary number of levels.
+    size_t walk_end = first_glob_segment;
+    while (walk_end < file_name_segment && segments[walk_end].find("**") == std::string_view::npos)
+        ++walk_end;
+
+    if (walk_end == first_glob_segment)
+        return {common_prefix};
+
+    std::vector<HivePartitionListingLevel> levels;
+    NamesAndTypesList known_hive_columns;
+    bool has_filter = false;
+    String partial_glob;
+    for (size_t i = 0; i < walk_end; ++i)
+    {
+        partial_glob += segments[i];
+        partial_glob += '/';
+
+        if (const auto key = hivePartitionKeyOfSegment(segments[i]))
+        {
+            if (const auto column = hive_columns.tryGetByName(*key))
+                known_hive_columns.push_back(*column);
+        }
+
+        if (i < first_glob_segment)
+            continue;
+
+        HivePartitionListingLevel level;
+        level.literal_prefix = literalPrefixOfSegment(segments[i]);
+        level.matcher = std::make_unique<re2::RE2>(makeRegexpPatternFromGlobs(partial_glob));
+        if (!level.matcher->ok())
+            throw Exception(
+                ErrorCodes::CANNOT_COMPILE_REGEXP, "Cannot compile regex from glob ({}): {}", partial_glob, level.matcher->error());
+        level.known_hive_columns = known_hive_columns;
+
+        if (!known_hive_columns.empty())
+        {
+            Block allowed_inputs;
+            for (const auto & column : known_hive_columns)
+                allowed_inputs.insert({column.type->createColumn(), column.type, column.name});
+            allowed_inputs.insert({ColumnUInt64::create(), std::make_shared<DataTypeUInt64>(), "_idx"});
+
+            /// Only the conjuncts of the condition that depend on the already known partition columns are kept,
+            /// so the filter is a necessary condition: a directory that fails it cannot contain matching objects.
+            if (auto filter_dag = VirtualColumnUtils::splitFilterDagForAllowedInputs(predicate, &allowed_inputs, getContext()))
+            {
+                VirtualColumnUtils::buildSetsForDAG(*filter_dag, getContext());
+                level.filter = std::make_shared<ExpressionActions>(std::move(*filter_dag));
+                has_filter = true;
+            }
+        }
+
+        levels.push_back(std::move(level));
+    }
+
+    /// Without a condition on some directory level the enumeration would only cost extra requests.
+    if (!has_filter)
+        return {common_prefix};
+
+    const size_t max_prefixes = settings[Setting::hive_partition_pruning_during_listing_max_prefixes];
+
+    String root;
+    for (size_t i = 0; i < first_glob_segment; ++i)
+    {
+        root += segments[i];
+        root += '/';
+    }
+
+    std::vector<String> directories{root};
+    size_t listed_directories = 0;
+    size_t pruned_directories = 0;
+    for (const auto & level : levels)
+    {
+        std::vector<String> next_directories;
+        for (const auto & directory : directories)
+        {
+            auto children = object_storage->listCommonPrefixes(directory + level.literal_prefix, list_object_keys_size);
+            listed_directories += children.size();
+
+            std::erase_if(children, [&](const String & child) { return !re2::RE2::FullMatch(child, *level.matcher); });
+
+            if (level.filter)
+            {
+                const size_t before_filter = children.size();
+                const auto paths = children;
+                VirtualColumnUtils::filterByPathOrFile(
+                    children, paths, level.filter, /*virtual_columns=*/{}, level.known_hive_columns, getContext());
+                pruned_directories += before_filter - children.size();
+            }
+
+            next_directories.insert(next_directories.end(), children.begin(), children.end());
+            if (next_directories.size() > max_prefixes)
+            {
+                ProfileEvents::increment(ProfileEvents::ObjectStorageListedCommonPrefixes, listed_directories);
+                ProfileEvents::increment(ProfileEvents::ObjectStorageHivePartitionPrunedPrefixes, pruned_directories);
+                LOG_DEBUG(
+                    log,
+                    "More than {} partition directories remain after pruning for path {}, listing the common prefix {} instead",
+                    max_prefixes, path, common_prefix);
+                return {common_prefix};
+            }
+        }
+
+        directories = std::move(next_directories);
+        if (directories.empty())
+            break;
+    }
+
+    ProfileEvents::increment(ProfileEvents::ObjectStorageListedCommonPrefixes, listed_directories);
+    ProfileEvents::increment(ProfileEvents::ObjectStorageHivePartitionPrunedPrefixes, pruned_directories);
+    LOG_DEBUG(
+        log,
+        "Resolved {} partition directories to list for path {}: listed {} directories, pruned {} by the query condition",
+        directories.size(), path, listed_directories, pruned_directories);
+
+    /// Objects are listed below each remaining directory starting from the literal part of the next segment.
+    const auto tail_literal_prefix = literalPrefixOfSegment(segments[walk_end]);
+    for (auto & directory : directories)
+        directory += tail_literal_prefix;
+    return directories;
+}
+
+bool StorageObjectStorageSource::GlobIterator::startListingNextPrefix()
+{
+    if (next_prefix_index >= prefixes_to_list.size())
+        return false;
+
+    object_storage_iterator = object_storage->iterate(prefixes_to_list[next_prefix_index], list_object_keys_size, with_tags, std::nullopt);
+    ++next_prefix_index;
+    return true;
+}
+
 size_t StorageObjectStorageSource::GlobIterator::estimatedKeysCount()
 {
+    if (object_infos.empty() && !is_finished && next_prefix_index < prefixes_to_list.size())
+        return std::numeric_limits<size_t>::max();
+
     if (object_infos.empty() && !is_finished && object_storage_iterator->isValid())
     {
         /// 1000 files were listed, and we cannot make any estimation of _how many more_ there are (because we list bucket lazily);
@@ -2034,6 +2254,9 @@ ObjectInfoPtr StorageObjectStorageSource::GlobIterator::nextUnlocked(size_t /* p
             auto result = object_storage_iterator->getCurrentBatchAndScheduleNext();
             if (!result.has_value())
             {
+                if (startListingNextPrefix())
+                    continue;
+
                 is_finished = true;
                 LOG_DEBUG(log, "Listing finished: total_listed={}, glob_filtered={}, predicate_filtered={}",
                     total_listed, total_glob_filtered, total_predicate_filtered);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -227,11 +227,21 @@ private:
     void createFilterAST(const String & any_key);
     void fillBufferForKey(const std::string & uri_key);
 
+    /// Resolves the key prefixes to list objects under. Normally it is just `common_prefix` (the path cut at the
+    /// first glob), but when the globbed path goes through Hive-style partitioned directories and the query
+    /// condition restricts the partition columns, the directory levels are enumerated with delimiter listing
+    /// and the directories that cannot satisfy the condition are pruned, see `use_hive_partition_pruning_during_listing`.
+    std::vector<String> resolveListingPrefixes(const ActionsDAG::Node * predicate, const String & common_prefix);
+    /// Starts listing the next prefix from `prefixes_to_list`. Returns false when there is nothing left to list.
+    bool startListingNextPrefix();
+
     const ObjectStoragePtr object_storage;
     const StorageObjectStorageConfigurationPtr configuration;
     const NamesAndTypesList virtual_columns;
     const NamesAndTypesList hive_columns;
     const bool throw_on_zero_files_match;
+    const size_t list_object_keys_size;
+    const bool with_tags;
     const LoggerPtr log;
 
     size_t index = 0;
@@ -240,6 +250,8 @@ private:
     ObjectInfos * read_keys;
     ExpressionActionsPtr filter_expr;
     ObjectStorageIteratorPtr object_storage_iterator;
+    std::vector<String> prefixes_to_list;
+    size_t next_prefix_index = 0;
     bool recursive{false};
     bool match_web_paths_only{false};
     std::vector<String> expanded_keys;

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -690,6 +690,12 @@ When setting `use_hive_partitioning` is set to 1, ClickHouse will detect Hive-st
 SELECT * FROM s3('s3://data/path/date=*/country=*/code=*/*.parquet') WHERE date > '2020-01-01' AND country = 'Netherlands' AND code = 42;
 ```
 
+### Partition pruning during listing {#hive-partition-pruning-during-listing}
+
+When the `WHERE` condition restricts partition columns that appear in directory-level glob segments (`date=*`, `country=*` and `code=*` in the example above), the partition directories are pruned while listing rather than after it. Each such level is enumerated with a delimiter listing request (`ListObjectsV2` with `Delimiter`), and a `name=value` directory that cannot satisfy the condition is skipped together with everything beneath it, so only the objects of the matching partitions are ever listed. In the example, only `date=<matching dates>/country=Netherlands/code=42/` is listed instead of the whole `s3://data/path/` prefix.
+
+This is controlled by the `use_hive_partition_pruning_during_listing` setting (enabled by default). The `hive_partition_pruning_during_listing_max_prefixes` setting bounds the number of directories kept at any level; above it the common prefix is listed at once as before. A `**` segment spans an arbitrary number of levels and stops the level-by-level enumeration, the levels before it are still pruned. The `ObjectStorageListedCommonPrefixes` and `ObjectStorageHivePartitionPrunedPrefixes` profile events show how many directories were enumerated and skipped.
+
 ## Accessing requester-pays buckets {#accessing-requester-pays-buckets}
 
 To access a requester-pays bucket, a header `x-amz-request-payer = requester` must be passed in any requests. This is achieved by passing the parameter `headers('x-amz-request-payer' = 'requester')` to the s3 function. For example:
@@ -1238,6 +1244,12 @@ Use virtual column, created with Hive-style partitioning
 ```sql
 SELECT * FROM azureBlobStorage(config, storage_account_url='...', container='...', blob_path='http://data/path/date=*/country=*/code=*/*.parquet') WHERE date > '2020-01-01' AND country = 'Netherlands' AND code = 42;
 ```
+
+### Partition pruning during listing {#hive-partition-pruning-during-listing}
+
+When the `WHERE` condition restricts partition columns that appear in directory-level glob segments (`date=*`, `country=*` and `code=*` in the example above), the partition directories are pruned while listing rather than after it. Each such level is enumerated with a hierarchical listing request (`List Blobs` with a delimiter), and a `name=value` directory that cannot satisfy the condition is skipped together with everything beneath it, so only the blobs of the matching partitions are ever listed.
+
+This is controlled by the `use_hive_partition_pruning_during_listing` setting (enabled by default). The `hive_partition_pruning_during_listing_max_prefixes` setting bounds the number of directories kept at any level; above it the common prefix is listed at once as before. A `**` segment spans an arbitrary number of levels and stops the level-by-level enumeration, the levels before it are still pruned. The `ObjectStorageListedCommonPrefixes` and `ObjectStorageHivePartitionPrunedPrefixes` profile events show how many directories were enumerated and skipped.
 
 ## Using Shared Access Signatures (SAS) {#using-shared-access-signatures-sas-sas-tokens}
 

--- a/tests/integration/test_storage_azure_blob_storage/test.py
+++ b/tests/integration/test_storage_azure_blob_storage/test.py
@@ -2061,3 +2061,92 @@ def test_invalid_upload_settings_do_not_affect_reads(cluster):
     )
 
     azure_query(node, "DROP TABLE test_reads_with_invalid_upload_settings")
+
+
+def test_hive_partition_pruning_during_listing(cluster):
+    node = cluster.instances["node"]
+    storage_account_url = cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+    prefix = f"hive_partition_pruning_during_listing_{random.randint(0, 10**9)}"
+    structure = "id UInt64, year UInt16, country String"
+
+    countries = ["DE", "FR", "US"]
+    for year in (2024, 2025, 2026):
+        for idx, country in enumerate(countries, start=1):
+            azure_query(
+                node,
+                f"INSERT INTO TABLE FUNCTION azureBlobStorage(azure_conf2, storage_account_url = '{storage_account_url}', "
+                f"container = 'cont', blob_path = '{prefix}/year={year}/country={country}/data.csv', format = 'CSV', structure = 'id UInt64') "
+                f"SELECT toUInt64({year} * 10 + {idx})",
+                settings={"azure_truncate_on_insert": 1},
+            )
+
+    def globbed(blob_path):
+        return (
+            f"azureBlobStorage(azure_conf2, storage_account_url = '{storage_account_url}', container = 'cont', "
+            f"blob_path = '{blob_path}', format = 'CSV', structure = '{structure}')"
+        )
+
+    def run(query, **settings):
+        log_comment = f"hive_pruning_{random.randint(0, 10**9)}"
+        result = azure_query(
+            node,
+            query,
+            settings={
+                "use_hive_partitioning": 1,
+                "log_queries": 1,
+                "log_comment": log_comment,
+                **settings,
+            },
+        )
+        node.query("SYSTEM FLUSH LOGS")
+        events = node.query(
+            f"""
+            SELECT
+                ProfileEvents['ObjectStorageListedObjects'],
+                ProfileEvents['ObjectStorageReadObjects'],
+                ProfileEvents['ObjectStorageListedCommonPrefixes'],
+                ProfileEvents['ObjectStorageHivePartitionPrunedPrefixes']
+            FROM system.query_log
+            WHERE log_comment = '{log_comment}' AND type = 'QueryFinish'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1
+            """
+        )
+        return result, tuple(int(value) for value in events.strip().split("\t"))
+
+    two_levels = globbed(f"{prefix}/year=*/country=*/*.csv")
+
+    # Both partition levels are constrained: the year level lists 3 directories and keeps 1,
+    # the country level lists 3 directories below it and keeps 1, so a single blob is listed.
+    result, events = run(
+        f"SELECT id FROM {two_levels} WHERE year = 2025 AND country = 'FR'"
+    )
+    assert result == "20252\n"
+    assert events == (1, 1, 6, 4)
+
+    # Without the optimization every blob under the common prefix is listed and filtered afterwards.
+    result, events = run(
+        f"SELECT id FROM {two_levels} WHERE year = 2025 AND country = 'FR'",
+        use_hive_partition_pruning_during_listing=0,
+    )
+    assert result == "20252\n"
+    assert events == (9, 1, 0, 0)
+
+    # A condition on the second level only: the first level is enumerated without pruning.
+    result, events = run(
+        f"SELECT id FROM {two_levels} WHERE country = 'US' ORDER BY id"
+    )
+    assert result == "20243\n20253\n20263\n"
+    assert events == (3, 3, 12, 6)
+
+    # Nothing matches: no blob is listed at all.
+    result, events = run(f"SELECT count() FROM {two_levels} WHERE year = 1999")
+    assert result == "0\n"
+    assert events == (0, 0, 3, 3)
+
+    # `**` spans levels and stops the enumeration; the levels before it are still pruned.
+    result, events = run(
+        f"SELECT id FROM {globbed(f'{prefix}/year=*/**.csv')} WHERE year = 2026 ORDER BY id"
+    )
+    assert result == "20261\n20262\n20263\n"
+    assert events == (3, 3, 3, 2)

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -3792,3 +3792,116 @@ def test_row_policy_over_csv(started_cluster):
     finally:
         run_query(instance, "DROP ROW POLICY test_row_policy_csv_p ON test_row_policy_csv")
         run_query(instance, "DROP TABLE test_row_policy_csv")
+
+
+def get_listing_profile_events(instance, query_id):
+    instance.query("SYSTEM FLUSH LOGS")
+    result = instance.query(
+        f"""
+        SELECT
+            ProfileEvents['ObjectStorageListedObjects'],
+            ProfileEvents['ObjectStorageReadObjects'],
+            ProfileEvents['ObjectStorageListedCommonPrefixes'],
+            ProfileEvents['ObjectStorageHivePartitionPrunedPrefixes']
+        FROM system.query_log
+        WHERE query_id = '{query_id}' AND type = 'QueryFinish'
+        ORDER BY event_time_microseconds DESC
+        LIMIT 1
+        """
+    )
+    return [int(value) for value in result.strip().split("\t")]
+
+
+def test_hive_partition_pruning_during_listing(started_cluster):
+    bucket = started_cluster.minio_bucket
+    instance = started_cluster.instances["dummy"]
+    prefix = f"test_hive_partition_pruning_during_listing_{generate_random_string()}"
+    url_prefix = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{prefix}"
+    structure = "id UInt64, year UInt16, country String"
+
+    countries = ["DE", "FR", "US"]
+    for year in (2024, 2025, 2026):
+        for idx, country in enumerate(countries, start=1):
+            run_query(
+                instance,
+                f"INSERT INTO FUNCTION s3('{url_prefix}/year={year}/country={country}/data.parquet', 'minio', '{minio_secret_key}', 'Parquet', 'id UInt64') "
+                f"SELECT toUInt64({year} * 10 + {idx}) SETTINGS s3_truncate_on_insert = 1",
+            )
+
+    globbed = f"s3('{url_prefix}/year=*/country=*/*.parquet', 'minio', '{minio_secret_key}', 'Parquet', '{structure}')"
+
+    def run(query, **settings):
+        query_id = f"hive_pruning_{uuid.uuid4()}"
+        result = run_query(
+            instance,
+            query,
+            query_id=query_id,
+            settings={"use_hive_partitioning": 1, "log_queries": 1, **settings},
+        )
+        return result, get_listing_profile_events(instance, query_id)
+
+    # Both partition levels are constrained: the year level lists 3 directories and keeps 1,
+    # the country level lists 3 directories below it and keeps 1, so a single object is listed.
+    result, (listed, read, directories, pruned) = run(
+        f"SELECT id FROM {globbed} WHERE year = 2025 AND country = 'FR'"
+    )
+    assert result == "20252\n"
+    assert (listed, read, directories, pruned) == (1, 1, 6, 4)
+
+    # Without the optimization every object under the common prefix is listed and filtered afterwards.
+    result, (listed, read, directories, pruned) = run(
+        f"SELECT id FROM {globbed} WHERE year = 2025 AND country = 'FR'",
+        use_hive_partition_pruning_during_listing=0,
+    )
+    assert result == "20252\n"
+    assert (listed, read, directories, pruned) == (9, 1, 0, 0)
+
+    # A range and an IN condition on different levels.
+    result, (listed, read, directories, pruned) = run(
+        f"SELECT id FROM {globbed} WHERE year >= 2025 AND country IN ('DE', 'US') ORDER BY id"
+    )
+    assert result == "20251\n20253\n20261\n20263\n"
+    assert (listed, read, directories, pruned) == (4, 4, 9, 3)
+
+    # Nothing matches: no object is listed at all.
+    result, (listed, read, directories, pruned) = run(
+        f"SELECT count() FROM {globbed} WHERE year = 1999"
+    )
+    assert result == "0\n"
+    assert (listed, read, directories, pruned) == (0, 0, 3, 3)
+
+    # The prefix limit bounds the enumeration: 3 year directories exceed the limit of 2,
+    # so the common prefix is listed as a whole and the result is still correct.
+    result, (listed, read, directories, pruned) = run(
+        f"SELECT id FROM {globbed} WHERE country = 'US' ORDER BY id",
+        hive_partition_pruning_during_listing_max_prefixes=2,
+    )
+    assert result == "20243\n20253\n20263\n"
+    assert (listed, read, directories, pruned) == (9, 3, 3, 0)
+
+    # `**` spans levels and stops the enumeration; the levels before it are still pruned.
+    result, (listed, read, directories, pruned) = run(
+        f"SELECT id FROM s3('{url_prefix}/year=*/**.parquet', 'minio', '{minio_secret_key}', 'Parquet', '{structure}') WHERE year = 2026 ORDER BY id"
+    )
+    assert result == "20261\n20262\n20263\n"
+    assert (listed, read, directories, pruned) == (3, 3, 3, 2)
+
+    # The table engine and the cluster function go through the same iterator.
+    table_name = f"{prefix}_table"
+    run_query(
+        instance,
+        f"CREATE TABLE {table_name} ({structure}) ENGINE = S3('{url_prefix}/year=*/country=*/*.parquet', 'minio', '{minio_secret_key}', 'Parquet')",
+    )
+    try:
+        result, (listed, read, directories, pruned) = run(
+            f"SELECT id FROM {table_name} WHERE year = 2024 AND country IN ('DE', 'FR') ORDER BY id"
+        )
+        assert result == "20241\n20242\n"
+        assert (listed, read, directories, pruned) == (2, 2, 6, 3)
+    finally:
+        run_query(instance, f"DROP TABLE {table_name}")
+
+    result, _ = run(
+        f"SELECT id FROM s3Cluster(cluster, '{url_prefix}/year=*/country=*/*.parquet', 'minio', '{minio_secret_key}', 'Parquet', '{structure}') WHERE year = 2025 AND country = 'FR' ORDER BY id"
+    )
+    assert result == "20252\n"

--- a/tests/queries/0_stateless/05141_hive_partition_pruning_during_listing.reference
+++ b/tests/queries/0_stateless/05141_hive_partition_pruning_during_listing.reference
@@ -1,0 +1,47 @@
+-- both_levels
+20252
+1	1	6	4
+-- disabled
+20252
+9	1	0	0
+-- range_and_in
+20251
+20253
+20261
+20263
+4	4	9	3
+-- second_level_only
+20243
+20253
+20263
+3	3	12	6
+-- no_matching_partition
+0
+0	0	3	3
+-- condition_on_file_column_and_virtual_column
+20252
+20253
+3	3	6	2
+-- or_condition
+20241
+20263
+2	2
+-- max_prefixes_fallback
+20243
+20253
+20263
+9	3	3	0
+-- literal_first_level
+20242
+1	1	3	2
+-- partial_literal_in_glob
+20261
+1	1	6	4
+-- double_star_only
+20252
+9	1	0	0
+-- level_before_double_star
+20261
+20262
+20263
+3	3	3	2

--- a/tests/queries/0_stateless/05141_hive_partition_pruning_during_listing.sh
+++ b/tests/queries/0_stateless/05141_hive_partition_pruning_during_listing.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel-replicas
+# Tag no-fasttest: requires S3 storage
+# Tag no-parallel-replicas: relies on query_log which does not account other replicas
+
+# Hive-style partitioned directories are pruned while listing: every `name=value` level covered by the glob is
+# enumerated with delimiter listing and the directories that cannot satisfy the condition are never listed.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+url_prefix="http://localhost:11111/test/${CLICKHOUSE_DATABASE}/05141_hive"
+structure="id UInt64, year UInt16, country String"
+
+idx=0
+for year in 2024 2025 2026; do
+    idx=0
+    for country in DE FR US; do
+        idx=$((idx + 1))
+        $CLICKHOUSE_CLIENT -q "INSERT INTO FUNCTION s3('${url_prefix}/year=${year}/country=${country}/data.parquet', 'test', 'testtest', 'Parquet', 'id UInt64') SELECT toUInt64(${year} * 10 + ${idx}) SETTINGS s3_truncate_on_insert = 1"
+    done
+done
+
+# $1 - case name, $2 - query, $3 - extra settings, $4 - whether to print the directory listing counters
+function run_case()
+{
+    local query_id="05141_${1}_${CLICKHOUSE_DATABASE}_$RANDOM$RANDOM"
+    echo "-- $1"
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "$2 SETTINGS use_hive_partitioning = 1, log_queries = 1${3}"
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+    if [ "$4" = "1" ]; then
+        columns="ProfileEvents['ObjectStorageListedObjects'] AS listed_objects, ProfileEvents['ObjectStorageReadObjects'] AS read_objects, ProfileEvents['ObjectStorageListedCommonPrefixes'] AS listed_directories, ProfileEvents['ObjectStorageHivePartitionPrunedPrefixes'] AS pruned_directories"
+    else
+        columns="ProfileEvents['ObjectStorageListedObjects'] AS listed_objects, ProfileEvents['ObjectStorageReadObjects'] AS read_objects"
+    fi
+    $CLICKHOUSE_CLIENT -q "
+SELECT ${columns}
+FROM system.query_log
+WHERE current_database = currentDatabase() AND query_id = '$query_id' AND type = 'QueryFinish' AND event_date >= yesterday()
+ORDER BY event_time_microseconds DESC
+LIMIT 1"
+}
+
+globbed="s3('${url_prefix}/year=*/country=*/*.parquet', 'test', 'testtest', 'Parquet', '${structure}')"
+
+run_case both_levels "SELECT id FROM ${globbed} WHERE year = 2025 AND country = 'FR' ORDER BY id" "" 1
+run_case disabled "SELECT id FROM ${globbed} WHERE year = 2025 AND country = 'FR' ORDER BY id" ", use_hive_partition_pruning_during_listing = 0" 1
+run_case range_and_in "SELECT id FROM ${globbed} WHERE year >= 2025 AND country IN ('DE', 'US') ORDER BY id" "" 1
+run_case second_level_only "SELECT id FROM ${globbed} WHERE country = 'US' ORDER BY id" "" 1
+run_case no_matching_partition "SELECT count() FROM ${globbed} WHERE year = 1999" "" 1
+run_case condition_on_file_column_and_virtual_column "SELECT id FROM ${globbed} WHERE year = 2025 AND id > 20251 AND _file = 'data.parquet' ORDER BY id" "" 1
+run_case or_condition "SELECT id FROM ${globbed} WHERE (year = 2024 AND country = 'DE') OR (year = 2026 AND country = 'US') ORDER BY id" "" 0
+run_case max_prefixes_fallback "SELECT id FROM ${globbed} WHERE country = 'US' ORDER BY id" ", hive_partition_pruning_during_listing_max_prefixes = 2" 1
+run_case literal_first_level "SELECT id FROM s3('${url_prefix}/year=2024/country=*/*.parquet', 'test', 'testtest', 'Parquet', '${structure}') WHERE country = 'FR' ORDER BY id" "" 1
+run_case partial_literal_in_glob "SELECT id FROM s3('${url_prefix}/year=202*/country=*/*.parquet', 'test', 'testtest', 'Parquet', '${structure}') WHERE year = 2026 AND country = 'DE' ORDER BY id" "" 1
+run_case double_star_only "SELECT id FROM s3('${url_prefix}/**.parquet', 'test', 'testtest', 'Parquet', '${structure}') WHERE year = 2025 AND country = 'FR' ORDER BY id" "" 1
+run_case level_before_double_star "SELECT id FROM s3('${url_prefix}/year=*/**.parquet', 'test', 'testtest', 'Parquet', '${structure}') WHERE year = 2026 ORDER BY id" "" 1


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/44246
Related: https://github.com/ClickHouse/ClickHouse/issues/23494

Reading a globbed Hive-style partitioned path such as `s3('s3://bucket/table/org=*/dt=*/*.parquet') WHERE org = 'x' AND dt = '2026-09-01'` lists every object under the common prefix `table/org=` (the path cut at the first glob character) and only then drops the keys that do not satisfy the condition. `use_hive_partitioning` does not change what is listed, it only makes the partition columns available to that post-listing filter. For a table with tens of millions of objects the listing alone takes tens of minutes and may time out, although the query needs a few hundred of them.

Both S3 and Azure Blob Storage expose a hierarchical form of the listing API (`ListObjectsV2` with `Delimiter`, `List Blobs` with a delimiter / `ListBlobsByHierarchy`) that returns the "directories" directly under a prefix without enumerating the objects beneath them. This change uses it to prune partition directories during listing:

- `IObjectStorage` gets `supportsListingCommonPrefixes` and `listCommonPrefixes`, implemented for S3 and Azure (the `CachedObjectStorage` wrapper forwards them). `ContainerClientWrapper::ListBlobsByHierarchy` strips the endpoint blob prefix like `ListBlobs` does.
- `GlobIterator` resolves the prefixes to list before listing objects. When the `WHERE` condition restricts partition columns that appear in directory-level glob segments, every such level (from the first globbed segment up to the file name segment or a `**` segment) is enumerated with `listCommonPrefixes`. At each level the partial path is matched against the glob, and the conjuncts of the condition that depend only on the partition columns known at that level (`splitFilterDagForAllowedInputs`) are evaluated on the directory path with the existing `filterByPathOrFile` machinery, so a pruned directory can never contain a matching object. Objects are then listed only below the surviving directories; the existing per-key glob and predicate filtering is unchanged and still applies to every listed key.
- The enumeration is skipped when there is no condition on any directory level (it would only add requests), when the storage does not support delimiter listing (HDFS, web), for archives, and for the `**`-only paths produced by `partition_strategy = 'hive'`. The new `hive_partition_pruning_during_listing_max_prefixes` setting (default 1000) bounds the number of directories kept at any level; above it the common prefix is listed at once as before, so the worst case adds a bounded number of requests.
- `use_hive_partition_pruning_during_listing` (default `true`) turns the optimization on and off. The new profile events `ObjectStorageListedCommonPrefixes` and `ObjectStorageHivePartitionPrunedPrefixes` show how many directories were enumerated and pruned.

For the example above, one delimiter listing of `table/org=` plus one of `table/org=x/dt=` replace the listing of the whole table, and only `table/org=x/dt=2026-09-01/` is listed for objects.

Tests: a stateless test (`05141_hive_partition_pruning_during_listing`) and integration tests for S3 (MinIO) and Azure (Azurite) check the results and, through the profile events, the exact number of listed objects and enumerated / pruned directories for conditions on both levels, on the second level only, ranges and `IN`, a non-matching partition, conditions mixed with file columns and `_file`, `OR` conditions, literal and partial-literal segments, `**`, the table engine, `s3Cluster`, the `max_prefixes` fallback and the setting turned off.

A possible follow-up is to issue the per-directory listing requests of one level in parallel; this change keeps them sequential.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prune Hive-style partitioned directories (`/name=value/`) during listing in the `s3` and `azureBlobStorage` table functions and engines: when the `WHERE` condition restricts partition columns, the directory levels of a globbed path are enumerated with the delimiter form of the listing API and non-matching partitions are skipped without listing the objects beneath them, instead of listing every object under the common prefix and filtering afterwards. Controlled by the new settings `use_hive_partition_pruning_during_listing` and `hive_partition_pruning_during_listing_max_prefixes`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118865&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118865](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118865+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
