### PR TITLE
Escape user-controlled strings written into the `.backup` manifest

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -477,6 +477,7 @@ void BackupImpl::writeBackupMetadata()
     chassert(!params.is_internal_backup);
     checkLockFile(true);
 
+    constexpr char metadata_file[] = ".backup";
 #if CLICKHOUSE_CLOUD
     /// A Keeper session can expire while this upload is in flight. The progress fingerprint covers every
     /// input written to the manifest, so a new owner can only publish the same metadata bytes.
@@ -486,15 +487,10 @@ void BackupImpl::writeBackupMetadata()
 
     std::unique_ptr<WriteBuffer> out;
     if (use_archive)
-        out = archive_writer->writeFile(".backup");
+        out = archive_writer->writeFile(metadata_file);
     else
-        out = writer->writeFile(".backup");
+        out = writer->writeFile(metadata_file);
 
-    /// Every user-controlled string below must go through this. `<< xml <<` escapes a `std::string_view` and a
-    /// `const char *`, but a `String` operand is an exact match for the generic `operator<<` template, which
-    /// copies the bytes verbatim - converting a `String` to a `std::string_view` is a user-defined conversion,
-    /// so the escaping overload loses overload resolution and the value lands in the manifest unescaped. See
-    /// `src/IO/Operators.h`.
     auto xml_string = [](const String & str) { return std::string_view(str.data(), str.size()); };
 
     *out << "<config>";
@@ -560,8 +556,8 @@ void BackupImpl::writeBackupMetadata()
 
     if (params.is_lightweight_snapshot)
     {
-        *out << "<original_endpoint>" << original_endpoint << "</original_endpoint>";
-        *out << "<original_namespace>" << original_namespace << "</original_namespace>";
+        *out << "<original_endpoint>" << xml << xml_string(original_endpoint) << "</original_endpoint>";
+        *out << "<original_namespace>" << xml << xml_string(original_namespace) << "</original_namespace>";
     }
 
     num_files = num_all_file_infos;
@@ -579,7 +575,7 @@ void BackupImpl::writeBackupMetadata()
 
         if (!info.object_key.empty())
         {
-            *out << "<object_key>" << info.object_key << "</object_key>";
+            *out << "<object_key>" << xml << xml_string(info.object_key) << "</object_key>";
             if (original_endpoint.empty())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "In lightweight snapshot backup, the endpoint should not be empty. Do not run this command with `ON CLUSTER`");
         }

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -490,6 +490,13 @@ void BackupImpl::writeBackupMetadata()
     else
         out = writer->writeFile(".backup");
 
+    /// Every user-controlled string below must go through this. `<< xml <<` escapes a `std::string_view` and a
+    /// `const char *`, but a `String` operand is an exact match for the generic `operator<<` template, which
+    /// copies the bytes verbatim - converting a `String` to a `std::string_view` is a user-defined conversion,
+    /// so the escaping overload loses overload resolution and the value lands in the manifest unescaped. See
+    /// `src/IO/Operators.h`.
+    auto xml_string = [](const String & str) { return std::string_view(str.data(), str.size()); };
+
     *out << "<config>";
     *out << "<version>" << (params.is_lightweight_snapshot ? CURRENT_BACKUP_VERSION : INITIAL_BACKUP_VERSION) << "</version>";
     *out << "<deduplicate_files>" << params.deduplicate_files << "</deduplicate_files>";
@@ -503,7 +510,7 @@ void BackupImpl::writeBackupMetadata()
          << "</timestamp>";
     *out << "<uuid>" << toString(*uuid) << "</uuid>";
     if (!backup_id.empty())
-        *out << "<backup_id>" << xml << backup_id << "</backup_id>";
+        *out << "<backup_id>" << xml << xml_string(backup_id) << "</backup_id>";
     if (data_file_name_generator != BackupDataFileNameGeneratorType::FirstFileName)
         *out << "<data_file_name_generator>" << SettingFieldBackupDataFileNameGeneratorTypeTraits::toString(data_file_name_generator)
              << "</data_file_name_generator>";
@@ -541,7 +548,9 @@ void BackupImpl::writeBackupMetadata()
                 base_backup_can_use_this_backup_credentials = base_backup_info_with_this_backup_credentials.toString() == effective_base_backup_info.toString();
             }
 
-            *out << "<base_backup>" << xml << base_backup_info_for_metadata.toString() << "</base_backup>";
+            /// Named rather than written inline so that the `std::string_view` does not point into a temporary.
+            const String base_backup_text = base_backup_info_for_metadata.toString();
+            *out << "<base_backup>" << xml << xml_string(base_backup_text) << "</base_backup>";
             *out << "<base_backup_uuid>" << getBaseBackupUnlocked()->getUUID() << "</base_backup_uuid>";
             if (base_backup_can_use_this_backup_credentials)
                 *out << "<" << BASE_BACKUP_COPY_S3_CREDENTIALS_FROM_BACKUP << ">true</"
@@ -565,7 +574,7 @@ void BackupImpl::writeBackupMetadata()
     {
         *out << "<file>";
 
-        *out << "<name>" << xml << info.file_name << "</name>";
+        *out << "<name>" << xml << xml_string(info.file_name) << "</name>";
         *out << "<size>" << info.size << "</size>";
 
         if (!info.object_key.empty())
@@ -588,7 +597,7 @@ void BackupImpl::writeBackupMetadata()
                 }
             }
             if (!info.data_file_name.empty() && (info.data_file_name != info.file_name))
-                *out << "<data_file>" << xml << info.data_file_name << "</data_file>";
+                *out << "<data_file>" << xml << xml_string(info.data_file_name) << "</data_file>";
             if (info.encrypted_by_disk)
                 *out << "<encrypted_by_disk>true</encrypted_by_disk>";
         }

--- a/tests/queries/0_stateless/04327_backup_s3_base_credentials_metadata.sh
+++ b/tests/queries/0_stateless/04327_backup_s3_base_credentials_metadata.sh
@@ -63,6 +63,15 @@ function rewrite_backup_metadata()
     $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "INSERT INTO FUNCTION s3($(s3_location $name/.backup), 'LineAsString') SETTINGS s3_truncate_on_insert=1 FORMAT LineAsString" <<< "$content"
 }
 
+function rewrite_base_backup_in_metadata()
+{
+    local name=$1 && shift
+    local base_backup=$1 && shift
+    local content
+    content=$($CLICKHOUSE_CLIENT "${client_opts[@]}" --param_base_backup="$base_backup" -q "SELECT replaceRegexpOne(line, '<base_backup>[^<]*</base_backup>', concat('<base_backup>', {base_backup:String}, '</base_backup>')) FROM s3($(s3_location $name/.backup), 'LineAsString') FORMAT LineAsString") || return 1
+    $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "INSERT INTO FUNCTION s3($(s3_location $name/.backup), 'LineAsString') SETTINGS s3_truncate_on_insert=1 FORMAT LineAsString" <<< "$content"
+}
+
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     DROP TABLE IF EXISTS data;
     CREATE TABLE data (key Int) ENGINE=MergeTree() ORDER BY tuple();
@@ -114,7 +123,7 @@ $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "BACKUP TABLE data TO S3($(s3_location
 # Imitate old metadata with embedded credentials and no marker.
 rewrite_backup_metadata inc_6 '<base_backup_copy_s3_credentials_from_backup>true</base_backup_copy_s3_credentials_from_backup>' ''
 rewrite_backup_metadata inc_6 '<use_same_s3_credentials_for_base_backup>true</use_same_s3_credentials_for_base_backup>' ''
-rewrite_backup_metadata inc_6 "S3('$(s3_url base)')" "S3('$(s3_url base)', 'test', 'testtest')"
+rewrite_base_backup_in_metadata inc_6 "S3('$(s3_url base)', 'test', 'testtest')"
 check_base_backup_in_metadata inc_6
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "RESTORE TABLE data AS data_6 FROM S3($(s3_location inc_6))" | cut -f2
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "SELECT count() FROM data_6"

--- a/tests/queries/0_stateless/05153_backup_metadata_xml_escaping.reference
+++ b/tests/queries/0_stateless/05153_backup_metadata_xml_escaping.reference
@@ -1,0 +1,2 @@
+backup_id	6
+base_backup	10

--- a/tests/queries/0_stateless/05153_backup_metadata_xml_escaping.sh
+++ b/tests/queries/0_stateless/05153_backup_metadata_xml_escaping.sh
@@ -13,9 +13,11 @@ CREATE TABLE tbl (a Int32) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO tbl VALUES (1), (2), (3);
 "
 
-# `SETTINGS id` is written to the manifest as `<backup_id>`.
+# `SETTINGS id` is written to the manifest as `<backup_id>`. The id has to be unique across the whole server,
+# not just this database - `BackupsWorker` rejects a second backup carrying an id it has already seen, which
+# the flaky check would hit on the second run.
 backup_with_id="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_id')"
-${CLICKHOUSE_CLIENT} --query "BACKUP TABLE tbl TO ${backup_with_id} SETTINGS id = 'a&b<c>d\"e'" > /dev/null
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE tbl TO ${backup_with_id} SETTINGS id = 'a&b<c>d\"e ${CLICKHOUSE_TEST_UNIQUE_NAME}'" > /dev/null
 ${CLICKHOUSE_CLIENT} --query "RESTORE TABLE tbl AS tbl_from_id FROM ${backup_with_id}" > /dev/null
 ${CLICKHOUSE_CLIENT} --query "SELECT 'backup_id', sum(a) FROM tbl_from_id"
 

--- a/tests/queries/0_stateless/05153_backup_metadata_xml_escaping.sh
+++ b/tests/queries/0_stateless/05153_backup_metadata_xml_escaping.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# The `.backup` manifest is XML, so every user-controlled string in it has to be escaped. A value that is not
+# escaped still produces a `BACKUP_CREATED`, and the damage only shows up at restore time as a SAX parse error,
+# with no way back to the data - so each of these asserts that the backup can actually be read again.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (a Int32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tbl VALUES (1), (2), (3);
+"
+
+# `SETTINGS id` is written to the manifest as `<backup_id>`.
+backup_with_id="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_id')"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE tbl TO ${backup_with_id} SETTINGS id = 'a&b<c>d\"e'" > /dev/null
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE tbl AS tbl_from_id FROM ${backup_with_id}" > /dev/null
+${CLICKHOUSE_CLIENT} --query "SELECT 'backup_id', sum(a) FROM tbl_from_id"
+
+# The base backup's locator is written to the incremental backup's manifest as `<base_backup>`, so a `&` in the
+# base backup's path reaches the manifest of the backup that refers to it.
+base_backup="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_base&1')"
+incremental_backup="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_incremental')"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE tbl TO ${base_backup}" > /dev/null
+${CLICKHOUSE_CLIENT} --query "INSERT INTO tbl VALUES (4)"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE tbl TO ${incremental_backup} SETTINGS base_backup = ${base_backup}" > /dev/null
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE tbl AS tbl_from_incremental FROM ${incremental_backup}" > /dev/null
+${CLICKHOUSE_CLIENT} --query "SELECT 'base_backup', sum(a) FROM tbl_from_incremental"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP TABLE tbl;
+DROP TABLE tbl_from_id;
+DROP TABLE tbl_from_incremental;
+"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-private/issues/73228

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed `BACKUP` writing a `.backup` manifest that is not well-formed XML when a value in it contained `&`, `<` or `>` — for example `BACKUP ... SETTINGS id = 'a&b'`, or an incremental backup whose `base_backup` path contained one of those characters. The backup reported `BACKUP_CREATED` but every later `RESTORE` from it failed with `SAXParseException: Invalid token`, leaving the data unreachable. Such values are now escaped. Backups already written with an unescaped value remain unreadable and have to be taken again.

### Description

Every user-controlled string in the `.backup` manifest was written unescaped. The failure is silent at backup time: the manifest is written, the query returns `BACKUP_CREATED`, and the corruption only surfaces when a `RESTORE` hands the bytes to Poco's SAX parser. There is no recovery short of hand-editing the manifest.

Two separate causes:

**Sites that used `<< xml <<` but passed a `String`.** `<< xml <<` only escapes a `std::string_view` or a `const char *`. A `String` operand is an exact match for the generic `operator<<` template in [`src/IO/Operators.h`](https://github.com/ClickHouse/ClickHouse/blob/master/src/IO/Operators.h), which calls `writeText` and copies the bytes verbatim; binding a `String` to `std::string_view` is a user-defined conversion, so the escaping overload loses overload resolution and never runs.

**Sites that used no manipulator at all.** Three fields were written straight to the buffer.

| element | source | user-controlled through | was |
| --- | --- | --- | --- |
| `<backup_id>` | `backup_id` | `BACKUP ... SETTINGS id = '...'` | `<< xml <<` with a `String` |
| `<base_backup>` | `BackupInfo::toString` | the base backup's locator, e.g. `Disk('backups', 'a&b')` | `<< xml <<` with a `String` |
| `<name>` | `BackupFileInfo::file_name` | file names inside the backup | `<< xml <<` with a `String` |
| `<data_file>` | `BackupFileInfo::data_file_name` | file names inside the backup | `<< xml <<` with a `String` |
| `<original_endpoint>` | `original_endpoint` | the snapshot's object storage endpoint | no manipulator |
| `<original_namespace>` | `original_namespace` | the snapshot's object storage namespace | no manipulator |
| `<object_key>` | `BackupFileInfo::object_key` | object storage keys | no manipulator |

Each now goes through an explicit `std::string_view` conversion.

**Sync with the private mirror.** The mirror already escapes six of these seven — `backup_id` is its one gap, which is what the linked issue reports. The public change uses the mirror's `xml_string` lambda verbatim and adopts its `metadata_file` constant, so `writeBackupMetadata` now differs only where the two genuinely diverge: the Cloud-only `<disk>` field, and the base backup locator, which private reads through `getBaseBackupMetadataUnlocked`. Public's `BackupInfo::toString` returns by value, so its locator is bound to a named local rather than written inline, to keep the `std::string_view` off a temporary.

### Manifest format

Escaping changes the manifest bytes for existing backups too, because `writeXMLStringForTextElementOrAttributeValue` also escapes `'` — and `BackupInfo::toString` is full of single quotes, so `<base_backup>` now reads `S3(&apos;http://...&apos;)`. This is what the private mirror already writes, and it round-trips: Poco decodes the entity back on read, so older servers restore these backups unchanged.

It does break anything that greps a manifest for raw text, which is what `04327_backup_s3_base_credentials_metadata` did — it injected credentials into `inc_6` by matching the locator's quoted form. Private already hit this and already has the fix (replace the whole `<base_backup>` element by regex); its version of the test is taken verbatim, and the reference file is identical in both repositories.

### Test

`tests/queries/0_stateless/05153_backup_metadata_xml_escaping.sh` covers `<backup_id>` (via `SETTINGS id`) and `<base_backup>` (via an incremental backup on top of a base backup whose path contains `&`), asserting in both cases that the backup restores and the rows come back — an unparseable manifest is exactly what a `RESTORE` would hit.

The other five are fixed but not covered. Paths inside a backup go through `escapeForFileName`, so I could not construct a table or database name that delivers a raw metacharacter to `<name>` or `<data_file>`; `<original_endpoint>`, `<original_namespace>` and `<object_key>` need a lightweight snapshot against object storage. They are fixed alongside the two that are testable rather than left as the remaining unescaped sites.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118898&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118898](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118898+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
