### PR TITLE
Bump `openssl` from openssl-3.5.7 to openssl-3.5.8

### DIFF
--- a/contrib/openssl-cmake/common/include/openssl/opensslv.h
+++ b/contrib/openssl-cmake/common/include/openssl/opensslv.h
@@ -29,7 +29,7 @@ extern "C" {
  */
 # define OPENSSL_VERSION_MAJOR  3
 # define OPENSSL_VERSION_MINOR  5
-# define OPENSSL_VERSION_PATCH  7
+# define OPENSSL_VERSION_PATCH  8
 
 /*
  * Additional version information
@@ -74,21 +74,21 @@ extern "C" {
  * longer variant with OPENSSL_VERSION_PRE_RELEASE_STR and
  * OPENSSL_VERSION_BUILD_METADATA_STR appended.
  */
-# define OPENSSL_VERSION_STR "3.5.7"
-# define OPENSSL_FULL_VERSION_STR "3.5.7"
+# define OPENSSL_VERSION_STR "3.5.8"
+# define OPENSSL_FULL_VERSION_STR "3.5.8"
 
 /*
  * SECTION 3: ADDITIONAL METADATA
  *
  * These strings are defined separately to allow them to be parsable.
  */
-# define OPENSSL_RELEASE_DATE "9 Jun 2026"
+# define OPENSSL_RELEASE_DATE "25 Aug 2026"
 
 /*
  * SECTION 4: BACKWARD COMPATIBILITY
  */
 
-# define OPENSSL_VERSION_TEXT "OpenSSL 3.5.7 9 Jun 2026"
+# define OPENSSL_VERSION_TEXT "OpenSSL 3.5.8 25 Aug 2026"
 
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
 # ifdef OPENSSL_VERSION_PRE_RELEASE

--- a/contrib/openssl-cmake/common/include/openssl/ssl.h
+++ b/contrib/openssl-cmake/common/include/openssl/ssl.h
@@ -2480,6 +2480,7 @@ __owur int SSL_get_conn_close_info(SSL *ssl,
 # define SSL_VALUE_STREAM_WRITE_BUF_SIZE            7
 # define SSL_VALUE_STREAM_WRITE_BUF_USED            8
 # define SSL_VALUE_STREAM_WRITE_BUF_AVAIL           9
+# define SSL_VALUE_QUIC_MAX_PENDING_CONNS          16
 
 # define SSL_VALUE_EVENT_HANDLING_MODE_INHERIT      0
 # define SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT     1
@@ -2727,8 +2728,18 @@ const CTLOG_STORE *SSL_CTX_get0_ctlog_store(const SSL_CTX *ctx);
 # define SSL_SECOP_OTHER_SIGALG  (5 << 16)
 # define SSL_SECOP_OTHER_CERT    (6 << 16)
 
-/* Indicated operation refers to peer key or certificate */
+/*
+ * Unused values - these do nothing and are never set.
+ * They are retained because of API. They should
+ * be removed next major
+ */
 # define SSL_SECOP_PEER          0x1000
+/* Peer EE key in certificate */
+# define SSL_SECOP_PEER_EE_KEY           (SSL_SECOP_EE_KEY | SSL_SECOP_PEER)
+/* Peer CA key in certificate */
+# define SSL_SECOP_PEER_CA_KEY           (SSL_SECOP_CA_KEY | SSL_SECOP_PEER)
+/* Peer CA digest algorithm in certificate */
+# define SSL_SECOP_PEER_CA_MD            (SSL_SECOP_CA_MD | SSL_SECOP_PEER)
 
 /* Values for "op" parameter in security callback */
 
@@ -2767,12 +2778,6 @@ const CTLOG_STORE *SSL_CTX_get0_ctlog_store(const SSL_CTX *ctx);
 # define SSL_SECOP_CA_KEY                (17 | SSL_SECOP_OTHER_CERT)
 /* CA digest algorithm in certificate */
 # define SSL_SECOP_CA_MD                 (18 | SSL_SECOP_OTHER_CERT)
-/* Peer EE key in certificate */
-# define SSL_SECOP_PEER_EE_KEY           (SSL_SECOP_EE_KEY | SSL_SECOP_PEER)
-/* Peer CA key in certificate */
-# define SSL_SECOP_PEER_CA_KEY           (SSL_SECOP_CA_KEY | SSL_SECOP_PEER)
-/* Peer CA digest algorithm in certificate */
-# define SSL_SECOP_PEER_CA_MD            (SSL_SECOP_CA_MD | SSL_SECOP_PEER)
 
 void SSL_set_security_level(SSL *s, int level);
 __owur int SSL_get_security_level(const SSL *s);


### PR DESCRIPTION
Updates `contrib/openssl` from `ClickHouse/openssl-3.5.7` (`26868a38972e`) to `ClickHouse/openssl-3.5.8` (`614167b874c6`), which tracks the upstream `openssl-3.5.8` tag released on 25 Aug 2026. The fork branch carries the same 13 ClickHouse patches as before — MSan/TSan/LSan suppressions, no `getrandom`, no `sendmmsg`/`recvmmsg`, ARM `getauxval` on musl, removed submodules — rebased 1:1 onto the new tag. We stay on the 3.5 LTS line.

3.5.8 is a security and bug-fix patch release, fixing CVE-2026-18798, CVE-2026-63072, CVE-2026-63073, CVE-2026-63074, CVE-2026-63075, CVE-2026-63076, CVE-2026-14456, CVE-2026-14457, CVE-2026-54874 and CVE-2026-75803 in the QUIC, CMS, CMP, DTLS and AEAD code paths. Nothing moved in the build surface: no `.c` files were added or removed under `crypto/`, `ssl/` or `providers/`, and the single deletion (`crypto/aes/aes_x86core.c`) was never referenced, so `contrib/openssl-cmake/CMakeLists.txt` needs no changes. The 29 touched perlasm generators only differ in copyright headers and an `icx`/`__clang_major__` fallback in AVX detection, and regenerating the assembly from 3.5.7 and from 3.5.8 produces byte-identical output, so the checked-in files under `contrib/openssl-cmake/asm/` are left alone.

On the ClickHouse side only the two checked-in generated headers needed adapting. `common/include/openssl/opensslv.h` gets the patch level 7 → 8, the new version strings and the 25 Aug 2026 release date. `common/include/openssl/ssl.h` gets the `ssl.h.in` delta applied by hand — the new `SSL_VALUE_QUIC_MAX_PENDING_CONNS` value and the `SSL_SECOP_PEER_*` defines moved next to `SSL_SECOP_PEER` and marked unused — rather than a wholesale regeneration, since the checked-in headers were not produced by the documented `Configure` line and carry flags (`OPENSSL_NO_FIPS_POST`, `OPENSSL_NO_FIPS_SECURITYCHECKS`, `OPENSSL_NO_ACVP_TESTS`) the sources depend on. No changes in `src/` or `.gitmodules`.

---

One thing to fix before pushing: the diff stat also contains `contrib/usearch` (submodule pointer moved), which is unrelated to this bump and isn't described above — drop it from the branch.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `openssl` to 3.5.8.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118927&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118927](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118927+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1054` (included in `26.9` and later)
- Backported to: `26.8.3.73`, `26.7.7.74`, `26.6.5.107`, `26.3.33.51`
<!-- ch-version-info:end -->