### PR TITLE
Assert the CPU overload probability ramp instead of its saturated value in test_server_overload

### DIFF
--- a/tests/integration/test_server_overload/configs/early_drop.xml
+++ b/tests/integration/test_server_overload/configs/early_drop.xml
@@ -1,8 +1,7 @@
 <clickhouse>
     <os_cpu_busy_time_threshold>300000</os_cpu_busy_time_threshold>
     <min_os_cpu_wait_time_ratio_to_drop_connection>1.0</min_os_cpu_wait_time_ratio_to_drop_connection>
-    <!-- The drop probability ramps linearly from min to max ratio, so it only reaches 1 at
-         max ratio. Keep max below the wait/busy ratio the synthetic load produces, so an
-         overloaded window always drops instead of rolling dice. -->
+    <!-- The drop probability ramps linearly from min ratio to max ratio, so a max close to min keeps
+         the per-probe probability high while the synthetic load runs. -->
     <max_os_cpu_wait_time_ratio_to_drop_connection>1.5</max_os_cpu_wait_time_ratio_to_drop_connection>
 </clickhouse>

--- a/tests/integration/test_server_overload/test.py
+++ b/tests/integration/test_server_overload/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import math
+import re
 import time
 
 import pytest
@@ -19,6 +21,26 @@ node2 = cluster.add_instance(
     main_configs=["configs/early_drop.xml"],
     clickhouse_start_cmd=f"taskset -c 1 {CLICKHOUSE_START_COMMAND}",
 )
+
+
+CPU_OVERLOAD_RAMP_RE = re.compile(
+    r"metric\) is ([-+0-9.eE]+)\. "
+    r"Min ratio for error (?:\([^)]*\) )?([-+0-9.eE]+), "
+    r"max ratio for error (?:\([^)]*\) )?([-+0-9.eE]+), "
+    r"probability used to decide whether to (?:discard the query|drop the connection) ([-+0-9.eE]+)\."
+)
+
+
+def assert_cpu_overload_ramp(message):
+    """The rejection came from the CPU overload throttle, and the probability it reported is the
+    linear interpolation of the ratio it reported between the min and max ratio settings."""
+    matches = CPU_OVERLOAD_RAMP_RE.findall(message)
+    assert matches, "Expected the CPU overload throttle to report the ratio and the probability it used"
+    for ratio, min_ratio, max_ratio, probability in matches:
+        ratio, min_ratio, max_ratio, probability = map(float, (ratio, min_ratio, max_ratio, probability))
+        expected = (min(max(min_ratio, ratio), max_ratio) - min_ratio) / (max_ratio - min_ratio)
+        assert math.isclose(probability, expected, abs_tol=1e-6), \
+            f"Probability {probability} does not match the ramp between {min_ratio} and {max_ratio} at ratio {ratio}"
 
 
 @pytest.fixture(scope="module")
@@ -46,7 +68,7 @@ def test_overload(started_cluster):
             node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=1, max_os_cpu_wait_time_ratio_to_throw=1.5")
         except QueryRuntimeException as ex:
             assert "(SERVER_OVERLOADED)" in str(ex), "Only server overloaded error is expected"
-            assert "probability used to decide whether to discard the query" in str(ex), "Expected the query to be rejected by the CPU overload throttle"
+            assert_cpu_overload_ramp(str(ex))
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
         time.sleep(0.3)
@@ -70,7 +92,7 @@ def test_drop_connections(started_cluster):
         except QueryRuntimeException as ex:
             assert "Connection reset by peer" in str(ex), "Only connection drop is expected"
             assert node2.contains_in_log("CPU is overloaded, CPU is waiting for execution way more than executing"), "Expected server overloaded error in the log"
-            assert node2.contains_in_log("probability used to decide whether to drop the connection"), "Expected message that the connection was dropped due to server overload in the log"
+            assert_cpu_overload_ramp(node2.grep_in_log("probability used to decide whether to drop the connection"))
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
         time.sleep(0.3)

--- a/tests/integration/test_server_overload/test.py
+++ b/tests/integration/test_server_overload/test.py
@@ -41,12 +41,12 @@ def test_overload(started_cluster):
 
     for i in range(60):
         try:
-            # Max ratio is below the wait/busy ratio the load above produces, so the
-            # probability ramp saturates at 1 and an overloaded server always throws.
+            # Rejection is probabilistic, ramping linearly from min ratio to max ratio, so probe in a
+            # loop; a max close to min keeps the per-probe probability high under this load.
             node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=1, max_os_cpu_wait_time_ratio_to_throw=1.5")
         except QueryRuntimeException as ex:
             assert "(SERVER_OVERLOADED)" in str(ex), "Only server overloaded error is expected"
-            assert "probability used to decide whether to discard the query 1." in str(ex), "Expected the throw probability to be saturated at 1, not a lucky Bernoulli draw"
+            assert "probability used to decide whether to discard the query" in str(ex), "Expected the query to be rejected by the CPU overload throttle"
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
         time.sleep(0.3)
@@ -71,7 +71,6 @@ def test_drop_connections(started_cluster):
             assert "Connection reset by peer" in str(ex), "Only connection drop is expected"
             assert node2.contains_in_log("CPU is overloaded, CPU is waiting for execution way more than executing"), "Expected server overloaded error in the log"
             assert node2.contains_in_log("probability used to decide whether to drop the connection"), "Expected message that the connection was dropped due to server overload in the log"
-            assert node2.contains_in_log("probability used to decide whether to drop the connection 1."), "Expected the drop probability to be saturated at 1, not a lucky Bernoulli draw"
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
             return
         time.sleep(0.3)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113529
Related: https://github.com/ClickHouse/ClickHouse/pull/115905


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a flaky assertion in `test_server_overload` that required the CPU overload rejection probability to be exactly 1.


### Description

`test_overload` asserted the *value* of the throttle's rejection probability (`"... discard the query 1."`), i.e. `p == 1`. Both setting pairs document `p` as a linear interpolation, and `ProfileEvents::checkCPUOverload` implements exactly that: `p = (clamp(ratio, min, max) - min) / (max - min)`. With the test's `min=1, max=1.5`, `p` reaches 1 only at a wait/busy ratio of 1.5; CI runners produce 1.287 - 1.393, so `p` is fractional and the assertion fails though the rejection is correct. Ratio 1.2870989304812834 gives 0.5741978609625669, exactly as logged. The assertion described the runner, not ClickHouse.

Both paths now check the reported probability against that interpolation of the *reported* ratio, printed in the same message, instead of requiring saturation. The identity holds at every ratio, so the check is runner-independent, and stronger than the assertion it replaces, which only held at `max`. A helper rather than a substring: a substring cannot express the ramp identity, and `SERVER_OVERLOADED` alone would not pin the rejection to the CPU throttle (workload-scheduler limits raise it too).

`max = 1.5` is kept: at CI's ratios the per-probe probability is 0.57 - 0.79, so a rejection within the 60 probes is near-certain.

Validation: raising `max` above this box's achievable ratio reproduces the CI condition; the unfixed test then fails 5/5 with the exact CI assertion and passes 5/5 with this change, same binary and config, the server reporting `p` = 0.24 - 0.31; 50/50 on the shipping config. Two server-side mutants show the checks bite: forcing `p` to 0.1 with the reported ratio left truthful reddens both tests; so does stripping the probability clause, while the error-code and log-line assertions still pass.

node2's `os_cpu_busy_time_threshold=300000` is unchanged, so #115905's sampling-window residual there stays out of scope.

No related open issue found. CI provenance (#117170, `Integration tests (amd_tsan, 1/6)`): https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117170&sha=ad5ec29019201a96407ab761b743ac4cde06dc43&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%201%2F6%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118900&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118900](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118900+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1286` (included in `26.9` and later)
<!-- ch-version-info:end -->