### PR TITLE
Count CPUs from sysfs instead of the libc

### DIFF
--- a/src/Common/PerCPU.cpp
+++ b/src/Common/PerCPU.cpp
@@ -2,21 +2,86 @@
 
 #if defined(OS_LINUX)
 #include <sys/sysinfo.h>
+#include <fcntl.h>
+#include <unistd.h>
 #elif defined(OS_DARWIN)
 #include <unistd.h>
 #endif
 
 #include <algorithm>
+#include <cstdlib>
 
 namespace PerCPU
 {
+
+namespace
+{
+
+#if defined(OS_LINUX)
+/// The kernel's `nr_cpu_ids`: `sched_getcpu` never returns an id at or above it. Read from
+/// `/sys/devices/system/cpu/possible`, a cpu-list such as `0-127`; returns 0 when the file is
+/// unreadable (no sysfs in the chroot) or not a cpu-list.
+///
+/// This deliberately does not go through the libc. `get_nprocs_conf` (`sysconf(_SC_NPROCESSORS_CONF)`)
+/// counts the configured CPUs with glibc but the CPUs in the calling thread's affinity mask with
+/// musl, so on a cpuset such as `{32,96}` musl reports 2 while the ids are still 32 and 96 - every
+/// per-CPU structure sized by that count would route both CPUs to its fallback shard.
+UInt32 readPossibleCPUCount() noexcept
+{
+    char buf[256];
+    int fd = ::open("/sys/devices/system/cpu/possible", O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+        return 0;
+    ssize_t n = ::read(fd, buf, sizeof(buf) - 1);
+    [[maybe_unused]] int err = ::close(fd);
+    chassert(!err);
+    if (n <= 0)
+        return 0;
+    buf[n] = 0;
+
+    /// Highest id in the list plus one. The storage is indexed by the raw id, so a gap in the
+    /// list (theoretically possible: `0-3,8-11`) must count towards the size.
+    UInt32 max_id = 0;
+    const char * p = buf;
+    bool any = false;
+    while (*p)
+    {
+        char * end = nullptr;
+        Int64 start = std::strtol(p, &end, 10);
+        if (end == p || start < 0)
+            return 0;
+        Int64 last = start;
+        if (*end == '-')
+        {
+            p = end + 1;
+            last = std::strtol(p, &end, 10);
+            if (end == p || last < start)
+                return 0;
+        }
+        max_id = std::max(max_id, static_cast<UInt32>(last));
+        any = true;
+        p = end;
+        if (*p == ',')
+            ++p;
+        else if (*p == '\n' || *p == 0)
+            break;
+        else
+            return 0;
+    }
+    return any ? max_id + 1 : 0;
+}
+#endif
+
+}
 
 UInt32 getNumCPUs() noexcept
 {
     static const UInt32 cached = []
     {
 #if defined(OS_LINUX)
-        const Int64 n = get_nprocs_conf();
+        Int64 n = readPossibleCPUCount();
+        if (n == 0)
+            n = get_nprocs_conf();
 #elif defined(OS_DARWIN)
         const Int64 n = ::sysconf(_SC_NPROCESSORS_ONLN);
 #else

--- a/src/Common/PerCPU.h
+++ b/src/Common/PerCPU.h
@@ -16,13 +16,17 @@ namespace PerCPU
 constexpr UInt32 MAX_CPUS = 1024;
 
 /// Number of CPUs `getCurrentCPU` can route to, capped at `MAX_CPUS`. Cached on first call.
-/// `get_nprocs_conf()` on Linux, `sysconf(_SC_NPROCESSORS_ONLN)` on Darwin; 1 on platforms where
-/// `getCurrentCPU` is unimplemented (routing collapses to one shard there) or if unavailable.
+/// On Linux the kernel's possible-CPU count (`/sys/devices/system/cpu/possible`, the bound on the
+/// ids `sched_getcpu` returns; falls back to `get_nprocs_conf()` without sysfs), so that it does not
+/// depend on the libc: musl's `sysconf(_SC_NPROCESSORS_CONF)` counts the affinity mask, which is
+/// smaller than the ids under a cpuset. `sysconf(_SC_NPROCESSORS_ONLN)` on Darwin; 1 on platforms
+/// where `getCurrentCPU` is unimplemented (routing collapses to one shard there) or if unavailable.
 UInt32 getNumCPUs() noexcept;
 
 /// Current CPU id, or -1 if unavailable (callers must treat a negative value as "unknown" and
-/// fall back to a fixed shard). The id is not guaranteed to be dense in [0, getNumCPUs()); callers
-/// bound it (`cpu % N` or `cpu < N ? cpu : 0`). Cheap on every supported platform (no syscall).
+/// fall back to a fixed shard). Ids are below getNumCPUs() except on hosts with more than
+/// `MAX_CPUS` CPUs, so callers still bound it (`cpu % N` or `cpu < N ? cpu : 0`). Cheap on every
+/// supported platform (no syscall).
 ALWAYS_INLINE inline Int32 getCurrentCPU()
 {
 #if defined(OS_LINUX)

--- a/src/Common/PerCPUMemory.h
+++ b/src/Common/PerCPUMemory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Common/PerCPU.h>
 #include <Common/PerCPUMemoryThreadState.h>
 #include <base/types.h>
 
@@ -55,10 +56,11 @@ public:
     /// per-CPU bound (only the per-thread cap applies).
     static constexpr Int64 UNLIMITED_BUDGET = std::numeric_limits<Int64>::max() / 2;
 
+    /// Slots are indexed by the raw `sched_getcpu` id, so the count must bound the ids, not the
+    /// affinity mask (which is what musl's `sysconf(_SC_NPROCESSORS_CONF)` reports): see `PerCPU::getNumCPUs`.
     static int numberOfCPUs()
     {
-        Int64 n = ::sysconf(_SC_NPROCESSORS_CONF);
-        return n > 0 ? static_cast<int>(n) : 0;
+        return static_cast<int>(PerCPU::getNumCPUs());
     }
 
     PerCPUMemory(int cpu_count_, Int64 capacity_, Int64 buffer_)

--- a/src/Common/getNumberOfCPUCoresToUse.cpp
+++ b/src/Common/getNumberOfCPUCoresToUse.cpp
@@ -13,7 +13,38 @@
 #include <filesystem>
 #include <thread>
 #include <set>
+#include <charconv>
+#include <optional>
 #include <vector>
+
+#if defined(OS_LINUX)
+namespace
+{
+    std::optional<uint32_t> countCPUsInList(const std::string & cpu_list);
+}
+#endif
+
+unsigned getNumberOfLogicalCPUCores()
+{
+    static const unsigned cores = []
+    {
+#if defined(OS_LINUX)
+        /// Read the kernel's own list of online CPUs. This is what glibc's sysconf(_SC_NPROCESSORS_ONLN) does.
+        /// musl derives the same sysconf value from the calling thread's affinity mask instead, so a server started
+        /// under `taskset` would see a different core count depending on the libc it was linked against, and every
+        /// `auto` setting and thread pool sized from it would differ. Reading sysfs directly makes the result
+        /// libc-independent. Cgroup CPU limits are applied on top by getNumberOfCPUCoresToUse.
+        std::ifstream online("/sys/devices/system/cpu/online");
+        std::string line;
+        if (online.is_open() && std::getline(online, line))
+            if (auto count = countCPUsInList(line))
+                return *count;
+        /// /sys is not mounted (chroot) or has an unexpected format.
+#endif
+        return std::thread::hardware_concurrency();
+    }();
+    return cores;
+}
 
 namespace
 {
@@ -28,6 +59,38 @@ int32_t readFrom(const std::filesystem::path & filename, int default_value)
     if (infile >> idata)
         return idata;
     return default_value;
+}
+
+/// Parse a kernel cpu-list such as "0-15" or "0,2-4,7" (the format of /sys/devices/system/cpu/* and
+/// cgroup cpuset files) and return the number of CPUs in it, or nullopt if the text is not a cpu-list.
+std::optional<uint32_t> countCPUsInList(const std::string & cpu_list)
+{
+    if (cpu_list.empty())
+        return std::nullopt;
+
+    auto parse = [](const std::string & text, int & value)
+    {
+        return std::from_chars(text.data(), text.data() + text.size(), value).ec == std::errc{};
+    };
+
+    std::vector<std::string> cpu_ranges;
+    boost::split(cpu_ranges, cpu_list, boost::is_any_of(","));
+    uint32_t cpus_count = 0;
+    for (const std::string & cpu_number_or_range : cpu_ranges)
+    {
+        std::vector<std::string> cpu_range;
+        boost::split(cpu_range, cpu_number_or_range, boost::is_any_of("-"));
+
+        int start = 0;
+        int end = 0;
+        if (cpu_range.size() == 1 && parse(cpu_range[0], start))
+            end = start;
+        else if (cpu_range.size() != 2 || !parse(cpu_range[0], start) || !parse(cpu_range[1], end) || end < start)
+            return std::nullopt;
+
+        cpus_count += static_cast<uint32_t>(end - start) + 1;
+    }
+    return cpus_count;
 }
 
 /// Try to look at cgroups limit if it is available.
@@ -72,28 +135,12 @@ uint32_t getCGroupLimitedCPUCores(unsigned default_cpu_count)
             {
                 // The line in the file is "0,2-4,6,9-14" cpu numbers
                 // It's always grouped and ordered
-                std::vector<std::string> cpu_ranges;
                 std::string cpuset_line;
                 cpuset_cpus_file >> cpuset_line;
-                if (cpuset_line.empty())
+                auto cpus_count = countCPUsInList(cpuset_line);
+                if (!cpus_count)
                     continue;
-                boost::split(cpu_ranges, cpuset_line, boost::is_any_of(","));
-                uint32_t cpus_count = 0;
-                for (const std::string& cpu_number_or_range : cpu_ranges)
-                {
-                    std::vector<std::string> cpu_range;
-                    boost::split(cpu_range, cpu_number_or_range, boost::is_any_of("-"));
-
-                    if (cpu_range.size() == 2)
-                    {
-                        int start = std::stoi(cpu_range[0]);
-                        int end = std::stoi(cpu_range[1]);
-                        cpus_count += (end - start) + 1;
-                    }
-                    else
-                        cpus_count++;
-                }
-                quota_count = std::min(cpus_count, quota_count);
+                quota_count = std::min(*cpus_count, quota_count);
                 break;
             }
         }
@@ -111,8 +158,8 @@ uint32_t getCGroupLimitedCPUCores(unsigned default_cpu_count)
 }
 #endif
 
-/// Returns number of physical cores, unlike std::thread::hardware_concurrency() which returns the logical core count. With 2-way SMT
-/// (HyperThreading) enabled, physical_concurrency() returns half of of std::thread::hardware_concurrency(), otherwise return the same.
+/// Returns number of physical cores, unlike getNumberOfLogicalCPUCores which returns the logical core count. With 2-way SMT
+/// (HyperThreading) enabled, physical_concurrency() returns half of getNumberOfLogicalCPUCores(), otherwise return the same.
 #if defined(__x86_64__) && defined(OS_LINUX)
 unsigned physical_concurrency()
 try
@@ -125,7 +172,7 @@ try
 
     if (!proc_cpuinfo.is_open())
         /// In obscure cases (chroot) /proc can be unmounted
-        return std::thread::hardware_concurrency();
+        return getNumberOfLogicalCPUCores();
 
     using CoreEntry = std::pair<size_t, size_t>; /// physical id, core id
     using CoreEntrySet = std::set<CoreEntry>;
@@ -157,17 +204,17 @@ try
             continue;
         }
     }
-    return core_entries.empty() ? /*unexpected format*/ std::thread::hardware_concurrency() : static_cast<unsigned>(core_entries.size());
+    return core_entries.empty() ? /*unexpected format*/ getNumberOfLogicalCPUCores() : static_cast<unsigned>(core_entries.size());
 }
 catch (const std::exception &)
 {
-    return std::thread::hardware_concurrency(); /// parsing error
+    return getNumberOfLogicalCPUCores(); /// parsing error
 }
 #endif
 
 unsigned getNumberOfCPUCoresToUseImpl()
 {
-    unsigned cores = std::thread::hardware_concurrency(); /// logical cores (with SMT/HyperThreading)
+    unsigned cores = getNumberOfLogicalCPUCores(); /// logical cores (with SMT/HyperThreading)
 
 #if defined(__x86_64__) && defined(OS_LINUX)
     /// Most x86_64 CPUs have 2-way SMT (Hyper-Threading).

--- a/src/Common/getNumberOfCPUCoresToUse.h
+++ b/src/Common/getNumberOfCPUCoresToUse.h
@@ -4,3 +4,8 @@
 /// between the number of physical and logical cores.
 /// Also under cgroups we respect possible cgroups limits.
 unsigned getNumberOfCPUCoresToUse();
+
+/// Number of online logical CPUs (with SMT/HyperThreading), read from the kernel on Linux so that the
+/// value does not depend on the libc: glibc and musl disagree about `sysconf(_SC_NPROCESSORS_ONLN)`
+/// for a process with a restricted affinity mask. Ignores cgroup limits and affinity.
+unsigned getNumberOfLogicalCPUCores();


### PR DESCRIPTION
Read the logical CPU count from `/sys/devices/system/cpu/online` and the per-CPU storage size from `/sys/devices/system/cpu/possible` instead of `std::thread::hardware_concurrency` / `sysconf(_SC_NPROCESSORS_CONF)`.

The kernel's lists bound the ids `sched_getcpu` returns and do not depend on the libc: glibc counts configured CPUs while musl counts the affinity mask, so under a sparse cpuset such as `{32,96}` a musl build sized per-CPU structures for 2 CPUs while the ids were still 32 and 96. With glibc the behaviour only changes for the logical core count under `taskset`, where the online count is now used and the cgroup limit is still applied on top.

`PerCPUMemory::numberOfCPUs` now goes through `PerCPU::getNumCPUs` so both agree; the cpu-list parser is shared with the cgroup `cpuset.cpus` reader and rejects malformed input instead of throwing from `std::stoi`.

Related: https://github.com/ClickHouse/ClickHouse/pull/109239

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Determine the number of CPUs from the kernel's sysfs lists instead of the libc, so per-CPU structures and `auto` thread counts do not depend on the libc's interpretation of the affinity mask.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118912&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118912](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118912+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
