### PR TITLE
Attach the performance comparison query results by name, not by list position

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -123,6 +123,10 @@ FROM input(
      unstable_threshold Float64'
 ) FORMAT TSV"""
 
+# Praktika expands exactly this sub-result into per-test-case CIDB rows: it is the
+# `result_name_for_cidb` of both performance jobs (ci/defs/job_configs.py).
+CIDB_TEST_CASES_RESULT_NAME = "Tests"
+
 RAW_QUERY_METRICS_TABLE = "query_metric_runs_v1"
 
 # --- Aggregate report tables on the play cluster --------------------------
@@ -1646,14 +1650,14 @@ def read_ci_checks_results(path):
     return results, malformed, True
 
 
-def import_ci_checks_results(path, results):
-    """Import `ci-checks.tsv` rows into the previous subtask's results.
+def import_ci_checks_results(path, results, target_name=CIDB_TEST_CASES_RESULT_NAME):
+    """Import `ci-checks.tsv` rows into the `target_name` sub-result.
 
     Returns True when the file was importable. A file with no data row at all -
     empty, or only the header lines - is reported and left unimported. That
-    distinction is a diagnostic one, not a data-preserving one: every subtask
-    `main()` appends before this call is built without a `results=` argument, so
-    the assignment target's row list is empty either way and there is nothing an
+    distinction is a diagnostic one, not a data-preserving one: the target
+    is built by `Result.from_commands_run`, which takes no `results=`
+    argument, so its row list is empty either way and there is nothing an
     empty assignment could destroy. A file that lost individual rows still
     imports the intact ones and reports how many it skipped, because degrading
     beats dying. An absent file is the atomic publish's own failure signal -
@@ -1671,8 +1675,11 @@ def import_ci_checks_results(path, results):
         return False
     if malformed:
         print(f"WARNING: ci-checks.tsv had {malformed} malformed row(s) - skipped")
-    # results[-2] is a previuos subtask
-    results[-2].results = test_results
+    target = next((r for r in results if r.name == target_name), None)
+    if target is None:
+        print(f"WARNING: no [{target_name}] sub-result to import ci-checks.tsv into")
+        return False
+    target.results = test_results
     return True
 
 
@@ -2164,7 +2171,9 @@ def main():
         commands = [
             run_tests,
         ]
-        results.append(Result.from_commands_run(name="Tests", command=commands))
+        results.append(
+            Result.from_commands_run(name=CIDB_TEST_CASES_RESULT_NAME, command=commands)
+        )
         res = results[-1].is_ok()
 
     if JobStages.EXPORT_LOGS in stages and not info.is_local_run:
@@ -2463,7 +2472,7 @@ def main():
         # Find the "Tests" sub-result that holds per-query results
         tests_result = None
         for r in results:
-            if r.name == "Tests" and r.results:
+            if r.name == CIDB_TEST_CASES_RESULT_NAME and r.results:
                 tests_result = r
                 break
         if tests_result:


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116035

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `Performance Comparison` checks export their per-query measurements to the CI database again; a job stage added on 2026-08-30 had silently redirected them to a sub-result nothing reads.


### Description

Per-query measurement rows for `Performance Comparison (*)` stopped reaching
`default.checks` on 2026-08-31, on all refs and both architectures: 1,403,582 rows on
2026-08-30, 30,694 on 2026-08-31, and zero from 2026-09-04 apart from stale-branch pull
requests.
Job-level rows kept arriving and the jobs stayed green, so the checks looked healthy.

**Root cause.** `import_ci_checks_results` attached the parsed `ci-checks.tsv` rows to
`results[-2]`, a list position, while praktika selects the sub-result it expands into
per-test-case rows by name (`result_name_for_cidb`, `"Tests"` for both perf jobs). They
agreed only by accident: the tail of `results` was `[..., "Tests", "Report"]`. #116035
added an `EXPORT_LOGS` stage between `TEST` and `REPORT` which appends a result, so
`results[-2]` began resolving to `"Export system logs"`: the rows landed on a sub-result
nothing reads, and `"Tests"` was left empty. No step failed, so the loss was silent. The
report's `Check Results` section and its `query history` links went empty too.

<details>
<summary>Observed result tree, master <code>af30b32ef31e</code>, job status OK</summary>

```
- 'Tests'              OK  children=0      <- praktika reads this one
- 'Export system logs' OK  children=1130   <- results[-2]: the rows went here
- 'Check Results'      OK  children=0      <- built from Tests, so also empty
```

</details>

**Change.** Look the target up by name, through one constant shared with the site that
creates the result and with the `Check Results` reader that already searched by name, so
another stage cannot move it again. Row names still come from `ci-checks.tsv`, so
`test_name` history queries stitch across the gap. Also removes an `IndexError` on a
resumed run (`--param report`), now a warning.

**Validation.** Against praktika's own selector: the pre-#116035 order imports 3 of 3 rows;
master's order, 0 of 3 before this change and 3 of 3 after; reverting just the lookup
returns it to 0. This PR runs the whole perf matrix on its own head, so its per-query rows
should go non-zero while master stays 0.

The gap cannot be backfilled: the rows were never sent. The perf verdict never broke (it
comes from `report.html`), and `perf_test_perf_changes_v1` / `query_metrics_v2` took rows
across the onset, so no baseline needs rebuilding.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118903&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118903](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118903+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1285` (included in `26.9` and later)
<!-- ch-version-info:end -->