### PR TITLE
Bump `abseil-cpp` from 20260526.0 to 20260817.0

### DIFF
--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -108,6 +108,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
+    absl::hardening
     absl::algorithm
     absl::core_headers
     absl::meta
@@ -132,11 +133,40 @@ absl_cc_library(
 # Internal-only target, do not depend on directly.
 absl_cc_library(
   NAME
+    base_cpu_detect
+  HDRS
+    "${DIR}/internal/cpu_detect.h"
+  SRCS
+    "${DIR}/internal/cpu_detect.cc"
+  DEPS
+    absl::base
+    absl::config
+  COPTS
+    ${ABSL_DEFAULT_COPTS}
+)
+
+# Internal-only target, do not depend on directly.
+absl_cc_library(
+  NAME
     errno_saver
   HDRS
     "${DIR}/internal/errno_saver.h"
   DEPS
     absl::config
+  COPTS
+    ${ABSL_DEFAULT_COPTS}
+)
+
+absl_cc_library(
+  NAME
+    hardening
+  HDRS
+    "${DIR}/internal/hardening.h"
+  SRCS
+    "${DIR}/internal/hardening.cc"
+  DEPS
+    absl::config
+    absl::core_headers
   COPTS
     ${ABSL_DEFAULT_COPTS}
 )
@@ -450,6 +480,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
+    absl::hardening
     absl::base_internal
     absl::core_headers
     absl::utility
@@ -466,6 +497,7 @@ absl_cc_library(
   DEPS
     absl::cleanup_internal
     absl::config
+    absl::hardening
     absl::core_headers
   PUBLIC
 )
@@ -489,6 +521,7 @@ absl_cc_library(
     absl::compare
     absl::compressed_tuple
     absl::config
+    absl::hardening
     absl::container_common
     absl::container_memory
     absl::cord
@@ -525,6 +558,7 @@ absl_cc_library(
     absl::compressed_tuple
     absl::algorithm
     absl::config
+    absl::hardening
     absl::core_headers
     absl::dynamic_annotations
     absl::throw_delegate
@@ -544,6 +578,7 @@ absl_cc_library(
     absl::base_internal
     absl::compressed_tuple
     absl::config
+    absl::hardening
     absl::core_headers
     absl::memory
     absl::span
@@ -559,6 +594,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
+    absl::hardening
     absl::algorithm
     absl::core_headers
     absl::inlined_vector_internal
@@ -869,21 +905,6 @@ set(DIR ${ABSL_ROOT_DIR}/absl/crc)
 # Internal-only target, do not depend on directly.
 absl_cc_library(
   NAME
-    crc_cpu_detect
-  HDRS
-    "${DIR}/internal/cpu_detect.h"
-  SRCS
-    "${DIR}/internal/cpu_detect.cc"
-  COPTS
-    ${ABSL_DEFAULT_COPTS}
-  DEPS
-    absl::base
-    absl::config
-)
-
-# Internal-only target, do not depend on directly.
-absl_cc_library(
-  NAME
     crc_internal
   HDRS
     "${DIR}/internal/crc.h"
@@ -895,7 +916,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
-    absl::crc_cpu_detect
+    absl::base_cpu_detect
     absl::config
     absl::core_headers
     absl::endian
@@ -921,7 +942,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
-    absl::crc_cpu_detect
+    absl::base_cpu_detect
     absl::crc_internal
     absl::non_temporal_memcpy
     absl::config
@@ -2941,7 +2962,6 @@ absl_cc_library(
     "${DIR}/internal/memutil.h"
     "${DIR}/internal/stringify_sink.h"
     "${DIR}/internal/stringify_sink.cc"
-    "${DIR}/internal/stl_type_traits.h"
     "${DIR}/internal/str_join_internal.h"
     "${DIR}/internal/str_split_internal.h"
     "${DIR}/match.cc"
@@ -2959,6 +2979,7 @@ absl_cc_library(
     absl::bits
     absl::charset
     absl::config
+    absl::hardening
     absl::core_headers
     absl::endian
     absl::int128
@@ -3245,6 +3266,7 @@ absl_cc_library(
   DEPS
     absl::base
     absl::config
+    absl::hardening
     absl::cord_internal
     absl::cordz_functions
     absl::cordz_info
@@ -3456,6 +3478,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
+    absl::hardening
     absl::algorithm
     absl::core_headers
     absl::nullability

--- a/utils/wasm-parser/CMakeLists.txt
+++ b/utils/wasm-parser/CMakeLists.txt
@@ -110,6 +110,7 @@ set (SUPPORT_SOURCES
     "${CH}/base/base/getPageSize.cpp"
     "${CH}/base/base/IPv4andIPv6.cpp"
     "${CH}/base/base/itoa.cpp"
+    "${CH}/contrib/abseil-cpp/absl/base/throw_delegate.cc"
     "${CH}/contrib/fmtlib/src/format.cc"
     "${CH}/contrib/zmij/zmij.cc"
     "${CH}/base/poco/Foundation/src/ASCIIEncoding.cpp"


### PR DESCRIPTION
Bumps `abseil-cpp` from `20260526.0` to `20260817.0`, keeping the contrib on upstream's latest release. Upstream reorganised CPU detection and turned `hardening` into a compiled target, so our CMake amalgamation needs matching edits.

ClickHouse-side changes

- `contrib/abseil-cpp` — submodule pointer moved to tag `20260817.0`.
- `contrib/abseil-cpp-cmake/CMakeLists.txt` — the hand-maintained amalgamation of upstream's per-directory CMake files:
  - added `base_cpu_detect` (upstream moved `cpu_detect.{h,cc}` to `absl/base/internal`), removed `crc_cpu_detect`, re-pointed `crc_internal` and `crc32c` at it;
  - `hardening` is now a compiled library (`internal/hardening.cc`); added `absl::hardening` to the dependents upstream declares for it;
  - dropped the deleted `strings/internal/stl_type_traits.h` from the `strings` sources.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `abseil-cpp` to 20260817.0.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118897&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118897](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118897+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
