### PR TITLE
Fix `FindSymbols.RunTimeNeedle` on non-SSE4.2 builds

### DIFF
--- a/src/Common/tests/gtest_find_symbols.cpp
+++ b/src/Common/tests/gtest_find_symbols.cpp
@@ -137,16 +137,10 @@ TEST(FindSymbols, RunTimeNeedle)
         test_haystack(short_haystack, unfindable_short_needle);
     }
 
+    // SearchSymbols rejects needles longer than SearchSymbols::BUFFER_SIZE on every platform,
+    // not only where the SSE4.2 path is compiled in.
     const std::string excessively_long_needle = "ABCDEFIJKLMNOPQRSTUVWXYZacfghijkmnpqstuvxz";
-#if defined (__SSE4_2__)
-    // Only x86 & SSE4.2: Assert big haystack is not accepted and exception is thrown
-    ASSERT_ANY_THROW(find_first_symbols(long_haystack, SearchSymbols(excessively_long_needle)));
-#else
-    // On other platforms, this should work fine:
-    const char * long_haystack_cstr = long_haystack.c_str();
-    const char * res = find_first_symbols(long_haystack_cstr, SearchSymbols(excessively_long_needle));
-    ASSERT_NE(res, nullptr);
-#endif
+    ASSERT_ANY_THROW(SearchSymbols{excessively_long_needle});
 }
 
 TEST(FindNotSymbols, AllSymbolsPresent)


### PR DESCRIPTION
`SearchSymbols` throws for needles longer than `BUFFER_SIZE` on every platform, but the test only expected the exception under `__SSE4_2__` and asserted a successful search elsewhere, so it fails on aarch64. Assert the exception unconditionally (directly on the `SearchSymbols` constructor, which is where it is thrown).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118908&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118908](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118908+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1046` (included in `26.9` and later)
<!-- ch-version-info:end -->