### PR TITLE
Docs: correct workload scheduling resource examples

### DIFF
--- a/docs/concepts/features/configuration/server-config/workload-scheduling.mdx
+++ b/docs/concepts/features/configuration/server-config/workload-scheduling.mdx
@@ -35,8 +35,8 @@ To enable IO scheduling for a specific disk, you have to create read and write r
 ```sql
 CREATE RESOURCE resource_name (WRITE DISK disk_name, READ DISK disk_name)
 -- or
-CREATE RESOURCE read_resource_name (WRITE DISK write_disk_name)
-CREATE RESOURCE write_resource_name (READ DISK read_disk_name)
+CREATE RESOURCE read_resource_name (READ DISK read_disk_name)
+CREATE RESOURCE write_resource_name (WRITE DISK write_disk_name)
 ```
 
 A resource can be used for any number of disks for READ or WRITE or both for READ and WRITE. There is a syntax allowing to use a resource for all the disks:


### PR DESCRIPTION
Correct the workload scheduling example so `read_resource_name` uses `READ DISK read_disk_name` and `write_resource_name` uses `WRITE DISK write_disk_name`. The previous SQL was valid, but the resource names described the opposite operations.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Correct the read and write resource examples in the workload scheduling documentation.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118884&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118884](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118884+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1008` (included in `26.9` and later)
<!-- ch-version-info:end -->