### PR TITLE
Keep the sparse and `LowCardinality` shortcuts away from non-deterministic functions

### DIFF
--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -691,7 +691,9 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
             return executeWithoutSparseColumns(arguments, result_type, input_rows_count, dry_run);
 
         auto columns_without_sparse = arguments;
-        if (num_sparse_columns == 1 && num_full_columns == 0)
+        /// The shortcut below evaluates the function once for the default value and reuses that result
+        /// for every default row, so it is only for a function that answers the same for the same input.
+        if (num_sparse_columns == 1 && num_full_columns == 0 && isDeterministicInScopeOfQuery())
         {
             auto & arg_with_sparse = columns_without_sparse[sparse_column_position];
             ColumnPtr sparse_offsets;
@@ -814,7 +816,12 @@ DataTypePtr IFunctionOverloadResolver::getReturnType(const ColumnsWithTypeAndNam
 
         auto type_without_low_cardinality = getReturnTypeWithoutLowCardinality(args_without_low_cardinality);
 
-        if (canBeExecutedOnLowCardinalityDictionary() && has_low_cardinality && num_full_low_cardinality_columns <= 1
+        /// A `LowCardinality` result means the function is executed once per dictionary entry and the
+        /// result is re-indexed, so every row holding the same key gets the same value. For a function
+        /// that is not deterministic within the query that is wrong - and pointless, since its values
+        /// are distinct per row anyway - so it keeps a full result and runs per row.
+        if (canBeExecutedOnLowCardinalityDictionary() && isDeterministicInScopeOfQuery() && has_low_cardinality
+            && num_full_low_cardinality_columns <= 1
             && num_full_ordinary_columns == 0 && type_without_low_cardinality->canBeInsideLowCardinality())
             return std::make_shared<DataTypeLowCardinality>(type_without_low_cardinality);
         return type_without_low_cardinality;

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -106,6 +106,14 @@ protected:
       */
     virtual bool useDefaultImplementationForSparseColumns() const { return true; }
 
+    /** Whether the function answers the same for the same input within one query. The shortcut for a
+      * single sparse argument executes the function once for the column's default value and stamps that
+      * one result onto every default row, which only stands for a function that does. `rand`,
+      * `generateUUIDv4` and friends take an argument precisely to defeat common subexpression
+      * elimination, so their per-row draws must survive a sparse argument.
+      */
+    virtual bool isDeterministicInScopeOfQuery() const { return true; }
+
     /** If function arguments have replicated columns with the same indexes and all other arguments are constants, call function on nested columns.
       * Otherwise, convert all replicated columns to ordinary columns.
       */

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -26,6 +26,7 @@ protected:
     bool useDefaultImplementationForLowCardinalityColumns() const final { return function->useDefaultImplementationForLowCardinalityColumns(); }
     bool useDefaultImplementationForSparseColumns() const final { return function->useDefaultImplementationForSparseColumns(); }
     bool useDefaultImplementationForReplicatedColumns() const final { return function->useDefaultImplementationForReplicatedColumns(); }
+    bool isDeterministicInScopeOfQuery() const final { return function->isDeterministicInScopeOfQuery(); }
 
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const final { return function->getArgumentsThatAreAlwaysConstant(); }
     bool canBeExecutedOnDefaultArguments() const override { return function->canBeExecutedOnDefaultArguments(); }

--- a/tests/queries/0_stateless/05168_sparse_column_nondeterministic_function.reference
+++ b/tests/queries/0_stateless/05168_sparse_column_nondeterministic_function.reference
@@ -1,0 +1,11 @@
+the column is stored sparse
+1
+a draw per row
+1
+1
+1
+the same for a LowCardinality argument
+1
+a deterministic function still reads the sparse column once per value
+50051000
+1001

--- a/tests/queries/0_stateless/05168_sparse_column_nondeterministic_function.sql
+++ b/tests/queries/0_stateless/05168_sparse_column_nondeterministic_function.sql
@@ -1,0 +1,28 @@
+-- A sparse column's default rows share one stored value, and the shortcut for a single sparse argument
+-- executes the function once for that value and stamps the result onto every default row. For `rand`
+-- and friends - which take an argument precisely to defeat common subexpression elimination - that
+-- collapsed tens of thousands of independent draws into one. The `LowCardinality` dictionary shortcut
+-- did the same per dictionary entry.
+
+DROP TABLE IF EXISTS t_sparse_nondeterministic;
+
+CREATE TABLE t_sparse_nondeterministic (id UInt64, s UInt64) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_sparse_nondeterministic SELECT number, if(number % 100 = 0, number + 1, 0) FROM numbers(100000);
+
+SELECT 'the column is stored sparse';
+SELECT countIf(serialization_kind = 'Sparse') > 0 FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_sparse_nondeterministic' AND column = 's' AND active;
+
+SELECT 'a draw per row';
+SELECT uniqExact(rand(s)) > 99000 FROM t_sparse_nondeterministic;
+SELECT uniqExact(generateUUIDv4(s)) > 99000 FROM t_sparse_nondeterministic;
+SELECT abs(count() - 50000) < 2000 FROM t_sparse_nondeterministic WHERE rand(s) % 2 = 0;
+
+SELECT 'the same for a LowCardinality argument';
+SELECT uniqExact(rand(toLowCardinality(if(number % 100 = 0, number + 1, 0)))) > 99000 FROM numbers(100000);
+
+SELECT 'a deterministic function still reads the sparse column once per value';
+SELECT sum(s + 1) FROM t_sparse_nondeterministic;
+SELECT uniqExact(toString(s)) FROM t_sparse_nondeterministic;
+
+DROP TABLE t_sparse_nondeterministic;

--- a/tests/queries/0_stateless/05168_sparse_column_nondeterministic_function.sql
+++ b/tests/queries/0_stateless/05168_sparse_column_nondeterministic_function.sql
@@ -6,7 +6,10 @@
 
 DROP TABLE IF EXISTS t_sparse_nondeterministic;
 
-CREATE TABLE t_sparse_nondeterministic (id UInt64, s UInt64) ENGINE = MergeTree ORDER BY id;
+-- The ratio is pinned: the harness randomizes it, and the column has to be stored sparse for this
+-- test to exercise the sparse path at all.
+CREATE TABLE t_sparse_nondeterministic (id UInt64, s UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
 
 INSERT INTO t_sparse_nondeterministic SELECT number, if(number % 100 = 0, number + 1, 0) FROM numbers(100000);
 


### PR DESCRIPTION
A sparse column stores one value for all its default rows, and the shortcut for a single sparse argument executes the function once for that value and stamps the one result onto every default row (`createWithOffsets` with `res[0]`). The `LowCardinality` shortcut does the same per dictionary entry. Neither consulted the function's determinism, so `rand`, `rand64`, `randCanonical`, `generateUUIDv4`, `generateUUIDv7` and `generateSnowflakeID` - which take an argument precisely so that a user can defeat common subexpression elimination - returned one shared value for tens of thousands of rows:

```sql
CREATE TABLE t_sp (id UInt64, s UInt64) ENGINE = MergeTree ORDER BY id;
INSERT INTO t_sp SELECT number, if(number % 100 = 0, number + 1, 0) FROM numbers(100000);
SELECT uniqExact(generateUUIDv4(s)) FROM t_sp;   -- 1002, not 100000
SELECT count() FROM t_sp WHERE rand(s) % 2 = 0;  -- ~500 or ~99500, never ~50000
```

Sparse serialization is on at defaults (`ratio_of_defaults_for_sparse_serialization = 0.9375`), and an `INSERT ... SELECT generateUUIDv4(other_column)` persists the duplicated identifiers.

`IExecutableFunction` now reports `isDeterministicInScopeOfQuery` (forwarded from the `IFunction` by the adaptor) and the sparse shortcut is taken only for a function that answers the same for the same input; the arguments are materialized otherwise, which is the path the same function already takes when more than one argument is sparse. For `LowCardinality` the decision moves one step earlier: a non-deterministic function no longer gets a `LowCardinality` result type, so its argument is materialized and it runs per row - the dictionary result would have been pointless for it anyway.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117209

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `rand`, `generateUUIDv4` and other non-deterministic functions returning one shared value for all default rows of a sparse column, or one value per dictionary entry of a `LowCardinality` argument.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118976&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118976](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118976+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
