### PR TITLE
Report a lossy constant normalization as an inexact atom

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2143,14 +2143,48 @@ static bool finalizeTransformedColumn(ColumnPtr & column, DataTypePtr & type)
 }
 
 
+/// Reports whether a cast into `cast_type` kept every value of `column`. A value that fits the target
+/// can still lose information on the way - `DateTime64(6)` truncated to `DateTime64(3)` - and no NULL
+/// marks that, so the only way to see it is to cast back and compare. `cast_column` is the result of
+/// that cast, already computed by the caller. A source type the reverse cast cannot represent answers
+/// `false`, the same as a value that does not come back unchanged. Positions where `kept` is zero hold
+/// values that have already left the set and are not examined.
+static bool castKeptEveryValue(
+    const ColumnPtr & column,
+    const DataTypePtr & type,
+    const ColumnPtr & cast_column,
+    const DataTypePtr & cast_type,
+    const IColumn::Filter * kept = nullptr)
+{
+    /// `castColumnAccurateOrNull` needs a target that can represent NULLs, and `canBeInsideNullable`
+    /// answers for the outer type only, so a `Tuple` holding an `Array` passes it and then throws.
+    const DataTypePtr source_type = removeLowCardinality(type);
+    if ((!source_type->isNullable() && !source_type->canBeInsideNullable()) || !canBeAccurateCastOrNullTarget(source_type))
+        return false;
+
+    ColumnPtr back_column = castColumnAccurateOrNull({cast_column, cast_type, ""}, source_type);
+
+    for (size_t i = 0, size = column->size(); i < size; ++i)
+    {
+        if (kept && !(*kept)[i])
+            continue;
+
+        if ((*back_column)[i] != (*column)[i])
+            return false;
+    }
+
+    return true;
+}
+
+
 /// Cast column to target_type and fail if the cast introduces NULLs.
 ///
 /// `out_is_exact` reports whether every value also survived the cast unchanged. A value that fits the
-/// target but loses information on the way - `DateTime64(6)` truncated to `DateTime64(3)`, `'007'`
-/// read as `7` - is not a NULL, so the probe below cannot see it, and a constant normalized that way
-/// stands for a different value than the query asked for. Whoever relies on the cast for an equality
-/// atom has to treat such an atom as relaxed: the key point it names has more than one preimage, so
-/// `notEquals` must not exclude it.
+/// target but loses information on the way - `DateTime64(6)` truncated to `DateTime64(3)` - is not a
+/// NULL, so the probe below cannot see it, and a constant normalized that way stands for a different
+/// value than the query asked for. Whoever relies on the cast for an equality atom has to treat such
+/// an atom as relaxed: the key point it names has more than one preimage, so `notEquals` must not
+/// exclude it.
 static bool castColumnWithoutNulls(
     ColumnPtr & column, DataTypePtr & type, const DataTypePtr & target_type, bool & out_is_exact)
 {
@@ -2188,22 +2222,10 @@ static bool castColumnWithoutNulls(
         if (b)
             return false;
 
-    /// Every value fits, so ask the reverse cast whether anything was lost on the way. A target the
-    /// reverse cast cannot represent, a value that does not come back, or a value that comes back
-    /// different all leave the cast inexact, which costs only the `can_be_false` half of the analysis.
-    const DataTypePtr source_probe_type = removeLowCardinality(type);
-    if ((!source_probe_type->isNullable() && !source_probe_type->canBeInsideNullable())
-        || !canBeAccurateCastOrNullTarget(source_probe_type))
-    {
-        out_is_exact = false;
-    }
-    else
-    {
-        ColumnPtr forward_column = castColumnAccurate({column, type, ""}, probe_type);
-        ColumnPtr back_column = castColumnAccurateOrNull({forward_column, probe_type, ""}, source_probe_type);
-        for (size_t i = 0, size = column->size(); i < size && out_is_exact; ++i)
-            out_is_exact = (*back_column)[i] == (*column)[i];
-    }
+    /// Every value fits, so ask the reverse cast whether anything was lost on the way. The probe above
+    /// is the forward cast, so it is read back instead of being computed again. An inexact cast costs
+    /// only the `can_be_false` half of the analysis.
+    out_is_exact = castKeptEveryValue(column, type, n.getNestedColumnPtr(), probe_type);
 
     /// No NULLs were introduced, so the cast is accurate for every value. Produce the requested
     /// target_type (which may be LowCardinality and/or Nullable); the accurate cast cannot throw

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2569,6 +2569,26 @@ bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     const bool transform_input_has_nan
         = !transform_applied && anyFieldSatisfies((*transform_input_column)[0], isNaNField);
 
+    /// A `String` constant does not name a value in its own domain: the comparison converts the spelling
+    /// into the type of the other side and compares there (`executeWithConstString` in
+    /// `FunctionsComparison.h`), so it is that conversion, not the spelling, that the predicate is about.
+    /// Rendering the normalized constant back into a string judges the spelling instead - `'2023-02-01
+    /// 12:00:00'` comes back as `'2023-02-01 12:00:00.000'` while naming exactly the same key point - so
+    /// ask the conversion the comparison itself uses whether the normalization is the value the predicate
+    /// names. A string-ish key column is left to the round trip: two string-ish types are compared as
+    /// bytes (`executeString`), where the padding a `FixedString` adds really does change the compared
+    /// value.
+    if (!cast_is_exact && !transform_applied)
+    {
+        const DataTypePtr comparison_type = removeLowCardinalityAndNullable(dag.input_type);
+
+        if (isStringOrFixedString(removeLowCardinalityAndNullable(out_type)) && !isStringOrFixedString(comparison_type))
+        {
+            const Field compared_value = tryConvertFieldToType(out_value, *comparison_type, out_type.get(), {});
+            cast_is_exact = !compared_value.isNull() && compared_value == (*transform_input_column)[0];
+        }
+    }
+
     ColumnPtr transformed_const_column = transform_input_column;
     DataTypePtr transformed_const_type = transform_input_type;
 

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2399,20 +2399,16 @@ static bool applyDeterministicDagToColumn(
     const String & input_name,
     const DeterministicKeyTransformDag & dag,
     ColumnPtr & out_column,
-    DataTypePtr & out_type)
+    DataTypePtr & out_type,
+    bool & out_cast_is_exact)
 {
     ColumnPtr transform_input_column;
     DataTypePtr transform_input_type;
     bool transform_applied = false;
-    bool cast_is_exact = true;
 
     if (!convertColumnForDeterministicDag(
-            in_column, in_type, input_name, dag, transform_input_column, transform_input_type, transform_applied, cast_is_exact))
-        return false;
-
-    /// A set atom has no relaxed form here - `notIn` would exclude a key point that has more than one
-    /// preimage - so a normalization that lost information declines index analysis altogether.
-    if (!cast_is_exact)
+            in_column, in_type, input_name, dag, transform_input_column, transform_input_type, transform_applied,
+            out_cast_is_exact))
         return false;
 
     if (transform_applied)
@@ -2670,8 +2666,11 @@ static bool tryPrepareSetColumnsForIndex(
     const std::vector<std::optional<DeterministicKeyTransformDag>> & set_transforming_dags,
     const DataTypes & data_types,
     const std::vector<MergeTreeSetIndex::KeyTuplePositionMapping> & indexes_mapping,
-    size_t args_count)
+    size_t args_count,
+    bool & out_is_exact)
 {
+    out_is_exact = true;
+
     Columns new_columns;
     DataTypes new_types;
     while (set_columns.size() < args_count) /// If we have a packed tuple inside, we unpack it
@@ -2724,14 +2723,19 @@ static bool tryPrepareSetColumnsForIndex(
             ColumnPtr transformed_set_column;
             DataTypePtr transformed_set_type;
             const auto & set_transforming_dag = *set_transforming_dags[indexes_mapping_index];
+            bool dag_cast_is_exact = true;
             if (!applyDeterministicDagToColumn(
                     set_column,
                     set_element_type,
                     set_transforming_dag.input_name,
                     set_transforming_dag,
                     transformed_set_column,
-                    transformed_set_type))
+                    transformed_set_type,
+                    dag_cast_is_exact))
                 return false;
+
+            if (!dag_cast_is_exact)
+                out_is_exact = false;
 
             set_column = transformed_set_column;
             set_element_type = transformed_set_type;
@@ -2792,6 +2796,19 @@ static bool tryPrepareSetColumnsForIndex(
             if ((!key_is_nullable && null_in_source) || (cast_failure_null_map[i] && !source_is_nothing))
                 filter[i] = 0;
         }
+
+        /// An element that fits the key type can still lose information on the way - a `DateTime64(6)`
+        /// element truncated to a `DateTime64(3)` key - which no NULL marks. The element then names a key
+        /// point the predicate does not, so the set is reported as inexact and the atom is relaxed: both
+        /// `notIn` excluding that point and `in` reading the atom as certainly true over a single-point
+        /// range are then wrong. The element itself stays - a relaxed atom is a superset of the predicate,
+        /// so the points it does exclude still prune for `in`. An all-NULL element (`Nothing`) names no
+        /// value and loses nothing.
+        if (!source_is_nothing
+            && !castKeptEveryValue(
+                set_column, set_element_type, cast_nullable_column->getNestedColumnPtr(),
+                removeNullable(key_column_type), &filter))
+            out_is_exact = false;
 
         if (key_is_nullable && (source_null_map || source_is_nothing))
         {
@@ -3077,8 +3094,9 @@ bool KeyCondition::tryPrepareSetIndexForIn(
         }
     }
 
+    bool set_is_exact = true;
     if (!tryPrepareSetColumnsForIndex(
-            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, left_args_count))
+            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, left_args_count, set_is_exact))
         return false;
 
     out.set_index = std::make_shared<MergeTreeSetIndex>(set_columns, std::move(indexes_mapping));
@@ -3103,7 +3121,12 @@ bool KeyCondition::tryPrepareSetIndexForIn(
     ///    For partition pruning we may transform set elements via functions from the key expression,
     ///    which relaxes the predicate. Example: `PARTITION BY toDate(ts)` allows turning
     ///    `ts NOT IN ('2026-02-03 19:00:00')` into `toDate(ts) NOT IN ('2026-02-03')`, which is not equivalent.
-    if (adjusted_indexes_mapping.size() < set_types.size())
+    ///
+    /// -  if normalizing an element into the key type lost information, `tryPrepareSetColumnsForIndex()`
+    ///    reports the set as inexact. The element names a key point the predicate does not, so neither
+    ///    `NOT IN` excluding that point nor `IN` being certainly true over it can be relied on. `IN` keeps
+    ///    the pruning it gets from the points the set does not hold.
+    if (adjusted_indexes_mapping.size() < set_types.size() || !set_is_exact)
         out.relaxed = true;
 
     return true;
@@ -3254,8 +3277,9 @@ bool KeyCondition::tryPrepareSetIndexForHas(
     Columns set_columns = {array_elements};
     DataTypes set_types = {array_nested_type};
 
+    bool set_is_exact = true;
     if (!tryPrepareSetColumnsForIndex(
-            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, key_args_count))
+            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, key_args_count, set_is_exact))
         return false;
 
     out.set_index = std::make_shared<MergeTreeSetIndex>(set_columns, std::move(indexes_mapping));
@@ -3281,7 +3305,12 @@ bool KeyCondition::tryPrepareSetIndexForHas(
     ///    which relaxes the predicate. Example: `PARTITION BY toDate(ts)` allows turning
     ///    `has([toDateTime('2026-02-03 19:00:00')], ts)` into `has([toDate('2026-02-03')], toDate(ts))`,
     ///    which is not equivalent.
-    if (adjusted_indexes_mapping.size() < set_types.size())
+    ///
+    /// -  if normalizing an element into the key type lost information, `tryPrepareSetColumnsForIndex()`
+    ///    reports the set as inexact. The element names a key point the predicate does not, so neither
+    ///    `NOT has` excluding that point nor `has` being certainly true over it can be relied on. `has`
+    ///    keeps the pruning it gets from the points the set does not hold.
+    if (adjusted_indexes_mapping.size() < set_types.size() || !set_is_exact)
         out.relaxed = true;
 
     return true;

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2144,8 +2144,18 @@ static bool finalizeTransformedColumn(ColumnPtr & column, DataTypePtr & type)
 
 
 /// Cast column to target_type and fail if the cast introduces NULLs.
-static bool castColumnWithoutNulls(ColumnPtr & column, DataTypePtr & type, const DataTypePtr & target_type)
+///
+/// `out_is_exact` reports whether every value also survived the cast unchanged. A value that fits the
+/// target but loses information on the way - `DateTime64(6)` truncated to `DateTime64(3)`, `'007'`
+/// read as `7` - is not a NULL, so the probe below cannot see it, and a constant normalized that way
+/// stands for a different value than the query asked for. Whoever relies on the cast for an equality
+/// atom has to treat such an atom as relaxed: the key point it names has more than one preimage, so
+/// `notEquals` must not exclude it.
+static bool castColumnWithoutNulls(
+    ColumnPtr & column, DataTypePtr & type, const DataTypePtr & target_type, bool & out_is_exact)
 {
+    out_is_exact = true;
+
     if (canBeSafelyCast(type, target_type))
     {
         column = castColumnAccurate({column, type, ""}, target_type);
@@ -2178,6 +2188,23 @@ static bool castColumnWithoutNulls(ColumnPtr & column, DataTypePtr & type, const
         if (b)
             return false;
 
+    /// Every value fits, so ask the reverse cast whether anything was lost on the way. A target the
+    /// reverse cast cannot represent, a value that does not come back, or a value that comes back
+    /// different all leave the cast inexact, which costs only the `can_be_false` half of the analysis.
+    const DataTypePtr source_probe_type = removeLowCardinality(type);
+    if ((!source_probe_type->isNullable() && !source_probe_type->canBeInsideNullable())
+        || !canBeAccurateCastOrNullTarget(source_probe_type))
+    {
+        out_is_exact = false;
+    }
+    else
+    {
+        ColumnPtr forward_column = castColumnAccurate({column, type, ""}, probe_type);
+        ColumnPtr back_column = castColumnAccurateOrNull({forward_column, probe_type, ""}, source_probe_type);
+        for (size_t i = 0, size = column->size(); i < size && out_is_exact; ++i)
+            out_is_exact = (*back_column)[i] == (*column)[i];
+    }
+
     /// No NULLs were introduced, so the cast is accurate for every value. Produce the requested
     /// target_type (which may be LowCardinality and/or Nullable); the accurate cast cannot throw
     /// here because the probe above already proved every value fits.
@@ -2201,9 +2228,11 @@ static bool convertColumnForDeterministicDag(
     const DeterministicKeyTransformDag & dag,
     ColumnPtr & out_column,
     DataTypePtr & out_type,
-    bool & out_transform_applied)
+    bool & out_transform_applied,
+    bool & out_cast_is_exact)
 {
     out_transform_applied = false;
+    out_cast_is_exact = true;
 
     ColumnPtr input_column = in_column->convertToFullIfWrapped()->convertToFullColumnIfLowCardinality();
     DataTypePtr input_type = removeLowCardinality(in_type);
@@ -2262,7 +2291,8 @@ static bool convertColumnForDeterministicDag(
             out_column = input_column;
             out_type = input_type;
 
-            if (!input_type->equals(*cast_result_type) && !castColumnWithoutNulls(out_column, out_type, cast_result_type))
+            if (!input_type->equals(*cast_result_type)
+                && !castColumnWithoutNulls(out_column, out_type, cast_result_type, out_cast_is_exact))
                 return false;
 
             return finalizeTransformedColumn(out_column, out_type);
@@ -2274,7 +2304,7 @@ static bool convertColumnForDeterministicDag(
             return true;
         }
 
-        if (!castColumnWithoutNulls(input_column, input_type, dag.input_type))
+        if (!castColumnWithoutNulls(input_column, input_type, dag.input_type, out_cast_is_exact))
             return false;
     }
 
@@ -2352,9 +2382,15 @@ static bool applyDeterministicDagToColumn(
     ColumnPtr transform_input_column;
     DataTypePtr transform_input_type;
     bool transform_applied = false;
+    bool cast_is_exact = true;
 
     if (!convertColumnForDeterministicDag(
-            in_column, in_type, input_name, dag, transform_input_column, transform_input_type, transform_applied))
+            in_column, in_type, input_name, dag, transform_input_column, transform_input_type, transform_applied, cast_is_exact))
+        return false;
+
+    /// A set atom has no relaxed form here - `notIn` would exclude a key point that has more than one
+    /// preimage - so a normalization that lost information declines index analysis altogether.
+    if (!cast_is_exact)
         return false;
 
     if (transform_applied)
@@ -2505,8 +2541,9 @@ bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     ColumnPtr transform_input_column;
     DataTypePtr transform_input_type;
     bool transform_applied = false;
+    bool cast_is_exact = true;
     if (!convertColumnForDeterministicDag(
-            const_column, out_type, expr_name, dag, transform_input_column, transform_input_type, transform_applied))
+            const_column, out_type, expr_name, dag, transform_input_column, transform_input_type, transform_applied, cast_is_exact))
         return false;
 
     /// The direct-CAST fast path converts and transforms in one step, so it produces no intermediate value
@@ -2525,8 +2562,11 @@ bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     /// The comparison reads the constant in the domain of the column the key expression consumes, where a
     /// NaN equals no value, not even itself. The transform maps it to an ordinary key value that the index
     /// compares as equal, so the atom is stricter than the predicate and its `can_be_false` is not usable.
+    /// A normalization that lost information leaves the key point with more than one preimage, so the
+    /// atom is stricter than the predicate for the same reason a non-injective transform is.
     out_atom_is_exact = isDeterministicTransformInjective(dag.actions->getActionsDAG(), expr_name, dag.output_name)
-        && !transform_input_has_nan;
+        && !transform_input_has_nan
+        && cast_is_exact;
 
     Field transformed_value = (*transformed_const_column)[0];
 

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2156,13 +2156,20 @@ static bool castKeptEveryValue(
     const DataTypePtr & cast_type,
     const IColumn::Filter * kept = nullptr)
 {
-    /// `castColumnAccurateOrNull` needs a target that can represent NULLs, and `canBeInsideNullable`
-    /// answers for the outer type only, so a `Tuple` holding an `Array` passes it and then throws.
     const DataTypePtr source_type = removeLowCardinality(type);
-    if ((!source_type->isNullable() && !source_type->canBeInsideNullable()) || !canBeAccurateCastOrNullTarget(source_type))
-        return false;
 
-    ColumnPtr back_column = castColumnAccurateOrNull({cast_column, cast_type, ""}, source_type);
+    /// The reverse cast has to be able to say that a value did not come back, which `accurateOrNull`
+    /// does by wrapping its target in `Nullable`; a target it cannot wrap (an `Array`, or a `Tuple`
+    /// holding one) leaves the question unanswered. A `Dynamic` cannot be wrapped either, because it
+    /// carries its own NULLs, but it also cannot refuse a value: every value fits a `Dynamic`, so there
+    /// the plain accurate cast is total and its result answers the question directly.
+    ColumnPtr back_column;
+    if (WhichDataType(*source_type).isDynamic())
+        back_column = castColumnAccurate({cast_column, cast_type, ""}, source_type);
+    else if (canBeAccurateCastOrNullTarget(source_type))
+        back_column = castColumnAccurateOrNull({cast_column, cast_type, ""}, source_type);
+    else
+        return false;
 
     for (size_t i = 0, size = column->size(); i < size; ++i)
     {
@@ -2223,9 +2230,10 @@ static bool castColumnWithoutNulls(
             return false;
 
     /// Every value fits, so ask the reverse cast whether anything was lost on the way. The probe above
-    /// is the forward cast, so it is read back instead of being computed again. An inexact cast costs
-    /// only the `can_be_false` half of the analysis.
-    out_is_exact = castKeptEveryValue(column, type, n.getNestedColumnPtr(), probe_type);
+    /// is the forward cast, so it is read back instead of being computed again - as its nested column,
+    /// whose type is the probe target with the `Nullable` that carried the failures removed. An inexact
+    /// cast costs only the `can_be_false` half of the analysis.
+    out_is_exact = castKeptEveryValue(column, type, n.getNestedColumnPtr(), removeNullable(probe_type));
 
     /// No NULLs were introduced, so the cast is accurate for every value. Produce the requested
     /// target_type (which may be LowCardinality and/or Nullable); the accurate cast cannot throw

--- a/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.reference
+++ b/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.reference
@@ -1,0 +1,14 @@
+a finer-scale constant
+2
+2
+0
+a representable constant still prunes
+1
+1
+the same shape in a partition key
+2
+2
+1
+a String constant that is not the key rendering
+1
+1

--- a/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.reference
+++ b/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.reference
@@ -5,6 +5,35 @@ a finer-scale constant
 a representable constant still prunes
 1
 1
+a String spelling of the same point
+1
+1
+the lossless normalizations prune
+1
+1
+1
+1
+the lossy normalization does not prune
+a finer-scale set element
+2
+2
+1
+1
+2
+2
+0
+0
+the same set element against a bare key
+2
+2
+1
+1
+2
+2
+0
+0
+a lossless set element prunes
+1
 the same shape in a partition key
 2
 2

--- a/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.sql
+++ b/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.sql
@@ -1,0 +1,45 @@
+-- Index analysis normalizes the constant into the type the key expression reads. A `DateTime64(6)`
+-- constant truncated to `DateTime64(3)` becomes the exact preimage of a real key point, and
+-- `notEquals` then excluded that point - dropping a row whose stored value really differs from the
+-- constant. Such an atom must stay relaxed: the key point has more than one preimage.
+
+DROP TABLE IF EXISTS t_lossy_const_key;
+
+CREATE TABLE t_lossy_const_key (d DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY toString(d);
+
+INSERT INTO t_lossy_const_key VALUES (toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC'));
+INSERT INTO t_lossy_const_key VALUES (toDateTime64('2023-02-01 13:00:00.000', 3, 'UTC'));
+
+SELECT 'a finer-scale constant';
+SELECT count() FROM t_lossy_const_key WHERE d != toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC');
+SELECT countIf(d != toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC')) FROM t_lossy_const_key;
+SELECT count() FROM t_lossy_const_key WHERE d = toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC');
+
+SELECT 'a representable constant still prunes';
+SELECT count() FROM t_lossy_const_key WHERE d != toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC');
+SELECT count() FROM t_lossy_const_key WHERE d = toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC');
+
+DROP TABLE t_lossy_const_key;
+
+SELECT 'the same shape in a partition key';
+
+CREATE TABLE t_lossy_const_part (d DateTime64(3, 'UTC')) ENGINE = MergeTree PARTITION BY toString(d) ORDER BY tuple();
+
+INSERT INTO t_lossy_const_part VALUES (toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC')), (toDateTime64('2023-02-01 13:00:00.000', 3, 'UTC'));
+
+SELECT count() FROM t_lossy_const_part WHERE d != toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC');
+SELECT count() FROM t_lossy_const_part WHERE d != toDateTime64('2023-02-01 12:00:00.001', 3, 'UTC');
+SELECT count() FROM t_lossy_const_part WHERE d = toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC');
+
+DROP TABLE t_lossy_const_part;
+
+SELECT 'a String constant that is not the key rendering';
+
+CREATE TABLE t_lossy_const_str (s String) ENGINE = MergeTree ORDER BY toInt64(s);
+
+INSERT INTO t_lossy_const_str VALUES ('7');
+
+SELECT count() FROM t_lossy_const_str WHERE s != '007';
+SELECT countIf(s != '007') FROM t_lossy_const_str;
+
+DROP TABLE t_lossy_const_str;

--- a/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.sql
+++ b/tests/queries/0_stateless/05164_key_condition_lossy_constant_not_equals.sql
@@ -19,9 +19,84 @@ SELECT 'a representable constant still prunes';
 SELECT count() FROM t_lossy_const_key WHERE d != toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC');
 SELECT count() FROM t_lossy_const_key WHERE d = toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC');
 
+-- A `String` constant is not a value in its own domain: the comparison converts the spelling into the
+-- type of the column and compares there, so a spelling that renders back differently - `12:00:00`
+-- comes back as `12:00:00.000` - still names exactly one key point and keeps its pruning.
+SELECT 'a String spelling of the same point';
+SELECT count() FROM t_lossy_const_key WHERE d != '2023-02-01 12:00:00';
+SELECT countIf(d != '2023-02-01 12:00:00') FROM t_lossy_const_key;
+
+-- Reporting a lossless normalization as lossy would silently disable pruning, which no answer can
+-- show. `max_rows_to_read` pins it: with the part holding the excluded key point pruned, the query
+-- reads the other row only.
+SELECT 'the lossless normalizations prune';
+SELECT count() FROM t_lossy_const_key WHERE d != toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC')
+    SETTINGS max_rows_to_read = 1, use_statistics_for_part_pruning = 0, use_query_condition_cache = 0,
+        enable_parallel_replicas = 0;
+SELECT count() FROM t_lossy_const_key WHERE d != toDateTime64('2023-02-01 12:00:00', 0, 'UTC')
+    SETTINGS max_rows_to_read = 1, use_statistics_for_part_pruning = 0, use_query_condition_cache = 0,
+        enable_parallel_replicas = 0;
+SELECT count() FROM t_lossy_const_key WHERE d != '2023-02-01 12:00:00.000'
+    SETTINGS max_rows_to_read = 1, use_statistics_for_part_pruning = 0, use_query_condition_cache = 0,
+        enable_parallel_replicas = 0;
+SELECT count() FROM t_lossy_const_key WHERE d != '2023-02-01 12:00:00'
+    SETTINGS max_rows_to_read = 1, use_statistics_for_part_pruning = 0, use_query_condition_cache = 0,
+        enable_parallel_replicas = 0;
+
+SELECT 'the lossy normalization does not prune';
+SELECT count() FROM t_lossy_const_key WHERE d != toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC')
+    SETTINGS max_rows_to_read = 1, use_statistics_for_part_pruning = 0, use_query_condition_cache = 0,
+        enable_parallel_replicas = 0; -- { serverError TOO_MANY_ROWS }
+
+-- `notIn` and `notHas` exclude a key point just like `notEquals`, so a truncated set element must not
+-- exclude it either. A literal set is coerced to the type of the left argument before the index sees
+-- it, which makes the index and the rows agree by construction; a subquery set keeps its own type.
+SELECT 'a finer-scale set element';
+SELECT count() FROM t_lossy_const_key WHERE d NOT IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
+SELECT countIf(d NOT IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'))) FROM t_lossy_const_key;
+SELECT count() FROM t_lossy_const_key WHERE d NOT IN (toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
+SELECT countIf(d NOT IN (toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'))) FROM t_lossy_const_key;
+SELECT count() FROM t_lossy_const_key WHERE NOT has([toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC')], d);
+SELECT countIf(NOT has([toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC')], d)) FROM t_lossy_const_key;
+SELECT count() FROM t_lossy_const_key WHERE d IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
+SELECT countIf(d IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'))) FROM t_lossy_const_key;
+
 DROP TABLE t_lossy_const_key;
 
+-- The set path normalizes an element into the key type with no key transform involved at all, so a
+-- bare key has the same hole, in both directions: `notIn` excluded a point the predicate does not
+-- name, and `in` was read as certainly true over that point, which answered a `count()` from the
+-- part without filtering its rows at all.
+SELECT 'the same set element against a bare key';
+
+DROP TABLE IF EXISTS t_lossy_const_plain;
+
+CREATE TABLE t_lossy_const_plain (d DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY d;
+
+INSERT INTO t_lossy_const_plain VALUES (toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC'));
+INSERT INTO t_lossy_const_plain VALUES (toDateTime64('2023-02-01 13:00:00.000', 3, 'UTC'));
+
+SELECT count() FROM t_lossy_const_plain WHERE d NOT IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
+SELECT countIf(d NOT IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'))) FROM t_lossy_const_plain;
+SELECT count() FROM t_lossy_const_plain WHERE d NOT IN (toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
+SELECT countIf(d NOT IN (toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'))) FROM t_lossy_const_plain;
+SELECT count() FROM t_lossy_const_plain WHERE NOT has([toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC')], d);
+SELECT countIf(NOT has([toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC')], d)) FROM t_lossy_const_plain;
+SELECT count() FROM t_lossy_const_plain WHERE d IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
+SELECT countIf(d IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'))) FROM t_lossy_const_plain;
+
+-- A lossless element keeps its pruning here too: one row of the subquery plus the row of the part the
+-- set index did not exclude.
+SELECT 'a lossless set element prunes';
+SELECT count() FROM t_lossy_const_plain WHERE d NOT IN (SELECT toDateTime64('2023-02-01 12:00:00', 0, 'UTC'))
+    SETTINGS max_rows_to_read = 2, use_statistics_for_part_pruning = 0, use_query_condition_cache = 0,
+        enable_parallel_replicas = 0;
+
+DROP TABLE t_lossy_const_plain;
+
 SELECT 'the same shape in a partition key';
+
+DROP TABLE IF EXISTS t_lossy_const_part;
 
 CREATE TABLE t_lossy_const_part (d DateTime64(3, 'UTC')) ENGINE = MergeTree PARTITION BY toString(d) ORDER BY tuple();
 
@@ -34,6 +109,8 @@ SELECT count() FROM t_lossy_const_part WHERE d = toDateTime64('2023-02-01 12:00:
 DROP TABLE t_lossy_const_part;
 
 SELECT 'a String constant that is not the key rendering';
+
+DROP TABLE IF EXISTS t_lossy_const_str;
 
 CREATE TABLE t_lossy_const_str (s String) ENGINE = MergeTree ORDER BY toInt64(s);
 


### PR DESCRIPTION
Index analysis normalizes a comparison constant into the type the key expression reads before applying the key transform, and `castColumnWithoutNulls` accepted that cast as exact whenever it produced no `NULL`s. A cast can lose information without producing a `NULL`: `accurateCastOrNull` from `DateTime64(6)` to `DateTime64(3)` truncates the sub-millisecond digits instead of answering `NULL`. The truncated constant is then the exact preimage of a real key point, so the `notEquals` atom excluded that point and the granule - or, with a partition key of the same shape, the whole partition - holding a live row was pruned:

```sql
CREATE TABLE t (d DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY toString(d);
INSERT INTO t VALUES (toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC'));
SELECT count() FROM t WHERE d != toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'); -- 0, the truth is 1
```

The cast now reports whether it was lossless, by casting back and comparing. A lossy normalization leaves the atom relaxed - the key point it names has more than one preimage, exactly as a non-injective transform does - so `notEquals` no longer excludes it while `equals` keeps its pruning.

The set path normalizes its elements the same way, and had the same hole with no key transform involved at all, in both directions (found in review):

```sql
CREATE TABLE t (d DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY d;
INSERT INTO t VALUES (toDateTime64('2023-02-01 12:00:00.000', 3, 'UTC'));

SELECT count() FROM t WHERE d NOT IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
-- 0, the truth is 1: the atom excluded the point the element was truncated to

SELECT count() FROM t WHERE d IN (SELECT toDateTime64('2023-02-01 12:00:00.000001', 6, 'UTC'));
-- 1, the truth is 0: the atom was read as certainly true over that point, so the count came from the
-- part without its rows being filtered
```

A lossy element now relaxes the set atom - `out.relaxed`, the mechanism the non-injective transform path already uses - instead of being reported as exact, so neither exclusion survives. The element itself stays in the set: a relaxed atom is a superset of the predicate, so the points the set does not hold still prune. A literal set hides the defect, because a literal is coerced to the type of the left argument before the index sees it, which makes the index and the rows agree by construction.

A `String` constant does not go through the round trip: the comparison converts the spelling into the type of the other side and compares there (`executeWithConstString`), so exactness is decided against that conversion rather than against the spelling. `'2023-02-01 12:00:00'` renders back as `'2023-02-01 12:00:00.000'` while naming exactly the same key point, and keeps its pruning.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118691
Related: https://github.com/ClickHouse/ClickHouse/pull/118688

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed rows silently dropped, or counted without being filtered, when a `DateTime64` constant of a finer scale than the column is compared with `!=`, `NOT IN` or `IN`: index analysis truncated the constant and treated the truncated value as the exact point the query asked for, pruning the granule or partition that held a matching row.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118957&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118957](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118957+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
