### PR TITLE
Compile idna as a single translation unit

### DIFF
--- a/contrib/idna-cmake/CMakeLists.txt
+++ b/contrib/idna-cmake/CMakeLists.txt
@@ -7,17 +7,12 @@ endif()
 
 set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/idna")
 
+# idna.cpp is an amalgamation: it #includes the other .cpp files of the
+# library (directly, or via mapping.cpp and normalization.cpp for the tables),
+# so it is the only translation unit to compile. Listing the included files as
+# well defines every symbol twice in the archive.
 set (SRCS
     "${LIBRARY_DIR}/src/idna.cpp"
-    "${LIBRARY_DIR}/src/mapping.cpp"
-    "${LIBRARY_DIR}/src/mapping_tables.cpp"
-    "${LIBRARY_DIR}/src/normalization.cpp"
-    "${LIBRARY_DIR}/src/normalization_tables.cpp"
-    "${LIBRARY_DIR}/src/punycode.cpp"
-    "${LIBRARY_DIR}/src/to_ascii.cpp"
-    "${LIBRARY_DIR}/src/to_unicode.cpp"
-    "${LIBRARY_DIR}/src/unicode_transcoding.cpp"
-    "${LIBRARY_DIR}/src/validity.cpp"
 )
 
 add_library (_idna ${SRCS})


### PR DESCRIPTION
`idna.cpp` is an amalgamation that `#include`s the other nine `.cpp` files of the library (seven directly, the two `*_tables.cpp` via `mapping.cpp` and `normalization.cpp`). Our `SRCS` list compiled all ten separately, so every symbol was defined twice in `_idna`. Archive resolution hides this in a plain link but it is fragile under LTO. Upstream builds only `idna.cpp`; do the same.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Compile the `idna` contrib library as a single translation unit instead of defining every symbol twice.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118906&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118906](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118906+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
