### PR TITLE
Re-run configure when liburing.spec changes

### DIFF
--- a/contrib/liburing-cmake/CMakeLists.txt
+++ b/contrib/liburing-cmake/CMakeLists.txt
@@ -40,7 +40,11 @@ configure_file (compat.h.in ${LIBURING_COMPAT_HEADER})
 set (LIBURING_GENERATED_INCLUDE_DIR "${ClickHouse_BINARY_DIR}/contrib/liburing/src/include")
 set (LIBURING_VERSION_HEADER "${LIBURING_GENERATED_INCLUDE_DIR}/liburing/io_uring_version.h")
 
-file (READ "${LIBURING_SOURCE_DIR}/../liburing.spec" LIBURING_SPEC)
+set (LIBURING_SPEC_FILE "${LIBURING_SOURCE_DIR}/../liburing.spec")
+# Re-run the configure step when the spec changes (e.g. after a submodule bump),
+# otherwise the generated io_uring_version.h keeps the previous version.
+set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${LIBURING_SPEC_FILE}")
+file (READ "${LIBURING_SPEC_FILE}" LIBURING_SPEC)
 
 string (REGEX MATCH "Version: ([0-9]+)\.([0-9]+)" _ ${LIBURING_SPEC})
 set (LIBURING_VERSION_MAJOR ${CMAKE_MATCH_1})


### PR DESCRIPTION
The version for the generated `io_uring_version.h` is read from `liburing.spec` with `file(READ)`, which does not register a configure dependency, so incremental builds keep a stale header after a submodule bump. Add the spec to `CMAKE_CONFIGURE_DEPENDS`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Re-run the CMake configure step when `liburing.spec` changes so the generated version header is not stale.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118907&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118907](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118907+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
