### PR TITLE
Bump `openldap` from OPENLDAP_REL_ENG_2_6_10 to OPENLDAP_REL_ENG_2_6_14

### DIFF
--- a/contrib/openldap-cmake/CMakeLists.txt
+++ b/contrib/openldap-cmake/CMakeLists.txt
@@ -34,7 +34,7 @@ set(OPENLDAP_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/openldap")
 # How these lists were generated?
 # I compiled the original OpenLDAP with it's original build system and copied the list of source files from build commands.
 
-set(OPENLDAP_VERSION_STRING "2.5.X")
+set(OPENLDAP_VERSION_STRING "2.6.14")
 
 macro(mkversion _lib_name)
     add_custom_command(


### PR DESCRIPTION
Bumps `openldap` from `OPENLDAP_REL_ENG_2_6_10` to `OPENLDAP_REL_ENG_2_6_14` (2026-08-06), the newest tag on the 2.6 release line. ClickHouse builds only the client-side `libldap` and `liblber`, so most of the upstream diff (slapd, lloadd, overlays, tests) does not apply.

What matters in the built subtree: a heap buffer overflow in `parse_whsp` and general LDIF parsing hardening in `ldif.c`, `getdn.c` and `schema.c` — empty types are rejected, parsing stops at nul-leading lines and no longer scrolls past nul bytes (ITS#10429, ITS#10430, ITS#10431); a potential NULL dereference in `ber_bvreplace_x` in `memory.c` (ITS#10438); support for the OpenSSL 4.0 series (ITS#10498), where `tls_o.c` gains `const` qualifiers on `X509_NAME`, `X509_NAME_ENTRY` and `ASN1_STRING` and reads string contents through `ASN1_STRING_get0_data` and `ASN1_STRING_length` instead of touching `->data` and `->length` directly, with wildcard-CN matching rewritten around that; and a teardown leak fix, `ldap_int_tls_destroy` now frees the `randfile`, `cacert`, `cert` and `key` options. The rest is copyright-year churn.

On the ClickHouse side only the submodule pointer and `OPENLDAP_VERSION_STRING` in `contrib/openldap-cmake/CMakeLists.txt` changed; the latter was still `2.5.X`, left over from the 2.5.16 -> 2.6.10 bump, and is now `2.6.14`. It is passed to `build/mkversion` and baked into the `__Version[]` string of the built libraries. No source files were added, removed or renamed, and `SRCS` in `libraries/liblber/Makefile.in` and `libraries/libldap/Makefile.in` is byte-identical to 2.6.10, so the CMake file lists are unchanged. `include/portable.hin`, `include/ldap_features.hin` and `include/lber_types.hin` differ only in the copyright line, so the pre-generated per-platform headers under `contrib/openldap-cmake/<os>_<arch>/include/` needed no regeneration. Nothing under `src/` required adaptation: no ClickHouse code reads `LDAP_VENDOR_VERSION` or `LDAP_API_VERSION`, and no `libldap` API used by ClickHouse changed signature. The submodule URL already points at upstream `https://github.com/openldap/openldap` unpatched, so no fork branch is needed and `.gitmodules` is untouched.

Two pre-existing issues are worth noting but are deliberately out of scope here. The committed per-platform `ldap_features.h` files still report a stale `LDAP_VENDOR_VERSION` (`20501` on most platforms, `000000` on `linux_s390x`) although the submodule is now at API version `20614`; these are autoconf output that no recent bump has refreshed, nothing in ClickHouse reads them, and regenerating all nine platform directories belongs in a separate change. Separately, `libraries/libldap/account_usability.c` is in upstream `SRCS` but missing from the ClickHouse source list; it is unchanged in 2.6.14 and the build and link succeed without it, so it only matters if ClickHouse ever calls `ldap_parse_account_usability_control`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `openldap` to 2.6.14.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118888&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118888](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118888+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
