### PR TITLE
Bump `minizip-ng` from 4.0.9 to 4.2.2

### DIFF
--- a/contrib/minizip-ng-cmake/CMakeLists.txt
+++ b/contrib/minizip-ng-cmake/CMakeLists.txt
@@ -28,9 +28,12 @@ set(MINIZIP_HDR
     ${_MINIZIP_SOURCE_DIR}/mz_strm_split.h
     ${_MINIZIP_SOURCE_DIR}/mz_strm_os.h
     ${_MINIZIP_SOURCE_DIR}/mz_zip.h
-    ${_MINIZIP_SOURCE_DIR}/mz_zip_rw.h)
+    ${_MINIZIP_SOURCE_DIR}/mz_zip_rw.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mz_config.h)
 
-set(MINIZIP_INC ${_MINIZIP_SOURCE_DIR})
+# `mz.h`, `mz_os.h` and `mz_strm_os_posix.c` include `mz_config.h`, which upstream generates with
+# CMake feature checks. ClickHouse ships a hardcoded copy of it in this directory instead.
+set(MINIZIP_INC ${_MINIZIP_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(MINIZIP_DEF)
 set(MINIZIP_PUBLIC_DEF)

--- a/contrib/minizip-ng-cmake/mz_config.h
+++ b/contrib/minizip-ng-cmake/mz_config.h
@@ -1,0 +1,38 @@
+/* ClickHouse-specific replacement for the `mz_config.h` header that upstream
+ * `minizip-ng` generates from `mz_config.h.cmakein` with compiler and system
+ * checks. ClickHouse builds are hermetic and cross-compiled, so the CMake
+ * `Check*` modules are forbidden and the values are hardcoded instead.
+ *
+ * All platforms ClickHouse targets (Linux with glibc or musl, macOS, FreeBSD)
+ * are POSIX systems providing `dirent.h`, `inttypes.h`, `stdint.h`, `DIR`,
+ * `fseeko`, `symlink` and `readlink`.
+ */
+
+#ifndef MZ_CONFIG_H
+#define MZ_CONFIG_H
+
+// Define to 1 if you have the <dirent.h> header file.
+#define HAVE_DIRENT_H 1
+
+// Define to 1 if you have the <sys/dirent.h> header file.
+#define HAVE_SYS_DIRENT_H 0
+
+// Define to 1 if you have the <inttypes.h> header file.
+#define HAVE_INTTYPES_H 1
+
+// Define to 1 if you have the <stdint.h> header file.
+#define HAVE_STDINT_H 1
+
+// Define to 1 if DIR* is defined.
+#define HAVE_PDIR 1
+
+// Define to 1 if fseeko() is defined.
+#define HAVE_FSEEKO 1
+
+// Define to 1 if symlink() is defined.
+#define HAVE_SYMLINK 1
+
+// Define to 1 if readlink() is defined.
+#define HAVE_READLINK 1
+
+#endif


### PR DESCRIPTION
Bumps `minizip-ng` from 4.0.9 to 4.2.2, staying on upstream `https://github.com/zlib-ng/minizip-ng` — no fork is needed, all adaptation fits in `contrib/minizip-ng-cmake/`.

The notable upstream change is that `mz.h`, `mz_os.h` and `mz_strm_os_posix.c` now include `mz_config.h`, which upstream generates from `mz_config.h.cmakein` using `check_include_file`, `check_type_size` and `check_function_exists`. Those CMake modules are not allowed in ClickHouse, so the header is hardcoded as `contrib/minizip-ng-cmake/mz_config.h` with values for the POSIX platforms we target (Linux glibc and musl, macOS, FreeBSD): `HAVE_DIRENT_H 1`, `HAVE_SYS_DIRENT_H 0`, `HAVE_INTTYPES_H 1`, `HAVE_STDINT_H 1`, `HAVE_PDIR 1`, `HAVE_FSEEKO 1`, `HAVE_SYMLINK 1`, `HAVE_READLINK 1`. Defining them to explicit `0`/`1` matters, because the checks changed from `#if defined(X)` to `#if X` for `HAVE_STDINT_H` and `HAVE_INTTYPES_H`, and the new macros are value-tested as well. `${CMAKE_CURRENT_SOURCE_DIR}` was added to `MINIZIP_INC`, which is applied as a `PUBLIC` include of `_minizip`, so the header is found both while building the library and where `src/IO/Archives` includes `unzip.h`/`zip.h`.

Upstream also added a PPMD compression method (`mz_strm_ppmd.c`, `MZ_COMPRESS_METHOD_PPMD`), which it enables by cloning `github.com/ip7z/7zip` at configure time. That is not vendored here, so the sources are not added and `HAVE_PPMD` is left undefined — everything guarding PPMD in `mz_zip.c` is behind `#if defined(HAVE_PPMD)`. PPMD-compressed entries therefore remain unsupported, same as in 4.0.9. The remaining public API changes are additive or `const`-only (`unzGetCurrentFileZStreamPos64`, `mz_zip_writer_get_follow_links`, `MZ_OPEN_MODE_NOFOLLOW`, `const` on the buffer parameters of `mz_zip_reader_open_buffer` and `mz_zip_writer_add_buffer`), so nothing in `src/` needed changes, and no dependency co-bumps were required — `zlib-ng`, `bzip2`, `xz`, `zstd` and OpenSSL are all consumed through existing `ch_contrib::` targets.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `minizip-ng` to 4.2.2.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118886&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118886](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118886+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1174` (included in `26.9` and later)
<!-- ch-version-info:end -->