### PR TITLE
Add checkStackSize() to JSON recursion

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -238,6 +238,8 @@ String canonicalizeTypeSpacing(const String & s)
 bool typesAreStructurallyIdentical(
     const Poco::Dynamic::Var & first_in, const Poco::Dynamic::Var & second_in, const std::unordered_map<String, String> & type_mapping)
 {
+    checkStackSize();
+
     Poco::Dynamic::Var first = first_in;
     Poco::Dynamic::Var second = second_in;
 
@@ -353,6 +355,8 @@ bool schemaFieldsAreStructurallyIdentical(const Poco::JSON::Object & first, cons
 
 bool schemasAreIdentical(const Poco::JSON::Object & first, const Poco::JSON::Object & second, const std::unordered_map<String, String> & type_mapping)
 {
+    checkStackSize();
+
     if (!first.isArray(f_fields) || !second.isArray(f_fields))
         return false;
     const auto first_fields = first.getArray(f_fields);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Summary

 Add `checkStackSize` to `schemasAreIdentical` and `typesAreStructurallyIdentical` in the Iceberg schema processor. These two functions recurse over each other while comparing the type descriptors of`metadata.json` schemas. The recursion is already bounded in practice, because `Poco::JSON::Parser` rejects documents nested deeper than 1000 levels (https://github.com/ClickHouse/ClickHouse/pull/107341). Now the parser limit is no longer the only thing standing between a hostile schema and the native stack.

### Changelog category (leave one):
Not for changelog

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118901&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118901](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118901+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
