### PR TITLE
Fix flaky 03443_reconnect_n_queries

### DIFF
--- a/tests/queries/0_stateless/03443_reconnect_n_queries.sh
+++ b/tests/queries/0_stateless/03443_reconnect_n_queries.sh
@@ -5,7 +5,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+LOG="$CLICKHOUSE_TMP/err-$CLICKHOUSE_DATABASE"
+
 # A loaded runner can need more than the default 10 s `connect_timeout` /
 # `handshake_timeout_ms` to accept the connection and send Hello; the benchmark
 # then aborts before its final report and prints no summary at all.
-$CLICKHOUSE_BENCHMARK --connect_timeout 60 --handshake_timeout_ms 60000 --iterations=10 --reconnect=2 <<< 'SELECT 1' 2>&1 | grep -F 'Queries executed' | tail -n1
+$CLICKHOUSE_BENCHMARK --connect_timeout 60 --handshake_timeout_ms 60000 --delay 0 --iterations=10 --reconnect=2 <<< 'SELECT 1' 1>/dev/null 2>"$LOG"
+
+grep -F 'Queries executed' "$LOG" | tail -n1
+# Separate grep: the exit status of a `grep | tail` pipeline is `tail`'s, which is
+# 0 even when nothing matched, so appending `|| cat` above would never fire.
+grep -qF 'Queries executed' "$LOG" || cat "$LOG" >&2
+
+rm "$LOG"

--- a/tests/queries/0_stateless/03443_reconnect_n_queries.sh
+++ b/tests/queries/0_stateless/03443_reconnect_n_queries.sh
@@ -5,4 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_BENCHMARK --iterations=10 --reconnect=2 <<< 'SELECT 1' 2>&1 | grep -F 'Queries executed' | tail -n1
+# A loaded runner can need more than the default 10 s `connect_timeout` /
+# `handshake_timeout_ms` to accept the connection and send Hello; the benchmark
+# then aborts before its final report and prints no summary at all.
+$CLICKHOUSE_BENCHMARK --connect_timeout 60 --handshake_timeout_ms 60000 --iterations=10 --reconnect=2 <<< 'SELECT 1' 2>&1 | grep -F 'Queries executed' | tail -n1


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113472
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03443_reconnect_n_queries` asserts one line, `Queries executed: 10 (100%).`. All four
recorded failures show it simply gone, stdout empty, with no diagnostic text at all.

`report` prints that line as its first statement (`programs/benchmark/Benchmark.cpp:812`)
from a single call site, `:651`, which is reached only if the rethrowing `pool.wait()` at
`:648` returns, so any errored query costs the whole summary. What supplies the error is a timeout asymmetry:
the benchmark reads `handshake_timeout_ms`, default `10000` (`src/Core/Settings.cpp:442`),
while `clickhouse-client` falls back to `300000`
(`src/Client/ConnectionParameters.cpp:407`), and `shell_config.sh` passes the benchmark no
timeouts. `--reconnect=2` re-exposes that budget mid-run, not once at startup.

Measured against an accept-and-stall listener, the current invocation dies at 10.70 s with
`Code: 209 ... (10000 ms) (SOCKET_TIMEOUT)` and no summary. `--handshake_timeout_ms 2000`
fails at 2.71 s printing `2000 ms`, while `--connect_timeout 2` alone still dies at
10.35 s printing `10000 ms`, so `handshake_timeout_ms` is the budget this signature
reaches. Delaying only the first handshake by 15 s, the current test fails with empty
stdout and the patched one passes. 50 runs pass. The flag pair matches #108570 (`01600`),
#111168 (`03630`) and #113472 (`02040`), and the assertion is untouched.

The second commit stops piping stderr into `grep`, which discarded the exception and is why
all four failures carry no diagnostic. That also bounds the claim: the stall is the
demonstrated mechanism for this signature, not proof of what fired in those four jobs.

On master 28 `.sh` tests invoke `CLICKHOUSE_BENCHMARK` and 3 carry these flags;
`01393_benchmark_secure_port`, `03623_benchmark_use_dashes_for_underscored_flags` and
`03653_benchmark_proto_caps_option` show the same signature once each. I can extend the
flags there, or give the tool a larger default, as follow-ups if wanted.

Related: #113472 (this is the residual its description disclosed). No open issue tracks
this test. One example report:
[amd_msan, WasmEdge, parallel, 2/3](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113868&sha=037ef93ccece5a8641798b85a1c68afd59f737d6&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118948&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118948](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118948+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
