### PR TITLE
Fix Keeper rejecting nodes whose empty ACL list has a nonzero ACL id

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -723,6 +723,11 @@ bool KeeperStorage::checkACL(ACLId acl_id, int32_t permission, int64_t session_i
         return true;
     const auto node_acls = acl_map.convertNumber(acl_id);
 
+    /// An empty ACL list means unrestricted. Keeper itself stores that as id 0, but a snapshot converted
+    /// from ZooKeeper can map a nonzero id to an empty list.
+    if (node_acls.empty())
+        return true;
+
     if (uncommitted_state.hasACL(session_id, committed, [](const auto & auth_id) { return auth_id.scheme == "super"; }))
         return true;
 

--- a/src/Coordination/tests/gtest_coordination_storage.cpp
+++ b/src/Coordination/tests/gtest_coordination_storage.cpp
@@ -1490,6 +1490,44 @@ TEST_P(CoordinationTest, TestBlockACL)
     }
 }
 
+/// A Keeper snapshot converted from ZooKeeper can carry an ACL map entry whose id is nonzero but whose
+/// ACL list is empty. An empty ACL list means unrestricted, whichever id carries it.
+TEST_P(CoordinationTest, TestEmptyACLListWithNonzeroId)
+{
+    using namespace DB;
+    using namespace Coordination;
+
+    const auto storage_ptr = DB::KeeperStorage::create(500, "", this->keeper_context);
+    DB::KeeperStorage & storage = *storage_ptr;
+    int64_t zxid = 0;
+
+    /// Mimic snapshot deserialization: addMapping starts the usage counter at 0, and every node
+    /// referencing the id adds one use.
+    storage.acl_map.addMapping(2, {});
+    addNode(storage, "/legacy_empty_acl", "data", /*ephemeral_owner=*/0, /*acl_id=*/2);
+    storage.acl_map.addUsage(2);
+
+    storage.acl_map.addMapping(3, {{.permissions = ACL::All, .scheme = "digest", .id = "user:password"}});
+    addNode(storage, "/restricted", "data", /*ephemeral_owner=*/0, /*acl_id=*/3);
+    storage.acl_map.addUsage(3);
+
+    const auto assert_get = [&](const std::string & path, Error expected)
+    {
+        int64_t new_zxid = ++zxid;
+        auto request = std::make_shared<ZooKeeperGetRequest>();
+        request->path = path;
+        storage.preprocessRequest(request, 1, 0, new_zxid, /*check_acl=*/true, /*digest=*/std::nullopt, /*log_idx=*/0);
+        auto responses = storage.processRequest(request, 1, new_zxid);
+        ASSERT_EQ(responses.size(), 1u);
+        ASSERT_EQ(responses[0].response->error, expected) << "path " << path;
+    };
+
+    /// The session adds no auth, so only the node's own ACL list decides.
+    assert_get("/legacy_empty_acl", Error::ZOK);
+    /// A nonzero id whose non-empty ACL list the session cannot satisfy is still refused.
+    assert_get("/restricted", Error::ZNOAUTH);
+}
+
 TEST_P(CoordinationTest, TestMultiWatches)
 {
     using namespace DB;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117603
Related: https://github.com/ClickHouse/ClickHouse/pull/106412


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed ClickHouse Keeper returning `ZNOAUTH` for every request on a node whose ACL list is empty but is stored under a nonzero internal ACL id, which happens for Keeper data converted from a ZooKeeper snapshot or written by a very old Keeper. Such nodes are unrestricted again, as they were before 26.6. Closes #117603.

### Description

Upgrading Keeper from 26.5 to 26.6 stops replication from starting: every request on the affected nodes returns `ZNOAUTH`, with no Keeper authentication configured. `ZNOAUTH` is in `isHardwareError`, so the client tears down the shared Keeper session and every replicated table reconnect-loops on `Connection loss`. The reporter measured 11,493,573 `KEEPER_EXCEPTION` in 58 minutes over 302 nodes.

#106412 changed `KeeperStorage::checkACL` from taking a path to taking an `ACLId`, and replaced the semantic test `if (node_acls.empty()) return true;` with the representational `if (acl_id == 0) return true;`. Those agree only while a nonzero id resolves to a non-empty list. `ACLMap::convertACLs`, the only way a running Keeper assigns an id today, keeps that true by returning 0 for an empty list. `ACLMap::addMapping` does not: it stores whatever a snapshot carries, so such an id misses the fast path and reaches `return false`.

Two sources, both surviving later snapshots: `deserializeACLMap` passes a ZooKeeper snapshot's ACL cache through unchanged, which is the reporter's case, and `convertACLs` only started returning 0 for an empty list in `9303b5f0ce8` (2021-12-28), so old native Keeper data can carry one too.

I restore the emptiness test once the id is resolved. It mutates nothing: no digest, snapshot format or setting change, and it cannot widen access, since a non-empty list the session does not satisfy is still refused and `fixupACL` already turns an ordinary `world:anyone:cdrwa` create into id 0. The `acl_id == 0` fast path stays, since `convertNumber` is an out-of-line call returning `ACLs` by value and the list paths run this predicate once per child.

The new `TEST_P` builds the state through `ACLMap::addMapping`, the surface deserialization uses: `ZNOAUTH` before the change, `ZOK` after, on both storage parameters, and a nonzero id with a non-empty unmatched list is still refused.

`c064fad5750f3d8` is on 26.6, 26.7 and 26.8, and not on 26.5.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118965&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118965](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118965+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1504` (included in `26.9` and later)
<!-- ch-version-info:end -->