### PR TITLE
Move the schema registry clamp bounds to Core/Defines.h

### DIFF
--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -178,4 +178,11 @@ static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_COLUMNS = 1'000'000uz;
 /// a row count read from the wire as `UInt64`.
 static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_ROWS = 1'000'000'000ULL;
 
+/// Bounds for the Confluent Schema Registry client. `doSettingsSanityCheckClamp` applies them to
+/// the settings, and `getFormatSettings` applies them again on the way into `FormatSettings`,
+/// because the clamp does not run for `ApplicationType::CLIENT`.
+static constexpr UInt64 MAX_SCHEMA_REGISTRY_TIMEOUT_SECONDS = 599;
+static constexpr UInt64 MAX_SCHEMA_REGISTRY_RETRIES = 20;
+static constexpr UInt64 MAX_SCHEMA_REGISTRY_INITIAL_BACKOFF_MS = 60000;
+
 }

--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -178,9 +178,6 @@ static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_COLUMNS = 1'000'000uz;
 /// a row count read from the wire as `UInt64`.
 static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_ROWS = 1'000'000'000ULL;
 
-/// Bounds for the Confluent Schema Registry client. `doSettingsSanityCheckClamp` applies them to
-/// the settings, and `getFormatSettings` applies them again on the way into `FormatSettings`,
-/// because the clamp does not run for `ApplicationType::CLIENT`.
 static constexpr UInt64 MAX_SCHEMA_REGISTRY_TIMEOUT_SECONDS = 599;
 static constexpr UInt64 MAX_SCHEMA_REGISTRY_RETRIES = 20;
 static constexpr UInt64 MAX_SCHEMA_REGISTRY_INITIAL_BACKOFF_MS = 60000;

--- a/src/Core/SettingsQuirks.h
+++ b/src/Core/SettingsQuirks.h
@@ -21,13 +21,6 @@ inline constexpr UInt64 MAX_SANE_READ_BUFFER_SIZE = 256 * 1024 * 1024; /// 256 M
 /// is clamped to it by `doSettingsSanityCheckClamp`.
 inline constexpr UInt64 MAX_TEMPORARY_FILES_BUFFER_SIZE = 1_GiB;
 
-/// Bounds for the Confluent Schema Registry client. `doSettingsSanityCheckClamp` applies them to
-/// the settings, and `getFormatSettings` applies them again on the way into `FormatSettings`,
-/// because the clamp does not run for `ApplicationType::CLIENT`.
-inline constexpr UInt64 MAX_SCHEMA_REGISTRY_TIMEOUT_SECONDS = 599;
-inline constexpr UInt64 MAX_SCHEMA_REGISTRY_RETRIES = 20;
-inline constexpr UInt64 MAX_SCHEMA_REGISTRY_INITIAL_BACKOFF_MS = 60000;
-
 /// Clamp a `temporary_files_buffer_size` that arrived in a serialized query plan, which does not
 /// go through `doSettingsSanityCheckClamp`. Warns when the value is reduced.
 UInt64 clampTemporaryFilesBufferSize(UInt64 buffer_size);

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -23,9 +23,9 @@
 #include <Common/KnownObjectNames.h>
 #include <Common/RemoteHostFilter.h>
 #include <Common/tryGetFileNameByFileDescriptor.h>
+#include <Core/Defines.h>
 #include <Core/FormatFactorySettings.h>
 #include <Core/Settings.h>
-#include <Core/SettingsQuirks.h>
 
 #include <boost/algorithm/string/case_conv.hpp>
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113787


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (code move, no user-visible change).

### Description

Requested by @ rschu1ze in review of #113787:
https://github.com/ClickHouse/ClickHouse/pull/113787#discussion_r3960920157

> This very central setting header is definitely not the right place for schema registry defines.

`MAX_SCHEMA_REGISTRY_TIMEOUT_SECONDS`, `MAX_SCHEMA_REGISTRY_RETRIES` and
`MAX_SCHEMA_REGISTRY_INITIAL_BACKOFF_MS` move from `src/Core/SettingsQuirks.h` to
`src/Core/Defines.h`, together with the comment that explains why the same bounds are applied at
two sites. The values (599, 20, 60000), the explicit `UInt64` type and the enclosing
`namespace DB` are unchanged.

One token is adapted: `inline constexpr` becomes `static constexpr`, the specifier `Defines.h` uses
for all 103 of its existing constants. Nothing takes the address of these three and both consumers
read them by value, so it is inert here; I will switch it back if you prefer the original spelling.

`SettingsQuirks.cpp` needs no change, since it already includes `<Core/Defines.h>`.
`FormatFactory.cpp` was reaching the constants through `<Core/SettingsQuirks.h>` and uses nothing
else from that header, so that include is replaced by `<Core/Defines.h>`.

No behaviour change, hence no new test. Validated by a full debug build.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118953&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118953](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118953+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1081` (included in `26.9` and later)
<!-- ch-version-info:end -->