### PR TITLE
Propagate the named aggregate's determinism through `arrayReduce`

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -158,6 +158,10 @@ public:
 
     String getName() const override { return getNameByTrait<Trait>(); }
 
+    /// The sampler seeds itself from `thread_local_rng` unless the query names a seed, and then every
+    /// evaluation of the same expression draws differently.
+    bool isDeterministic() const override { return Trait::sampler != Sampler::RNG || seed.has_value(); }
+
     void insertWithSampler(Data & a, const T & v, Arena * arena) const
     {
         ++a.total_values;
@@ -522,6 +526,10 @@ public:
     }
 
     String getName() const override { return getNameByTrait<Trait>(); }
+
+    /// The sampler seeds itself from `thread_local_rng` unless the query names a seed, and then every
+    /// evaluation of the same expression draws differently.
+    bool isDeterministic() const override { return Trait::sampler != Sampler::RNG || seed.has_value(); }
 
     void insertWithSampler(Data & a, const Node * v, Arena * arena) const
     {

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -450,6 +450,18 @@ public:
       */
     virtual AggregateFunctionPtr getNestedFunction() const { return {}; }
 
+    /** Whether the function answers the same for the same input. `groupArraySample` without an explicit
+      * seed draws from a thread-local generator for every state it creates, so it does not - and an
+      * expression that runs it (`arrayReduce('groupArraySample(2)', ...)`) must not be presented to the
+      * optimizer as deterministic. Combinators propagate the wrapped function's answer.
+      */
+    virtual bool isDeterministic() const
+    {
+        if (auto nested = getNestedFunction())
+            return nested->isDeterministic();
+        return true;
+    }
+
     const DataTypePtr & getResultType() const override { return result_type; }
     const DataTypes & getArgumentTypes() const override { return argument_types; }
 

--- a/src/Functions/array/arrayReduce.cpp
+++ b/src/Functions/array/arrayReduce.cpp
@@ -51,7 +51,10 @@ public:
 
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
-    bool useDefaultImplementationForConstants() const override { return true; }
+    /// With a non-deterministic aggregate this must stay off: the default implementation executes the
+    /// function on a single row and replicates the result to the whole block, which turns per-row draws
+    /// into one draw for the query. `executeImpl` materializes a constant array argument itself.
+    bool useDefaultImplementationForConstants() const override { return aggregate_function->isDeterministic(); }
     /// As we parse the function name and deal with arrays we don't want to default NULL handler, which will hide
     /// nullability from us (which also means hidden from the aggregate functions)
     bool useDefaultImplementationForNulls() const override { return false; }
@@ -63,6 +66,13 @@ public:
     {
         return aggregate_function->getResultType();
     }
+
+    /// The aggregate that the string argument names decides this: a `groupArraySample` without a seed
+    /// makes the expression non-deterministic, and both the filter push-down and constant folding have
+    /// to see that. A deterministic aggregate - the overwhelmingly common case - is unaffected.
+    bool isDeterministic() const override { return aggregate_function->isDeterministic(); }
+    bool isDeterministicInScopeOfQuery() const override { return aggregate_function->isDeterministic(); }
+    bool isSuitableForConstantFolding() const override { return aggregate_function->isDeterministic(); }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
 

--- a/src/Functions/array/arrayReduceInRanges.cpp
+++ b/src/Functions/array/arrayReduceInRanges.cpp
@@ -54,13 +54,23 @@ public:
 
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
-    bool useDefaultImplementationForConstants() const override { return true; }
+    /// With a non-deterministic aggregate this must stay off: the default implementation executes the
+    /// function on a single row and replicates the result to the whole block, which turns per-row draws
+    /// into one draw for the query. `executeImpl` materializes a constant array argument itself.
+    bool useDefaultImplementationForConstants() const override { return aggregate_function->isDeterministic(); }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0}; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & /*arguments*/) const override
     {
         return std::make_shared<DataTypeArray>(aggregate_function->getResultType());
     }
+
+    /// The aggregate that the string argument names decides this: a `groupArraySample` without a seed
+    /// makes the expression non-deterministic, and both the filter push-down and constant folding have
+    /// to see that. A deterministic aggregate - the overwhelmingly common case - is unaffected.
+    bool isDeterministic() const override { return aggregate_function->isDeterministic(); }
+    bool isDeterministicInScopeOfQuery() const override { return aggregate_function->isDeterministic(); }
+    bool isSuitableForConstantFolding() const override { return aggregate_function->isDeterministic(); }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
 

--- a/tests/queries/0_stateless/05166_array_reduce_seeded_aggregate_determinism.reference
+++ b/tests/queries/0_stateless/05166_array_reduce_seeded_aggregate_determinism.reference
@@ -1,0 +1,9 @@
+the predicate is evaluated per group
+1
+a constant argument is not folded into one draw
+1
+a seeded sample stays deterministic
+1
+a deterministic aggregate still folds
+6
+1

--- a/tests/queries/0_stateless/05166_array_reduce_seeded_aggregate_determinism.sql
+++ b/tests/queries/0_stateless/05166_array_reduce_seeded_aggregate_determinism.sql
@@ -1,0 +1,19 @@
+-- `arrayReduce` runs the aggregate its string argument names, so an unseeded `groupArraySample` makes
+-- the expression non-deterministic. Reported as deterministic, its `HAVING` predicate was pushed below
+-- the aggregation - evaluated once per row instead of once per group, so a group survived if any of its
+-- rows drew favorably - and a constant-argument call was folded into a single draw for the query.
+
+SELECT 'the predicate is evaluated per group';
+-- Each of the 100 groups survives with probability 1/2 when the predicate is evaluated once per group,
+-- and with probability 1 - 2^-100 when it is evaluated for each of the group's 100 rows.
+SELECT count() < 100 FROM (SELECT number % 100 AS g FROM numbers(10000) GROUP BY g HAVING arrayReduce('groupArraySample(1)', [g, g + 1000])[1] < 1000);
+
+SELECT 'a constant argument is not folded into one draw';
+SELECT uniqExact(x) > 1 FROM (SELECT arrayReduce('groupArraySample(1)', [1, 2, 3])[1] AS x FROM numbers(200));
+
+SELECT 'a seeded sample stays deterministic';
+SELECT uniqExact(x) FROM (SELECT arrayReduce('groupArraySample(1, 42)', [1, 2, 3])[1] AS x FROM numbers(200));
+
+SELECT 'a deterministic aggregate still folds';
+SELECT arrayReduce('sum', [1, 2, 3]);
+SELECT uniqExact(x) FROM (SELECT arrayReduce('max', [1, 2, 3]) AS x FROM numbers(200));


### PR DESCRIPTION
`arrayReduce` and `arrayReduceInRanges` execute the aggregate their string argument names, but reported deterministic whatever that aggregate is. `groupArraySample` without an explicit seed seeds itself from `thread_local_rng` for every state it creates, so `arrayReduce('groupArraySample(1)', ...)` is a non-deterministic expression that the optimizer was told is deterministic, with two silently wrong results at default settings:

- a `HAVING` predicate built from it was pushed below the aggregation - legal only for a deterministic predicate - and evaluated once per input row instead of once per group, so a group survived if any of its rows drew favorably;
- with constant arguments the default implementation for constants executed it on a single row and replicated the result, collapsing what should be an independent draw per row into one draw for the whole query.

`IAggregateFunction::isDeterministic` reports the property (propagated through combinators via `getNestedFunction`, as the neighbouring virtuals do), the `groupArray*` implementations answer for their sampler, and both functions pass it on as their own determinism, their suitability for constant folding, and their use of the default implementation for constants. A seeded sample and every deterministic aggregate - the overwhelmingly common case - keep folding and push-down as they were.

Known limitation: the guards that consult `IFunctionOverloadResolver::isDeterministic` before the call is built (the query cache, projection matching, the replicated-mutation check, the row-policy push-down and early short-circuit guards) work on the function name alone and cannot see which aggregate the string names. They keep answering `true`, because the conservative answer would reject or de-optimize every `arrayReduce('sum', ...)` for the sake of an unseeded `groupArraySample` inside a mutation or a row policy.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117759
Related: https://github.com/ClickHouse/ClickHouse/pull/117747

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `arrayReduce` over a non-deterministic aggregate such as an unseeded `groupArraySample` being treated as deterministic, which pushed a `HAVING` predicate below the aggregation and collapsed per-row draws into a single one.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118971&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118971](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118971+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.92` (included in `26.10` and later)
<!-- ch-version-info:end -->