### PR TITLE
QueryRunner: Query log secret masking

### DIFF
--- a/src/Storages/StorageQueryRunner.cpp
+++ b/src/Storages/StorageQueryRunner.cpp
@@ -17,6 +17,8 @@
 #include <Interpreters/executeQuery.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTSQLSecurity.h>
+#include <Parsers/ParserQuery.h>
+#include <Parsers/parseQuery.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/Sinks/SinkToStorage.h>
@@ -29,6 +31,7 @@
 #include <Common/Exception.h>
 #include <Common/LoggingHelpers.h>
 #include <Common/QueryScope.h>
+#include <Common/SensitiveDataMasker.h>
 #include <Common/SettingsChanges.h>
 #include <Common/Stopwatch.h>
 #include <Common/ThreadPool.h>
@@ -63,9 +66,13 @@ namespace Setting
     extern const SettingsLoadBalancing load_balancing;
     extern const SettingsString log_comment;
     extern const SettingsBool log_queries;
+    extern const SettingsUInt64 log_queries_cut_to_length;
     extern const SettingsMilliseconds log_queries_min_query_duration_ms;
     extern const SettingsLogQueriesType log_queries_min_type;
     extern const SettingsBool log_query_settings;
+    extern const SettingsUInt64 max_parser_backtracks;
+    extern const SettingsUInt64 max_parser_depth;
+    extern const SettingsUInt64 max_query_size;
 }
 
 namespace QueryRunnerSetting
@@ -500,7 +507,7 @@ private:
                 }
                 else
                 {
-                    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The `QueryRunner` engine does not support this query: {}", job.query);
+                    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The `QueryRunner` engine does not support this query");
                 }
             }
             io.onFinish();
@@ -632,6 +639,27 @@ private:
 
         const auto event_time = std::chrono::system_clock::now();
 
+        const char * pos = job.query.data();
+        const char * end = pos + job.query.size();
+        ParserQuery parser(end, /*allow_settings_after_format_in_insert_*/ true, /*implicit_select_*/ true);
+        String parse_error;
+        const ASTPtr ast = tryParseQuery(
+            parser,
+            pos,
+            end,
+            parse_error,
+            /*hilite*/ false,
+            "",
+            /*allow_multi_statements*/ false,
+            settings[Setting::max_query_size],
+            settings[Setting::max_parser_depth],
+            settings[Setting::max_parser_backtracks],
+            /*skip_insignificant*/ true);
+        const UInt64 cut_to_length = settings[Setting::log_queries_cut_to_length];
+        const String query_for_logging = ast && ast->hasSecretParts()
+            ? ast->formatForLogging(cut_to_length)
+            : wipeSensitiveDataAndCutToLength(job.query, cut_to_length, true);
+
         query_log->add([&](QueryLogElement & element)
         {
             element.type = type;
@@ -640,7 +668,7 @@ private:
             element.query_start_time = timeInSeconds(query_start_time);
             element.query_start_time_microseconds = timeInMicroseconds(query_start_time);
             element.query_duration_ms = duration_ms;
-            element.query = job.query;
+            element.query = query_for_logging;
             element.current_database = job.database;
             element.log_comment = settings[Setting::log_comment];
             element.client_info = job_context->getClientInfo();

--- a/tests/integration/test_query_runner/test.py
+++ b/tests/integration/test_query_runner/test.py
@@ -134,6 +134,22 @@ def test_cluster_query_log():
     )
 
 
+def test_cluster_query_log_hides_secrets():
+    node_query_runner.query(runner_ddl("query String, settings Map(String, String)", "synchronous", "cluster"))
+    node_query_runner.query(
+        "INSERT INTO runner VALUES ("
+        "'SELECT * FROM url(''http://cluster_user:cluster_secret@node_cluster:8123/?query=SELECT+1'', ''LineAsString'', ''s String'')', "
+        "{'log_comment': 'qr_cluster_log_secret'})"
+    )
+    node_query_runner.query("SYSTEM FLUSH LOGS query_log")
+    assert_eq_with_retry(
+        node_query_runner,
+        "SELECT type, query LIKE '%[HIDDEN]%', query LIKE '%cluster_secret%' FROM system.query_log "
+        "WHERE log_comment = 'qr_cluster_log_secret' AND is_internal ORDER BY type",
+        "QueryStart\t1\t0\nQueryFinish\t1\t0",
+    )
+
+
 def test_cluster_insert_requires_remote():
     node_query_runner.query(runner_ddl("query String", "synchronous", "cluster"))
     node_query_runner.query("CREATE USER no_remote_user")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Mask secrets in the queries that a cluster-mode `QueryRunner` table writes to `system.query_log`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118978&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118978](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118978+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
