### PR TITLE
Require the privilege on every table in an `Alias` chain

### DIFF
--- a/src/Interpreters/InterpreterShowCreateQuery.cpp
+++ b/src/Interpreters/InterpreterShowCreateQuery.cpp
@@ -169,7 +169,7 @@ QueryPipeline InterpreterShowCreateQuery::executeImpl()
         {
             auto table = DatabaseCatalog::instance().tryGetTable(table_id, getContext());
             if (const auto * alias = table ? table->as<StorageAlias>() : nullptr;
-                alias && !alias->isTargetTableGranted(getContext(), AccessType::SHOW_COLUMNS, {}))
+                alias && !alias->isDeclaredTargetGranted(getContext(), AccessType::SHOW_COLUMNS, {}))
                 throw Exception(ErrorCodes::ACCESS_DENIED, "Not enough privileges to show metadata exposed by {}", table_id.getNameForLogs());
         }
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -1147,11 +1147,13 @@ bool TreeRewriterResult::collectUsedColumns(const ASTPtr & query, bool is_select
             auto query_context = CurrentThread::tryGetQueryContext();
             auto access = query_context ? query_context->getAccess() : nullptr;
             const auto & storage_id = storage->getStorageID();
+            /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
+            const bool alias_chain_granted = access && alias->isTargetTableGranted(query_context, AccessType::SELECT, {});
             for (const auto & column : source_columns)
             {
                 if (access
                     && access->isGranted(AccessType::SELECT, storage_id.database_name, storage_id.table_name, column.name)
-                    && alias->isTargetTableGranted(query_context, AccessType::SELECT, column.name))
+                    && (alias_chain_granted || alias->isTargetTableGranted(query_context, AccessType::SELECT, column.name)))
                     accessible_columns.push_back(column);
             }
         }

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -1147,13 +1147,16 @@ bool TreeRewriterResult::collectUsedColumns(const ASTPtr & query, bool is_select
             auto query_context = CurrentThread::tryGetQueryContext();
             auto access = query_context ? query_context->getAccess() : nullptr;
             const auto & storage_id = storage->getStorageID();
-            /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
-            const bool alias_chain_granted = access && alias->isTargetTableGranted(query_context, AccessType::SELECT, {});
+            /// One walk for the whole table: the per-column checks below must not resolve the chain again
+            /// for every column.
+            const NameSet chain_granted = access
+                ? alias->filterColumnsGrantedThroughChain(query_context, AccessType::SELECT, source_columns.getNames())
+                : NameSet{};
             for (const auto & column : source_columns)
             {
                 if (access
                     && access->isGranted(AccessType::SELECT, storage_id.database_name, storage_id.table_name, column.name)
-                    && (alias_chain_granted || alias->isTargetTableGranted(query_context, AccessType::SELECT, column.name)))
+                    && chain_granted.contains(column.name))
                     accessible_columns.push_back(column);
             }
         }

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -396,13 +396,22 @@ NameSet checkAccessRights(const StoragePtr & storage, const StorageID & storage_
           */
         auto access = query_context->getAccess();
         const auto * alias = storage->as<StorageAlias>();
-        /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
-        const bool alias_chain_granted = alias && alias->isTargetTableGranted(query_context, AccessType::SELECT, {});
+        /// One walk for the whole table: the per-column checks below must not resolve the chain again
+        /// for every column.
+        NameSet chain_granted;
+        if (alias)
+        {
+            Names all_columns;
+            all_columns.reserve(storage_snapshot->metadata->getColumns().size());
+            for (const auto & column : storage_snapshot->metadata->getColumns())
+                all_columns.push_back(column.name);
+            chain_granted = alias->filterColumnsGrantedThroughChain(query_context, AccessType::SELECT, all_columns);
+        }
         for (const auto & column : storage_snapshot->metadata->getColumns())
         {
             /// An `Alias` also requires access to the selected column of its target table.
             if (access->isGranted(AccessType::SELECT, storage_id.database_name, storage_id.table_name, column.name)
-                && (!alias || alias_chain_granted || alias->isTargetTableGranted(query_context, AccessType::SELECT, column.name)))
+                && (!alias || chain_granted.contains(column.name)))
                 accessible_columns.insert(column.name);
         }
 

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -396,11 +396,13 @@ NameSet checkAccessRights(const StoragePtr & storage, const StorageID & storage_
           */
         auto access = query_context->getAccess();
         const auto * alias = storage->as<StorageAlias>();
+        /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
+        const bool alias_chain_granted = alias && alias->isTargetTableGranted(query_context, AccessType::SELECT, {});
         for (const auto & column : storage_snapshot->metadata->getColumns())
         {
             /// An `Alias` also requires access to the selected column of its target table.
             if (access->isGranted(AccessType::SELECT, storage_id.database_name, storage_id.table_name, column.name)
-                && (!alias || alias->isTargetTableGranted(query_context, AccessType::SELECT, column.name)))
+                && (!alias || alias_chain_granted || alias->isTargetTableGranted(query_context, AccessType::SELECT, column.name)))
                 accessible_columns.insert(column.name);
         }
 

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -73,29 +73,41 @@ bool StorageAlias::isDeclaredTargetGranted(ContextPtr query_context, AccessType 
     return access->isGranted(access_type, target_database, target_table, column_name);
 }
 
-bool StorageAlias::isTargetTableGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const
+NameSet StorageAlias::filterColumnsGrantedThroughChain(
+    ContextPtr query_context, AccessType access_type, const Names & column_names) const
 {
     /// `getInMemoryMetadataPtr` forwards through nested aliases, so a caller reads the metadata of the
     /// chain's last table, and `read` authorizes every hop by re-entering `read` on each one.
+    NameSet granted(column_names.begin(), column_names.end());
     std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> authorized;
     const StorageAlias * alias = this;
     /// Owns the storage `alias` points into, from the second hop on.
     StoragePtr alias_holder;
 
-    while (alias->isDeclaredTargetGranted(query_context, access_type, column_name))
+    while (!granted.empty())
     {
+        std::erase_if(granted, [&](const String & column_name)
+        { return !alias->isDeclaredTargetGranted(query_context, access_type, column_name); });
+        if (granted.empty())
+            break;
+
         /// A cyclic chain is loadable state, so a repeated name means there is no final table left to
         /// reach, and every name in the chain is authorized.
         if (!authorized.emplace(alias->target_database, alias->target_table).second)
-            return true;
+            break;
 
         alias_holder = alias->tryGetTargetTable();
         alias = alias_holder ? alias_holder->as<StorageAlias>() : nullptr;
         if (!alias)
-            return true;
+            break;
     }
 
-    return false;
+    return granted;
+}
+
+bool StorageAlias::isTargetTableGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const
+{
+    return !filterColumnsGrantedThroughChain(query_context, access_type, {column_name}).empty();
 }
 
 /// AliasSink: Writes data to the target table using full INSERT pipeline

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -61,7 +61,7 @@ StoragePtr StorageAlias::getTargetTable(std::optional<TargetAccess> access_check
     return DatabaseCatalog::instance().getTable(StorageID(target_database, target_table), getContext());
 }
 
-bool StorageAlias::isTargetTableGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const
+bool StorageAlias::isDeclaredTargetGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const
 {
     if (!query_context)
         return false;
@@ -71,6 +71,31 @@ bool StorageAlias::isTargetTableGranted(ContextPtr query_context, AccessType acc
         return access->isGranted(access_type, target_database, target_table);
 
     return access->isGranted(access_type, target_database, target_table, column_name);
+}
+
+bool StorageAlias::isTargetTableGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const
+{
+    /// `getInMemoryMetadataPtr` forwards through nested aliases, so a caller reads the metadata of the
+    /// chain's last table, and `read` authorizes every hop by re-entering `read` on each one.
+    std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> authorized;
+    const StorageAlias * alias = this;
+    /// Owns the storage `alias` points into, from the second hop on.
+    StoragePtr alias_holder;
+
+    while (alias->isDeclaredTargetGranted(query_context, access_type, column_name))
+    {
+        /// A cyclic chain is loadable state, so a repeated name means there is no final table left to
+        /// reach, and every name in the chain is authorized.
+        if (!authorized.emplace(alias->target_database, alias->target_table).second)
+            return true;
+
+        alias_holder = alias->tryGetTargetTable();
+        alias = alias_holder ? alias_holder->as<StorageAlias>() : nullptr;
+        if (!alias)
+            return true;
+    }
+
+    return false;
 }
 
 /// AliasSink: Writes data to the target table using full INSERT pipeline

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -48,6 +48,10 @@ public:
     /// definition and resolve nothing through it.
     bool isDeclaredTargetGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const;
 
+    /// Returns the subset of `column_names` the current user has this access to on every table this
+    /// alias resolves through. Resolves the chain once, whatever the grants look like.
+    NameSet filterColumnsGrantedThroughChain(ContextPtr query_context, AccessType access_type, const Names & column_names) const;
+
     /// Read from target table
     void read(
         QueryPlan & query_plan,

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -39,9 +39,14 @@ public:
     StoragePtr getTargetTable(std::optional<TargetAccess> access_check = std::nullopt) const;
     StoragePtr tryGetTargetTable() const { return DatabaseCatalog::instance().tryGetTable(StorageID(target_database, target_table), getContext()); }
 
-    /// Returns whether the current user has the specified access to the target table or column.
+    /// Returns whether the current user has the specified access to every table this alias resolves
+    /// through, i.e. the whole chain when the target is itself an Alias. For callers that read metadata.
     /// An empty `column_name` represents table-level access.
     bool isTargetTableGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const;
+
+    /// Same, for the target named in this alias's own definition only. For callers that expose that
+    /// definition and resolve nothing through it.
+    bool isDeclaredTargetGranted(ContextPtr query_context, AccessType access_type, const String & column_name) const;
 
     /// Read from target table
     void read(

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -149,6 +149,11 @@ protected:
             SerializationInfoByName serialization_hints{{}};
             StoragePtr storage = storages.at(std::make_pair(database_name, table_name));
             const auto * alias = storage->as<StorageAlias>();
+            /// The chain an Alias resolves through is the same for every column, and a table-level grant
+            /// covers all of them, so one check answers every column loop below. Resolving the chain
+            /// costs a catalog lookup per hop, and for a target in a Remote, PostgreSQL or SQLite
+            /// database each of those is a fresh schema fetch.
+            const bool alias_chain_granted = alias && alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, {});
 
             {
                 TableLockHolder table_lock = storage->tryLockForShare(query_id, Poco::Timespan(lock_acquire_timeout.count() * 1000));
@@ -168,7 +173,7 @@ protected:
                 {
                     for (const auto & column : columns)
                     {
-                        if (!alias || alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
+                        if (!alias || alias_chain_granted || alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
                         {
                             can_expose_any_column_metadata = true;
                             break;
@@ -212,7 +217,7 @@ protected:
                 if (need_to_check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))
                     continue;
 
-                if (alias && !alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
+                if (alias && !alias_chain_granted && !alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
                     continue;
 
                 size_t src_index = 0;

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -149,10 +149,7 @@ protected:
             SerializationInfoByName serialization_hints{{}};
             StoragePtr storage = storages.at(std::make_pair(database_name, table_name));
             const auto * alias = storage->as<StorageAlias>();
-            /// The chain an Alias resolves through is the same for every column, and a table-level grant
-            /// covers all of them, so one check answers every column loop below. Resolving the chain
-            /// costs a catalog lookup per hop, and for a target in a Remote, PostgreSQL or SQLite
-            /// database each of those is a fresh schema fetch.
+            /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
             const bool alias_chain_granted = alias && alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, {});
 
             {

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -149,8 +149,9 @@ protected:
             SerializationInfoByName serialization_hints{{}};
             StoragePtr storage = storages.at(std::make_pair(database_name, table_name));
             const auto * alias = storage->as<StorageAlias>();
-            /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
-            const bool alias_chain_granted = alias && alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, {});
+            /// One walk for the whole table: the per-column checks below must not resolve the chain again
+            /// for every column.
+            NameSet chain_granted;
 
             {
                 TableLockHolder table_lock = storage->tryLockForShare(query_id, Poco::Timespan(lock_acquire_timeout.count() * 1000));
@@ -164,13 +165,22 @@ protected:
                 const auto metadata_snapshot = storage->getInMemoryMetadataPtr(context, false);
                 columns = metadata_snapshot->getColumns();
 
+                if (alias)
+                {
+                    Names all_columns;
+                    all_columns.reserve(columns.size());
+                    for (const auto & column : columns)
+                        all_columns.push_back(column.name);
+                    chain_granted = alias->filterColumnsGrantedThroughChain(context, AccessType::SHOW_COLUMNS, all_columns);
+                }
+
                 const bool needs_column_metadata = columns_mask[7] || columns_mask[8] || columns_mask[9] || columns_mask[21];
                 bool can_expose_any_column_metadata = !needs_column_metadata;
                 if (needs_column_metadata)
                 {
                     for (const auto & column : columns)
                     {
-                        if (!alias || alias_chain_granted || alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
+                        if (!alias || chain_granted.contains(column.name))
                         {
                             can_expose_any_column_metadata = true;
                             break;
@@ -214,7 +224,7 @@ protected:
                 if (need_to_check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))
                     continue;
 
-                if (alias && !alias_chain_granted && !alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
+                if (alias && !chain_granted.contains(column.name))
                     continue;
 
                 size_t src_index = 0;

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -92,18 +92,26 @@ static void fillDataWithTableColumns(
         return; // table was dropped while acquiring the lock
 
     const auto * alias = table->as<StorageAlias>();
-    /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
-    const bool alias_chain_granted = alias && alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, {});
-
     const auto snapshot = table->getInMemoryMetadataPtr(context, false);
     const auto & columns = snapshot->getColumns();
+    /// One walk for the whole table: the per-column checks below must not resolve the chain again for
+    /// every column.
+    NameSet chain_granted;
+    if (alias)
+    {
+        Names all_columns;
+        all_columns.reserve(columns.size());
+        for (const auto & column : columns)
+            all_columns.push_back(column.name);
+        chain_granted = alias->filterColumnsGrantedThroughChain(context, AccessType::SHOW_COLUMNS, all_columns);
+    }
+
     for (const auto & column : columns)
     {
         if (check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))
             continue;
 
-        if (alias && !alias_chain_granted
-            && !alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
+        if (alias && !chain_granted.contains(column.name))
             continue;
 
         res_columns[0]->insert(column.name);

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -91,6 +91,10 @@ static void fillDataWithTableColumns(
     if (table_lock == nullptr)
         return; // table was dropped while acquiring the lock
 
+    const auto * alias = table->as<StorageAlias>();
+    /// One chain check answers every column; see the comment in StorageSystemColumns.
+    const bool alias_chain_granted = alias && alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, {});
+
     const auto snapshot = table->getInMemoryMetadataPtr(context, false);
     const auto & columns = snapshot->getColumns();
     for (const auto & column : columns)
@@ -98,8 +102,8 @@ static void fillDataWithTableColumns(
         if (check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))
             continue;
 
-        if (const auto * alias = table->as<StorageAlias>();
-            alias && !alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
+        if (alias && !alias_chain_granted
+            && !alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, column.name))
             continue;
 
         res_columns[0]->insert(column.name);

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -92,7 +92,7 @@ static void fillDataWithTableColumns(
         return; // table was dropped while acquiring the lock
 
     const auto * alias = table->as<StorageAlias>();
-    /// One chain check answers every column; see the comment in StorageSystemColumns.
+    /// A table-level grant covers every column, so a granted chain answers the per-column checks below.
     const bool alias_chain_granted = alias && alias->isTargetTableGranted(context, AccessType::SHOW_COLUMNS, {});
 
     const auto snapshot = table->getInMemoryMetadataPtr(context, false);

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -582,6 +582,8 @@ protected:
                         const auto * alias = table.second->as<StorageAlias>();
                         const bool can_expose_metadata
                             = !alias || alias->isTargetTableGranted(context, AccessType::SHOW_TABLES, {});
+                        const bool can_expose_declared_definition
+                            = !alias || alias->isDeclaredTargetGranted(context, AccessType::SHOW_TABLES, {});
                         size_t src_index = 0;
                         size_t res_index = 0;
 
@@ -634,7 +636,7 @@ protected:
                         if (columns_mask[src_index++])
                         {
                             auto temp_db = DatabaseCatalog::instance().getDatabaseForTemporaryTables();
-                            ASTPtr ast = can_expose_metadata && temp_db
+                            ASTPtr ast = can_expose_declared_definition && temp_db
                                 ? temp_db->tryGetCreateTableQuery(table.second->getStorageID().getTableName(), context)
                                 : nullptr;
                             res_columns[res_index++]->insert(ast ? format({context, *ast}) : "");
@@ -757,6 +759,8 @@ protected:
                 const auto * alias = table ? table->as<StorageAlias>() : nullptr;
                 const bool can_expose_metadata
                     = table && (!alias || alias->isTargetTableGranted(context, AccessType::SHOW_TABLES, {}));
+                const bool can_expose_declared_definition
+                    = table && (!alias || alias->isDeclaredTargetGranted(context, AccessType::SHOW_TABLES, {}));
 
                 TableLockHolder lock;
 
@@ -867,7 +871,7 @@ protected:
                         .engine_full = columns_mask[src_index + 1] != 0,
                         .as_select = columns_mask[src_index + 2] != 0};
 
-                    auto rendered = can_expose_metadata
+                    auto rendered = can_expose_declared_definition
                         ? database->getRenderedCreateTableQuery(table_name, context, fields)
                         : renderCreateQuery(nullptr, RenderOptions{}, fields);
 

--- a/tests/queries/0_stateless/04946_storage_alias_attach_stored_definition.reference
+++ b/tests/queries/0_stateless/04946_storage_alias_attach_stored_definition.reference
@@ -14,3 +14,5 @@ BAD_ARGUMENTS
 -- a stored self-referential definition loads
 -- and reading it is bounded
 TOO_DEEP_RECURSION
+-- and describing it is bounded too
+TOO_DEEP_RECURSION

--- a/tests/queries/0_stateless/04946_storage_alias_attach_stored_definition.sh
+++ b/tests/queries/0_stateless/04946_storage_alias_attach_stored_definition.sh
@@ -85,6 +85,9 @@ ATTACH TABLE \`${CLICKHOUSE_DATABASE_2}\`.renamed;
 echo '-- and reading it is bounded'
 $CLICKHOUSE_CLIENT -q "SELECT * FROM \`${CLICKHOUSE_DATABASE_2}\`.renamed;" 2>&1 | grep -m 1 -o -F 'TOO_DEEP_RECURSION'
 
+echo '-- and describing it is bounded too'
+$CLICKHOUSE_CLIENT -q "DESCRIBE TABLE \`${CLICKHOUSE_DATABASE_2}\`.renamed;" 2>&1 | grep -m 1 -o -F 'TOO_DEEP_RECURSION'
+
 # Drop it immediately: nothing after this point needs the alias, and every statement it stays
 # alive for is one another session can trip over (see the no-parallel note above).
 $CLICKHOUSE_CLIENT -q "

--- a/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.reference
+++ b/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.reference
@@ -1,0 +1,35 @@
+Test DESCRIBE through the chain
+ACCESS_DENIED
+Test system.columns through the chain
+0
+Test resolved and declared system.tables columns through the chain
+1	1	1	1	1	1
+Test SHOW CREATE TABLE exposes the declared target
+1
+1
+0
+Control: the same filter over a definition that does name the target
+match
+Test DESCRIBE of the last alias in the chain
+ACCESS_DENIED
+Test SELECT through the chain
+ACCESS_DENIED
+Test hasColumnInTable through the chain
+ACCESS_DENIED
+Test system.projections, system.constraints and system.data_skipping_indices through the chain
+0	0	0
+Test DESCRIBE with only the middle alias of the chain ungranted
+ACCESS_DENIED
+Test system.columns with a column-level grant on the final table
+secret_id
+Test DESCRIBE through the chain with the final target granted
+secret_id	UInt64
+secret_payload	String
+Test system.columns through the chain with the final target granted
+2
+Test resolved and declared system.tables columns through the chain with the final target granted
+secret_id	2	1
+Test hasColumnInTable through the chain with the final target granted
+1
+Test system.projections, system.constraints and system.data_skipping_indices with the final target granted
+1	1	1

--- a/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.reference
+++ b/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.reference
@@ -18,9 +18,13 @@ Test hasColumnInTable through the chain
 ACCESS_DENIED
 Test system.projections, system.constraints and system.data_skipping_indices through the chain
 0	0	0
+Test system.completions through the chain
+0
 Test DESCRIBE with only the middle alias of the chain ungranted
 ACCESS_DENIED
 Test system.columns with a column-level grant on the final table
+secret_id
+Test system.completions with a column-level grant on the final table
 secret_id
 Test DESCRIBE through the chain with the final target granted
 secret_id	UInt64
@@ -33,3 +37,5 @@ Test hasColumnInTable through the chain with the final target granted
 1
 Test system.projections, system.constraints and system.data_skipping_indices with the final target granted
 1	1	1
+Test system.completions through the chain with the final target granted
+2

--- a/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.reference
+++ b/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.reference
@@ -24,6 +24,8 @@ Test DESCRIBE with only the middle alias of the chain ungranted
 ACCESS_DENIED
 Test system.columns with a column-level grant on the final table
 secret_id
+Test system.columns with a column revoked on the final table
+secret_id
 Test system.completions with a column-level grant on the final table
 secret_id
 Test DESCRIBE through the chain with the final target granted

--- a/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.sh
+++ b/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.sh
@@ -39,8 +39,9 @@ ${CLICKHOUSE_CLIENT} --multiquery --query "
     GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON chain_a1 TO ${user};
     GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON chain_a2 TO ${user};
     GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON chain_a3 TO ${user};
-    -- These three are outside the system.tables/system.columns carve-out, so they need an explicit
+    -- These four are outside the system.tables/system.columns carve-out, so they need an explicit
     -- grant once select_from_system_db_requires_grant is on.
+    GRANT SELECT ON system.completions TO ${user};
     GRANT SELECT ON system.constraints TO ${user};
     GRANT SELECT ON system.projections TO ${user};
     GRANT SELECT ON system.data_skipping_indices TO ${user};
@@ -55,6 +56,7 @@ ${CLICKHOUSE_CLIENT} --multiquery --query "
     GRANT SHOW TABLES, SHOW COLUMNS ON chain_a2 TO ${col_user};
     GRANT SHOW TABLES, SHOW COLUMNS ON chain_a3 TO ${col_user};
     GRANT SHOW COLUMNS(secret_id) ON chain_base TO ${col_user};
+    GRANT SELECT ON system.completions TO ${col_user};
 "
 
 echo "Test DESCRIBE through the chain"
@@ -107,6 +109,13 @@ ${CLICKHOUSE_CLIENT} --user="${user}" --query "
         (SELECT count() FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'chain_a1');
 "
 
+# `belongs` carries no database qualifier, so every completions arm runs as a restricted user: only such a
+# user reaches the SHOW_TABLES filter that keeps a concurrent copy of this test out of the result.
+echo "Test system.completions through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT count() FROM system.completions WHERE context = 'column' AND belongs = 'chain_a1';
+"
+
 # `mid_user` holds the grant on the declared target `chain_a2` and on the final table `chain_base`, and
 # nothing on the hop between them, so a check that skips intermediate names still passes.
 echo "Test DESCRIBE with only the middle alias of the chain ungranted"
@@ -115,6 +124,11 @@ ${CLICKHOUSE_CLIENT} --user="${mid_user}" --query "DESCRIBE TABLE chain_a1;" 2>&
 echo "Test system.columns with a column-level grant on the final table"
 ${CLICKHOUSE_CLIENT} --user="${col_user}" --query "
     SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'chain_a1' ORDER BY name;
+"
+
+echo "Test system.completions with a column-level grant on the final table"
+${CLICKHOUSE_CLIENT} --user="${col_user}" --query "
+    SELECT word FROM system.completions WHERE context = 'column' AND belongs = 'chain_a1' ORDER BY word;
 "
 
 ${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON chain_base TO ${user};"
@@ -146,6 +160,11 @@ ${CLICKHOUSE_CLIENT} --user="${user}" --query "
         (SELECT count() FROM system.projections WHERE database = currentDatabase() AND table = 'chain_a1'),
         (SELECT count() FROM system.constraints WHERE database = currentDatabase() AND table = 'chain_a1'),
         (SELECT count() FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'chain_a1');
+"
+
+echo "Test system.completions through the chain with the final target granted"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT count() FROM system.completions WHERE context = 'column' AND belongs = 'chain_a1';
 "
 
 ${CLICKHOUSE_CLIENT} --multiquery --query "

--- a/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.sh
+++ b/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+user="chain_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+mid_user="chain_mid_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+col_user="chain_col_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+# Build `chain_a1 -> chain_a2 -> chain_a3 -> chain_base`. Every CREATE names a target that is either
+# absent or not an Alias, which is the only order the point-in-time Alias -> Alias rejection accepts.
+# The user holds everything on the three alias names and nothing at all on `chain_base`.
+${CLICKHOUSE_CLIENT} --multiquery --query "
+    DROP USER IF EXISTS ${user};
+    DROP USER IF EXISTS ${mid_user};
+    DROP USER IF EXISTS ${col_user};
+    DROP TABLE IF EXISTS chain_a1;
+    DROP TABLE IF EXISTS chain_a2;
+    DROP TABLE IF EXISTS chain_a3;
+    DROP TABLE IF EXISTS chain_base;
+
+    CREATE TABLE chain_base
+    (
+        secret_id UInt64,
+        secret_payload String,
+        INDEX secret_idx secret_id TYPE minmax GRANULARITY 1,
+        PROJECTION secret_proj (SELECT secret_id ORDER BY secret_id),
+        CONSTRAINT secret_positive CHECK secret_id > 0
+    )
+    ENGINE = MergeTree ORDER BY secret_id;
+    INSERT INTO chain_base VALUES (1, 'first'), (2, 'second');
+
+    CREATE TABLE chain_a1 ENGINE = Alias(currentDatabase(), 'chain_a2');
+    CREATE TABLE chain_a2 ENGINE = Alias(currentDatabase(), 'chain_a3');
+    CREATE TABLE chain_a3 ENGINE = Alias(currentDatabase(), 'chain_base');
+
+    CREATE USER ${user} NOT IDENTIFIED;
+    GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON chain_a1 TO ${user};
+    GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON chain_a2 TO ${user};
+    GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON chain_a3 TO ${user};
+    -- These three are outside the system.tables/system.columns carve-out, so they need an explicit
+    -- grant once select_from_system_db_requires_grant is on.
+    GRANT SELECT ON system.constraints TO ${user};
+    GRANT SELECT ON system.projections TO ${user};
+    GRANT SELECT ON system.data_skipping_indices TO ${user};
+
+    CREATE USER ${mid_user} NOT IDENTIFIED;
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a1 TO ${mid_user};
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a2 TO ${mid_user};
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_base TO ${mid_user};
+
+    CREATE USER ${col_user} NOT IDENTIFIED;
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a1 TO ${col_user};
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a2 TO ${col_user};
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a3 TO ${col_user};
+    GRANT SHOW COLUMNS(secret_id) ON chain_base TO ${col_user};
+"
+
+echo "Test DESCRIBE through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "DESCRIBE TABLE chain_a1;" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+echo "Test system.columns through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = 'chain_a1';
+"
+
+echo "Test resolved and declared system.tables columns through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT
+        empty(sorting_key),
+        isNull(total_rows),
+        position(create_table_query, 'chain_a2') > 0,
+        position(create_table_query, 'chain_base') = 0,
+        position(create_table_query, 'secret_') = 0,
+        notEmpty(engine_full)
+    FROM system.tables
+    WHERE database = currentDatabase() AND name = 'chain_a1';
+"
+
+echo "Test SHOW CREATE TABLE exposes the declared target"
+ddl=$(${CLICKHOUSE_CLIENT} --user="${user}" --query "SHOW CREATE TABLE chain_a1 FORMAT TSVRaw" 2>&1)
+echo "$ddl" | grep -c "ENGINE = Alias"
+echo "$ddl" | grep -c "'chain_a2'"
+echo "$ddl" | grep -cE "chain_base|secret_"
+
+# Control: `chain_a3` was created while `chain_base` already existed, so its own stored definition names
+# that table (and, until #115141 lands, carries its columns too). The same filter over it must match, or
+# the `0` above would be proving nothing.
+echo "Control: the same filter over a definition that does name the target"
+${CLICKHOUSE_CLIENT} --query "SHOW CREATE TABLE chain_a3 FORMAT TSVRaw" 2>&1 | grep -qE "chain_base|secret_" && echo "match"
+
+echo "Test DESCRIBE of the last alias in the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "DESCRIBE TABLE chain_a3;" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+echo "Test SELECT through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "SELECT count() FROM chain_a1;" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+echo "Test hasColumnInTable through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "SELECT hasColumnInTable(currentDatabase(), 'chain_a1', 'secret_payload');" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+echo "Test system.projections, system.constraints and system.data_skipping_indices through the chain"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT
+        (SELECT count() FROM system.projections WHERE database = currentDatabase() AND table = 'chain_a1'),
+        (SELECT count() FROM system.constraints WHERE database = currentDatabase() AND table = 'chain_a1'),
+        (SELECT count() FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'chain_a1');
+"
+
+# `mid_user` holds the grant on the declared target `chain_a2` and on the final table `chain_base`, and
+# nothing on the hop between them, so a check that skips intermediate names still passes.
+echo "Test DESCRIBE with only the middle alias of the chain ungranted"
+${CLICKHOUSE_CLIENT} --user="${mid_user}" --query "DESCRIBE TABLE chain_a1;" 2>&1 | grep -o -m1 "ACCESS_DENIED"
+
+echo "Test system.columns with a column-level grant on the final table"
+${CLICKHOUSE_CLIENT} --user="${col_user}" --query "
+    SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'chain_a1' ORDER BY name;
+"
+
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON chain_base TO ${user};"
+
+echo "Test DESCRIBE through the chain with the final target granted"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "DESCRIBE TABLE chain_a1;" | cut -f1,2
+
+echo "Test system.columns through the chain with the final target granted"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = 'chain_a1';
+"
+
+echo "Test resolved and declared system.tables columns through the chain with the final target granted"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT
+        sorting_key,
+        total_rows,
+        position(create_table_query, 'chain_a2') > 0
+    FROM system.tables
+    WHERE database = currentDatabase() AND name = 'chain_a1';
+"
+
+echo "Test hasColumnInTable through the chain with the final target granted"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "SELECT hasColumnInTable(currentDatabase(), 'chain_a1', 'secret_payload');"
+
+echo "Test system.projections, system.constraints and system.data_skipping_indices with the final target granted"
+${CLICKHOUSE_CLIENT} --user="${user}" --query "
+    SELECT
+        (SELECT count() FROM system.projections WHERE database = currentDatabase() AND table = 'chain_a1'),
+        (SELECT count() FROM system.constraints WHERE database = currentDatabase() AND table = 'chain_a1'),
+        (SELECT count() FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'chain_a1');
+"
+
+${CLICKHOUSE_CLIENT} --multiquery --query "
+    DROP TABLE chain_a1;
+    DROP TABLE chain_a2;
+    DROP TABLE chain_a3;
+    DROP TABLE chain_base;
+    DROP USER ${user};
+    DROP USER ${mid_user};
+    DROP USER ${col_user};
+"

--- a/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.sh
+++ b/tests/queries/0_stateless/05137_storage_alias_chain_metadata_access_rights.sh
@@ -7,6 +7,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 user="chain_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 mid_user="chain_mid_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 col_user="chain_col_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rev_user="chain_rev_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 
 # Build `chain_a1 -> chain_a2 -> chain_a3 -> chain_base`. Every CREATE names a target that is either
 # absent or not an Alias, which is the only order the point-in-time Alias -> Alias rejection accepts.
@@ -15,6 +16,7 @@ ${CLICKHOUSE_CLIENT} --multiquery --query "
     DROP USER IF EXISTS ${user};
     DROP USER IF EXISTS ${mid_user};
     DROP USER IF EXISTS ${col_user};
+    DROP USER IF EXISTS ${rev_user};
     DROP TABLE IF EXISTS chain_a1;
     DROP TABLE IF EXISTS chain_a2;
     DROP TABLE IF EXISTS chain_a3;
@@ -57,6 +59,13 @@ ${CLICKHOUSE_CLIENT} --multiquery --query "
     GRANT SHOW TABLES, SHOW COLUMNS ON chain_a3 TO ${col_user};
     GRANT SHOW COLUMNS(secret_id) ON chain_base TO ${col_user};
     GRANT SELECT ON system.completions TO ${col_user};
+
+    CREATE USER ${rev_user} NOT IDENTIFIED;
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a1 TO ${rev_user};
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a2 TO ${rev_user};
+    GRANT SHOW TABLES, SHOW COLUMNS ON chain_a3 TO ${rev_user};
+    GRANT SHOW COLUMNS ON chain_base TO ${rev_user};
+    REVOKE SHOW COLUMNS(secret_payload) ON chain_base FROM ${rev_user};
 "
 
 echo "Test DESCRIBE through the chain"
@@ -126,6 +135,13 @@ ${CLICKHOUSE_CLIENT} --user="${col_user}" --query "
     SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'chain_a1' ORDER BY name;
 "
 
+# `rev_user` holds the privilege on every table in the chain, with one column revoked on the final one,
+# so the answer must come from the per-column check and not from the table-level one.
+echo "Test system.columns with a column revoked on the final table"
+${CLICKHOUSE_CLIENT} --user="${rev_user}" --query "
+    SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'chain_a1' ORDER BY name;
+"
+
 echo "Test system.completions with a column-level grant on the final table"
 ${CLICKHOUSE_CLIENT} --user="${col_user}" --query "
     SELECT word FROM system.completions WHERE context = 'column' AND belongs = 'chain_a1' ORDER BY word;
@@ -175,4 +191,5 @@ ${CLICKHOUSE_CLIENT} --multiquery --query "
     DROP USER ${user};
     DROP USER ${mid_user};
     DROP USER ${col_user};
+    DROP USER ${rev_user};
 "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117702#discussion_r3954240986
Related: https://github.com/ClickHouse/ClickHouse/pull/117490
Related: https://github.com/ClickHouse/ClickHouse/pull/117448

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed metadata disclosure through a chain of `Alias` tables. `DESCRIBE`, `hasColumnInTable`, `system.columns`, `system.tables`, `system.projections`, `system.constraints` and `system.data_skipping_indices` now require the privilege on every table an `Alias` resolves through, as reading its rows already did; previously only the table named in the alias's own definition was checked, so a user granted on `outer` and `inner` but not on the final table could read that table's schema. `SHOW CREATE TABLE` and `system.tables`'s `create_table_query`, `engine_full` and `as_select` expose only the alias's own definition and still require the privilege on the declared target alone.

### Description

`StorageAlias::isTargetTableGranted` authorized only the name in the alias's own definition, while `getInMemoryMetadataPtr` resolves *through* nested aliases. A chained state is reachable and must stay loadable: `registerStorageAlias` rejects an `Alias` target only in a freshly supplied definition whose target already exists, so an outer alias created while the inner name is absent stores a chain the check never saw; rejecting it at load time would fail the load. The read path is unaffected: it is recursive, so every hop authorizes its own target.

One rule, two predicates. `isTargetTableGranted` keeps its name, so a call site added later inherits the strict check, and now walks the chain iteratively: the visited set lets a cyclic definition terminate, and iteration avoids the `TOO_DEEP_RECURSION` the 8 row-filtering `system.*` sites cannot take. The extracted one-hop body becomes `isDeclaredTargetGranted` for the two surfaces that render the stored definition and resolve nothing through it. Every other call site keeps the strict predicate. Callers that need every column's answer ask the chain question once per table, not once per column.

The new stateless test builds a three-hop chain and asserts the disclosure is gone wherever the missing grant sits, the declared surface still works, and a granted user loses nothing; it fails on master. All 35 `ENGINE = Alias` stateless tests stay green, and `system.columns` over 200 alias tables to local targets costs the same (0.08 s).

Separately owned, not fixed here: `lazy_load_tables` hides the engine from these checks (#117490); `Alias` row policies are still combined one hop deep, which #118668 refactors; `MySQLHandler::comFieldList` and `TableFunctionLoop::getActualTableStructure` do not reach the guard at all.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118967&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118967](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118967+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
