### PR TITLE
Vectorized memchr and strlen for x86_64 in libllvmlibc

### DIFF
--- a/contrib/libllvmlibc-cmake/CMakeLists.txt
+++ b/contrib/libllvmlibc-cmake/CMakeLists.txt
@@ -62,6 +62,9 @@ set(SRCS
 # there and let the interceptor wrap the system memmem, as before this PR.
 if (NOT SANITIZE)
     list (APPEND SRCS "${CMAKE_CURRENT_SOURCE_DIR}/string/memmem.cpp")
+    # x86_64-only strong memchr/strlen (the file is empty on other arches, where
+    # the Arm Optimized Routines already provide vectorized versions).
+    list (APPEND SRCS "${CMAKE_CURRENT_SOURCE_DIR}/string/str_functions.cpp")
 endif ()
 
 set(LIBC_NAMESPACE "__llvm_libc")

--- a/contrib/libllvmlibc-cmake/CMakeLists.txt
+++ b/contrib/libllvmlibc-cmake/CMakeLists.txt
@@ -62,8 +62,8 @@ set(SRCS
 # there and let the interceptor wrap the system memmem, as before this PR.
 if (NOT SANITIZE)
     list (APPEND SRCS "${CMAKE_CURRENT_SOURCE_DIR}/string/memmem.cpp")
-    # x86_64-only strong memchr/strlen (the file is empty on other arches, where
-    # the Arm Optimized Routines already provide vectorized versions).
+    # x86_64-only strong memchr/strlen; the file is empty on other arches, which
+    # keep the libc implementations.
     list (APPEND SRCS "${CMAKE_CURRENT_SOURCE_DIR}/string/str_functions.cpp")
 endif ()
 

--- a/contrib/libllvmlibc-cmake/string/str_functions.cpp
+++ b/contrib/libllvmlibc-cmake/string/str_functions.cpp
@@ -3,9 +3,11 @@
 // LLVM-libc's are byte loops). glibc uses EVEX/AVX2 assembly for both, and the
 // CSV parser showed musl's word-at-a-time `memchr` taking twice the samples.
 //
-// Vector loads are done on 32-byte-aligned addresses only, so they never cross
-// a page boundary and cannot fault even when they reach past the buffer (the
-// bytes outside [s, s + n) are masked off before the result is used). Not built
+// Vector loads are done on aligned addresses only, and the unrolled loop on
+// addresses aligned to its whole stride, so no load ever crosses a page
+// boundary: reading past the buffer or past the first match stays inside a
+// page that is known to be mapped, and the bytes outside [s, s + n) are masked
+// off before the result is used. Not built
 // under sanitizers: their interceptors define strong `memchr`/`strlen` and the
 // wrapped libc versions carry the range checks.
 
@@ -110,6 +112,18 @@ extern "C" void *memchr(const void *s, int c, size_t n) noexcept {
     return const_cast<char *>(p + __builtin_ctzll(m));
 
   a += VEC;
+  // Callers may pass an `n` that overstates the buffer and rely on the search
+  // stopping at the first match (musl's strnlen passes the caller's limit,
+  // realpath's is PATH_MAX past a shorter string), so `end` does not bound the
+  // readable memory. Re-align to the 4 * VEC stride before the unrolled loop:
+  // a 4 * VEC-aligned group never crosses a page, so it is only ever read
+  // beyond the match within the page that holds the match.
+  for (; a + VEC <= end && (reinterpret_cast<uintptr_t>(a) & (4 * VEC - 1));
+       a += VEC) {
+    m = eq_mask(a, needle);
+    if (m)
+      return const_cast<char *>(a + __builtin_ctzll(m));
+  }
   for (; a + 4 * VEC <= end; a += 4 * VEC)
     if (const char *r = scan4(a, needle))
       return const_cast<char *>(r);

--- a/contrib/libllvmlibc-cmake/string/str_functions.cpp
+++ b/contrib/libllvmlibc-cmake/string/str_functions.cpp
@@ -1,0 +1,148 @@
+// Strong x86_64 `memchr` and `strlen`, overriding musl's generic C versions in
+// the static link (musl ships x86_64 assembly only for memcpy/memmove/memset;
+// LLVM-libc's are byte loops). glibc uses EVEX/AVX2 assembly for both, and the
+// CSV parser showed musl's word-at-a-time `memchr` taking twice the samples.
+//
+// Vector loads are done on 32-byte-aligned addresses only, so they never cross
+// a page boundary and cannot fault even when they reach past the buffer (the
+// bytes outside [s, s + n) are masked off before the result is used). Not built
+// under sanitizers: their interceptors define strong `memchr`/`strlen` and the
+// wrapped libc versions carry the range checks.
+
+#if defined(__x86_64__)
+
+#include <immintrin.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+#if defined(__AVX2__)
+
+constexpr size_t VEC = 32;
+using vec_t = __m256i;
+
+__attribute__((always_inline)) inline vec_t splat(unsigned char c) {
+  return _mm256_set1_epi8(static_cast<char>(c));
+}
+__attribute__((always_inline)) inline vec_t eq_vec(const void *aligned,
+                                                   vec_t needle) {
+  vec_t v = _mm256_load_si256(static_cast<const vec_t *>(aligned));
+  return _mm256_cmpeq_epi8(v, needle);
+}
+__attribute__((always_inline)) inline vec_t or_vec(vec_t a, vec_t b) {
+  return _mm256_or_si256(a, b);
+}
+__attribute__((always_inline)) inline uint64_t to_mask(vec_t v) {
+  return static_cast<uint32_t>(_mm256_movemask_epi8(v));
+}
+
+#else // x86-64-v2 compat build: SSE2
+
+constexpr size_t VEC = 16;
+using vec_t = __m128i;
+
+__attribute__((always_inline)) inline vec_t splat(unsigned char c) {
+  return _mm_set1_epi8(static_cast<char>(c));
+}
+__attribute__((always_inline)) inline vec_t eq_vec(const void *aligned,
+                                                   vec_t needle) {
+  vec_t v = _mm_load_si128(static_cast<const vec_t *>(aligned));
+  return _mm_cmpeq_epi8(v, needle);
+}
+__attribute__((always_inline)) inline vec_t or_vec(vec_t a, vec_t b) {
+  return _mm_or_si128(a, b);
+}
+__attribute__((always_inline)) inline uint64_t to_mask(vec_t v) {
+  return static_cast<uint32_t>(_mm_movemask_epi8(v));
+}
+
+#endif
+
+__attribute__((always_inline)) inline uint64_t eq_mask(const void *aligned,
+                                                       vec_t needle) {
+  return to_mask(eq_vec(aligned, needle));
+}
+
+// Scan 4 * VEC bytes starting at the aligned `a`: one branch per iteration on
+// the OR of the four compares (glibc unrolls the same way), then locate the
+// first match only when there is one. Returns nullptr if none.
+__attribute__((always_inline)) inline const char *scan4(const char *a,
+                                                        vec_t needle) {
+  const vec_t e0 = eq_vec(a, needle);
+  const vec_t e1 = eq_vec(a + VEC, needle);
+  const vec_t e2 = eq_vec(a + 2 * VEC, needle);
+  const vec_t e3 = eq_vec(a + 3 * VEC, needle);
+  if (to_mask(or_vec(or_vec(e0, e1), or_vec(e2, e3))) == 0)
+    return nullptr;
+  if (uint64_t m = to_mask(e0))
+    return a + __builtin_ctzll(m);
+  if (uint64_t m = to_mask(e1))
+    return a + VEC + __builtin_ctzll(m);
+  if (uint64_t m = to_mask(e2))
+    return a + 2 * VEC + __builtin_ctzll(m);
+  return a + 3 * VEC + __builtin_ctzll(to_mask(e3));
+}
+
+__attribute__((always_inline)) inline const char *align_down(const char *p) {
+  return reinterpret_cast<const char *>(reinterpret_cast<uintptr_t>(p) &
+                                        ~(uintptr_t{VEC} - 1));
+}
+
+} // namespace
+
+extern "C" void *memchr(const void *s, int c, size_t n) noexcept {
+  if (n == 0)
+    return nullptr;
+  const char *p = static_cast<const char *>(s);
+  const char *end = p + n;
+  const vec_t needle = splat(static_cast<unsigned char>(c));
+
+  // First block: drop the bytes before `p`.
+  const char *a = align_down(p);
+  uint64_t m = eq_mask(a, needle) >> (p - a);
+  // Bytes at or past `end` are not part of the buffer. `end - p` can only be
+  // < VEC here if the whole buffer fits into this first block.
+  if (static_cast<size_t>(end - p) < VEC)
+    m &= (uint64_t{1} << (end - p)) - 1;
+  if (m)
+    return const_cast<char *>(p + __builtin_ctzll(m));
+
+  a += VEC;
+  for (; a + 4 * VEC <= end; a += 4 * VEC)
+    if (const char *r = scan4(a, needle))
+      return const_cast<char *>(r);
+  for (; a + VEC <= end; a += VEC) {
+    m = eq_mask(a, needle);
+    if (m)
+      return const_cast<char *>(a + __builtin_ctzll(m));
+  }
+
+  if (a < end) {
+    m = eq_mask(a, needle) & ((uint64_t{1} << (end - a)) - 1);
+    if (m)
+      return const_cast<char *>(a + __builtin_ctzll(m));
+  }
+  return nullptr;
+}
+
+extern "C" size_t strlen(const char *s) noexcept {
+  const vec_t zero = splat(0);
+  const char *a = align_down(s);
+  uint64_t m = eq_mask(a, zero) >> (s - a);
+  if (m)
+    return static_cast<size_t>(__builtin_ctzll(m));
+  a += VEC;
+  // Re-align to the 4 * VEC stride so the unrolled loads stay within one page.
+  for (; reinterpret_cast<uintptr_t>(a) & (4 * VEC - 1); a += VEC) {
+    m = eq_mask(a, zero);
+    if (m)
+      return static_cast<size_t>(a - s) + static_cast<size_t>(__builtin_ctzll(m));
+  }
+  for (;; a += 4 * VEC)
+    if (const char *r = scan4(a, zero))
+      return static_cast<size_t>(r - s);
+}
+
+#endif // __x86_64__

--- a/contrib/libllvmlibc-cmake/string/str_functions.cpp
+++ b/contrib/libllvmlibc-cmake/string/str_functions.cpp
@@ -7,9 +7,11 @@
 // addresses aligned to its whole stride, so no load ever crosses a page
 // boundary: reading past the buffer or past the first match stays inside a
 // page that is known to be mapped, and the bytes outside [s, s + n) are masked
-// off before the result is used. Not built
-// under sanitizers: their interceptors define strong `memchr`/`strlen` and the
-// wrapped libc versions carry the range checks.
+// off before the result is used. `n` is treated as a count of bytes left to
+// look at and never added to the pointer, since callers may pass a limit that
+// overstates the buffer, up to SIZE_MAX. Not built under sanitizers: their
+// interceptors define strong `memchr`/`strlen` and the wrapped libc versions
+// carry the range checks.
 
 #if defined(__x86_64__)
 
@@ -98,43 +100,53 @@ extern "C" void *memchr(const void *s, int c, size_t n) noexcept {
   if (n == 0)
     return nullptr;
   const char *p = static_cast<const char *>(s);
-  const char *end = p + n;
   const vec_t needle = splat(static_cast<unsigned char>(c));
 
+  // `n` is only an upper bound on how far to look, never turned into a
+  // pointer: callers may pass an `n` that overstates the buffer and rely on
+  // the search stopping at the first match (musl's strnlen passes the caller's
+  // limit, realpath's is PATH_MAX past a shorter string, strndup(s, -1) passes
+  // SIZE_MAX), so `p + n` may lie outside the object or wrap the address space
+  // altogether. The search is driven by the number of bytes left to look at,
+  // and the pointer only ever advances to the next aligned block, which is at
+  // most `n` bytes in.
+  //
   // First block: drop the bytes before `p`.
   const char *a = align_down(p);
-  uint64_t m = eq_mask(a, needle) >> (p - a);
-  // Bytes at or past `end` are not part of the buffer. `end - p` can only be
-  // < VEC here if the whole buffer fits into this first block.
-  if (static_cast<size_t>(end - p) < VEC)
-    m &= (uint64_t{1} << (end - p)) - 1;
+  const size_t head = static_cast<size_t>(p - a);
+  uint64_t m = eq_mask(a, needle) >> head;
+  // Bytes at or past `p + n` are not part of the buffer. This can only happen
+  // in the first block if the whole buffer fits into it.
+  if (n < VEC)
+    m &= (uint64_t{1} << n) - 1;
   if (m)
     return const_cast<char *>(p + __builtin_ctzll(m));
-
+  // The first block covered `VEC - head` bytes of the buffer.
+  if (n <= VEC - head)
+    return nullptr;
+  size_t remaining = n - (VEC - head);
   a += VEC;
-  // Callers may pass an `n` that overstates the buffer and rely on the search
-  // stopping at the first match (musl's strnlen passes the caller's limit,
-  // realpath's is PATH_MAX past a shorter string), so `end` does not bound the
-  // readable memory. Re-align to the 4 * VEC stride before the unrolled loop:
-  // a 4 * VEC-aligned group never crosses a page, so it is only ever read
-  // beyond the match within the page that holds the match.
-  for (; a + VEC <= end && (reinterpret_cast<uintptr_t>(a) & (4 * VEC - 1));
-       a += VEC) {
+
+  // Re-align to the 4 * VEC stride before the unrolled loop: a 4 * VEC-aligned
+  // group never crosses a page, so it is only ever read beyond the match
+  // within the page that holds the match.
+  for (; remaining >= VEC && (reinterpret_cast<uintptr_t>(a) & (4 * VEC - 1));
+       a += VEC, remaining -= VEC) {
     m = eq_mask(a, needle);
     if (m)
       return const_cast<char *>(a + __builtin_ctzll(m));
   }
-  for (; a + 4 * VEC <= end; a += 4 * VEC)
+  for (; remaining >= 4 * VEC; a += 4 * VEC, remaining -= 4 * VEC)
     if (const char *r = scan4(a, needle))
       return const_cast<char *>(r);
-  for (; a + VEC <= end; a += VEC) {
+  for (; remaining >= VEC; a += VEC, remaining -= VEC) {
     m = eq_mask(a, needle);
     if (m)
       return const_cast<char *>(a + __builtin_ctzll(m));
   }
 
-  if (a < end) {
-    m = eq_mask(a, needle) & ((uint64_t{1} << (end - a)) - 1);
+  if (remaining) {
+    m = eq_mask(a, needle) & ((uint64_t{1} << remaining) - 1);
     if (m)
       return const_cast<char *>(a + __builtin_ctzll(m));
   }


### PR DESCRIPTION
Split from https://github.com/ClickHouse/ClickHouse/pull/109239, kept separate so a perf regression can be reverted alone.

Adds strong AVX2 (SSE2 on the x86-64-v2 build) `memchr` and `strlen` to `libllvmlibc`. Loads are aligned and never cross a page; the unrolled loop is aligned to its 128-byte stride so an overstated `n` (e.g. `strnlen` with `PATH_MAX` in `realpath`) cannot fault before the match is reported. Not built under sanitizers. Other architectures keep the libc implementations. Microbenchmark vs musl's C `memchr`: 3.7x at 16 bytes, 16x at 8 KiB, on par with glibc.

Related: https://github.com/ClickHouse/ClickHouse/pull/109239

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add vectorized `memchr` and `strlen` implementations for x86_64.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118911&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118911](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118911+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
