### PR TITLE
Keep a non-deterministic expression out of a DAG with `arrayJoin`

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/mergeExpressions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/mergeExpressions.cpp
@@ -1,4 +1,5 @@
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
+#include <Processors/QueryPlan/Optimizations/Utils.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Interpreters/ActionsDAG.h>
@@ -43,7 +44,12 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, co
         /// We cannot combine actions with arrayJoin and stateful function because we not always can reorder them.
         /// Example: select rowNumberInBlock() from (select arrayJoin([1, 2]))
         /// Such a query will return two zeroes if we combine actions together.
-        if (child_actions.hasArrayJoin() && parent_actions.hasStatefulFunctions())
+        /// A function that is merely non-deterministic within the query (`rand64`, `generateUUIDv4`,
+        /// ...) has the same problem for the same reason: merged into the child DAG it is computed
+        /// once per source row and the value is then replicated across the rows the `arrayJoin`
+        /// expands, instead of being drawn once per output row.
+        if (child_actions.hasArrayJoin()
+            && (parent_actions.hasStatefulFunctions() || dagContainsNonDeterministicFunction(parent_actions)))
             return 0;
 
         /// Propagate the flag from either side: if the child is a discarding step (or any
@@ -68,7 +74,10 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &, co
         auto & child_actions = child_expr->getExpression();
         auto & parent_actions = parent_filter->getExpression();
 
-        if (child_actions.hasArrayJoin() && parent_actions.hasStatefulFunctions())
+        /// Same as for the expression step above: a stateful or non-deterministic filter must not be
+        /// computed before the `arrayJoin` replicates the rows it applies to.
+        if (child_actions.hasArrayJoin()
+            && (parent_actions.hasStatefulFunctions() || dagContainsNonDeterministicFunction(parent_actions)))
             return 0;
 
         const bool prevent_input_removal = child_expr->isInputRemovalPrevented() || parent_filter->isInputRemovalPrevented();

--- a/tests/queries/0_stateless/05165_merge_expressions_non_deterministic_array_join.reference
+++ b/tests/queries/0_stateless/05165_merge_expressions_non_deterministic_array_join.reference
@@ -1,0 +1,9 @@
+one draw per output row
+400	400
+400	400
+the same without the optimization
+400	400
+a filter over the expanded rows
+400
+deterministic in the query: one value for every row
+1	400

--- a/tests/queries/0_stateless/05165_merge_expressions_non_deterministic_array_join.sql
+++ b/tests/queries/0_stateless/05165_merge_expressions_non_deterministic_array_join.sql
@@ -1,0 +1,17 @@
+-- The expression-merge optimization must not fuse a non-deterministic expression into a DAG that
+-- contains `arrayJoin`: merged, the value is computed once per source row and then replicated across
+-- the rows the `arrayJoin` expands, instead of being drawn once per output row.
+
+SELECT 'one draw per output row';
+SELECT uniqExact(r), count() FROM (SELECT rand64() AS r FROM (SELECT arrayJoin(range(4)) AS x FROM numbers(100)));
+SELECT uniqExact(id), count() FROM (SELECT generateUUIDv4() AS id FROM (SELECT arrayJoin(range(4)) AS x FROM numbers(100)));
+
+SELECT 'the same without the optimization';
+SELECT uniqExact(r), count() FROM (SELECT rand64() AS r FROM (SELECT arrayJoin(range(4)) AS x FROM numbers(100)))
+SETTINGS query_plan_merge_expressions = 0;
+
+SELECT 'a filter over the expanded rows';
+SELECT count() FROM (SELECT x FROM (SELECT arrayJoin(range(4)) AS x FROM numbers(100)) WHERE rand64() % 1 = 0);
+
+SELECT 'deterministic in the query: one value for every row';
+SELECT uniqExact(t), count() FROM (SELECT now() AS t FROM (SELECT arrayJoin(range(4)) AS x FROM numbers(100)));


### PR DESCRIPTION
The expression-merge optimization refuses to fuse a parent expression into a child DAG that contains `arrayJoin` only when the parent has stateful functions. A merely non-deterministic parent (`rand64`, `generateUUIDv4`, ...) passed that gate and was then computed before the row replication: one draw per source row, replicated across all the rows the `arrayJoin` expands, instead of one draw per output row.

```sql
SELECT uniqExact(r), count() FROM (SELECT rand64() AS r FROM (SELECT arrayJoin(range(4)) AS x FROM numbers(100)));
-- 100  400  <- each draw repeated on all 4 expanded rows
```

The result is wrong at default settings and the wrong data persists through `INSERT ... SELECT`. The gate now declines a parent that is non-deterministic within the query as well, using the same predicate the `ArrayJoinStep` routes adopted in #117756: `now`/`today`/`currentUser` are deterministic in the scope of a query and still merge.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118471
Related: https://github.com/ClickHouse/ClickHouse/pull/117756

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `rand`/`generateUUIDv4` and other non-deterministic functions being evaluated before an `arrayJoin` replicates the rows, which silently duplicated their values across the expanded rows.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118963&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118963](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118963+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1095` (included in `26.9` and later)
<!-- ch-version-info:end -->