### PR TITLE
Keep a Tuple element's Nullable in the merged JOIN USING key type

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -5786,7 +5786,10 @@ void QueryAnalyzer::resolveJoin(QueryTreeNodePtr & join_node, IdentifierResolveS
                 && is_inner_or_semi
                 && !is_asof_inequality_key)
             {
-                if (auto subtype = JoinCommon::tryGetCommonSubtypeForJoinKeys(expression_types[0], expression_types[1]))
+                /// A conversion of the whole key column into this type runs before the join, so it must
+                /// hold every source value: `is_nullable` at the top level, the flag inside a Tuple.
+                if (auto subtype = JoinCommon::tryGetCommonSubtypeForJoinKeys(
+                        expression_types[0], expression_types[1], /* force_support_conversion= */ true))
                 {
                     bool is_nullable = isNullableOrLowCardinalityNullable(expression_types[0]) || isNullableOrLowCardinalityNullable(expression_types[1]);
                     common_type = is_nullable ? makeNullable(subtype) : subtype;

--- a/src/Interpreters/JoinUtils.cpp
+++ b/src/Interpreters/JoinUtils.cpp
@@ -230,7 +230,8 @@ static bool hasNullableLowCardinalityTupleElement(const DataTypePtr & type)
         { return element->isLowCardinalityNullable() || hasNullableLowCardinalityTupleElement(element); });
 }
 
-DataTypePtr tryGetCommonSubtypeForJoinKeys(const DataTypePtr & left_type, const DataTypePtr & right_type)
+DataTypePtr tryGetCommonSubtypeForJoinKeys(
+    const DataTypePtr & left_type, const DataTypePtr & right_type, bool force_support_conversion)
 {
     if (hasNullableLowCardinalityTupleElement(left_type) || hasNullableLowCardinalityTupleElement(right_type))
         return nullptr;
@@ -243,7 +244,7 @@ DataTypePtr tryGetCommonSubtypeForJoinKeys(const DataTypePtr & left_type, const 
     if (!std::ranges::all_of(types, hasOnlyIntegerLeaves))
         return nullptr;
 
-    auto subtype = getMostSubtype(types, /* throw_if_result_is_nothing= */ false);
+    auto subtype = getMostSubtype(types, /* throw_if_result_is_nothing= */ false, force_support_conversion);
     /// `accurateCastOrNull` reports an inexact conversion by returning NULL, so the type has to be
     /// allowed inside Nullable, and the same holds for the elements of a Tuple, recursively.
     if (isNothing(subtype) || !subtype->canBeInsideNullable() || !isSupportedByAccurateCastOrNull(subtype))

--- a/src/Interpreters/JoinUtils.h
+++ b/src/Interpreters/JoinUtils.h
@@ -90,8 +90,13 @@ private:
   * can hold are `[0, 9223372036854775807]`, and all of them fit into `UInt64`.
   *
   * The result is never Nullable or LowCardinality. Returns nullptr if there is no such type.
+  *
+  * `force_support_conversion` keeps a Tuple element that is Nullable on one side only, so that a whole
+  * key column can be converted to the result, which is what the merged `USING` column needs. A key
+  * conversion target must have no Nullable element at all, see `removeNullableInsideTuple`.
   */
-DataTypePtr tryGetCommonSubtypeForJoinKeys(const DataTypePtr & left_type, const DataTypePtr & right_type);
+DataTypePtr tryGetCommonSubtypeForJoinKeys(
+    const DataTypePtr & left_type, const DataTypePtr & right_type, bool force_support_conversion = false);
 
 /** Removes the `Nullable` wrappers of the elements of a Tuple, recursively. Returns other types unchanged.
   *

--- a/tests/queries/0_stateless/05139_join_using_merged_key_nullable_tuple_element.reference
+++ b/tests/queries/0_stateless/05139_join_using_merged_key_nullable_tuple_element.reference
@@ -1,0 +1,15 @@
+A Tuple element that is Nullable on one side only
+1
+(1)	Tuple(Nullable(UInt64))
+The same join with ON keeps the key of each side
+(1)	(1)
+The Nullable element on the right, where the merged column reaches it
+(1)	Tuple(Nullable(UInt64))
+Only the element that needs it becomes Nullable
+(1,2)	Tuple(Nullable(UInt64), UInt64)
+SEMI JOIN takes the key of the preserved side
+(1)
+An element out of the common range still matches nothing
+(1)
+Nullable on both sides keeps the type the subtype already carries
+(1)	Tuple(Nullable(UInt64))

--- a/tests/queries/0_stateless/05139_join_using_merged_key_nullable_tuple_element.sql
+++ b/tests/queries/0_stateless/05139_join_using_merged_key_nullable_tuple_element.sql
@@ -1,0 +1,36 @@
+-- The merged USING key column is materialized by converting each source key to the published type,
+-- before the join filters anything. That type therefore has to hold every value the source keys hold,
+-- including a NULL element that the common subtype dropped because the other side had none there.
+-- https://github.com/ClickHouse/ClickHouse/pull/112951
+
+SET enable_analyzer = 1;
+
+SELECT 'A Tuple element that is Nullable on one side only';
+SELECT count() FROM (SELECT tuple(if(number = 0, NULL, CAST(1, 'Nullable(Int64)'))) AS t FROM numbers(2)) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'UInt64')) AS t) AS b USING (t);
+SELECT t, toTypeName(t) FROM (SELECT tuple(if(number = 0, NULL, CAST(1, 'Nullable(Int64)'))) AS t FROM numbers(2)) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'UInt64')) AS t) AS b USING (t);
+
+SELECT 'The same join with ON keeps the key of each side';
+SELECT a.t, b.t FROM (SELECT tuple(if(number = 0, NULL, CAST(1, 'Nullable(Int64)'))) AS t FROM numbers(2)) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'UInt64')) AS t) AS b ON a.t = b.t;
+
+SELECT 'The Nullable element on the right, where the merged column reaches it';
+SELECT b.t, toTypeName(b.t) FROM (SELECT tuple(CAST(1, 'UInt64')) AS t) AS a
+INNER JOIN (SELECT tuple(if(number = 0, NULL, CAST(1, 'Nullable(Int64)'))) AS t FROM numbers(2)) AS b USING (t);
+
+SELECT 'Only the element that needs it becomes Nullable';
+SELECT t, toTypeName(t) FROM (SELECT (if(number = 0, NULL, CAST(1, 'Nullable(Int64)')), CAST(2, 'Int64')) AS t FROM numbers(2)) AS a
+INNER JOIN (SELECT (CAST(1, 'UInt64'), CAST(2, 'UInt64')) AS t) AS b USING (t);
+
+SELECT 'SEMI JOIN takes the key of the preserved side';
+SELECT t FROM (SELECT tuple(if(number = 0, NULL, CAST(1, 'Nullable(Int64)'))) AS t FROM numbers(2)) AS a
+SEMI LEFT JOIN (SELECT tuple(CAST(1, 'UInt64')) AS t) AS b USING (t);
+
+SELECT 'An element out of the common range still matches nothing';
+SELECT t FROM (SELECT tuple(CAST(number - 1, 'Int64')) AS t FROM numbers(3)) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'UInt64')) AS t) AS b USING (t) ORDER BY ALL;
+
+SELECT 'Nullable on both sides keeps the type the subtype already carries';
+SELECT t, toTypeName(t) FROM (SELECT tuple(CAST(1, 'Nullable(UInt64)')) AS t) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'Nullable(Int64)')) AS t) AS b USING (t);


### PR DESCRIPTION
---8<--- PR BODY BELOW ---8<---
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/112951
Related: https://github.com/ClickHouse/ClickHouse/pull/117409

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Requested by @ nickitat in https://github.com/ClickHouse/ClickHouse/pull/117409#discussion_r3957610454.

Projecting the `USING` key of an `INNER` or `SEMI` join whose keys have no least supertype throws, while
the same join without that projection answers correctly:

```sql
SELECT t
FROM (SELECT tuple(if(number = 0, NULL, CAST(1, 'Nullable(Int64)'))) AS t FROM numbers(2)) AS a
INNER JOIN (SELECT tuple(CAST(1, 'UInt64')) AS t) AS b USING (t);
-- Code: 349. Cannot convert NULL value to non-Nullable type
```

`count()` over that join answers `1` and `ON a.t = b.t` returns `(1)`, so the row the projection failed on
is one the join drops.

The merged `USING` column is materialized by converting a whole key column to the type the analyzer
publishes, and it runs before the join filters anything, so that type has to hold every value the source
keys hold. `resolveJoinUsing` enforces that at the top level only: `getMostSubtype` drops the `Nullable`
of a Tuple element when the other side has none, which a top-level test cannot see, so the published type
was `Tuple(UInt64)`.

I ask `getMostSubtype` for the merged type in its `force_support_conversion` mode, documented as "a type
which may be used to convert each argument to". The published type becomes `Tuple(Nullable(UInt64))` and
the existing conversion becomes total. The key comparison keeps the default mode, which is what its
`accurateCastOrNull` needs: a key with no representation must be reported by a NULL of the whole key, not
of one element. The modes differ only where an element is Nullable on exactly one side.

Worth knowing: for such a key `USING` now publishes `Tuple(Nullable(U))` where it published `Tuple(U)`,
and the qualified columns of both sides agree on it. Master only since #112951, so no backport;
`04669_join_key_no_supertype` is unchanged. Passing `false` for the new argument reddens the new test.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118902&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118902](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118902+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
