### PR TITLE
Do not build a key range from a `NULL` or a `NaN` nested in a `Tuple`

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -4030,6 +4030,78 @@ static bool tryRewriteFloatLiteralForIntKeyComparison(
     UNREACHABLE();
 }
 
+namespace
+{
+
+/// Whether `field`, or any element nested in it, satisfies `predicate`. `Field::isNull` and
+/// `Field::isNaN` only look at the top level, while a whole-tuple comparison carries its `NULL`s and
+/// `NaN`s inside a `Tuple`.
+template <typename Predicate>
+bool anyNestedField(const Field & field, Predicate && predicate)
+{
+    if (predicate(field))
+        return true;
+
+    switch (field.getType())
+    {
+        case Field::Types::Tuple:
+        {
+            for (const auto & element : field.safeGet<Tuple>())
+                if (anyNestedField(element, predicate))
+                    return true;
+            return false;
+        }
+        case Field::Types::Array:
+        {
+            for (const auto & element : field.safeGet<Array>())
+                if (anyNestedField(element, predicate))
+                    return true;
+            return false;
+        }
+        case Field::Types::Map:
+        {
+            for (const auto & element : field.safeGet<Map>())
+                if (anyNestedField(element, predicate))
+                    return true;
+            return false;
+        }
+        default:
+            return false;
+    }
+}
+
+/// A `NULL` or a `NaN` inside a constant makes the comparison against it "not true" for every row -
+/// `NULL` for a `NULL` element and false for a `NaN` one - whatever the key values are. In key order
+/// both have a definite position instead, so the range built from such a constant covers granules
+/// whose rows the predicate rejects.
+bool constantHasNullOrNaNInside(const Field & field)
+{
+    return anyNestedField(field, [](const Field & element)
+    {
+        /// A `Null` field also carries the `-inf`/`+inf` stand-ins of a key range, which a constant
+        /// never is, so ask for a real NULL.
+        const bool is_real_null = element.isNull() && !element.isPositiveInfinity() && !element.isNegativeInfinity();
+        return is_real_null || element.isNaN();
+    });
+}
+
+/// The same for a key bound. A `NaN` or a `NULL` nested in a `Tuple` bound is invisible to
+/// `Field::isNaN` and `Field::isNull`, and a granule whose bound holds one cannot be proven wholly
+/// inside a comparison range: the row-level comparison of such a value is false (for a `NaN`) or
+/// `NULL` (for a `NULL`), and `WHERE` rejects both, while key order gives the value a definite
+/// position.
+bool boundHasNaNOrNullInside(const Field & field)
+{
+    return anyNestedField(field, [](const Field & element)
+    {
+        /// A `Null` field is also how a `Range` spells `-inf`/`+inf`, which is not a NULL key value.
+        const bool is_real_null = element.isNull() && !element.isPositiveInfinity() && !element.isNegativeInfinity();
+        return is_real_null || element.isNaN();
+    });
+}
+
+}
+
 bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const BuildInfo & info, RPNElement & out)
 {
     const auto * node_dag = node.getDAGNode();
@@ -4342,6 +4414,17 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
                 /// For other comparison operators, skip building the atom
                 return false;
             }
+
+            /// The two checks above only look at the top level of the constant. A `NULL` or a `NaN`
+            /// nested in a `Tuple` - what a whole-tuple comparison carries - slips past them, and it
+            /// makes an atom built from that constant unsound: at row level the comparison is `NULL`
+            /// or false for every row, while in key order the constant has a definite position, so the
+            /// range covers granules whose rows the predicate rejects. Nothing is pruned by such a
+            /// range anyway, and the exact-count optimization would count those rows without ever
+            /// evaluating the filter. The same holds once a key transform maps the constant into key
+            /// space, which is where the nested value stops being visible at all.
+            if (constantHasNullOrNaNInside(const_value))
+                return false;
 
             bool condition_is_relaxed = false;
             bool constant_chain_is_positive = true;
@@ -6204,12 +6287,20 @@ BoolMask KeyCondition::checkInHyperrectangle(
             ///   so no comparison condition can be true.
             /// - If only right bound is NaN: the range extends into NaN territory,
             ///   so it cannot be fully contained (NaN values don't satisfy the condition).
+            /// - A NaN or a NULL nested in a Tuple bound - the bound of a whole-tuple key comparison - is
+            ///   invisible to `Field::isNaN` and `Field::isNull`, and key order does not reproduce the
+            ///   row-level comparison for it either, so the containment claim is dropped.
+            ///   `intersects` is left alone: keeping the granule is the safe direction.
             if (unlikely(key_range.left.isNaN()))
             {
                 intersects = false;
                 contains = false;
             }
             else if (unlikely(key_range.right.isNaN()))
+            {
+                contains = false;
+            }
+            else if (unlikely(boundHasNaNOrNullInside(key_range.left) || boundHasNaNOrNullInside(key_range.right)))
             {
                 contains = false;
             }
@@ -6645,12 +6736,18 @@ BoolMask KeyCondition::checkInHyperrectangle(
                         ///   so no comparison condition can be true.
                         /// - If only right bound is NaN: the range extends into NaN territory,
                         ///   so it cannot be fully contained (NaN values don't satisfy the condition).
+                        /// - A NaN or a NULL nested in a Tuple bound is invisible to `Field::isNaN`
+                        ///   and `Field::isNull`, so only the containment claim is dropped.
                         if (unlikely(key_range.left.isNaN()))
                         {
                             intersects = false;
                             contains = false;
                         }
                         else if (unlikely(key_range.right.isNaN()))
+                        {
+                            contains = false;
+                        }
+                        else if (unlikely(boundHasNaNOrNullInside(key_range.left) || boundHasNaNOrNullInside(key_range.right)))
                         {
                             contains = false;
                         }
@@ -6671,12 +6768,18 @@ BoolMask KeyCondition::checkInHyperrectangle(
                     ///   so no comparison condition can be true.
                     /// - If only right bound is NaN: the range extends into NaN territory,
                     ///   so it cannot be fully contained (NaN values don't satisfy the condition).
+                    /// - A NaN or a NULL nested in a Tuple bound is invisible to `Field::isNaN` and
+                    ///   `Field::isNull`, so only the containment claim is dropped.
                     if (unlikely(key_range.left.isNaN()))
                     {
                         intersects = false;
                         contains = false;
                     }
                     else if (unlikely(key_range.right.isNaN()))
+                    {
+                        contains = false;
+                    }
+                    else if (unlikely(boundHasNaNOrNullInside(key_range.left) || boundHasNaNOrNullInside(key_range.right)))
                     {
                         contains = false;
                     }

--- a/tests/queries/0_stateless/05161_pk_tuple_nested_nan_null.reference
+++ b/tests/queries/0_stateless/05161_pk_tuple_nested_nan_null.reference
@@ -1,0 +1,20 @@
+a NaN in the constant
+0
+0
+0
+0
+0
+0
+0
+an ordinary constant still counts and prunes
+3
+4
+a NaN in the key data
+2
+2
+2
+2
+a NULL in the constant, through a key transform
+0
+0
+1

--- a/tests/queries/0_stateless/05161_pk_tuple_nested_nan_null.sql
+++ b/tests/queries/0_stateless/05161_pk_tuple_nested_nan_null.sql
@@ -1,0 +1,57 @@
+-- A `NULL` or a `NaN` nested in a `Tuple` constant makes a comparison against that constant "not
+-- true" for every row - `NULL` for a `NULL` element, false for a `NaN` one - while in key order the
+-- constant has a definite position. A `NaN` nested in a `Tuple` key value is the mirror case: the
+-- granule holding it cannot be proven wholly inside a comparison range. In both directions `count()`
+-- has to agree with the rows the same predicate returns.
+
+DROP TABLE IF EXISTS t_pk_tuple_nan_const;
+
+CREATE TABLE t_pk_tuple_nan_const (t Tuple(Float64, Int32), x Int32) ENGINE = MergeTree ORDER BY t
+SETTINGS index_granularity = 4;
+
+INSERT INTO t_pk_tuple_nan_const VALUES ((1.,1),0),((2.,1),0),((10.,1),1),((500.,7),1),((600.,1),0),((700.,1),0),((800.,1),0),((900.,1),0);
+
+SELECT 'a NaN in the constant';
+SELECT count() FROM t_pk_tuple_nan_const WHERE t <= (nan, 3);
+SELECT count() FROM t_pk_tuple_nan_const WHERE t < (nan, 3);
+SELECT count() FROM t_pk_tuple_nan_const WHERE t >= (nan, 3);
+SELECT count() FROM t_pk_tuple_nan_const WHERE t = (nan, 3);
+-- A folded computed constant reaches the index the same way.
+SELECT count() FROM t_pk_tuple_nan_const WHERE t <= (sqrt(-1.), 3);
+-- The trivial-count rewrite of the same predicate.
+SELECT count() FROM (SELECT * FROM t_pk_tuple_nan_const WHERE t <= (nan, 3));
+-- A real read of the same predicate, for comparison.
+SELECT sum(x) FROM t_pk_tuple_nan_const WHERE t <= (nan, 3);
+
+SELECT 'an ordinary constant still counts and prunes';
+SELECT count() FROM t_pk_tuple_nan_const WHERE t <= (10., 1);
+SELECT count() FROM t_pk_tuple_nan_const WHERE t >= (600., 1);
+
+DROP TABLE t_pk_tuple_nan_const;
+
+SELECT 'a NaN in the key data';
+
+CREATE TABLE t_pk_tuple_nan_data (t Tuple(Float64, Int32), x Int32) ENGINE = MergeTree ORDER BY t
+SETTINGS index_granularity = 4;
+
+INSERT INTO t_pk_tuple_nan_data VALUES ((1.,1),0),((2.,1),0),((10.,1),1),((500.,7),1),((nan,2),0),((nan,3),0),((nan,4),0),((nan,5),0);
+
+SELECT count() FROM t_pk_tuple_nan_data WHERE t >= (5., 3);
+SELECT count() FROM (SELECT * FROM t_pk_tuple_nan_data WHERE t >= (5., 3));
+SELECT sum(x) FROM t_pk_tuple_nan_data WHERE t >= (5., 3);
+SELECT count() FROM t_pk_tuple_nan_data WHERE t <= (5., 3);
+
+DROP TABLE t_pk_tuple_nan_data;
+
+SELECT 'a NULL in the constant, through a key transform';
+
+CREATE TABLE t_pk_tuple_null_transform (t Tuple(Nullable(Float64), Float64)) ENGINE = MergeTree ORDER BY toString(t)
+SETTINGS index_granularity = 1;
+
+INSERT INTO t_pk_tuple_null_transform VALUES ((NULL,1)),((2,2)),((3,3));
+
+SELECT count() FROM t_pk_tuple_null_transform WHERE t = (NULL, 1);
+SELECT count() FROM t_pk_tuple_null_transform WHERE t != (NULL, 1);
+SELECT count() FROM t_pk_tuple_null_transform WHERE t = (2, 2);
+
+DROP TABLE t_pk_tuple_null_transform;


### PR DESCRIPTION
`Field::isNull` and `Field::isNaN` only look at the top level of a `Field`, so a `NULL` or a `NaN` nested in a `Tuple` slips past every check built on them. A whole-tuple comparison carries exactly that, and primary-key analysis then treats such a value as an ordinary point of key order:

- A constant with a nested `NaN` produced a real key range. At row level `t <= (nan, 3)` is false for every row, but in key order `NaN` sorts above every ordinary value, so every granule was judged wholly inside `(-Inf, (nan, 3)]` and the exact-count projection counted its rows without evaluating the filter: `count()` answered 8 where `SELECT *` returned nothing. Once a key transform maps the constant into key space (`ORDER BY toString(t)`), a nested `NULL` does the same: `'(NULL,1)' = '(NULL,1)'` matches in key space while `t = (NULL, 1)` is `NULL` for every row.
- A `NaN` nested in a granule bound is the mirror case: the granule holding it can never be proven wholly inside a comparison range, because the row-level comparison is false there while key order gives the value a definite position. `count()` answered 6 where the same predicate returned 2 rows.

A constant that holds a nested `NULL` or `NaN` no longer produces an atom, so the granules are read and the filter decides. On the bound side only the containment claim is dropped - `intersects` is left as computed, so every pruning decision stays the over-approximation the two-valued range algebra requires. The bound side covers a nested `NULL` as well as a nested `NaN`: `WHERE` rejects a row whose comparison is `NULL` just as it rejects a false one, so a granule whose bound holds one cannot be claimed to match wholly either - the same reasoning `mayReadNullKeyValue` already applies to a flat `Nullable` key column.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118687
Closes: https://github.com/ClickHouse/ClickHouse/issues/118837
Closes: https://github.com/ClickHouse/ClickHouse/issues/117819
Related: https://github.com/ClickHouse/ClickHouse/pull/117501

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `count()` counting rows that the filter rejects when a whole-tuple comparison against a `Tuple` primary key involves a `NULL` or a `NaN` nested in the constant, or a `NaN` nested in the key data.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118944&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118944](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118944+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
