### PR TITLE
Convert a constant array's elements with their own type in the `bloom_filter` index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -839,12 +839,16 @@ static ColumnPtr createColumnFromConstantArray(
     if (value_field.getType() != Field::Types::Array)
         return nullptr;
 
+    /// The elements' own type. `convertFieldToType` needs it to convert a value that carries a unit -
+    /// a `Date` day number probed against an `Array(DateTime)` column - instead of re-basing its raw
+    /// number as seconds, which hashes something the column can never hold. Every other call in this
+    /// file passes the same hint.
     DataTypePtr element_type;
-    if (coerce_like_search_function && value_type)
+    if (value_type)
         if (const auto * value_array_type = typeid_cast<const DataTypeArray *>(removeLowCardinalityAndNullable(value_type).get()))
             element_type = value_array_type->getNestedType();
 
-    const bool coerce = element_type && searchFunctionCoercesConstant(element_type, actual_type);
+    const bool coerce = coerce_like_search_function && element_type && searchFunctionCoercesConstant(element_type, actual_type);
     const bool is_nullable = actual_type->isNullable();
     const auto * fixed_string_type = typeid_cast<const DataTypeFixedString *>(actual_type.get());
     auto mutable_column = actual_type->createColumn();
@@ -866,7 +870,7 @@ static ColumnPtr createColumnFromConstantArray(
 
         Field converted = coerce
             ? coerceStringFieldLikeSearchFunction(f, element_type, actual_type, /*cast_to_supertype=*/ true)
-            : convertFieldToType(f, *actual_type);
+            : convertFieldToType(f, *actual_type, element_type.get());
         if (converted.isNull())
             return nullptr;
 

--- a/tests/queries/0_stateless/04652_enum_constant_vs_string_column.reference
+++ b/tests/queries/0_stateless/04652_enum_constant_vs_string_column.reference
@@ -50,5 +50,5 @@ control_bool_to_string	1
 control_plain_string_constant	1
 control_fixed_string_padding	1
 known_limitation_array_element	1
-known_limitation_has_any	1
-known_limitation_has_all	1
+bloom_filter_has_any	1
+bloom_filter_has_all	1

--- a/tests/queries/0_stateless/04652_enum_constant_vs_string_column.sql
+++ b/tests/queries/0_stateless/04652_enum_constant_vs_string_column.sql
@@ -390,16 +390,17 @@ SELECT 'control_fixed_string_padding', (SELECT count() FROM pk_fixed10 WHERE key
     SETTINGS use_skip_indexes = 0, optimize_use_implicit_projections = 0) = 8;
 
 -- An Enum element inside a container is still converted to the number, because the Array/Tuple/Map
--- recursion of convertFieldToType passes no element type hint down, and so does
--- createColumnFromConstantArray in the bloom filter condition. The cells below assert the current
--- (wrong) values rather than the desired ones, so the limitation is documented instead of hidden.
+-- recursion of convertFieldToType passes no element type hint down. The cell below asserts the current
+-- (wrong) value rather than the desired one, so the limitation is documented instead of hidden.
 -- The hint propagation is added by https://github.com/ClickHouse/ClickHouse/pull/110084.
 SELECT 'known_limitation_array_element', (SELECT hex(x[1]) FROM values('x Array(String)', [CAST('7', 'Enum8(\'7\' = 3)')])) = '33';
 
--- hasAny and hasAll go through createColumnFromConstantArray, so their bloom filter lookup still uses
--- the number and over prunes. Unlike has, which converts the element with the hint and is fixed above.
-SELECT 'known_limitation_has_any', (SELECT groupArray(v) FROM bf_array WHERE hasAny(v, [CAST('7', 'Enum8(\'7\' = 3)')])) = [];
-SELECT 'known_limitation_has_all', (SELECT groupArray(v) FROM bf_array WHERE hasAll(v, [CAST('7', 'Enum8(\'7\' = 3)')])) = [];
+-- hasAny and hasAll go through createColumnFromConstantArray, which converts the elements with their
+-- own type as well, so their bloom filter lookup agrees with the function - as it does for has above.
+SELECT 'bloom_filter_has_any', (SELECT groupArray(v) FROM bf_array WHERE hasAny(v, [CAST('7', 'Enum8(\'7\' = 3)')]))
+    = (SELECT groupArray(v) FROM bf_array WHERE hasAny(v, [CAST('7', 'Enum8(\'7\' = 3)')]) SETTINGS use_skip_indexes = 0);
+SELECT 'bloom_filter_has_all', (SELECT groupArray(v) FROM bf_array WHERE hasAll(v, [CAST('7', 'Enum8(\'7\' = 3)')]))
+    = (SELECT groupArray(v) FROM bf_array WHERE hasAll(v, [CAST('7', 'Enum8(\'7\' = 3)')]) SETTINGS use_skip_indexes = 0);
 
 DROP TABLE ref_str;
 DROP TABLE pk_str;

--- a/tests/queries/0_stateless/05163_bloom_filter_array_date_literal.reference
+++ b/tests/queries/0_stateless/05163_bloom_filter_array_date_literal.reference
@@ -1,0 +1,14 @@
+Array(DateTime) with a Date literal
+1
+1
+1
+1
+Array(DateTime) with a Date32 literal
+1
+1
+a same-type literal still finds the row
+1
+0
+Array(DateTime64) with a Date literal
+1
+1

--- a/tests/queries/0_stateless/05163_bloom_filter_array_date_literal.sql
+++ b/tests/queries/0_stateless/05163_bloom_filter_array_date_literal.sql
@@ -1,0 +1,48 @@
+-- The `bloom_filter` skip index hashes the elements of a constant array argument of `hasAny`/`hasAll`
+-- after converting them to the indexed type. A `Date` literal carries a unit, so converting it without
+-- its own type re-based the day number as seconds and no granule matched; a `Date32` literal took the
+-- throwing path of the same conversion instead. The index must answer as the function does.
+
+-- A `Date32` literal and a `DateTime` column meet in a `DateTime64` supertype, and the literal is
+-- converted with the session's time zone, so the comparison is only time-zone independent when the
+-- session time zone is fixed.
+SET session_timezone = 'UTC';
+
+DROP TABLE IF EXISTS t_bf_array_date;
+
+CREATE TABLE t_bf_array_date (id UInt64, arr Array(DateTime('UTC')), INDEX bf arr TYPE bloom_filter GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4;
+
+INSERT INTO t_bf_array_date SELECT number, [toDateTime('2030-05-05 05:05:05', 'UTC') + number] FROM numbers(40) WHERE number != 21;
+INSERT INTO t_bf_array_date VALUES (21, [toDateTime('2024-01-02 00:00:00', 'UTC')]);
+OPTIMIZE TABLE t_bf_array_date FINAL;
+
+SELECT 'Array(DateTime) with a Date literal';
+SELECT count() FROM t_bf_array_date WHERE hasAny(arr, [toDate('2024-01-02')]) SETTINGS use_skip_indexes = 0;
+SELECT count() FROM t_bf_array_date WHERE hasAny(arr, [toDate('2024-01-02')]);
+SELECT count() FROM t_bf_array_date WHERE hasAll(arr, [toDate('2024-01-02')]);
+SELECT count() FROM t_bf_array_date WHERE has([toDate('2024-01-02')], arr[1]);
+
+SELECT 'Array(DateTime) with a Date32 literal';
+SELECT count() FROM t_bf_array_date WHERE hasAny(arr, [toDate32('2024-01-02')]) SETTINGS use_skip_indexes = 0;
+SELECT count() FROM t_bf_array_date WHERE hasAny(arr, [toDate32('2024-01-02')]);
+
+SELECT 'a same-type literal still finds the row';
+SELECT count() FROM t_bf_array_date WHERE hasAny(arr, [toDateTime('2024-01-02 00:00:00', 'UTC')]);
+SELECT count() FROM t_bf_array_date WHERE hasAny(arr, [toDate('2024-01-03')]);
+
+DROP TABLE t_bf_array_date;
+
+SELECT 'Array(DateTime64) with a Date literal';
+
+CREATE TABLE t_bf_array_dt64 (id UInt64, arr Array(DateTime64(3, 'UTC')), INDEX bf arr TYPE bloom_filter GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4;
+
+INSERT INTO t_bf_array_dt64 SELECT number, [toDateTime64('2030-05-05 05:05:05', 3, 'UTC') + number] FROM numbers(40) WHERE number != 21;
+INSERT INTO t_bf_array_dt64 VALUES (21, [toDateTime64('2024-01-02 00:00:00', 3, 'UTC')]);
+OPTIMIZE TABLE t_bf_array_dt64 FINAL;
+
+SELECT count() FROM t_bf_array_dt64 WHERE hasAny(arr, [toDate('2024-01-02')]) SETTINGS use_skip_indexes = 0;
+SELECT count() FROM t_bf_array_dt64 WHERE hasAny(arr, [toDate('2024-01-02')]);
+
+DROP TABLE t_bf_array_dt64;


### PR DESCRIPTION
The `bloom_filter` skip index hashes the elements of a constant-array argument of `hasAny`/`hasAll` after converting them to the indexed type, and `createColumnFromConstantArray` converted each element without passing its own type. `convertFieldToType` needs that hint to convert a value that carries a unit: without it a `Date` literal probed against an `Array(DateTime)` column had its day number re-based as seconds (`EXPLAIN indexes = 1` shows the index probing `hasAny(arr, [19724])` where the same-type control probes `[1704153600]`), so no granule matched and the query silently returned fewer rows than with `use_skip_indexes = 0`. A `Date32` literal took the throwing path of the same conversion instead and failed index analysis with `TYPE_MISMATCH` for a query that executes fine without the index.

The elements are now converted with the constant array's own element type, which is what every other `convertFieldToType` call in the file already passes.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118876
Related: https://github.com/ClickHouse/ClickHouse/pull/118689

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `bloom_filter` skip index dropping granules that hold matching rows for `hasAny`/`hasAll` against a constant array whose elements are of a different date/time type than the indexed column, and `TYPE_MISMATCH` for a `Date32` element.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118956&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118956](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118956+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
