### PR TITLE
Carry the mutation version onto a rewritten lightweight `DELETE`

### DIFF
--- a/src/Storages/MergeTree/AlterConversions.cpp
+++ b/src/Storages/MergeTree/AlterConversions.cpp
@@ -115,6 +115,13 @@ static MutationCommand createLightweightDeleteCommand(const MutationCommand & co
     if (!mutation_command)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to parse command {}", alter_command->formatForErrorMessage());
 
+    /// The rewritten command stands for the same mutation, so it carries its version - as
+    /// `createCommandWithUpdatedColumns` does for its own rewrite. Without it the on-fly stage built
+    /// from this command has no version bound, `getMaxPatchVersionForStep` returns none, and the
+    /// patch-visibility window of the stage is unbounded above: a patch part created *after* this
+    /// `DELETE` would be applied before its predicate is evaluated.
+    mutation_command->mutation_version = command.mutation_version;
+
     return *mutation_command;
 }
 

--- a/tests/queries/0_stateless/05160_lwd_pending_delete_over_later_patch.reference
+++ b/tests/queries/0_stateless/05160_lwd_pending_delete_over_later_patch.reference
@@ -1,0 +1,10 @@
+on the fly
+5	1
+without the patch
+5	2
+materialized
+5	1
+patch first, on the fly
+0
+patch first, materialized
+0

--- a/tests/queries/0_stateless/05160_lwd_pending_delete_over_later_patch.sql
+++ b/tests/queries/0_stateless/05160_lwd_pending_delete_over_later_patch.sql
@@ -1,0 +1,57 @@
+-- A pending lightweight `DELETE` evaluates its predicate over the data as of its own mutation
+-- version, so a patch part created after it is not visible to that predicate - the on-fly read must
+-- agree with what materializing the mutation produces.
+
+DROP TABLE IF EXISTS t_pending_delete_patch;
+
+CREATE TABLE t_pending_delete_patch (id UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_pending_delete_patch VALUES (1, 1), (5, 2);
+
+SYSTEM STOP MERGES t_pending_delete_patch;
+
+SET lightweight_deletes_sync = 0, mutations_sync = 0;
+DELETE FROM t_pending_delete_patch WHERE c = 1;
+
+UPDATE t_pending_delete_patch SET c = 1 WHERE id = 5;
+
+SELECT 'on the fly';
+SELECT id, c FROM t_pending_delete_patch ORDER BY id SETTINGS apply_mutations_on_fly = 1;
+
+SELECT 'without the patch';
+SELECT id, c FROM t_pending_delete_patch ORDER BY id SETTINGS apply_mutations_on_fly = 1, apply_patch_parts = 0;
+
+SYSTEM START MERGES t_pending_delete_patch;
+SET mutations_sync = 2;
+ALTER TABLE t_pending_delete_patch DELETE WHERE 0;
+
+SELECT 'materialized';
+SELECT id, c FROM t_pending_delete_patch ORDER BY id;
+
+DROP TABLE t_pending_delete_patch;
+
+-- The reverse order: the patch is older than the `DELETE`, so its value is what the predicate sees.
+
+CREATE TABLE t_pending_delete_patch (id UInt64, c UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_pending_delete_patch VALUES (1, 1), (5, 2);
+
+UPDATE t_pending_delete_patch SET c = 1 WHERE id = 5;
+
+SYSTEM STOP MERGES t_pending_delete_patch;
+SET lightweight_deletes_sync = 0, mutations_sync = 0;
+DELETE FROM t_pending_delete_patch WHERE c = 1;
+
+SELECT 'patch first, on the fly';
+SELECT count() FROM t_pending_delete_patch SETTINGS apply_mutations_on_fly = 1;
+
+SYSTEM START MERGES t_pending_delete_patch;
+SET mutations_sync = 2;
+ALTER TABLE t_pending_delete_patch DELETE WHERE 0;
+
+SELECT 'patch first, materialized';
+SELECT count() FROM t_pending_delete_patch;
+
+DROP TABLE t_pending_delete_patch;


### PR DESCRIPTION
A lightweight `DELETE` becomes a mutation of the form `UPDATE _row_exists = 0 WHERE pred`. For an on-fly read (`apply_mutations_on_fly = 1`), `AlterConversions::filterMutationCommands` rewrites it into a `DELETE`-typed command through `createLightweightDeleteCommand`, which built the command with `MutationCommand::parse` and never carried over `mutation_version` - unlike its sibling `createCommandWithUpdatedColumns`. The version-less command produced a version-less on-fly stage, so `getMaxPatchVersionForStep` returned no bound and the patch-visibility window of that stage was unbounded above: a patch part created by a later lightweight `UPDATE` became visible to the pending `DELETE`'s predicate.

The `DELETE` then evaluated its predicate over data it must not see. In the reported case the on-fly read returned no rows at all, and the same rows came back once the mutation materialized - physical mutation execution applies only patch parts at or below the mutation version. Copying the version onto the rewritten command makes the on-fly read agree with the materialized result.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118049

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a pending lightweight `DELETE` read with `apply_mutations_on_fly = 1` evaluating its predicate over patch parts created after it, which made rows disappear from the result and reappear after the mutation materialized.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118919&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118919](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118919+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
