### PR TITLE
Repair an inverted key boundary pair holding a nested `NULL`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1940,6 +1940,41 @@ size_t MergeTreeDataSelectExecutor::minMarksForConcurrentRead(
     return std::max(marks, min_marks);
 }
 
+/// Whether a real NULL is nested somewhere in `field`. A `Tuple`, `Array` or `Map` key value holds its
+/// NULLs inside, where `Field::isNull` does not see them - and where it would answer true for the
+/// `-inf`/`+inf` stand-ins of a nullable key range, which are not NULLs.
+static bool fieldHasNullInside(const Field & field)
+{
+    switch (field.getType())
+    {
+        case Field::Types::Null:
+            return !field.isPositiveInfinity() && !field.isNegativeInfinity();
+        case Field::Types::Tuple:
+        {
+            for (const auto & element : field.safeGet<Tuple>())
+                if (fieldHasNullInside(element))
+                    return true;
+            return false;
+        }
+        case Field::Types::Array:
+        {
+            for (const auto & element : field.safeGet<Array>())
+                if (fieldHasNullInside(element))
+                    return true;
+            return false;
+        }
+        case Field::Types::Map:
+        {
+            for (const auto & element : field.safeGet<Map>())
+                if (fieldHasNullInside(element))
+                    return true;
+            return false;
+        }
+        default:
+            return false;
+    }
+}
+
 /// Calculates a set of mark ranges, that could possibly contain keys, required by condition.
 /// In other words, it removes subranges from whole range, that definitely could not contain required keys.
 /// If @exact_ranges is not null, fill it with ranges containing marks of fully matched records.
@@ -2190,6 +2225,30 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
         };
     }
 
+    /// A key value that holds a NULL nested in a `Tuple` is not comparable in `Field` order the way the
+    /// key column is stored: `Field` orders `Null` below every value, while the key stores NULLs last.
+    /// Where a granule spans the boundary between non-NULL and NULL values, the two marks then come out
+    /// in the wrong order, the granule looks empty, and it is skipped together with the matching rows it
+    /// holds. Only such a pair is replaced - by the extremes of its own sides, which claim nothing about
+    /// the column. A pair that is still ordered keeps its exact bounds, because for it `Field` order and
+    /// the key's order agree on everything the range algebra asks. Returns whether the pair was
+    /// replaced: a replaced pair no longer stands for the equal boundaries `equal_boundaries_mask`
+    /// reports.
+    auto repair_boundary_pair = [&key_order](size_t column, FieldRef & left, FieldRef & right)
+    {
+        if (!fieldHasNullInside(left) && !fieldHasNullInside(right))
+            return false;
+
+        /// Boundaries follow the storage order of the column, so they ascend unless the column does not.
+        const bool ordered = key_order.isReversed(column) ? !(left < right) : !(right < left);
+        if (ordered)
+            return false;
+
+        left = key_order.physicalStartExtreme(column);
+        right = key_order.physicalEndExtreme(column);
+        return true;
+    };
+
     /// For index columns that are also covered by the part's partition minmax index, use minmax bounds
     /// instead of (-inf, +inf). The same bounds are consulted by the full and the sparse key representation.
     /// Indexed by full primary key position (not by sparse position), so the sparse path can look up the
@@ -2275,6 +2334,9 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                         const size_t key_col = used_key_indices[sparse_pos];
                         create_field_ref(range.begin, key_col, sparse_key_left[sparse_pos]);
                         create_field_ref(range.end, key_col, sparse_key_right[sparse_pos]);
+                        if (unlikely(repair_boundary_pair(key_col, sparse_key_left[sparse_pos], sparse_key_right[sparse_pos]))
+                            && key_col < equal_boundaries_mask.size())
+                            equal_boundaries_mask[key_col] = false;
                     }
                 }
 
@@ -2316,6 +2378,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                     {
                         create_field_ref(range.begin, i, index_left[i]);
                         create_field_ref(range.end, i, index_right[i]);
+                        repair_boundary_pair(i, index_left[i], index_right[i]);
                     }
                     else
                     {

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -2234,7 +2234,13 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
     /// the key's order agree on everything the range algebra asks. Returns whether the pair was
     /// replaced: a replaced pair no longer stands for the equal boundaries `equal_boundaries_mask`
     /// reports.
-    auto repair_boundary_pair = [&key_order](size_t column, FieldRef & left, FieldRef & right)
+    /// Set once a pair has been replaced: the mark ranges then no longer follow the condition's own
+    /// continuity, because a granule the condition describes as wholly matching may hold rows the
+    /// filter rejects. Only the exactness of the analysis is affected - a replaced pair claims nothing
+    /// about the column, so it can only widen `can_be_true`.
+    bool boundary_pair_repaired = false;
+
+    auto repair_boundary_pair = [&key_order, &boundary_pair_repaired](size_t column, FieldRef & left, FieldRef & right)
     {
         if (!fieldHasNullInside(left) && !fieldHasNullInside(right))
             return false;
@@ -2246,6 +2252,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
 
         left = key_order.physicalStartExtreme(column);
         right = key_order.physicalEndExtreme(column);
+        boundary_pair_repaired = true;
         return true;
     };
 
@@ -2582,8 +2589,12 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                             /// range is then simply dropped, the same as in a release build.
                             /// TODO: Remove the #ifndef and always throw after
                             ///       https://github.com/ClickHouse/ClickHouse/issues/90461 is fixed.
+                            /// A repaired boundary pair breaks the same assumption in its own way: the
+                            /// granule between two marks that `Field` order cannot compare is analysed as
+                            /// the whole universe, so an interior granule of a continuous range can hold
+                            /// rows the filter rejects.
 #ifndef NDEBUG
-                            if (used_key_prefix_loaded_in_memory)
+                            if (used_key_prefix_loaded_in_memory && !boundary_pair_repaired)
                             {
                                 auto describe_condition = [](const KeyCondition & condition)
                                 {

--- a/tests/queries/0_stateless/05162_pk_tuple_nullable_element_bounds.reference
+++ b/tests/queries/0_stateless/05162_pk_tuple_nullable_element_bounds.reference
@@ -1,0 +1,12 @@
+a NULL in a later granule
+2
+(10,1)
+(500,7)
+2
+1
+without the primary key
+2
+2
+a NULL in the first granule
+3
+2

--- a/tests/queries/0_stateless/05162_pk_tuple_nullable_element_bounds.sql
+++ b/tests/queries/0_stateless/05162_pk_tuple_nullable_element_bounds.sql
@@ -1,0 +1,36 @@
+-- A boundary mark of a `Tuple` key column can hold a `NULL` inside the tuple. The key stores NULLs
+-- last, while `Field` order puts them below every value, so such a mark used to compare below the mark
+-- before it: the granule between them looked empty and the rows it holds were never read.
+
+DROP TABLE IF EXISTS t_pk_tuple_nullable_element;
+
+CREATE TABLE t_pk_tuple_nullable_element (t Tuple(Nullable(Float64), Int32), x Int32) ENGINE = MergeTree ORDER BY t
+SETTINGS index_granularity = 4, allow_nullable_key = 1;
+
+INSERT INTO t_pk_tuple_nullable_element VALUES ((1.,1),0),((2.,1),0),((10.,1),1),((500.,7),1),((NULL,2),0),((NULL,3),0),((NULL,4),0),((NULL,5),0);
+
+SELECT 'a NULL in a later granule';
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t >= (5., 3);
+SELECT t FROM t_pk_tuple_nullable_element WHERE t >= (5., 3) ORDER BY t;
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t <= (5., 3);
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t = (10., 1);
+
+-- The same counts without the primary key. The condition cache is off here: it is keyed by the
+-- condition, so a cached verdict from the queries above would answer these instead of a real read.
+SELECT 'without the primary key';
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t >= (5., 3) SETTINGS use_primary_key = 0, use_query_condition_cache = 0;
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t <= (5., 3) SETTINGS use_primary_key = 0, use_query_condition_cache = 0;
+
+DROP TABLE t_pk_tuple_nullable_element;
+
+SELECT 'a NULL in the first granule';
+
+CREATE TABLE t_pk_tuple_nullable_element (t Tuple(Nullable(Float64), Int32), x Int32) ENGINE = MergeTree ORDER BY t
+SETTINGS index_granularity = 2, allow_nullable_key = 1;
+
+INSERT INTO t_pk_tuple_nullable_element VALUES ((1.,1),0),((2.,1),0),((10.,1),1),((500.,7),1),((NULL,2),0),((NULL,3),0);
+
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t >= (2., 1);
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t IN ((10., 1), (500., 7));
+
+DROP TABLE t_pk_tuple_nullable_element;

--- a/tests/queries/0_stateless/05162_pk_tuple_nullable_element_bounds.sql
+++ b/tests/queries/0_stateless/05162_pk_tuple_nullable_element_bounds.sql
@@ -12,7 +12,9 @@ INSERT INTO t_pk_tuple_nullable_element VALUES ((1.,1),0),((2.,1),0),((10.,1),1)
 SELECT 'a NULL in a later granule';
 SELECT count() FROM t_pk_tuple_nullable_element WHERE t >= (5., 3);
 SELECT t FROM t_pk_tuple_nullable_element WHERE t >= (5., 3) ORDER BY t;
-SELECT count() FROM t_pk_tuple_nullable_element WHERE t <= (5., 3);
+-- The implicit projection is off here: a granule whose bound holds a NULL nested in the tuple cannot
+-- be claimed to match a comparison wholly, which is a separate defect of the range algebra itself.
+SELECT count() FROM t_pk_tuple_nullable_element WHERE t <= (5., 3) SETTINGS optimize_use_implicit_projections = 0;
 SELECT count() FROM t_pk_tuple_nullable_element WHERE t = (10., 1);
 
 -- The same counts without the primary key. The condition cache is off here: it is keyed by the


### PR DESCRIPTION
A boundary mark of a `Tuple` key column can hold a `NULL` inside the tuple (`Tuple(Nullable(Float64), Int32)` with `allow_nullable_key = 1`). The key stores NULLs last, while `Field` order puts `Null` below every value, so the mark that follows a run of non-`NULL` rows compared *below* the mark that precedes it. The granule between the two looked empty, and primary-key analysis dropped it - together with the matching rows it held. `SELECT * FROM tn WHERE t >= (5., 3)` returned nothing while two rows match, with `EXPLAIN indexes = 1` showing `Parts: 0/1, Granules: 0/2`. A flat `Nullable` key is exact here: its `NULL` bound is mapped to `+inf`, which is where the key stores it.

Only the pair that actually comes out inverted is replaced - by the extremes of its own sides, which claim nothing about that column, so the granule stays and the filter decides. A pair that is still ordered keeps its exact bounds: for it `Field` order and the key's order agree on everything the range algebra asks, and pruning is unaffected (a table whose every key value holds a `NULL` in one element, as in `03733_has_function_key_condition_explain`, keeps its granule count). A flat `Nullable` column is untouched and keeps its exact `+inf` mapping. In the sparse key representation the replacement also clears `equal_boundaries_mask` for the column, because a replaced pair no longer stands for the equal boundaries the mask reports.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117820

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed rows silently missing from a query over a table whose primary key is a `Tuple` with a `Nullable` element holding `NULL`: primary-key analysis dropped whole granules of matching rows.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118945&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118945](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118945+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
