### PR TITLE
Make ColumnConst refuse patch application

### DIFF
--- a/src/Columns/ColumnConst.cpp
+++ b/src/Columns/ColumnConst.cpp
@@ -136,6 +136,16 @@ ColumnPtr ColumnConst::index(const IColumn & indexes, size_t limit) const
     return ColumnConst::create(data, limit);
 }
 
+ColumnPtr ColumnConst::updateFrom(const Patch &) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method updateFrom is not supported for {}", getName());
+}
+
+void ColumnConst::updateInplaceFrom(const Patch &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method updateInplaceFrom is not supported for {}", getName());
+}
+
 VectorWithMemoryTracking<MutableColumnPtr> ColumnConst::scatter(size_t num_columns, const Selector & selector) const
 {
     if (s != selector.size())

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -242,6 +242,13 @@ public:
     void updatePermutation(PermutationSortDirection direction, PermutationSortStability stability,
                         size_t limit, int nan_direction_hint, Permutation & res, EqualRanges & equal_ranges) const override;
 
+    /// A patch writes distinct values into distinct rows, which a Const column cannot represent.
+    /// Refuse instead of inheriting the IColumnHelper implementations: the in-place one reaches
+    /// `IColumn::updateAt` and throws anyway, but the copying one would silently discard every
+    /// patched value, because `ColumnConst::insertFrom` only advances the size.
+    ColumnPtr updateFrom(const Patch & patch) const override;
+    void updateInplaceFrom(const Patch & patch) override;
+
     size_t byteSize() const override
     {
         return data->byteSize() + sizeof(s);

--- a/src/Columns/tests/gtest_column_const.cpp
+++ b/src/Columns/tests/gtest_column_const.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnsNumber.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+
+/// A patch writes distinct values into distinct rows, which a Const column cannot represent.
+/// Both patch entry points must refuse it rather than inherit the `IColumnHelper` implementations:
+/// the copying one would return a `ColumnConst` still holding the old value, silently discarding
+/// every patched value while advancing the destination versions as if it had written them.
+TEST(ColumnConst, RefusesPatchApplication)
+{
+    auto nested = ColumnUInt64::create();
+    nested->insert(1u);
+    auto column_const = ColumnConst::create(std::move(nested), 3);
+
+    auto source_column = ColumnUInt64::create();
+    source_column->insert(42u);
+
+    IColumn::Versions source_versions{2};
+    IColumn::Versions destination_versions{1, 1, 1};
+    IColumn::Offsets source_rows{0};
+    IColumn::Offsets destination_rows{1};
+
+    IColumn::Patch patch
+    {
+        .sources = {{*source_column, source_versions}},
+        .src_col_indices = nullptr,
+        .src_row_indices = source_rows,
+        .dst_row_indices = destination_rows,
+        .dst_versions = destination_versions,
+    };
+
+    auto expect_not_implemented = [](auto && call)
+    {
+        try
+        {
+            call();
+        }
+        catch (const Exception & e)
+        {
+            EXPECT_EQ(e.code(), ErrorCodes::NOT_IMPLEMENTED) << e.displayText();
+            return;
+        }
+        FAIL() << "expected an exception, but the patch was accepted";
+    };
+
+    /// Call through `IColumn`: `IColumnHelper` declares both overrides private, so going through
+    /// the concrete type would not even compile without the overrides under test.
+    const IColumn & constant_column = *column_const;
+    expect_not_implemented([&] { constant_column.updateFrom(patch); });
+
+    auto mutable_const = IColumn::mutate(std::move(column_const));
+    IColumn & mutable_constant_column = *mutable_const;
+    expect_not_implemented([&] { mutable_constant_column.updateInplaceFrom(patch); });
+
+    /// The destination versions must be untouched: refusing must not look like a partial apply.
+    EXPECT_EQ(destination_versions[1], 1u);
+}


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118545

## Problem

`ColumnConst` silently accepts patch application. Applying a patch to one through `IColumn` — patch row 1 of a 3-row column with version 2 — currently does this:

```
column.updateFrom(patch)   ->  returns normally, value unchanged
destination_versions[1]    ->  2      (advanced as if the write had happened)
```

No exception, the patched value is gone, and the row now records a version for a value that was never written, so a later patch with a lower version for that row is skipped too.

This is exactly the shape of the wrong-results bug fixed in #118545, where a constant-folded column reached patch application. That PR fixed the two call sites by materializing the column first; nothing stopped the *next* caller from making the same mistake, and the reason the mistake was expensive is this silent acceptance.

## Root cause

`ColumnConst` is `COWHelper<IColumnHelper<ColumnConst>, ColumnConst>` and overrides neither method, so it inherits both:

- `updateInplaceFrom` → `dst.updateAt(...)`. `ColumnConst` has no `updateAt` override either, so this reaches the `IColumn::updateAt` throw. Loud, fine.
- `updateFrom` → `cloneEmpty()`, which for `ColumnConst` still holds the original constant, then per row `insertRangeFrom` / `insertFrom` — and `ColumnConst::insertFrom` only advances `s`. Silent.

Which one you get is decided by `ColumnConst::isFixedAndContiguous` forwarding to the nested column, i.e. by the column's type. That is why the bug in #118203 threw for `Int32`/`FixedString` but silently returned wrong values for `String`/`Nullable`/`LowCardinality` — one defect, two very different blast radii, and the dangerous half was the silent one.

## Solution

Override both to throw `NOT_IMPLEMENTED`, as `ColumnLazy` already does. `ColumnLazy` is the precedent that "this column class cannot be a patch destination" is expressed by refusing the primitive, not by hoping every caller materializes first.

Scope, stated plainly: **only the `updateFrom` half is a behaviour change.** `updateInplaceFrom` already threw the same error code through `IColumn::updateAt`; it is overridden for symmetry and a more accurate message, not to fix anything.

The overrides are unreachable on master today — outside `src/Columns` the primitive has four call sites, all in `applyPatches.cpp` and `applyPatchesLegacy.cpp`, and after #118545 none passes a `ColumnConst`. They exist so a future omission fails loudly.

## Tests

`src/Columns/tests/gtest_column_const.cpp` drives both entry points through `IColumn` (`IColumnHelper` declares them private, so calling through the concrete type would not compile without the overrides under test) and asserts `NOT_IMPLEMENTED`, plus that the destination versions are left untouched — refusing must not look like a partial apply.

Verified against a Debug build:

| binary | `ColumnConst.RefusesPatchApplication` |
| --- | --- |
| without the overrides | **FAIL** — `updateFrom` accepts the patch, and `destination_versions[1]` becomes 2 |
| with the overrides | PASS |

The failing control reproduces the silent-drop *and* the version advance in a unit test, which until now was only established by reading the code.

No collateral damage: the 157 tests of the `Column*` and `ApplyPatches*` suites pass, and the `03100_lwu_*`, `04629_lwu*` and `03047_on_fly_mutations*` functional clusters were run against a server with the guard, checking specifically whether either new exception ever appears — it never does.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user visible: the new overrides are unreachable on master. This is defensive hardening so that a future regression of the #118203 kind fails loudly instead of returning wrong results.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118952&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118952](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118952+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
