### PR TITLE
Never instrument the libc and the sanitizer runtimes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,7 +778,16 @@ if (FUZZER)
         if (NOT(target STREQUAL "_fuzzer" OR target STREQUAL "_fuzzer_no_main" OR target MATCHES ".*isal.*"))
             get_target_property(target_type ${target} TYPE)
             if (NOT(target_type STREQUAL "INTERFACE_LIBRARY" OR target_type STREQUAL "UTILITY"))
-                target_compile_options(${target} PRIVATE "-fsanitize=fuzzer-no-link")
+                # Targets compiled with -fno-sanitize=all must never be instrumented:
+                # a later -fsanitize=fuzzer-no-link overrides it and re-enables
+                # SanitizerCoverage. That is fatal for the in-tree libc and sanitizer
+                # runtimes (musl, clang_rt_*): their startup code (CRT, __init_libc)
+                # runs before any coverage runtime exists, so every executable would
+                # crash at startup.
+                get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
+                if (NOT target_compile_options MATCHES "-fno-sanitize=all")
+                    target_compile_options(${target} PRIVATE "-fsanitize=fuzzer-no-link")
+                endif()
             endif()
             if (target_type STREQUAL "EXECUTABLE" AND target MATCHES ".+_fuzzer")
                 message(STATUS "${target} instrumented with fuzzer")

--- a/contrib/compiler-rt-cmake/CMakeLists.txt
+++ b/contrib/compiler-rt-cmake/CMakeLists.txt
@@ -237,6 +237,11 @@ target_compile_options(clang_rt_builtins PRIVATE
     -fvisibility=hidden
     -fomit-frame-pointer
     -nostdinc++
+    # Never instrument the builtins: they are called from arbitrary contexts,
+    # including libc startup and sanitizer-runtime internals. Also marks the
+    # target for the top-level FUZZER loop, which skips targets carrying
+    # -fno-sanitize=all instead of appending -fsanitize=fuzzer-no-link.
+    -fno-sanitize=all
     # Suppress all warnings — these are external sources we don't audit.
     -w
 )
@@ -313,6 +318,13 @@ set(SANITIZER_COMMON_FLAGS
     -funwind-tables
     -fno-stack-protector
     -fvisibility=hidden
+    # A sanitizer runtime must never itself be instrumented: it would recurse
+    # into itself, and its early-init code runs before instrumentation runtimes
+    # exist. This also marks the target for the top-level FUZZER loop, which
+    # skips targets carrying -fno-sanitize=all instead of appending
+    # -fsanitize=fuzzer-no-link (that would override this flag and re-enable
+    # SanitizerCoverage).
+    -fno-sanitize=all
     # Suppress all warnings — these are external sources we don't audit.
     -w
 )

--- a/contrib/musl-cmake/CMakeLists.txt
+++ b/contrib/musl-cmake/CMakeLists.txt
@@ -1666,6 +1666,11 @@ target_compile_options(musl PRIVATE
     -fno-stack-protector
     -fomit-frame-pointer
 
+    # Never instrument libc: its early-init code (__init_libc, CRT) runs before
+    # sanitizer runtimes are initialized, and sanitizers hook the public libc
+    # functions with interceptors instead (same model as with uninstrumented glibc).
+    -fno-sanitize=all
+
     # Unwind tables: required for C++ exceptions and stack traces through musl.
     -funwind-tables
     -fasynchronous-unwind-tables
@@ -1721,6 +1726,7 @@ target_compile_options(musl-crt1 PRIVATE
     -std=c99
     -ffreestanding
     -fno-stack-protector
+    -fno-sanitize=all
     -fno-builtin
 )
 add_dependencies(musl-crt1 musl-headers)


### PR DESCRIPTION
Compile `clang_rt_builtins`, every sanitizer runtime, `musl` and `musl-crt1` with `-fno-sanitize=all`. The builtins run in arbitrary contexts including libc startup, an instrumented sanitizer runtime recurses into itself, and libc early-init runs before any runtime exists (sanitizers hook the public libc functions through interceptors instead).

The top-level `FUZZER` loop appended `-fsanitize=fuzzer-no-link` to every target, which overrides `-fno-sanitize=all` and re-enables SanitizerCoverage; it now skips targets carrying the flag. This also corrects glibc fuzzer builds, where the sanitizer runtimes were coverage-instrumented.

Related: https://github.com/ClickHouse/ClickHouse/pull/109239

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Never sanitizer- or fuzzer-instrument the compiler-rt builtins, the sanitizer runtimes, or the bundled libc.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118913&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118913](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118913+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1045` (included in `26.9` and later)
<!-- ch-version-info:end -->