### PR TITLE
Fix Rust symbols shadowing llvm-libc under ThinLTO

### DIFF
--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -21,6 +21,20 @@ if (ENABLE_LLVM_LIBC_MATH)
     set (DEFAULT_LIBS "${DEFAULT_LIBS} -llibllvmlibc")
 
     if (NOT SANITIZE)
+        # Force every llvm-libc member into the link ahead of all objects and archives
+        # (linker flags precede them on the link line; -L placement does not matter to ld).
+        # Symbol resolution in archives is first-definition-wins in command-line order, and
+        # the Rust static libraries precede libllvmlibc there, so without this the libm
+        # functions Rust's compiler_builtins exports (cbrt, fmod, fma - baseline-CPU builds)
+        # would shadow the llvm-libc ones whenever symbol localization is bypassed. With all
+        # members pre-loaded, later archives can never supply an already-defined symbol, so
+        # this also covers the mem functions without per-symbol -u flags.
+        #
+        # Skipped under sanitizers, where the interceptors must wrap the libc mem functions
+        # instead (same reason the -u forcing was skipped before).
+        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--whole-archive -llibllvmlibc -Wl,--no-whole-archive")
+        # Redundant with --whole-archive above, but kept as a backstop for the mem functions
+        # in case the whole-archive link is ever weakened or repositioned.
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-u,memcpy -Wl,-u,memmove -Wl,-u,memset -Wl,-u,memcmp")
     endif()
 endif()

--- a/cmake/localize_rust_c_symbols.sh
+++ b/cmake/localize_rust_c_symbols.sh
@@ -79,9 +79,13 @@ trap cleanup EXIT
 # metadata, linker scripts); those are non-fatal as long as one member is read.
 # T/D/B/C/W/V are the defined globals and i is an IFUNC (glibc resolves ceil,
 # rint, trunc, ... this way); undefined (U) and local (lowercase) are excluded.
+# Under ThinLTO the reference archives contain LLVM bitcode members, for which
+# llvm-nm prints dashes instead of a hex address; accept both, otherwise the
+# reference set comes out empty and nothing is localized (this is how the Rust
+# cbrt shadowed the llvm-libc one in release builds, which set ENABLE_THINLTO).
 defined_globals() {
     { "$NM" "$1" 2>/dev/null; "$NM" -D "$1" 2>/dev/null; } \
-        | grep -E '^[0-9a-f]+ [TDBCWVi] ' \
+        | grep -E '^([0-9a-f]+|-+) [TDBCWVi] ' \
         | awk '{print $3}' \
         | sed 's/@.*//'
 }

--- a/contrib/libllvmlibc-cmake/CMakeLists.txt
+++ b/contrib/libllvmlibc-cmake/CMakeLists.txt
@@ -30,7 +30,11 @@ set(SRCS
     "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/fmodl.cpp"
     "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/frexp.cpp"
     "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/frexpl.cpp"
-    "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/hypot.cpp"
+    # hypot deliberately omitted: llvm-libc's is a correctly-rounded
+    # digit-recurrence loop that ignores LIBC_MATH_HAS_SKIP_ACCURATE_PASS and
+    # measures ~22x slower than the platform one (91 ns vs 4.2 ns per call on
+    # Neoverse-V2); the libc hypot (musl, or glibc in dynamic builds) wins the
+    # link instead.
     "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/ldexp.cpp"
     "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/ldexpf.cpp"
     "${LIBLLVMLIBC_SOURCE_DIR}/src/math/generic/ldexpl.cpp"


### PR DESCRIPTION
Split from https://github.com/ClickHouse/ClickHouse/pull/109239. Affects current glibc release builds, not only the static one.

Under ThinLTO the reference archives contain bitcode members, for which `llvm-nm` prints dashes instead of an address; `localize_rust_c_symbols.sh` required a hex address, so its reference set was empty and nothing was localized. The Rust `compiler_builtins` `cbrt`/`fmod`/`fma` (baseline x86-64) then won over the llvm-libc ones. Fix the regex, and additionally link `libllvmlibc` with `--whole-archive` so resolution no longer depends on archive order. Also stop taking `hypot` from llvm-libc: its correctly-rounded loop is ~22x slower than the libc one.

Related: https://github.com/ClickHouse/ClickHouse/pull/109239

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `cbrt`, `fmod` and `fma` from Rust's `compiler_builtins` shadowing the faster llvm-libc implementations in ThinLTO release builds, and use the libc `hypot` instead of the slow llvm-libc one.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118910&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118910](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118910+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
