### PR TITLE
Create IcebergRESTCatalogHandler [1/n]

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -4468,7 +4468,7 @@ void Server::createServers(
                         port_name,
                         "Iceberg REST catalog: http://" + address.toString(),
                         std::make_unique<HTTPServer>(
-                            httpContext(), createIcebergRESTCatalogHandlerFactory(warehouse), server_pool, socket, http_params, nullptr, ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes));
+                            httpContext(), createIcebergRESTCatalogHandlerFactory(*this, warehouse), server_pool, socket, http_params, nullptr, ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes));
                 });
             }
         }

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -143,6 +143,7 @@
 #include <Server/ProxyV1HandlerFactory.h>
 #include <Server/TLSHandlerFactory.h>
 #include <Server/KeeperHTTPHandlerFactory.h>
+#include <Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.h>
 #include <Server/ArrowFlight/ArrowFlightServer.h>
 #include <Interpreters/AsynchronousInsertQueue.h>
 
@@ -4445,6 +4446,32 @@ void Server::createServers(
                 });
             }
         }
+
+        if (server_type.shouldStart(ServerType::Type::ICEBERG_REST_CATALOG) && !config.getString("iceberg_rest_catalog.port", "").empty())
+        {
+            port_name = "iceberg_rest_catalog.port";
+            auto warehouse = config.getString("iceberg_rest_catalog.warehouse", "");
+            if (warehouse.empty())
+            {
+                LOG_ERROR(&logger(), "Not starting the Iceberg REST catalog server: 'iceberg_rest_catalog.warehouse' is not set");
+            }
+            else
+            {
+                createServer(config, listen_host, port_name, listen_try, start_servers, servers, [&](UInt16 port) -> ProtocolServerAdapter
+                {
+                    Poco::Net::ServerSocket socket;
+                    auto address = socketBindListen(server_settings, socket, listen_host, port);
+                    socket.setReceiveTimeout(settings[Setting::http_receive_timeout]);
+                    socket.setSendTimeout(settings[Setting::http_send_timeout]);
+                    return ProtocolServerAdapter(
+                        listen_host,
+                        port_name,
+                        "Iceberg REST catalog: http://" + address.toString(),
+                        std::make_unique<HTTPServer>(
+                            httpContext(), createIcebergRESTCatalogHandlerFactory(warehouse), server_pool, socket, http_params, nullptr, ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes));
+                });
+            }
+        }
     }
 }
 
@@ -4732,6 +4759,13 @@ void Server::updateServers(
             {
                 force_restart = true;
                 LOG_TRACE(log, "<prometheus.keeper_metrics_only> had been changed, will reload {}", server->getDescription());
+            }
+            /// The warehouse name is baked into the Iceberg REST catalog handler factory, so if
+            /// the section changes, the listener must be restarted.
+            if (port_name == "iceberg_rest_catalog.port" && !isSameConfiguration(previous_config, config, "iceberg_rest_catalog"))
+            {
+                force_restart = true;
+                LOG_TRACE(log, "<iceberg_rest_catalog> had been changed, will reload {}", server->getDescription());
             }
             /// `asynchronous_metrics_key_values_mode` decides whether the keys of the key-value asynchronous
             /// metrics are written as Prometheus labels (`device="sda"`) or mangled into the metric name. A

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1205,6 +1205,16 @@
     </prometheus>
     -->
 
+    <!-- Embedded Iceberg REST catalog server (experimental). Not recommended for production use.
+         Only a small subset of the Iceberg REST API is implemented, and the catalog state is kept in memory,
+         so it is lost on server restart. Disabled unless the port is set. -->
+    <!--
+    <iceberg_rest_catalog>
+        <port>8182</port>
+        <warehouse>my_warehouse</warehouse>
+    </iceberg_rest_catalog>
+    -->
+
     <!-- Query log. Used only for queries with setting log_queries = 1. -->
     <query_log>
         <!-- What table to insert data. If table is not exist, it will be created.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -435,6 +435,7 @@ endif()
 
 add_object_library(clickhouse_server Server)
 add_object_library(clickhouse_server_http Server/HTTP)
+add_object_library(clickhouse_server_iceberg_rest_catalog Server/IcebergRESTCatalog)
 
 # Track dependencies for #embed directives so that changes to embedded files trigger recompilation.
 set_source_files_properties(Server/WebUIRequestHandler.cpp PROPERTIES OBJECT_DEPENDS

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -2212,6 +2212,7 @@ void ServerSettings::checkUnknownSettings(const Poco::Util::AbstractConfiguratio
         "remote_url_allow_hosts",
         "http_handlers",
         "arrowflight",
+        "iceberg_rest_catalog",
         "proxy",
         "enable_http_stacktrace",
         "enable_verbose_replicas_status",

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -575,6 +575,8 @@ String toString(ClientInfo::Interface interface)
             return "BACKGROUND";
         case ClientInfo::Interface::ARROW_FLIGHT:
             return "ARROWFLIGHT";
+        case ClientInfo::Interface::ICEBERG_REST_CATALOG:
+            return "ICEBERG_REST_CATALOG";
     }
 
     return fmt::format("Unknown server interface ({}).", static_cast<int>(interface));

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -53,6 +53,7 @@ public:
         PROMETHEUS = 8,
         BACKGROUND = 9, // e.g. queries from refreshable materialized views
         ARROW_FLIGHT = 10,
+        ICEBERG_REST_CATALOG = 11,
     };
 
     enum class HTTPMethod : uint8_t

--- a/src/Interpreters/SessionLog.cpp
+++ b/src/Interpreters/SessionLog.cpp
@@ -119,8 +119,9 @@ ColumnsDescription SessionLogElement::getColumnsDescription()
             {"Prometheus",             static_cast<Int8>(Interface::PROMETHEUS)},
             {"Background",             static_cast<Int8>(Interface::BACKGROUND)},
             {"ArrowFlight",            static_cast<Int8>(Interface::ARROW_FLIGHT)},
+            {"IcebergRESTCatalog",     static_cast<Int8>(Interface::ICEBERG_REST_CATALOG)},
         });
-    static_assert(magic_enum::enum_count<Interface>() == 10, "Please update the array above to match the enum.");
+    static_assert(magic_enum::enum_count<Interface>() == 11, "Please update the array above to match the enum.");
 
     auto lc_string_datatype = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
 

--- a/src/Server/IcebergRESTCatalog/IIcebergRESTCatalogStore.h
+++ b/src/Server/IcebergRESTCatalog/IIcebergRESTCatalogStore.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <base/types.h>
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace DB
+{
+
+/// Support multi-level namespace names.
+using IcebergNamespaceName = std::vector<String>;
+
+/// Storage backend of native Iceberg REST catalog (RFC: issue #114697).
+/// Work in progress, not ready for production use.
+class IIcebergRESTCatalogStore
+{
+public:
+    virtual ~IIcebergRESTCatalogStore() = default;
+
+    /// Returns false if the namespace already exists. Any other failure throws.
+    virtual bool createNamespace(const IcebergNamespaceName & name, std::map<String, String> properties) = 0;
+
+    virtual bool namespaceExists(const IcebergNamespaceName & name) const = 0;
+
+    /// Lists direct children of `parent` or top-level namespaces when `parent` is empty.
+    virtual std::vector<IcebergNamespaceName> listNamespaces(const IcebergNamespaceName & parent) const = 0;
+};
+
+using IcebergRESTCatalogStorePtr = std::shared_ptr<IIcebergRESTCatalogStore>;
+
+}

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.cpp
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.cpp
@@ -1,11 +1,19 @@
 #include <Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h>
 
+#include <Access/Credentials.h>
+#include <Core/Settings.h>
 #include <IO/HTTPCommon.h>
 #include <IO/LimitReadBuffer.h>
 #include <IO/Operators.h>
 #include <IO/ReadHelpers.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/Session.h>
+#include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPServerRequest.h>
 #include <Server/HTTP/HTTPServerResponse.h>
+#include <Server/HTTP/authenticateUserByHTTP.h>
+#include <Server/HTTPHandler.h>
+#include <Server/IServer.h>
 
 #include <Poco/JSON/Array.h>
 #include <Poco/JSON/Parser.h>
@@ -19,6 +27,13 @@
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int ACCESS_DENIED;
+    extern const int AUTHENTICATION_FAILED;
+    extern const int REQUIRED_PASSWORD;
+}
 
 namespace
 {
@@ -58,11 +73,28 @@ std::optional<String> getQueryParameter(const Poco::URI & uri, const String & na
 
 }
 
-IcebergRESTCatalogHandler::IcebergRESTCatalogHandler(String warehouse_, IcebergRESTCatalogStorePtr store_)
+IcebergRESTCatalogHandler::IcebergRESTCatalogHandler(IServer & server_, String warehouse_, IcebergRESTCatalogStorePtr store_)
     : log(getLogger("IcebergRESTCatalogHandler"))
+    , server(server_)
     , warehouse(std::move(warehouse_))
     , store(std::move(store_))
 {
+}
+
+ContextMutablePtr IcebergRESTCatalogHandler::authenticateUser(HTTPServerRequest & request, HTTPServerResponse & response, Session & session) const
+{
+    /// Only the URI is parsed here, so the body stays available for the route handlers.
+    HTMLForm params(server.context()->getSettingsRef(), request);
+    /// No fixed user: every request must carry its own credentials.
+    const HTTPHandlerConnectionConfig connection_config;
+    /// Each request gets a fresh handler, so partial multi-step credentials do not survive a 401 anyway.
+    std::unique_ptr<Credentials> request_credentials;
+    if (!authenticateUserByHTTP(request, params, response, session, request_credentials, connection_config, server.context(), log))
+        return nullptr;
+
+    auto context = session.makeQueryContext();
+    context->setCurrentQueryId("");
+    return context;
 }
 
 std::optional<String> IcebergRESTCatalogHandler::readRequestBody(HTTPServerRequest & request, HTTPServerResponse & response, size_t max_size)
@@ -118,6 +150,11 @@ void IcebergRESTCatalogHandler::handleRequest(HTTPServerRequest & request, HTTPS
 {
     try
     {
+        Session session(server.context(), ClientInfo::Interface::ICEBERG_REST_CATALOG, request.isSecure());
+        auto context = authenticateUser(request, response, session);
+        if (!context)
+            return; /// 401 with `WWW-Authenticate` is already sent.
+
         Poco::URI uri;
         std::vector<std::string> segments;
         try
@@ -191,12 +228,30 @@ void IcebergRESTCatalogHandler::handleRequest(HTTPServerRequest & request, HTTPS
     }
     catch (...)
     {
+        auto status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        String type = "InternalServerError";
+        String message = "Internal server error";
+
+        const int code = getCurrentExceptionCode();
+        /// `AccessControl` reports a wrong password for the `default` user as `REQUIRED_PASSWORD`.
+        if (code == ErrorCodes::AUTHENTICATION_FAILED || code == ErrorCodes::REQUIRED_PASSWORD)
+        {
+            status = Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED;
+            type = "NotAuthorizedException";
+            message = getCurrentExceptionMessage(false);
+        }
+        else if (code == ErrorCodes::ACCESS_DENIED)
+        {
+            status = Poco::Net::HTTPResponse::HTTP_FORBIDDEN;
+            type = "ForbiddenException";
+            message = getCurrentExceptionMessage(false);
+        }
+
         tryLogCurrentException(log, "Failed to process Iceberg REST catalog request");
         try
         {
             if (!response.sent())
-                sendError(
-                    response, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, "InternalServerError", "Internal server error");
+                sendError(response, status, type, message);
         }
         catch (...)
         {

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.cpp
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.cpp
@@ -1,0 +1,355 @@
+#include <Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h>
+
+#include <IO/HTTPCommon.h>
+#include <IO/LimitReadBuffer.h>
+#include <IO/Operators.h>
+#include <IO/ReadHelpers.h>
+#include <Server/HTTP/HTTPServerRequest.h>
+#include <Server/HTTP/HTTPServerResponse.h>
+
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Stringifier.h>
+
+#include <base/unit.h>
+#include <boost/algorithm/string/split.hpp>
+#include <fmt/ranges.h>
+
+#include <sstream>
+
+namespace DB
+{
+
+namespace
+{
+
+constexpr size_t MAX_NAMESPACE_CREATE_BODY_SIZE = 1_MiB;
+constexpr char NAMESPACE_LEVEL_SEPARATOR = '\x1F';
+
+IcebergNamespaceName splitNamespace(const String & value)
+{
+    IcebergNamespaceName result;
+    boost::split(result, value, [](char c) { return c == NAMESPACE_LEVEL_SEPARATOR; });
+    return result;
+}
+
+String joinNamespace(const IcebergNamespaceName & name)
+{
+    return fmt::format("{}", fmt::join(name, "."));
+}
+
+Poco::JSON::Array namespaceToJSON(const IcebergNamespaceName & name)
+{
+    Poco::JSON::Array result;
+    for (const auto & level : name)
+        result.add(level);
+    return result;
+}
+
+std::optional<String> getQueryParameter(const Poco::URI & uri, const String & name)
+{
+    for (const auto & [key, value] : uri.getQueryParameters())
+    {
+        if (key == name)
+            return value;
+    }
+    return std::nullopt;
+}
+
+}
+
+IcebergRESTCatalogHandler::IcebergRESTCatalogHandler(String warehouse_, IcebergRESTCatalogStorePtr store_)
+    : log(getLogger("IcebergRESTCatalogHandler"))
+    , warehouse(std::move(warehouse_))
+    , store(std::move(store_))
+{
+}
+
+std::optional<String> IcebergRESTCatalogHandler::readRequestBody(HTTPServerRequest & request, HTTPServerResponse & response, size_t max_size)
+{
+    String body;
+    /// Read one byte past the limit, otherwise an oversized body is silently truncated.
+    LimitReadBuffer limited_stream(*request.getStream(), LimitReadBuffer::Settings{.read_no_more = max_size + 1});
+    readStringUntilEOF(body, limited_stream);
+
+    if (body.size() > max_size)
+    {
+        /// The rest of the body stays unread, so the connection cannot be reused for the next request.
+        response.setKeepAlive(false);
+        sendError(
+            response,
+            Poco::Net::HTTPResponse::HTTP_REQUEST_ENTITY_TOO_LARGE,
+            "RequestEntityTooLargeException",
+            fmt::format("Request body must not exceed {} bytes", max_size));
+        return {};
+    }
+
+    return body;
+}
+
+void IcebergRESTCatalogHandler::sendJSON(
+    HTTPServerResponse & response, const Poco::JSON::Object & json, Poco::Net::HTTPResponse::HTTPStatus status)
+{
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    oss.exceptions(std::ios::failbit);
+    Poco::JSON::Stringifier::stringify(json, oss);
+
+    setResponseDefaultHeaders(response);
+    response.setStatus(status);
+    response.setContentType("application/json");
+    *response.send() << oss.str();
+}
+
+void IcebergRESTCatalogHandler::sendError(
+    HTTPServerResponse & response, Poco::Net::HTTPResponse::HTTPStatus status, const String & type, const String & message)
+{
+    /// ErrorModel from the Iceberg REST specification.
+    Poco::JSON::Object error;
+    error.set("message", message);
+    error.set("type", type);
+    error.set("code", static_cast<int>(status));
+
+    Poco::JSON::Object result;
+    result.set("error", error);
+    sendJSON(response, result, status);
+}
+
+void IcebergRESTCatalogHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
+{
+    try
+    {
+        Poco::URI uri;
+        std::vector<std::string> segments;
+        try
+        {
+            uri = Poco::URI(request.getURI());
+            uri.getPathSegments(segments);
+        }
+        catch (const Poco::Exception &)
+        {
+            sendError(response, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "BadRequestException", "Malformed request URI");
+            return;
+        }
+
+        auto match = matchIcebergRESTRoute(request.getMethod(), segments);
+        if (!match)
+        {
+            sendError(
+                response,
+                Poco::Net::HTTPResponse::HTTP_NOT_FOUND,
+                "NotFoundException",
+                fmt::format("No route for {} {}", request.getMethod(), uri.getPath()));
+            return;
+        }
+
+        /// The spec reserves 406 UnsupportedOperationResponse for operations the server does not support.
+        if (!match->route->implemented)
+        {
+            sendError(
+                response,
+                Poco::Net::HTTPResponse::HTTP_NOT_ACCEPTABLE,
+                "UnsupportedOperationException",
+                fmt::format("Not implemented: {}", toString(match->route->operation)));
+            return;
+        }
+
+        if (auto prefix = match->path_params.find("prefix"); prefix != match->path_params.end())
+        {
+            if (prefix->second != warehouse)
+            {
+                sendError(
+                    response,
+                    Poco::Net::HTTPResponse::HTTP_NOT_FOUND,
+                    "NotFoundException",
+                    fmt::format("Unknown prefix: {}", prefix->second));
+                return;
+            }
+        }
+
+        switch (match->route->operation)
+        {
+            case IcebergRESTOperation::GetConfig:
+                handleGetConfig(uri, response);
+                return;
+            case IcebergRESTOperation::ListNamespaces:
+                handleListNamespaces(uri, response);
+                return;
+            case IcebergRESTOperation::CreateNamespace:
+                handleCreateNamespace(request, response);
+                return;
+            case IcebergRESTOperation::NamespaceExists:
+                handleNamespaceExists(*match, response);
+                return;
+            default:
+                sendError(
+                    response,
+                    Poco::Net::HTTPResponse::HTTP_NOT_ACCEPTABLE,
+                    "UnsupportedOperationException",
+                    fmt::format("Not implemented: {}", toString(match->route->operation)));
+                return;
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Failed to process Iceberg REST catalog request");
+        try
+        {
+            if (!response.sent())
+                sendError(
+                    response, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, "InternalServerError", "Internal server error");
+        }
+        catch (...)
+        {
+            LOG_ERROR(log, "Cannot send exception to client");
+        }
+    }
+}
+
+void IcebergRESTCatalogHandler::handleGetConfig(const Poco::URI & uri, HTTPServerResponse & response) const
+{
+    auto requested_warehouse = getQueryParameter(uri, "warehouse");
+    if (!requested_warehouse)
+    {
+        sendError(
+            response, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "BadRequestException", "This server requires the warehouse query parameter");
+        return;
+    }
+
+    if (*requested_warehouse != warehouse)
+    {
+        sendError(
+            response,
+            Poco::Net::HTTPResponse::HTTP_NOT_FOUND,
+            "NoSuchWarehouseException",
+            fmt::format("Unknown warehouse: {}", *requested_warehouse));
+        return;
+    }
+
+    Poco::JSON::Object defaults;
+    Poco::JSON::Object overrides;
+    Poco::JSON::Array endpoints;
+
+
+    overrides.set("prefix", warehouse);
+    for (const auto & route : getIcebergRESTRoutes())
+    {
+        if (!route.implemented)
+            continue;
+        endpoints.add(fmt::format("{} /{}", route.method, fmt::join(route.pattern, "/")));
+    }
+
+    Poco::JSON::Object result;
+    result.set("defaults", defaults);
+    result.set("overrides", overrides);
+    result.set("endpoints", endpoints);
+    sendJSON(response, result, Poco::Net::HTTPResponse::HTTP_OK);
+}
+
+void IcebergRESTCatalogHandler::handleListNamespaces(const Poco::URI & uri, HTTPServerResponse & response) const
+{
+    IcebergNamespaceName parent;
+    if (auto parent_param = getQueryParameter(uri, "parent"); parent_param && !parent_param->empty())
+    {
+        parent = splitNamespace(*parent_param);
+        if (!store->namespaceExists(parent))
+        {
+            sendError(
+                response,
+                Poco::Net::HTTPResponse::HTTP_NOT_FOUND,
+                "NoSuchNamespaceException",
+                fmt::format("Namespace does not exist: {}", joinNamespace(parent)));
+            return;
+        }
+    }
+
+    Poco::JSON::Array namespaces;
+    for (const auto & name : store->listNamespaces(parent))
+        namespaces.add(namespaceToJSON(name));
+
+    Poco::JSON::Object result;
+    result.set("namespaces", namespaces);
+    sendJSON(response, result, Poco::Net::HTTPResponse::HTTP_OK);
+}
+
+void IcebergRESTCatalogHandler::handleNamespaceExists(const IcebergRESTRouteMatch & match, HTTPServerResponse & response) const
+{
+    const auto name = splitNamespace(match.path_params.at("namespace"));
+    if (!store->namespaceExists(name))
+    {
+        sendError(
+            response,
+            Poco::Net::HTTPResponse::HTTP_NOT_FOUND,
+            "NoSuchNamespaceException",
+            fmt::format("Namespace does not exist: {}", joinNamespace(name)));
+        return;
+    }
+
+    setResponseDefaultHeaders(response);
+    response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_NO_CONTENT);
+    response.send();
+}
+
+void IcebergRESTCatalogHandler::handleCreateNamespace(HTTPServerRequest & request, HTTPServerResponse & response) const
+{
+    const auto body = readRequestBody(request, response, MAX_NAMESPACE_CREATE_BODY_SIZE);
+    if (!body)
+        return;
+
+    IcebergNamespaceName name;
+    std::map<String, String> properties;
+    try
+    {
+        Poco::JSON::Parser parser;
+        const auto json = parser.parse(*body).extract<Poco::JSON::Object::Ptr>();
+
+        const auto namespace_array = json->getArray("namespace");
+        if (!namespace_array || namespace_array->size() == 0)
+            throw Poco::Exception("'namespace' must be a non-empty array");
+
+        for (const auto & level : *namespace_array)
+        {
+            if (level.extract<String>().empty())
+                throw Poco::Exception("namespace levels must be non-empty strings");
+            name.push_back(level.extract<String>());
+        }
+
+        if (json->has("properties"))
+        {
+            const auto properties_object = json->getObject("properties");
+            if (!properties_object)
+                throw Poco::Exception("'properties' must be an object");
+            for (const auto & [key, value] : *properties_object)
+                properties[key] = value.extract<String>();
+        }
+    }
+    catch (const Poco::Exception & e)
+    {
+        sendError(
+            response,
+            Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+            "BadRequestException",
+            fmt::format("Malformed create namespace request: {}", e.displayText()));
+        return;
+    }
+
+    if (!store->createNamespace(name, properties))
+    {
+        sendError(
+            response,
+            Poco::Net::HTTPResponse::HTTP_CONFLICT,
+            "AlreadyExistsException",
+            fmt::format("Namespace already exists: {}", joinNamespace(name)));
+        return;
+    }
+
+    Poco::JSON::Object properties_json;
+    for (const auto & [key, value] : properties)
+        properties_json.set(key, value);
+
+    Poco::JSON::Object result;
+    result.set("namespace", namespaceToJSON(name));
+    result.set("properties", properties_json);
+    sendJSON(response, result, Poco::Net::HTTPResponse::HTTP_OK);
+}
+
+}

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Interpreters/Context_fwd.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <Server/IcebergRESTCatalog/IIcebergRESTCatalogStore.h>
 #include <Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.h>
@@ -14,15 +15,22 @@
 namespace DB
 {
 
+class IServer;
+class Session;
+
 /// Serves the Iceberg REST catalog v1 API (RFC: issue #114697).
+/// Every request is authenticated with the regular HTTP credentials (Basic, `X-ClickHouse-User`, certificates).
 class IcebergRESTCatalogHandler : public HTTPRequestHandler
 {
 public:
-    IcebergRESTCatalogHandler(String warehouse_, IcebergRESTCatalogStorePtr store_);
+    IcebergRESTCatalogHandler(IServer & server_, String warehouse_, IcebergRESTCatalogStorePtr store_);
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
 
 private:
+    /// Returns nullptr when the response has already been sent (401 with `WWW-Authenticate`).
+    ContextMutablePtr authenticateUser(HTTPServerRequest & request, HTTPServerResponse & response, Session & session) const;
+
     void handleGetConfig(const Poco::URI & uri, HTTPServerResponse & response) const;
     void handleListNamespaces(const Poco::URI & uri, HTTPServerResponse & response) const;
     void handleCreateNamespace(HTTPServerRequest & request, HTTPServerResponse & response) const;
@@ -36,6 +44,7 @@ private:
         HTTPServerResponse & response, Poco::Net::HTTPResponse::HTTPStatus status, const String & type, const String & message);
 
     LoggerPtr log;
+    IServer & server;
     const String warehouse;
     IcebergRESTCatalogStorePtr store;
 };

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Server/HTTP/HTTPRequestHandler.h>
+#include <Server/IcebergRESTCatalog/IIcebergRESTCatalogStore.h>
+#include <Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.h>
+#include <Common/logger_useful.h>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/URI.h>
+
+#include <optional>
+
+namespace DB
+{
+
+/// Serves the Iceberg REST catalog v1 API (RFC: issue #114697).
+class IcebergRESTCatalogHandler : public HTTPRequestHandler
+{
+public:
+    IcebergRESTCatalogHandler(String warehouse_, IcebergRESTCatalogStorePtr store_);
+
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+
+private:
+    void handleGetConfig(const Poco::URI & uri, HTTPServerResponse & response) const;
+    void handleListNamespaces(const Poco::URI & uri, HTTPServerResponse & response) const;
+    void handleCreateNamespace(HTTPServerRequest & request, HTTPServerResponse & response) const;
+    void handleNamespaceExists(const IcebergRESTRouteMatch & match, HTTPServerResponse & response) const;
+
+    /// Reads the whole request body. Returns nullopt after answering 413 if the body exceeds max_size.
+    static std::optional<String> readRequestBody(HTTPServerRequest & request, HTTPServerResponse & response, size_t max_size);
+
+    static void sendJSON(HTTPServerResponse & response, const Poco::JSON::Object & json, Poco::Net::HTTPResponse::HTTPStatus status);
+    static void sendError(
+        HTTPServerResponse & response, Poco::Net::HTTPResponse::HTTPStatus status, const String & type, const String & message);
+
+    LoggerPtr log;
+    const String warehouse;
+    IcebergRESTCatalogStorePtr store;
+};
+
+}

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.cpp
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.cpp
@@ -23,7 +23,8 @@ std::unique_ptr<HTTPRequestHandler> IcebergRESTCatalogHandlerFactory::createRequ
 
 HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(IServer & server, String warehouse)
 {
-    return std::make_shared<IcebergRESTCatalogHandlerFactory>(server, std::move(warehouse), getSharedInMemoryIcebergRESTCatalogStore());
+    auto store = getSharedInMemoryIcebergRESTCatalogStore(warehouse);
+    return std::make_shared<IcebergRESTCatalogHandlerFactory>(server, std::move(warehouse), std::move(store));
 }
 
 }

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.cpp
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.cpp
@@ -4,13 +4,12 @@
 #include <Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h>
 #include <Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h>
 
-#include <Poco/Net/HTTPRequest.h>
-
 namespace DB
 {
 
-IcebergRESTCatalogHandlerFactory::IcebergRESTCatalogHandlerFactory(String warehouse_, IcebergRESTCatalogStorePtr store_)
+IcebergRESTCatalogHandlerFactory::IcebergRESTCatalogHandlerFactory(IServer & server_, String warehouse_, IcebergRESTCatalogStorePtr store_)
     : log(getLogger(name))
+    , server(server_)
     , warehouse(std::move(warehouse_))
     , store(std::move(store_))
 {
@@ -19,18 +18,12 @@ IcebergRESTCatalogHandlerFactory::IcebergRESTCatalogHandlerFactory(String wareho
 std::unique_ptr<HTTPRequestHandler> IcebergRESTCatalogHandlerFactory::createRequestHandler(const HTTPServerRequest & request)
 {
     LOG_TRACE(log, "HTTP request for {}. {}", name, request.toStringForLogging());
-
-    const auto & method = request.getMethod();
-    if (method == Poco::Net::HTTPRequest::HTTP_GET || method == Poco::Net::HTTPRequest::HTTP_HEAD
-        || method == Poco::Net::HTTPRequest::HTTP_POST || method == Poco::Net::HTTPRequest::HTTP_DELETE)
-        return std::make_unique<IcebergRESTCatalogHandler>(warehouse, store);
-
-    return nullptr;
+    return std::make_unique<IcebergRESTCatalogHandler>(server, warehouse, store);
 }
 
-HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(String warehouse)
+HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(IServer & server, String warehouse)
 {
-    return std::make_shared<IcebergRESTCatalogHandlerFactory>(std::move(warehouse), getSharedInMemoryIcebergRESTCatalogStore());
+    return std::make_shared<IcebergRESTCatalogHandlerFactory>(server, std::move(warehouse), getSharedInMemoryIcebergRESTCatalogStore());
 }
 
 }

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.cpp
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.cpp
@@ -1,0 +1,36 @@
+#include <Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.h>
+
+#include <Server/HTTP/HTTPServerRequest.h>
+#include <Server/IcebergRESTCatalog/IcebergRESTCatalogHandler.h>
+#include <Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h>
+
+#include <Poco/Net/HTTPRequest.h>
+
+namespace DB
+{
+
+IcebergRESTCatalogHandlerFactory::IcebergRESTCatalogHandlerFactory(String warehouse_, IcebergRESTCatalogStorePtr store_)
+    : log(getLogger(name))
+    , warehouse(std::move(warehouse_))
+    , store(std::move(store_))
+{
+}
+
+std::unique_ptr<HTTPRequestHandler> IcebergRESTCatalogHandlerFactory::createRequestHandler(const HTTPServerRequest & request)
+{
+    LOG_TRACE(log, "HTTP request for {}. {}", name, request.toStringForLogging());
+
+    const auto & method = request.getMethod();
+    if (method == Poco::Net::HTTPRequest::HTTP_GET || method == Poco::Net::HTTPRequest::HTTP_HEAD
+        || method == Poco::Net::HTTPRequest::HTTP_POST || method == Poco::Net::HTTPRequest::HTTP_DELETE)
+        return std::make_unique<IcebergRESTCatalogHandler>(warehouse, store);
+
+    return nullptr;
+}
+
+HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(String warehouse)
+{
+    return std::make_shared<IcebergRESTCatalogHandlerFactory>(std::move(warehouse), getSharedInMemoryIcebergRESTCatalogStore());
+}
+
+}

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.h
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.h
@@ -7,20 +7,23 @@
 namespace DB
 {
 
+class IServer;
+
 class IcebergRESTCatalogHandlerFactory : public HTTPRequestHandlerFactory
 {
 public:
-    IcebergRESTCatalogHandlerFactory(String warehouse_, IcebergRESTCatalogStorePtr store_);
+    IcebergRESTCatalogHandlerFactory(IServer & server_, String warehouse_, IcebergRESTCatalogStorePtr store_);
 
     std::unique_ptr<HTTPRequestHandler> createRequestHandler(const HTTPServerRequest & request) override;
 
 private:
     const std::string name = "IcebergRESTCatalogHandler-factory";
     LoggerPtr log;
+    IServer & server;
     const String warehouse;
     IcebergRESTCatalogStorePtr store;
 };
 
-HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(String warehouse);
+HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(IServer & server, String warehouse);
 
 }

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.h
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogHandlerFactory.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Server/HTTP/HTTPRequestHandlerFactory.h>
+#include <Server/IcebergRESTCatalog/IIcebergRESTCatalogStore.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+
+class IcebergRESTCatalogHandlerFactory : public HTTPRequestHandlerFactory
+{
+public:
+    IcebergRESTCatalogHandlerFactory(String warehouse_, IcebergRESTCatalogStorePtr store_);
+
+    std::unique_ptr<HTTPRequestHandler> createRequestHandler(const HTTPServerRequest & request) override;
+
+private:
+    const std::string name = "IcebergRESTCatalogHandler-factory";
+    LoggerPtr log;
+    const String warehouse;
+    IcebergRESTCatalogStorePtr store;
+};
+
+HTTPRequestHandlerFactoryPtr createIcebergRESTCatalogHandlerFactory(String warehouse);
+
+}

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.cpp
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.cpp
@@ -1,0 +1,101 @@
+#include <Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.h>
+
+#include <Poco/Net/HTTPRequest.h>
+
+#include <base/EnumReflection.h>
+
+namespace DB
+{
+
+std::string toString(IcebergRESTOperation operation)
+{
+    return std::string(magic_enum::enum_name(operation));
+}
+
+const std::vector<IcebergRESTRoute> & getIcebergRESTRoutes()
+{
+    using Poco::Net::HTTPRequest;
+
+    /// Fully-literal routes go before parameterized siblings so that literal segments win.
+    static const std::vector<IcebergRESTRoute> routes =
+    {
+        {HTTPRequest::HTTP_GET, {"v1", "config"}, IcebergRESTOperation::GetConfig, true},
+        {HTTPRequest::HTTP_POST, {"v1", "oauth", "tokens"}, IcebergRESTOperation::GetToken, false},
+
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "tables", "rename"}, IcebergRESTOperation::RenameTable, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "transactions", "commit"}, IcebergRESTOperation::CommitTransaction, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "views", "rename"}, IcebergRESTOperation::RenameView, false},
+
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces"}, IcebergRESTOperation::ListNamespaces, true},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces"}, IcebergRESTOperation::CreateNamespace, true},
+
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}"}, IcebergRESTOperation::LoadNamespace, false},
+        {HTTPRequest::HTTP_HEAD, {"v1", "{prefix}", "namespaces", "{namespace}"}, IcebergRESTOperation::NamespaceExists, true},
+        {HTTPRequest::HTTP_DELETE, {"v1", "{prefix}", "namespaces", "{namespace}"}, IcebergRESTOperation::DropNamespace, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "properties"}, IcebergRESTOperation::UpdateNamespaceProperties, false},
+
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "tables"}, IcebergRESTOperation::ListTables, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables"}, IcebergRESTOperation::CreateTable, false},
+
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}"}, IcebergRESTOperation::LoadTable, false},
+        {HTTPRequest::HTTP_HEAD, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}"}, IcebergRESTOperation::TableExists, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}"}, IcebergRESTOperation::UpdateTable, false},
+        {HTTPRequest::HTTP_DELETE, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}"}, IcebergRESTOperation::DropTable, false},
+
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "register"}, IcebergRESTOperation::RegisterTable, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "unregister"}, IcebergRESTOperation::UnregisterTable, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "metrics"}, IcebergRESTOperation::ReportMetrics, false},
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "credentials"}, IcebergRESTOperation::LoadCredentials, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "sign"}, IcebergRESTOperation::SignRequest, false},
+
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "plan"}, IcebergRESTOperation::PlanTableScan, false},
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "plan", "{plan-id}"}, IcebergRESTOperation::FetchPlanningResult, false},
+        {HTTPRequest::HTTP_DELETE, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "plan", "{plan-id}"}, IcebergRESTOperation::CancelPlanning, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "tables", "{table}", "tasks"}, IcebergRESTOperation::FetchScanTasks, false},
+
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "views"}, IcebergRESTOperation::ListViews, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "views"}, IcebergRESTOperation::CreateView, false},
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "views", "{view}"}, IcebergRESTOperation::LoadView, false},
+        {HTTPRequest::HTTP_HEAD, {"v1", "{prefix}", "namespaces", "{namespace}", "views", "{view}"}, IcebergRESTOperation::ViewExists, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "views", "{view}"}, IcebergRESTOperation::ReplaceView, false},
+        {HTTPRequest::HTTP_DELETE, {"v1", "{prefix}", "namespaces", "{namespace}", "views", "{view}"}, IcebergRESTOperation::DropView, false},
+        {HTTPRequest::HTTP_POST, {"v1", "{prefix}", "namespaces", "{namespace}", "register-view"}, IcebergRESTOperation::RegisterView, false},
+
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "functions"}, IcebergRESTOperation::ListFunctions, false},
+        {HTTPRequest::HTTP_GET, {"v1", "{prefix}", "namespaces", "{namespace}", "functions", "{function}"}, IcebergRESTOperation::LoadFunction, false},
+    };
+    return routes;
+}
+
+std::optional<IcebergRESTRouteMatch> matchIcebergRESTRoute(const std::string & method, const std::vector<std::string> & segments)
+{
+    for (const auto & route : getIcebergRESTRoutes())
+    {
+        if (method != route.method || segments.size() != route.pattern.size())
+            continue;
+
+        IcebergRESTRouteMatch match;
+        match.route = &route;
+
+        bool matched = true;
+        for (size_t i = 0; i < segments.size(); ++i)
+        {
+            const auto & pattern_segment = route.pattern[i];
+            if (pattern_segment.starts_with('{'))
+            {
+                match.path_params[pattern_segment.substr(1, pattern_segment.size() - 2)] = segments[i];
+            }
+            else if (pattern_segment != segments[i])
+            {
+                matched = false;
+                break;
+            }
+        }
+
+        if (matched)
+            return match;
+    }
+    return std::nullopt;
+}
+
+}

--- a/src/Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.h
+++ b/src/Server/IcebergRESTCatalog/IcebergRESTCatalogRouter.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace DB
+{
+
+/// Operations of the Iceberg REST catalog v1 API (RFC: issue #114697).
+enum class IcebergRESTOperation
+{
+    GetConfig,
+    ListNamespaces,
+    CreateNamespace,
+    LoadNamespace,
+    NamespaceExists,
+    DropNamespace,
+    UpdateNamespaceProperties,
+    ListTables,
+    CreateTable,
+    LoadTable,
+    TableExists,
+    UpdateTable,
+    DropTable,
+    RenameTable,
+    RegisterTable,
+    UnregisterTable,
+    ReportMetrics,
+    CommitTransaction,
+    /// The operations below are recognized so that they answer 406 instead of 404, but there are no plans to support them.
+    GetToken,
+    LoadCredentials,
+    SignRequest,
+    PlanTableScan,
+    FetchPlanningResult,
+    CancelPlanning,
+    FetchScanTasks,
+    ListViews,
+    CreateView,
+    LoadView,
+    ReplaceView,
+    DropView,
+    ViewExists,
+    RenameView,
+    RegisterView,
+    ListFunctions,
+    LoadFunction,
+};
+
+std::string toString(IcebergRESTOperation operation);
+
+struct IcebergRESTRoute
+{
+    /// HTTP_GET, HTTP_POST, etc.
+    std::string method;
+    /// Path segments
+    std::vector<std::string> pattern;
+    IcebergRESTOperation operation;
+    bool implemented;
+};
+
+struct IcebergRESTRouteMatch
+{
+    const IcebergRESTRoute * route = nullptr;
+    /// Captured placeholders: "prefix", "namespace", "table". Values are percent-decoded.
+    std::unordered_map<std::string, std::string> path_params;
+};
+
+const std::vector<IcebergRESTRoute> & getIcebergRESTRoutes();
+
+/// Returns nullopt when no route matches.
+std::optional<IcebergRESTRouteMatch> matchIcebergRESTRoute(const std::string & method, const std::vector<std::string> & segments);
+
+}

--- a/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.cpp
+++ b/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.cpp
@@ -36,9 +36,15 @@ std::vector<IcebergNamespaceName> InMemoryIcebergRESTCatalogStore::listNamespace
     return result;
 }
 
-IcebergRESTCatalogStorePtr getSharedInMemoryIcebergRESTCatalogStore()
+IcebergRESTCatalogStorePtr getSharedInMemoryIcebergRESTCatalogStore(const String & warehouse)
 {
-    static IcebergRESTCatalogStorePtr store = std::make_shared<InMemoryIcebergRESTCatalogStore>();
+    static std::mutex mutex;
+    static std::map<String, IcebergRESTCatalogStorePtr> stores;
+
+    std::lock_guard lock(mutex);
+    auto & store = stores[warehouse];
+    if (!store)
+        store = std::make_shared<InMemoryIcebergRESTCatalogStore>();
     return store;
 }
 

--- a/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.cpp
+++ b/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.cpp
@@ -1,0 +1,45 @@
+#include <Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h>
+
+#include <algorithm>
+
+namespace DB
+{
+
+bool InMemoryIcebergRESTCatalogStore::createNamespace(const IcebergNamespaceName & name, std::map<String, String> properties)
+{
+    std::lock_guard lock(mutex);
+    if (!namespaces.emplace(name, std::move(properties)).second)
+        return false;
+
+    /// Create the parents if needed, so that the tree stays walkable from the root.
+    for (size_t level = 1; level < name.size(); ++level)
+        namespaces.emplace(IcebergNamespaceName(name.begin(), name.begin() + level), std::map<String, String>{});
+
+    return true;
+}
+
+bool InMemoryIcebergRESTCatalogStore::namespaceExists(const IcebergNamespaceName & name) const
+{
+    std::lock_guard lock(mutex);
+    return namespaces.contains(name);
+}
+
+std::vector<IcebergNamespaceName> InMemoryIcebergRESTCatalogStore::listNamespaces(const IcebergNamespaceName & parent) const
+{
+    std::lock_guard lock(mutex);
+    std::vector<IcebergNamespaceName> result;
+    for (const auto & [name, _] : namespaces)
+    {
+        if (name.size() == parent.size() + 1 && std::equal(parent.begin(), parent.end(), name.begin()))
+            result.push_back(name);
+    }
+    return result;
+}
+
+IcebergRESTCatalogStorePtr getSharedInMemoryIcebergRESTCatalogStore()
+{
+    static IcebergRESTCatalogStorePtr store = std::make_shared<InMemoryIcebergRESTCatalogStore>();
+    return store;
+}
+
+}

--- a/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h
+++ b/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h
@@ -21,7 +21,7 @@ private:
     std::map<IcebergNamespaceName, std::map<String, String>> namespaces;
 };
 
-/// Shared across listeners for all listen hosts and across STOP/START LISTEN cycles.
-IcebergRESTCatalogStorePtr getSharedInMemoryIcebergRESTCatalogStore();
+/// One store per warehouse, shared across listeners for all listen hosts, STOP/START LISTEN cycles and config reloads.
+IcebergRESTCatalogStorePtr getSharedInMemoryIcebergRESTCatalogStore(const String & warehouse);
 
 }

--- a/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h
+++ b/src/Server/IcebergRESTCatalog/InMemoryIcebergRESTCatalogStore.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Server/IcebergRESTCatalog/IIcebergRESTCatalogStore.h>
+
+#include <mutex>
+
+namespace DB
+{
+
+/// Process-local catalog store, lost on server restart. Scaffolding until the Keeper-backed store lands.
+class InMemoryIcebergRESTCatalogStore : public IIcebergRESTCatalogStore
+{
+public:
+    bool createNamespace(const IcebergNamespaceName & name, std::map<String, String> properties) override;
+    bool namespaceExists(const IcebergNamespaceName & name) const override;
+    std::vector<IcebergNamespaceName> listNamespaces(const IcebergNamespaceName & parent) const override;
+
+private:
+    mutable std::mutex mutex;
+    /// Flat map of full multi-level names; std::map keeps listing deterministic.
+    std::map<IcebergNamespaceName, std::map<String, String>> namespaces;
+};
+
+/// Shared across listeners for all listen hosts and across STOP/START LISTEN cycles.
+IcebergRESTCatalogStorePtr getSharedInMemoryIcebergRESTCatalogStore();
+
+}

--- a/src/Server/ServerType.cpp
+++ b/src/Server/ServerType.cpp
@@ -59,6 +59,7 @@ bool ServerType::shouldStart(Type server_type, const std::string & server_custom
             case Type::INTERSERVER_HTTP:
             case Type::INTERSERVER_HTTPS:
             case Type::ARROW_FLIGHT:
+            case Type::ICEBERG_REST_CATALOG:
                 return true;
             default:
                 return false;
@@ -154,6 +155,9 @@ bool ServerType::shouldStop(const std::string & port_name) const
 
     else if (port_name == "cloud.port")
         port_type = Type::CLOUD;
+
+    else if (port_name == "iceberg_rest_catalog.port")
+        port_type = Type::ICEBERG_REST_CATALOG;
 
     else
         return false;

--- a/src/Server/ServerType.h
+++ b/src/Server/ServerType.h
@@ -29,6 +29,7 @@ public:
         QUERIES_DEFAULT,
         QUERIES_CUSTOM,
         CLOUD,
+        ICEBERG_REST_CATALOG,
         END
     };
 

--- a/tests/integration/test_iceberg_rest_catalog_server/configs/iceberg_rest_catalog.xml
+++ b/tests/integration/test_iceberg_rest_catalog_server/configs/iceberg_rest_catalog.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <iceberg_rest_catalog>
+        <port>8182</port>
+        <warehouse>my_warehouse</warehouse>
+    </iceberg_rest_catalog>
+</clickhouse>

--- a/tests/integration/test_iceberg_rest_catalog_server/test.py
+++ b/tests/integration/test_iceberg_rest_catalog_server/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import base64
 import time
 import uuid
 
@@ -11,8 +12,12 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance(
-    "node", main_configs=["configs/iceberg_rest_catalog.xml"], stay_alive=True
+    "node",
+    main_configs=["configs/iceberg_rest_catalog.xml"],
+    stay_alive=True,
 )
+
+DEFAULT_AUTH = ("default", "")
 
 CATALOG_PORT = 8182
 
@@ -42,8 +47,12 @@ def catalog_url(path):
     return f"http://{node.ip_address}:{CATALOG_PORT}{path}"
 
 
-def catalog_request(method, path, json=None, params=None, expected_code=200):
-    response = requests.request(method, catalog_url(path), json=json, params=params)
+def catalog_request(
+    method, path, json=None, params=None, expected_code=200, auth=None, headers=None
+):
+    response = requests.request(
+        method, catalog_url(path), json=json, params=params, auth=auth, headers=headers
+    )
     assert response.status_code == expected_code, (
         f"Expected {expected_code}, got {response.status_code}. "
         f"Response: {response.text}"
@@ -122,7 +131,9 @@ def test_namespaces(started_cluster):
     assert list_namespaces(parent=f"{ns}\x1feu") == [[ns, "eu", "west"]]
     assert list_namespaces(parent=f"{ns}\x1feu\x1fwest") == []
 
-    response = requests.head(catalog_url(f"/v1/my_warehouse/namespaces/{ns}%1Feu%1Fwest"))
+    response = requests.head(
+        catalog_url(f"/v1/my_warehouse/namespaces/{ns}%1Feu%1Fwest")
+    )
     assert response.status_code == 204, response.text
 
     response = catalog_request(
@@ -171,9 +182,7 @@ def test_namespace_exists(started_cluster):
 
 def test_malformed_create_namespace(started_cluster):
     for body in [None, {}, {"namespace": []}, {"namespace": [""]}]:
-        response = requests.post(
-            catalog_url("/v1/my_warehouse/namespaces"), json=body
-        )
+        response = requests.post(catalog_url("/v1/my_warehouse/namespaces"), json=body)
         assert response.status_code == 400, response.text
         assert_error_shape(response, "BadRequestException")
 
@@ -246,17 +255,73 @@ def test_stop_start_listen(started_cluster):
     assert [ns] in list_namespaces()
 
 
+def test_authentication(started_cluster):
+    # (basic auth, headers, is_ok)
+    cases = [
+        (DEFAULT_AUTH, None, True),
+        (("default", "wrong"), None, False),
+        (("no_such_user", ""), None, False),
+        (None, {"X-ClickHouse-User": "default", "X-ClickHouse-Key": ""}, True),
+        (None, {"X-ClickHouse-User": "default", "X-ClickHouse-Key": "wrong"}, False),
+    ]
+    for auth, headers, is_ok in cases:
+        response = catalog_request(
+            "GET",
+            "/v1/my_warehouse/namespaces",
+            expected_code=200 if is_ok else 401,
+            auth=auth,
+            headers=headers,
+        )
+        if not is_ok:
+            assert_error_shape(response, "NotAuthorizedException")
+
+
+def test_auth_failure_does_not_poison_connection(started_cluster):
+    session = requests.Session()
+    response = session.get(
+        catalog_url("/v1/my_warehouse/namespaces"), auth=("default", "wrong")
+    )
+    assert response.status_code == 401
+    response = session.get(
+        catalog_url("/v1/my_warehouse/namespaces"), auth=DEFAULT_AUTH
+    )
+    assert response.status_code == 200
+
+
+def test_client_auth_header(started_cluster):
+    # (credentials, is_ok)
+    cases = [
+        (b"default:", True),
+        (b"default:wrong", False),
+    ]
+    for credentials, is_ok in cases:
+        token = base64.b64encode(credentials).decode()
+        # The client fetches /v1/config on CREATE DATABASE, so wrong credentials fail there with the server's 401.
+        query = f"""
+            DROP DATABASE IF EXISTS rest_client_auth_db;
+            SET allow_experimental_database_iceberg = 1;
+            CREATE DATABASE rest_client_auth_db
+            ENGINE = DataLakeCatalog('http://localhost:{CATALOG_PORT}/v1')
+            SETTINGS catalog_type = 'rest', warehouse = 'my_warehouse',
+                auth_header = 'Authorization: Basic {token}'
+            """
+        if is_ok:
+            node.query(query)
+            node.query("DROP DATABASE IF EXISTS rest_client_auth_db")
+        else:
+            error = node.query_and_get_error(query)
+            assert "401" in error, error
+
+
 def test_clickhouse_rest_catalog_client(started_cluster):
     ns = f"client_{uuid.uuid4().hex[:8]}"
     create_namespace([ns])
 
-    node.query(
-        f"""
+    node.query(f"""
         DROP DATABASE IF EXISTS rest_client_db;
         SET allow_experimental_database_iceberg = 1;
         CREATE DATABASE rest_client_db
         ENGINE = DataLakeCatalog('http://localhost:{CATALOG_PORT}/v1')
         SETTINGS catalog_type = 'rest', warehouse = 'my_warehouse'
-        """
-    )
+        """)
     node.query("DROP DATABASE IF EXISTS rest_client_db")

--- a/tests/integration/test_iceberg_rest_catalog_server/test.py
+++ b/tests/integration/test_iceberg_rest_catalog_server/test.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+
+import time
+import uuid
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node", main_configs=["configs/iceberg_rest_catalog.xml"], stay_alive=True
+)
+
+CATALOG_PORT = 8182
+
+
+def wait_catalog_ready(timeout=60):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            requests.get(catalog_url("/v1/config"), timeout=1)
+            return
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.1)
+    raise AssertionError("Catalog port did not start accepting connections")
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        wait_catalog_ready()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def catalog_url(path):
+    return f"http://{node.ip_address}:{CATALOG_PORT}{path}"
+
+
+def catalog_request(method, path, json=None, params=None, expected_code=200):
+    response = requests.request(method, catalog_url(path), json=json, params=params)
+    assert response.status_code == expected_code, (
+        f"Expected {expected_code}, got {response.status_code}. "
+        f"Response: {response.text}"
+    )
+    return response
+
+
+def assert_error_shape(response, expected_type):
+    error = response.json()["error"]
+    assert error["type"] == expected_type
+    assert error["code"] == response.status_code
+    assert error["message"]
+
+
+def create_namespace(name_levels, properties=None, expected_code=200):
+    body = {"namespace": name_levels}
+    if properties is not None:
+        body["properties"] = properties
+    return catalog_request(
+        "POST", "/v1/my_warehouse/namespaces", json=body, expected_code=expected_code
+    )
+
+
+def list_namespaces(parent=None):
+    params = {"parent": parent} if parent is not None else None
+    response = catalog_request("GET", "/v1/my_warehouse/namespaces", params=params)
+    return response.json()["namespaces"]
+
+
+def test_config(started_cluster):
+    response = catalog_request(
+        "GET", "/v1/config", params={"warehouse": "my_warehouse"}
+    )
+    result = response.json()
+    assert result["overrides"]["prefix"] == "my_warehouse"
+    assert result["defaults"] == {}
+    assert result["endpoints"] == [
+        "GET /v1/config",
+        "GET /v1/{prefix}/namespaces",
+        "POST /v1/{prefix}/namespaces",
+        "HEAD /v1/{prefix}/namespaces/{namespace}",
+    ]
+
+    response = catalog_request("GET", "/v1/config", expected_code=400)
+    assert_error_shape(response, "BadRequestException")
+
+    response = catalog_request(
+        "GET", "/v1/config", params={"warehouse": "unknown"}, expected_code=404
+    )
+    assert_error_shape(response, "NoSuchWarehouseException")
+
+
+def test_namespaces(started_cluster):
+    ns = f"sales_{uuid.uuid4().hex[:8]}"
+
+    response = create_namespace([ns], properties={"location": "s3://bucket/sales/"})
+    result = response.json()
+    assert result["namespace"] == [ns]
+    assert result["properties"] == {"location": "s3://bucket/sales/"}
+
+    response = create_namespace([ns], expected_code=409)
+    assert_error_shape(response, "AlreadyExistsException")
+
+    create_namespace([ns, "eu"])
+
+    top_level = list_namespaces()
+    assert [ns] in top_level
+    assert [ns, "eu"] not in top_level
+
+    assert list_namespaces(parent=ns) == [[ns, "eu"]]
+
+    # Multi-part namespaces are joined with the unit separator 0x1F (url encoded `%1F`),
+    # which is the spec default when /config does not override `namespace-separator`.
+    create_namespace([ns, "eu", "west"])
+    assert list_namespaces(parent=ns) == [[ns, "eu"]]
+    assert list_namespaces(parent=f"{ns}\x1feu") == [[ns, "eu", "west"]]
+    assert list_namespaces(parent=f"{ns}\x1feu\x1fwest") == []
+
+    response = requests.head(catalog_url(f"/v1/my_warehouse/namespaces/{ns}%1Feu%1Fwest"))
+    assert response.status_code == 204, response.text
+
+    response = catalog_request(
+        "GET",
+        "/v1/my_warehouse/namespaces",
+        params={"parent": f"{ns}\x1fmissing"},
+        expected_code=404,
+    )
+    assert_error_shape(response, "NoSuchNamespaceException")
+
+    response = catalog_request(
+        "GET",
+        "/v1/my_warehouse/namespaces",
+        params={"parent": "missing"},
+        expected_code=404,
+    )
+    assert_error_shape(response, "NoSuchNamespaceException")
+
+
+def test_create_namespace_creates_parents(started_cluster):
+    ns = f"parents_{uuid.uuid4().hex[:8]}"
+
+    create_namespace([ns, "eu", "west"])
+
+    assert [ns] in list_namespaces()
+    assert list_namespaces(parent=ns) == [[ns, "eu"]]
+    assert list_namespaces(parent=f"{ns}\x1feu") == [[ns, "eu", "west"]]
+
+    # The parents are created with empty properties, and creating them again conflicts.
+    response = create_namespace([ns, "eu"], expected_code=409)
+    assert_error_shape(response, "AlreadyExistsException")
+
+
+def test_namespace_exists(started_cluster):
+    ns = f"exists_{uuid.uuid4().hex[:8]}"
+    create_namespace([ns])
+
+    response = requests.head(catalog_url(f"/v1/my_warehouse/namespaces/{ns}"))
+    assert response.status_code == 204, response.text
+    assert response.text == ""
+
+    response = requests.head(catalog_url("/v1/my_warehouse/namespaces/missing"))
+    assert response.status_code == 404, response.text
+    assert response.text == ""
+
+
+def test_malformed_create_namespace(started_cluster):
+    for body in [None, {}, {"namespace": []}, {"namespace": [""]}]:
+        response = requests.post(
+            catalog_url("/v1/my_warehouse/namespaces"), json=body
+        )
+        assert response.status_code == 400, response.text
+        assert_error_shape(response, "BadRequestException")
+
+
+def test_not_implemented(started_cluster):
+    response = catalog_request(
+        "GET", "/v1/my_warehouse/namespaces/sales/tables", expected_code=406
+    )
+    assert_error_shape(response, "UnsupportedOperationException")
+
+    response = catalog_request(
+        "POST", "/v1/my_warehouse/namespaces/sales/tables", expected_code=406
+    )
+    assert_error_shape(response, "UnsupportedOperationException")
+
+    response = catalog_request(
+        "POST", "/v1/my_warehouse/tables/rename", expected_code=406
+    )
+    assert_error_shape(response, "UnsupportedOperationException")
+
+    response = requests.head(catalog_url("/v1/my_warehouse/namespaces/sales/tables/t"))
+    assert response.status_code == 406
+
+    # Views and functions are part of the spec, but there are no plans for this server to support them.
+    response = catalog_request(
+        "GET", "/v1/my_warehouse/namespaces/sales/functions", expected_code=406
+    )
+    assert_error_shape(response, "UnsupportedOperationException")
+
+    response = catalog_request(
+        "GET", "/v1/my_warehouse/namespaces/sales/views", expected_code=406
+    )
+    assert_error_shape(response, "UnsupportedOperationException")
+
+
+def test_not_found_shape(started_cluster):
+    response = catalog_request("GET", "/v1/nonsense", expected_code=404)
+    assert_error_shape(response, "NotFoundException")
+
+    response = catalog_request(
+        "GET", "/v1/other_warehouse/namespaces", expected_code=404
+    )
+    assert_error_shape(response, "NotFoundException")
+
+
+def test_stop_start_listen(started_cluster):
+    ns = f"persistent_{uuid.uuid4().hex[:8]}"
+    create_namespace([ns])
+
+    node.query("SYSTEM STOP LISTEN ICEBERG REST CATALOG")
+    for _ in range(100):
+        try:
+            requests.get(catalog_url("/v1/config"), timeout=1)
+        except requests.exceptions.ConnectionError:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError("Catalog port is still accepting connections")
+
+    node.query("SYSTEM START LISTEN ICEBERG REST CATALOG")
+    for _ in range(100):
+        try:
+            requests.get(catalog_url("/v1/config"), timeout=1)
+            break
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.1)
+    else:
+        raise AssertionError("Catalog port did not start accepting connections")
+
+    assert [ns] in list_namespaces()
+
+
+def test_clickhouse_rest_catalog_client(started_cluster):
+    ns = f"client_{uuid.uuid4().hex[:8]}"
+    create_namespace([ns])
+
+    node.query(
+        f"""
+        DROP DATABASE IF EXISTS rest_client_db;
+        SET allow_experimental_database_iceberg = 1;
+        CREATE DATABASE rest_client_db
+        ENGINE = DataLakeCatalog('http://localhost:{CATALOG_PORT}/v1')
+        SETTINGS catalog_type = 'rest', warehouse = 'my_warehouse'
+        """
+    )
+    node.query("DROP DATABASE IF EXISTS rest_client_db")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/issues/114697
-->

### Summary
This is the first part of the embedded Iceberg REST catalog server. The server starts only when the `iceberg_rest_catalog` section with a `port` and a `warehouse` is present in the server configuration.

 It supports only a few endpoints: `GET /v1/config`, `GET /v1/{prefix}/namespaces`, `POST /v1/{prefix}/namespaces`, and `HEAD /v1/{prefix}/namespaces/{namespace}`. All other routes from the Iceberg REST
 specification are recognized but return "not implemented".

 For now, the backend is an in-memory store, so the catalog state is lost on server restart. It will later be replaced by Keeper storage. The feature is experimental and not yet recommended for production use.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry:
Added an experimental embedded Iceberg REST catalog server with an in-memory namespace store and ClickHouse HTTP authentication. It currently supports `GET /v1/config`, namespace listing and creation, and namespace existence checks.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118924&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118924](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118924+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
