### PR TITLE
Allow trivial count optimization with value-only patches

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -698,6 +698,20 @@ void MergeTreeData::MutationsSnapshotBase::addPatches(DataPartsVector patches_)
     params.need_patch_parts = true;
 }
 
+bool MergeTreeData::MutationsSnapshotBase::hasLightweightDeletedMask() const
+{
+    if (params.has_lightweight_delete_parts)
+        return true;
+
+    return std::ranges::any_of(patches_by_partition, [](const auto & partition)
+    {
+        return std::ranges::any_of(partition.second, [](const auto & patch)
+        {
+            return patch->hasLightweightDelete();
+        });
+    });
+}
+
 NameSet MergeTreeData::MutationsSnapshotBase::getColumnsUpdatedInPatches() const
 {
     if (!params.need_patch_parts)
@@ -13407,7 +13421,7 @@ bool MergeTreeData::supportsTrivialCountOptimization(const StorageSnapshotPtr & 
     if (!mutations_snapshot)
         return supports_trivial_count();
 
-    return !mutations_snapshot->hasDataMutations() && !mutations_snapshot->hasPatchParts() && !mutations_snapshot->hasLightweightDeletedMask();
+    return !mutations_snapshot->hasDataMutations() && !mutations_snapshot->hasLightweightDeletedMask();
 }
 
 MergeTreeData::PartsSnapshotInfo MergeTreeData::getPartsSnapshotInfo(const DataPartsVector & parts)

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -652,7 +652,7 @@ public:
         bool hasAlterMutations() const final { return counters.num_alter > 0; }
         bool hasMetadataMutations() const final { return counters.num_metadata > 0; }
         bool hasAnyMutations() const { return hasDataMutations() || hasAlterMutations() || hasMetadataMutations(); }
-        bool hasLightweightDeletedMask() const final { return params.has_lightweight_delete_parts; }
+        bool hasLightweightDeletedMask() const final;
 
     protected:
         NameSet getColumnsUpdatedInPatches() const;

--- a/tests/queries/0_stateless/05142_lwu_trivial_count.reference
+++ b/tests/queries/0_stateless/05142_lwu_trivial_count.reference
@@ -1,0 +1,19 @@
+--- V2: value-only patches ---
+1000
+1
+990
+10
+--- V2: pending delete patches ---
+1	1
+980
+0
+1000
+970
+--- V1: value-only patches ---
+1
+--- V1: pending delete patches ---
+990
+0
+--- FINAL: value-only patches ---
+1000
+500

--- a/tests/queries/0_stateless/05142_lwu_trivial_count.sql
+++ b/tests/queries/0_stateless/05142_lwu_trivial_count.sql
@@ -1,0 +1,123 @@
+SET enable_lightweight_update = 1, apply_patch_parts = 1, optimize_trivial_count_query = 1;
+-- Exercise trivial count eligibility without using explicit or implicit projections.
+SET optimize_use_projections = 0, optimize_use_implicit_projections = 0;
+
+SELECT '--- V2: value-only patches ---';
+
+DROP TABLE IF EXISTS t_lwu_trivial_count;
+CREATE TABLE t_lwu_trivial_count
+(
+    id UInt64,
+    v Nullable(UInt64)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS enable_block_number_column = 1,
+    enable_block_offset_column = 1,
+    patch_parts_version = 'v2';
+
+-- Keep the patches pending so the queries exercise patch application during reads.
+SYSTEM STOP MERGES t_lwu_trivial_count;
+INSERT INTO t_lwu_trivial_count SELECT number, number FROM numbers(1000);
+UPDATE t_lwu_trivial_count SET v = NULL WHERE id < 10;
+
+-- Changing values preserves all 1000 rows and allows a metadata-only count.
+SELECT count() FROM t_lwu_trivial_count;
+
+SELECT countIf(explain LIKE '%Optimized trivial count%')
+FROM (EXPLAIN SELECT count() FROM t_lwu_trivial_count);
+
+-- Counting non-null values must apply the patch: ten values became `NULL`.
+SELECT count(v) FROM t_lwu_trivial_count;
+
+-- A filtered count must also see the ten patched values.
+SELECT count() FROM t_lwu_trivial_count WHERE isNull(v);
+
+SELECT '--- V2: pending delete patches ---';
+
+-- Delete twenty rows through a patch, leaving the base parts without a delete mask.
+DELETE FROM t_lwu_trivial_count WHERE id >= 980
+SETTINGS lightweight_delete_mode = 'lightweight_update_force';
+
+-- Verify that the delete mask exists only in patch parts.
+SELECT countIf(has_lightweight_delete AND startsWith(name, 'patch')) > 0,
+    countIf(has_lightweight_delete AND NOT startsWith(name, 'patch')) = 0
+FROM system.parts
+WHERE database = currentDatabase() AND table = 't_lwu_trivial_count' AND active;
+
+-- The pending delete reduces the count to 980 and prevents the metadata-only plan.
+SELECT count() FROM t_lwu_trivial_count;
+
+SELECT countIf(explain LIKE '%Optimized trivial count%')
+FROM (EXPLAIN SELECT count() FROM t_lwu_trivial_count);
+
+-- Ignoring patches exposes all 1000 original rows.
+SELECT count() FROM t_lwu_trivial_count SETTINGS apply_patch_parts = 0;
+
+-- Applying both patches leaves 970 non-null values: 1000 minus 20 deleted and 10 null rows.
+SELECT count(v) FROM t_lwu_trivial_count;
+
+DROP TABLE t_lwu_trivial_count;
+
+SELECT '--- V1: value-only patches ---';
+
+-- Legacy value-only patches must also allow a metadata-only count.
+CREATE TABLE t_lwu_trivial_count
+(
+    id UInt64,
+    v UInt64
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS enable_block_number_column = 1,
+    enable_block_offset_column = 1,
+    patch_parts_version = 'v1';
+
+SYSTEM STOP MERGES t_lwu_trivial_count;
+INSERT INTO t_lwu_trivial_count SELECT number, number FROM numbers(1000);
+UPDATE t_lwu_trivial_count SET v = v + 1 WHERE 1;
+
+SELECT countIf(explain LIKE '%Optimized trivial count%')
+FROM (EXPLAIN SELECT count() FROM t_lwu_trivial_count);
+
+SELECT '--- V1: pending delete patches ---';
+
+-- A legacy delete patch must reduce the count to 990 and disable the optimization.
+DELETE FROM t_lwu_trivial_count WHERE id < 10
+SETTINGS lightweight_delete_mode = 'lightweight_update_force';
+
+SELECT count() FROM t_lwu_trivial_count;
+
+SELECT countIf(explain LIKE '%Optimized trivial count%')
+FROM (EXPLAIN SELECT count() FROM t_lwu_trivial_count);
+
+DROP TABLE t_lwu_trivial_count;
+
+SELECT '--- FINAL: value-only patches ---';
+
+-- `FINAL` must still deduplicate rows when patches only change values.
+CREATE TABLE t_lwu_trivial_count
+(
+    id UInt64,
+    v UInt64,
+    version UInt64
+)
+ENGINE = ReplacingMergeTree(version)
+ORDER BY id
+SETTINGS enable_block_number_column = 1,
+    enable_block_offset_column = 1,
+    patch_parts_version = 'v2';
+
+SYSTEM STOP MERGES t_lwu_trivial_count;
+
+-- Insert two parts containing different versions of the same 500 keys.
+INSERT INTO t_lwu_trivial_count SELECT number, number, number FROM numbers(500);
+INSERT INTO t_lwu_trivial_count SELECT number, number + 500, number + 500 FROM numbers(500);
+UPDATE t_lwu_trivial_count SET v = 0 WHERE id < 10;
+
+-- A plain count sees 1000 rows; `FINAL` keeps only the latest version of each key.
+SELECT count() FROM t_lwu_trivial_count;
+
+SELECT count() FROM t_lwu_trivial_count FINAL;
+
+DROP TABLE t_lwu_trivial_count;


### PR DESCRIPTION
An otherwise eligible `SELECT count() FROM t` loses trivial count optimization whenever the table has patch parts, even when they only change values. This can make a row count read and apply patches unnecessarily.

Allow metadata-only counting with value-only patches. Check pending patch parts as well as base parts for lightweight-delete masks, so delete patches prevent the optimization even before they are materialized.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118605
Related: https://github.com/ClickHouse/clickhouse-private/issues/73146
Related: https://github.com/ClickHouse/ClickHouse/pull/103182

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow trivial count optimization for tables with lightweight-update patches that only change values, avoiding unnecessary table and patch reads for otherwise eligible row-count queries.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118882&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118882](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118882+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1405` (included in `26.9` and later)
<!-- ch-version-info:end -->