### PR TITLE
Keep the one-shot delay failpoint effective for both queries of 05137

### DIFF
--- a/src/Server/StatelessWorker/StatelessTaskExecutor.cpp
+++ b/src/Server/StatelessWorker/StatelessTaskExecutor.cpp
@@ -148,12 +148,12 @@ StatelessTaskExecutor::Result StatelessTaskExecutor::startTask(const String & un
             tryLogCurrentException(getLogger("StatelessTaskExecutor"),
                 fmt::format("Task {} failed", task_description.task.task_id));
             auto failure = currentTaskFailure();
-            /// Lets the failures this one causes in the connected tasks reach the initiator first.
-            fiu_do_on(FailPoints::distributed_plan_delay_root_cause_report,
+            /// Lets the failures this one causes in the connected tasks reach the initiator first. The
+            /// failpoint fires once, so a consequence must not be the failure that spends it.
+            if (!DistributedQueryCancellation::isConsequence(failure.code))
             {
-                if (!DistributedQueryCancellation::isConsequence(failure.code))
-                    sleepForMilliseconds(1000);
-            });
+                fiu_do_on(FailPoints::distributed_plan_delay_root_cause_report, { sleepForMilliseconds(1000); });
+            }
             task_promise->set_value(std::move(failure));
         }
     };

--- a/tests/queries/0_stateless/05137_distributed_plan_reports_root_cause.sql
+++ b/tests/queries/0_stateless/05137_distributed_plan_reports_root_cause.sql
@@ -24,9 +24,10 @@ SELECT throwIf(rowNumberInAllBlocks() > 10, 'main task fails') FROM t_root_cause
 SELECT x, count() FROM t_root_cause WHERE NOT throwIf(x = 777, 'reading task fails') GROUP BY x FORMAT Null; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 
 -- The worker reports the failing task late, so every follow-on failure reaches the initiator first.
+-- The failpoint fires once, so it is enabled before each query.
 SYSTEM ENABLE FAILPOINT distributed_plan_delay_root_cause_report;
-
 SELECT throwIf(rowNumberInAllBlocks() > 10, 'main task fails') FROM t_root_cause FORMAT Null; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+SYSTEM ENABLE FAILPOINT distributed_plan_delay_root_cause_report;
 SELECT x, count() FROM t_root_cause WHERE NOT throwIf(x = 777, 'reading task fails') GROUP BY x FORMAT Null; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 
 SYSTEM DISABLE FAILPOINT distributed_plan_delay_root_cause_report;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118390
Related: https://github.com/ClickHouse/ClickHouse/pull/118863
Related: https://github.com/ClickHouse/ClickHouse/pull/105942

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The `distributed_plan_delay_root_cause_report` failpoint became one-shot in #118390 so that a failed
run cannot leave it enabled for later tests. `05137_distributed_plan_reports_root_cause` enables it
once and runs two queries under it, so the first query spends the shot and the second runs without
the delay it is meant to exercise. The test now enables the failpoint before each of the two queries.

On the worker the consequence check moves out of the failpoint block: a task that failed because
another one did must not be the failure that spends the one shot.

Measured with the test's four failing queries in `system.query_log`: before, the two queries under
the failpoint take 1005 ms and 11 ms; after, 1006 ms and 1020 ms.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118974&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118974](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118974+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
