### PR TITLE
Enable XRay under musl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if (NOT ENABLE_XRAY)
     set (ENABLE_XRAY 0)
 endif()
 
-if (NOT ((ARCH_AMD64 OR ARCH_AARCH64) AND OS_LINUX) OR SANITIZE OR USE_MUSL)
+if (NOT ((ARCH_AMD64 OR ARCH_AARCH64) AND OS_LINUX) OR SANITIZE)
     message (STATUS "Not using LLVM XRay, only Linux on amd64 and aarch64 is supported without sanitizers")
     set (ENABLE_XRAY 0)
 endif()

--- a/contrib/compiler-rt-cmake/CMakeLists.txt
+++ b/contrib/compiler-rt-cmake/CMakeLists.txt
@@ -631,17 +631,16 @@ endif()
 # ============================================================
 #
 if (ENABLE_XRAY)
-    # XRay archive: common runtime + all three modes (FDR, basic, profiling) +
-    # per-arch trampolines + sanitizer_common (XRay reuses sanitizer_common's
-    # allocator and printing helpers).
+    # XRay archive: common runtime + per-arch trampolines + sanitizer_common
+    # (XRay reuses sanitizer_common's allocator and printing helpers).
     #
-    # Bundle list mirrors the OBJECT_LIBS for clang_rt.xray (STATIC) in
-    # contrib/llvm-project/compiler-rt/lib/xray/CMakeLists.txt:
-    #   RTXray (= XRAY_SOURCES + ${arch}_SOURCES) + RTXrayFDR + RTXrayBASIC +
-    #   RTXrayPROFILING + RTSanitizerCommon[+Libc].
-    # Upstream additionally builds clang_rt.xray-fdr/-basic/-profiling as
-    # separate archives so an application can link only the modes it uses;
-    # ClickHouse always wants all of them, so we collapse into one archive.
+    # The logging modes (FDR, basic, profiling) are deliberately NOT bundled:
+    # ClickHouse compiles with -fxray-modes=none (see
+    # cmake/xray_instrumentation.cmake) and drives instrumentation through
+    # custom handlers only. This archive is linked --whole-archive (the
+    # runtime's init lives in a preinit_array entry nothing references), so
+    # bundling a mode would run its static initializers in every executable;
+    # xray_fdr_logging's initializer crashes at startup on musl.
     set(_xray_arch_cpp "")
     set(_xray_arch_asm "")
     if     (ARCH_AMD64)
@@ -665,8 +664,7 @@ if (ENABLE_XRAY)
     endif()
 
     set(_xray_combined_full "")
-    foreach (s ${XRAY_COMMON_SOURCES} ${XRAY_FDR_SOURCES} ${XRAY_BASIC_SOURCES}
-                ${XRAY_PROFILING_SOURCES} ${_xray_arch_cpp} ${_xray_arch_asm})
+    foreach (s ${XRAY_COMMON_SOURCES} ${_xray_arch_cpp} ${_xray_arch_asm})
         list(APPEND _xray_combined_full "${XRAY_DIR}/${s}")
     endforeach()
     foreach (s ${SANITIZER_COMMON_SOURCES} ${SANITIZER_COMMON_LIBC_SOURCES})

--- a/contrib/musl-cmake/CMakeLists.txt
+++ b/contrib/musl-cmake/CMakeLists.txt
@@ -1679,6 +1679,22 @@ target_compile_options(musl PRIVATE
     -Werror=pointer-arith
 )
 
+if (ENABLE_XRAY)
+    # Emit XRay sleds in libc too, so `SYSTEM INSTRUMENT` can patch musl
+    # functions. Sleds are inert nops until patched, so early-init code is
+    # unaffected. The dispatch handler's thread-local reentrancy guard makes
+    # patching functions the handler itself calls safe. CRT objects stay
+    # uninstrumented. Note this only covers C sources - the hot asm routines
+    # (memcpy and friends) have no sleds. Flags mirror
+    # cmake/xray_instrumentation.cmake, which runs only after contrib is
+    # configured.
+    target_compile_options(musl PRIVATE
+        -fxray-instrument
+        -fxray-modes=none
+        -fxray-instrumentation-bundle=function
+    )
+endif ()
+
 # Suppress warnings expected in musl's own code
 target_compile_options(musl PRIVATE
     -Wno-unused-function


### PR DESCRIPTION
Allow `ENABLE_XRAY` with `USE_MUSL`, compile musl with XRay sleds so `SYSTEM INSTRUMENT` can patch libc functions, and stop bundling the XRay logging modes (FDR, basic, profiling) into `clang_rt_xray`. ClickHouse compiles with `-fxray-modes=none` and uses its own handlers, so the modes were dead weight; since the archive is linked `--whole-archive`, bundling them also ran their static initializers in every executable, and `xray_fdr_logging`'s crashes at startup on musl.

Nothing in CI sets `ENABLE_XRAY`, so this is low-risk but not exercised by CI.

Related: https://github.com/ClickHouse/ClickHouse/pull/109239

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow building with XRay instrumentation under musl.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118914&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118914](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118914+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
