### PR TITLE
Remove the license_file server setting

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1401,7 +1401,6 @@ Threads for cleanup of shared merge tree snapshot cleaner threads. Only availabl
     DECLARE(UInt64, keeper_multiread_batch_size, 10'000, R"(
 Maximum size of batch for MultiRead request to [Zoo]Keeper that support batching. If set to 0, batching is disabled. Available only in ClickHouse Cloud.
 )", 0) \
-    DECLARE(String, license_file, "", "License file contents for ClickHouse Enterprise Edition", 0) \
     DECLARE(String, license_public_key_for_testing, "", "Licensing demo key, for CI use only", 0) \
     DECLARE(Bool, show_license_expiration_warnings, true, "Show the warning about the upcoming license expiration in system.warnings", 0) \
     DECLARE(NonZeroUInt64, prefetch_threadpool_pool_size, 100, R"(Size of background pool for prefetches for remote object storages)", 0) \
@@ -2287,6 +2286,11 @@ void ServerSettings::checkUnknownSettings(const Poco::Util::AbstractConfiguratio
         "library_bridge",
         "odbc_bridge",
         "jdbc_bridge",
+
+        /// The license text. Read directly from the config by the enterprise build and deliberately not
+        /// declared as a server setting: a `ServerSettings` entry is returned verbatim by
+        /// `system.server_settings` and by `getServerSetting`, and no user needs to read the license.
+        "license_file",
 
         /// Sections used in private builds (shared catalog, distributed cache, stateless workers, cloud readiness)
         "shared_database_catalog",
@@ -3640,7 +3644,6 @@ ChangeableSettingsMap collectChangeableServerSettings(ContextPtr context)
 
             {"merge_workload", {context->getMergeWorkload(), ChangeableWithoutRestart::Yes}},
             {"mutation_workload", {context->getMutationWorkload(), ChangeableWithoutRestart::Yes}},
-            {"license_file", {context->getLicenseFile(), ChangeableWithoutRestart::Yes}},
             {"show_license_expiration_warnings", {std::to_string(context->getShowLicenseExpirationWarnings()), ChangeableWithoutRestart::Yes}},
             {"throw_on_unknown_workload", {std::to_string(context->getThrowOnUnknownWorkload()), ChangeableWithoutRestart::Yes}},
             {"cpu_slot_preemption", {std::to_string(context->getCPUSlotPreemption()), ChangeableWithoutRestart::Yes}},

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -604,7 +604,7 @@ struct ContextSharedPart : boost::noncopyable
     String buffer_profile_name;                                 /// Profile used by Buffer engine for flushing to the underlying
     String merge_workload TSA_GUARDED_BY(mutex);                /// Workload setting value that is used by all merges
     String mutation_workload TSA_GUARDED_BY(mutex);             /// Workload setting value that is used by all mutations
-    String license_file TSA_GUARDED_BY(mutex);                  /// BYOC license text
+    String license_file TSA_GUARDED_BY(mutex);                  /// BYOC license text, deliberately not exposed to SQL
     bool show_license_expiration_warnings TSA_GUARDED_BY(mutex) = true; /// Whether to show the license expiration warning in system.warnings
     bool throw_on_unknown_workload TSA_GUARDED_BY(mutex) = false;
     bool cpu_slot_preemption TSA_GUARDED_BY(mutex) = false;

--- a/tests/integration/test_unknown_config_option/configs/config.d/existing_keys.xml
+++ b/tests/integration/test_unknown_config_option/configs/config.d/existing_keys.xml
@@ -58,6 +58,9 @@
          library bridge) is removed, but a config carried over an upgrade may still contain the
          `catboost_lib_path` stanza. It must stay accepted as a no-op instead of failing startup. -->
     <catboost_lib_path>/var/lib/clickhouse/catboost_lib/</catboost_lib_path>
+    <!-- The license text, read directly by the enterprise build. Deliberately not a `ServerSettings`
+         entry, so it is never returned by `system.server_settings` or by `getServerSetting`. -->
+    <license_file>placeholder license text</license_file>
     <library_bridge>
         <host>localhost</host>
         <port>9012</port>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118981&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118981](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118981+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1114` (included in `26.9` and later)
<!-- ch-version-info:end -->