### PR TITLE
Bump `rocksdb` from v10.10.1 to v11.8.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,7 +136,7 @@
 	url = https://github.com/danlark1/miniselect
 [submodule "contrib/rocksdb"]
 	path = contrib/rocksdb
-	url = https://github.com/facebook/rocksdb
+	url = https://github.com/ClickHouse/rocksdb
 [submodule "contrib/xz"]
 	path = contrib/xz
 	url = https://github.com/tukaani-project/xz

--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -33,8 +33,12 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/cache/sharded_cache.cc
     ${ROCKSDB_SOURCE_DIR}/cache/tiered_secondary_cache.cc
     ${ROCKSDB_SOURCE_DIR}/db/arena_wrapped_db_iter.cc
+    ${ROCKSDB_SOURCE_DIR}/db/version_util.cc
     ${ROCKSDB_SOURCE_DIR}/db/attribute_group_iterator_impl.cc
     ${ROCKSDB_SOURCE_DIR}/db/blob/blob_contents.cc
+    ${ROCKSDB_SOURCE_DIR}/db/blob/blob_file_partition_manager.cc
+    ${ROCKSDB_SOURCE_DIR}/db/blob/blob_gen2_format.cc
+    ${ROCKSDB_SOURCE_DIR}/db/blob/blob_write_batch_transformer.cc
     ${ROCKSDB_SOURCE_DIR}/db/blob/blob_fetcher.cc
     ${ROCKSDB_SOURCE_DIR}/db/blob/blob_file_addition.cc
     ${ROCKSDB_SOURCE_DIR}/db/blob/blob_file_builder.cc
@@ -117,6 +121,7 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/db/wal_edit.cc
     ${ROCKSDB_SOURCE_DIR}/db/wal_manager.cc
     ${ROCKSDB_SOURCE_DIR}/db/wide/wide_column_serialization.cc
+    ${ROCKSDB_SOURCE_DIR}/db/wide/read_path_blob_resolver.cc
     ${ROCKSDB_SOURCE_DIR}/db/wide/wide_columns.cc
     ${ROCKSDB_SOURCE_DIR}/db/wide/wide_columns_helper.cc
     ${ROCKSDB_SOURCE_DIR}/db/write_batch.cc
@@ -185,6 +190,7 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/port/stack_trace.cc
     ${ROCKSDB_SOURCE_DIR}/table/adaptive/adaptive_table_factory.cc
     ${ROCKSDB_SOURCE_DIR}/table/block_based/binary_search_index_reader.cc
+    ${ROCKSDB_SOURCE_DIR}/table/block_based/multi_scan_index_iterator.cc
     ${ROCKSDB_SOURCE_DIR}/table/block_based/block.cc
     ${ROCKSDB_SOURCE_DIR}/table/block_based/block_based_table_builder.cc
     ${ROCKSDB_SOURCE_DIR}/table/block_based/block_based_table_factory.cc
@@ -243,6 +249,8 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/trace_replay/trace_record.cc
     ${ROCKSDB_SOURCE_DIR}/trace_replay/trace_replay.cc
     ${ROCKSDB_SOURCE_DIR}/util/async_file_reader.cc
+    ${ROCKSDB_SOURCE_DIR}/util/coro_stats_util.cc
+    ${ROCKSDB_SOURCE_DIR}/util/io_dispatcher_imp.cc
     ${ROCKSDB_SOURCE_DIR}/util/cleanable.cc
     ${ROCKSDB_SOURCE_DIR}/util/coding.cc
     ${ROCKSDB_SOURCE_DIR}/util/compaction_job_stats_impl.cc
@@ -269,6 +277,11 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/util/write_batch_util.cc
     ${ROCKSDB_SOURCE_DIR}/util/xxhash.cc
     ${ROCKSDB_SOURCE_DIR}/utilities/agg_merge/agg_merge.cc
+    ${ROCKSDB_SOURCE_DIR}/utilities/copy_engine/copy_engine.cc
+    ${ROCKSDB_SOURCE_DIR}/utilities/sorted_run_builder/sorted_run_builder.cc
+    ${ROCKSDB_SOURCE_DIR}/utilities/trie_index/bitvector.cc
+    ${ROCKSDB_SOURCE_DIR}/utilities/trie_index/louds_trie.cc
+    ${ROCKSDB_SOURCE_DIR}/utilities/trie_index/trie_index_factory.cc
     ${ROCKSDB_SOURCE_DIR}/utilities/backup/backup_engine.cc
     ${ROCKSDB_SOURCE_DIR}/utilities/checkpoint/checkpoint_impl.cc
     ${ROCKSDB_SOURCE_DIR}/utilities/compaction_filters.cc

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -661,7 +661,7 @@ void StorageEmbeddedRocksDB::initDB()
     }
     else
     {
-        rocksdb::DB * db = nullptr;
+        std::unique_ptr<rocksdb::DB> db;
         if (read_only)
             status = rocksdb::DB::OpenForReadOnly(merged, rocksdb_dir, &db);
         else
@@ -670,7 +670,7 @@ void StorageEmbeddedRocksDB::initDB()
         if (!status.ok())
             throw Exception(ErrorCodes::ROCKSDB_ERROR, "Failed to open rocksdb path at: {}: {}", rocksdb_dir, status.ToString());
 
-        rocksdb_ptr = std::unique_ptr<rocksdb::DB>(db);
+        rocksdb_ptr = std::move(db);
     }
 }
 


### PR DESCRIPTION
Bumps `rocksdb` from 10.10.1 to 11.8.1, a major upstream release that removes the deprecated raw `DB*` open overloads and adds several new blob and index subsystems.

### ClickHouse-side changes
- `contrib/rocksdb-cmake/CMakeLists.txt` — added the 13 new upstream library sources (blob partition manager, blob gen2 format and write-batch transformer, read-path blob resolver, multi-scan index iterator, trie index, copy engine, sorted run builder, io dispatcher, coro stats, `db/version_util.cc`).
- `src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp` — switched to the `std::unique_ptr<rocksdb::DB>*` overloads of `DB::Open` / `DB::OpenForReadOnly`, since the raw `DB*` overloads were removed in 11.0.

### Fork
Pinned to `ClickHouse/rocksdb` branch `ClickHouse/v11.8.1`, which is upstream v11.8.1 plus the one carried ClickHouse patch — `pmull_runtime_flag` made `std::atomic<bool>` in `util/crc32c.cc` to fix a TSan data race when several RocksDB instances open concurrently — rebased in ClickHouse/rocksdb#35.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `rocksdb` to v11.8.1.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118929&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118929](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118929+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.347` (included in `26.10` and later)
<!-- ch-version-info:end -->