### PR TITLE
Docs: show a GCP example for clickhousectl cloud postgres create

### DIFF
--- a/docs/concepts/features/interfaces/cli.mdx
+++ b/docs/concepts/features/interfaces/cli.mdx
@@ -456,13 +456,21 @@ clickhousectl cloud postgres list
 clickhousectl cloud postgres list --filter state=running
 clickhousectl cloud postgres get <pg-id>
 
-# Create a service
+# Create a service on AWS (the default provider)
 clickhousectl cloud postgres create \
   --name my-pg \
   --region us-east-1 \
   --size m7i.2xlarge \
   --pg-version 17 \
   --ha-type sync
+
+# Create a service on GCP (private preview); region and size use GCP names
+clickhousectl cloud postgres create \
+  --name my-pg \
+  --provider gcp \
+  --region us-central1 \
+  --size c4a-standard-4 \
+  --pg-version 18
 
 # Update and delete
 clickhousectl cloud postgres update <pg-id> --size m7i.4xlarge
@@ -496,9 +504,9 @@ clickhousectl cloud postgres restore <pg-id> --name restored --restore-target 20
 | Option | Description |
 |--------|-------------|
 | `--name` | Service name (required) |
-| `--region` | Region, e.g. `us-east-1` (required) |
-| `--size` | Instance size, e.g. `m7i.2xlarge` (required) |
-| `--provider` | Cloud provider (default: `aws`) |
+| `--region` | Region, e.g. `us-east-1` on AWS or `us-central1` on GCP (required) |
+| `--size` | Instance size, e.g. `m7i.2xlarge` on AWS or `c4a-standard-4` on GCP (required) |
+| `--provider` | Cloud provider: `aws`, `gcp` (default: `aws`) |
 | `--pg-version` | Major version: `18`, `17` |
 | `--ha-type` | High availability: `none`, `async`, `sync` |
 | `--tag` | Resource tag `key` or `key=value` (repeatable) |

--- a/docs/concepts/features/interfaces/cli.mdx
+++ b/docs/concepts/features/interfaces/cli.mdx
@@ -448,7 +448,7 @@ clickhousectl cloud service backup-config update <service-id> \
 
 ### Postgres services {#postgres-services}
 
-`clickhousectl` can also create and manage [ClickHouse Cloud Postgres](/products/managed-postgres/overview) services, mirroring the ClickHouse service commands above.
+`clickhousectl` can also create and manage [ClickHouse Cloud Postgres](/products/managed-postgres/overview) services, mirroring the ClickHouse service commands above. GCP is in [private preview](https://clickhouse.com/cloud/postgres#gcp-waitlist); pass `--provider gcp` with a GCP region and instance size.
 
 ```bash
 # List and inspect
@@ -469,7 +469,7 @@ clickhousectl cloud postgres create \
   --name my-pg \
   --provider gcp \
   --region us-central1 \
-  --size c4a-standard-4 \
+  --size c4-standard-4 \
   --pg-version 18
 
 # Update and delete
@@ -505,7 +505,7 @@ clickhousectl cloud postgres restore <pg-id> --name restored --restore-target 20
 |--------|-------------|
 | `--name` | Service name (required) |
 | `--region` | Region, e.g. `us-east-1` on AWS or `us-central1` on GCP (required) |
-| `--size` | Instance size, e.g. `m7i.2xlarge` on AWS or `c4a-standard-4` on GCP (required) |
+| `--size` | Instance size, e.g. `m7i.2xlarge` on AWS or `c4-standard-4` on GCP (required) |
 | `--provider` | Cloud provider: `aws`, `gcp` (default: `aws`) |
 | `--pg-version` | Major version: `18`, `17` |
 | `--ha-type` | High availability: `none`, `async`, `sync` |


### PR DESCRIPTION
Related: https://github.com/ClickHouse/clickhousectl/pull/799

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Summary

ClickHouse Managed Postgres is entering private preview on GCP. The `clickhousectl` page only showed an AWS `cloud postgres create` example, and its options table did not name the accepted providers.

- Add a GCP create example (`--provider gcp`, GCP region and instance size) beside the AWS one.
- List the accepted providers (`aws`, `gcp`) and GCP-style region and size examples in the create options table.
- Link the GCP private preview waitlist from the Postgres services intro.

The CLI has accepted `--provider gcp` since v0.4.2; this mirrors the README change in clickhousectl PR #799.

### Verification

The example command was run as written on 2026-09-08 with the released `clickhousectl 0.4.2` against an organization enabled on the GCP preview. The `c4-standard-4` service reached `running` in about 8 minutes on a `*.us-central1.gcp.pg.clickhouse.cloud` hostname, and `psql` connected and returned PostgreSQL 18.6 on x86_64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118881&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118881](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118881+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1058` (included in `26.9` and later)
<!-- ch-version-info:end -->