### PR TITLE
Do not check the `HDFS` database's host while replaying metadata

### DIFF
--- a/src/Databases/DatabaseHDFS.cpp
+++ b/src/Databases/DatabaseHDFS.cpp
@@ -60,8 +60,6 @@ DatabaseHDFS::DatabaseHDFS(const String & name_, const String & source_url, Cont
         if (!re2::RE2::FullMatch(source, std::string(HDFS_HOST_REGEXP)))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad HDFS host: {}. "
                             "It should have structure 'hdfs://<host_name>:<port>'", source);
-
-        context_->getGlobalContext()->getRemoteHostFilter().checkURL(Poco::URI(source));
     }
 }
 
@@ -257,6 +255,18 @@ void registerDatabaseHDFS(DatabaseFactory & factory)
             const auto & arguments = engine->arguments->children;
             source_url = safeGetLiteralValue<String>(arguments[0], engine_name);
         }
+
+        /** The allowlist is checked here rather than in the constructor, and not for the server's own
+          * metadata replay. Startup rebuilds every database by replaying its stored `ATTACH DATABASE`
+          * statement and `loadMetadata` aborts on the first exception, so a check that throws there
+          * takes the whole server down with it - and tightening `remote_url_allow_hosts` is exactly
+          * what turns a stored host into a disallowed one. Every statement a user writes, `CREATE` and
+          * `ATTACH` alike, is still checked up front, and the allowlist holds for every use of the
+          * database regardless: `DatabaseHDFS::checkUrl` runs it for each table, which is where
+          * `DatabaseS3` enforces it too.
+          */
+        if (!args.internal && !source_url.empty())
+            args.context->getGlobalContext()->getRemoteHostFilter().checkURL(Poco::URI(source_url));
 
         return std::make_shared<DatabaseHDFS>(args.database_name, source_url, args.context);
     };

--- a/tests/integration/test_database_hdfs_url_allowlist/configs/allowlist.xml
+++ b/tests/integration/test_database_hdfs_url_allowlist/configs/allowlist.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <remote_url_allow_hosts>
+        <host>allowed.example.com:9000</host>
+    </remote_url_allow_hosts>
+</clickhouse>

--- a/tests/integration/test_database_hdfs_url_allowlist/test.py
+++ b/tests/integration/test_database_hdfs_url_allowlist/test.py
@@ -1,0 +1,61 @@
+"""Tightening `remote_url_allow_hosts` must not make a server with an `HDFS` database unbootable.
+
+Startup rebuilds every database by replaying its stored `ATTACH DATABASE` statement, and
+`loadMetadata` aborts on the first exception, so a host check that throws there takes every other
+database down with it. The check belongs to the use of the database, not to its metadata replay.
+"""
+
+import os
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+cluster = ClickHouseCluster(__file__)
+# No `remote_url_allow_hosts` to begin with: that is the state the stored definition is created in.
+node = cluster.add_instance("node", main_configs=[], stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_server_starts_after_the_allowlist_excludes_a_stored_hdfs_database(started_cluster):
+    # No HDFS cluster is needed: `CREATE DATABASE ... ENGINE = HDFS(...)` performs no connection, which
+    # is what makes this state easy to reach.
+    node.query("CREATE DATABASE hdfs_db ENGINE = HDFS('hdfs://nn.example.invalid:9000')")
+    node.query("CREATE TABLE default.bystander (k UInt64) ENGINE = MergeTree ORDER BY k")
+    node.query("INSERT INTO default.bystander SELECT number FROM numbers(100)")
+
+    node.copy_file_to_container(
+        os.path.join(SCRIPT_DIR, "configs/allowlist.xml"),
+        "/etc/clickhouse-server/config.d/allowlist.xml",
+    )
+    node.restart_clickhouse()
+
+    # The bystander table - and the server - survive the tightening.
+    assert node.query("SELECT count() FROM default.bystander") == "100\n"
+    assert node.query("SELECT count() FROM system.databases WHERE name = 'hdfs_db'") == "1\n"
+
+    # The allowlist still holds for every use of the database, now at use time rather than at startup:
+    # resolution asks `isTableExist`, which refuses the disallowed host, so the database exposes no
+    # table for it, and a path that resolves the table directly names the URL.
+    error = node.query_and_get_error("SELECT count() FROM hdfs_db.`some_file.tsv`")
+    assert "UNKNOWN_TABLE" in error, error
+    error = node.query_and_get_error("INSERT INTO hdfs_db.`some_file.tsv` VALUES (1)")
+    assert "UNACCEPTABLE_URL" in error, error
+
+    # A definition the user introduces now is still refused up front.
+    error = node.query_and_get_error("CREATE DATABASE hdfs_db2 ENGINE = HDFS('hdfs://nn.example.invalid:9000')")
+    assert "UNACCEPTABLE_URL" in error, error
+    assert node.query("SELECT count() FROM system.databases WHERE name = 'hdfs_db2'") == "0\n"
+
+    node.query("DROP DATABASE hdfs_db SYNC")
+    node.query("DROP TABLE default.bystander SYNC")


### PR DESCRIPTION
`DatabaseHDFS` ran the `remote_url_allow_hosts` check in its constructor. Server startup rebuilds every database by replaying its stored `ATTACH DATABASE` statement and `loadMetadata` aborts on the first exception, so if an `HDFS` database was created while no allowlist was configured and the allowlist is later tightened to exclude the stored host, the whole server refuses to start:

```
<Error> Application: Caught exception while loading metadata: Code: 491. DB::Exception: URL "hdfs://nn.example.invalid:9000" is not allowed in configuration file, see <remote_url_allow_hosts>: while loading database `hb` from file metadata/hb.sql. (UNACCEPTABLE_URL)
```

Every other database goes down with it, and the trigger is an ordinary hardening step. Reaching the state is easy because `CREATE DATABASE ... ENGINE = HDFS(...)` performs no connection, so the definition persists even for a cluster that never existed.

The check moves to the engine's registration and is skipped for the server's own metadata replay (`Arguments::internal`), so every statement a user writes - `CREATE` and `ATTACH` alike - is still refused up front. The allowlist holds for every use of the database regardless: `DatabaseHDFS::checkUrl` runs it per table, which is where `DatabaseS3` enforces it too, so the disallowed host exposes no table and a path that resolves one names the URL.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118686

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server refusing to start after `remote_url_allow_hosts` was tightened while a database with the `HDFS` engine existed: the host check ran during metadata loading and took every other database down with it.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118964&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118964](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118964+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1094` (included in `26.9` and later)
<!-- ch-version-info:end -->