### PR TITLE
Flush `Buffer` tables before any database shuts down

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -312,6 +312,57 @@ void DatabaseCatalog::shutdownImpl(std::function<void()> shutdown_system_logs)
 
     /// We still hold "databases" (instead of std::move) for Buffer tables to flush data correctly.
 
+    /** Hand the buffered rows over before any database goes away.
+      *
+      * A `Buffer` table flushes into its destination when its own database shuts down, and databases
+      * shut down one at a time in name order: a destination in an earlier-sorting database is already
+      * gone by then ("Destination table ... doesn't exist. Block of data is discarded."), and a chain
+      * of `Buffer` tables moves rows at most one link per pass, so the rows left in an
+      * already-prepared `Buffer` die with it. Both are silent losses of acknowledged rows on a
+      * graceful shutdown.
+      *
+      * So drain every table of every database here, repeating while a pass still moves something -
+      * one pass per link of the longest chain. The number of tables bounds the number of passes; a
+      * `Buffer` whose destination is itself would otherwise keep the loop alive forever.
+      */
+    {
+        size_t total_tables = 0;
+        std::vector<StoragePtr> buffered_tables;
+        for (const auto & database : current_databases)
+        {
+            for (auto it = database.second->getTablesIterator(getContext(), {}, /*skip_not_loaded=*/ true); it->isValid(); it->next())
+            {
+                ++total_tables;
+                buffered_tables.push_back(it->table());
+            }
+        }
+
+        for (size_t pass = 0; pass <= total_tables; ++pass)
+        {
+            size_t flushed = 0;
+            for (const auto & table : buffered_tables)
+            {
+                if (!table)
+                    continue;
+
+                try
+                {
+                    flushed += table->flushBufferedRowsBeforeShutdown();
+                }
+                catch (...)
+                {
+                    tryLogCurrentException(
+                        log, fmt::format("Failed to flush buffered rows of table {}", table->getStorageID().getNameForLogs()));
+                }
+            }
+
+            if (flushed == 0)
+                break;
+
+            LOG_TRACE(log, "Flushed {} buffers of tables before shutdown (pass {})", flushed, pass + 1);
+        }
+    }
+
     /// Delay shutdown of temporary and system databases. They will be shutdown last.
     /// Because some databases might use them until their shutdown is called, but calling shutdown
     /// on temporary database means clearing its set of tables, which will lead to unnecessary errors like "table not found".

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -330,10 +330,23 @@ void DatabaseCatalog::shutdownImpl(std::function<void()> shutdown_system_logs)
         std::vector<StoragePtr> buffered_tables;
         for (const auto & database : current_databases)
         {
-            for (auto it = database.second->getTablesIterator(getContext(), {}, /*skip_not_loaded=*/ true); it->isValid(); it->next())
+            /// Only user databases: enumerating a predefined one can materialize a lazily created
+            /// system table during shutdown, and none of them holds a `Buffer` table anyway.
+            if (isPredefinedDatabase(database.first))
+                continue;
+
+            try
             {
-                ++total_tables;
-                buffered_tables.push_back(it->table());
+                for (auto it = database.second->getTablesIterator(getContext(), {}, /*skip_not_loaded=*/ true); it->isValid(); it->next())
+                {
+                    ++total_tables;
+                    buffered_tables.push_back(it->table());
+                }
+            }
+            catch (...)
+            {
+                tryLogCurrentException(
+                    log, fmt::format("Failed to list tables of database {} before shutdown", backQuoteIfNeed(database.first)));
             }
         }
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -644,6 +644,16 @@ public:
     /// Might be called multiple times; only the first call needs to be processed.
     /// Data in memory need to be persistent. Any background work that affects other tables
     /// (e.g. materialized view refreshes that create/drop tables) needs to be stopped.
+    /** Hand over rows that are still buffered in memory, before any database is shut down.
+      *
+      * A `Buffer` table writes into another table, which may live in another database or be another
+      * `Buffer`. Databases shut down one at a time in name order, so by the time a `Buffer` prepares
+      * for shutdown its destination can already be gone, and one pass moves rows at most one link
+      * down a chain. `DatabaseCatalog` therefore calls this for every table first, repeating while
+      * rows keep moving; the return value is the number of buffers this call actually flushed.
+      */
+    virtual size_t flushBufferedRowsBeforeShutdown() { return 0; }
+
     virtual void flushAndPrepareForShutdown() {}
 
     /// Asks table to stop executing some action identified by action_type

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -930,6 +930,21 @@ void StorageBuffer::startup()
 }
 
 
+size_t StorageBuffer::flushBufferedRowsBeforeShutdown()
+{
+    /// Sequential and without the threshold check: this runs once per shutdown, before any database
+    /// is gone, and every buffer that holds anything has to move now. The destination may be another
+    /// `Buffer` that is drained by a later pass of the caller's loop.
+    size_t buffers_flushed = 0;
+    for (auto & buffer : buffers)
+    {
+        if (flushBuffer(buffer, /*check_thresholds=*/ false, /*locked=*/ false))
+            ++buffers_flushed;
+    }
+    return buffers_flushed;
+}
+
+
 void StorageBuffer::flushAndPrepareForShutdown()
 {
     if (!flush_handle)

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -100,6 +100,8 @@ public:
 
     void startup() override;
     /// Flush all buffers into the subordinate table and stop background thread.
+    size_t flushBufferedRowsBeforeShutdown() override;
+
     void flushAndPrepareForShutdown() override;
     bool optimize(
         const ASTPtr & query,

--- a/tests/integration/test_buffer_flush_on_shutdown/test.py
+++ b/tests/integration/test_buffer_flush_on_shutdown/test.py
@@ -1,0 +1,62 @@
+"""A graceful shutdown must hand a `Buffer` table's rows over to its destination.
+
+Databases shut down one at a time in name order, so a destination in an earlier-sorting database is
+already gone when the `Buffer` prepares for shutdown, and a chain of `Buffer` tables moves rows at
+most one link per pass. Both losses are silent: the client saw the `INSERT` succeed.
+"""
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=[], stay_alive=True)
+
+# Far away, so nothing flushes on its own before the shutdown.
+BUFFER_THRESHOLDS = "1, 100000, 100000, 1000000, 1000000000, 10000000, 1000000000"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_buffer_destination_in_another_database(started_cluster):
+    # `za` sorts before `zb`, so `za` is shut down (and its tables released) first.
+    node.query("CREATE DATABASE IF NOT EXISTS za")
+    node.query("CREATE DATABASE IF NOT EXISTS zb")
+    node.query("CREATE TABLE za.mt (x UInt64) ENGINE = MergeTree ORDER BY x")
+    node.query(f"CREATE TABLE zb.buf (x UInt64) ENGINE = Buffer(za, mt, {BUFFER_THRESHOLDS})")
+
+    node.query("INSERT INTO zb.buf SELECT number FROM numbers(100)")
+    assert node.query("SELECT count() FROM za.mt") == "0\n"
+
+    node.restart_clickhouse()
+
+    assert node.query("SELECT count() FROM za.mt") == "100\n"
+
+    node.query("DROP DATABASE zb SYNC")
+    node.query("DROP DATABASE za SYNC")
+
+
+def test_chain_of_buffer_tables(started_cluster):
+    # Every destination sorts before its source, which is the order the shutdown walks.
+    node.query("CREATE DATABASE IF NOT EXISTS d3")
+    node.query("CREATE TABLE d3.mt (x UInt64) ENGINE = MergeTree ORDER BY x")
+    node.query(f"CREATE TABLE d3.a1 (x UInt64) ENGINE = Buffer(d3, mt, {BUFFER_THRESHOLDS})")
+    node.query(f"CREATE TABLE d3.b2 (x UInt64) ENGINE = Buffer(d3, a1, {BUFFER_THRESHOLDS})")
+    node.query(f"CREATE TABLE d3.c3 (x UInt64) ENGINE = Buffer(d3, b2, {BUFFER_THRESHOLDS})")
+
+    node.query("INSERT INTO d3.c3 SELECT number FROM numbers(100)")
+    assert node.query("SELECT count() FROM d3.mt") == "0\n"
+    assert node.query("SELECT count() FROM d3.c3") == "100\n"
+
+    node.restart_clickhouse()
+
+    assert node.query("SELECT count() FROM d3.mt") == "100\n"
+
+    node.query("DROP DATABASE d3 SYNC")


### PR DESCRIPTION
A `Buffer` table hands its in-memory rows to its destination when its own database shuts down, and `DatabaseCatalog::shutdownImpl` shuts databases down one at a time in name order. Two silent losses of acknowledged rows follow from that on an ordinary graceful shutdown:

- a destination in an earlier-sorting database is already gone by then, and `StorageBuffer` takes the missing-destination branch: `Destination table za.mt doesn't exist. Block of data is discarded.` (#117845);
- a chain of `Buffer` tables moves rows at most one link per sequential pass, and rows left in an already-prepared `Buffer` die with its in-memory buffer, so a chain of depth three or more loses everything (#117834).

Both are deterministic at default settings whenever the destination sorts before its source, and `StorageBuffer.h` promises the opposite ("When you destroy a Buffer table, all remaining data is flushed to the subordinate table").

Every table of every database is now asked to hand over its buffered rows *before* any database shuts down, repeating while a pass still moves something - one pass per link of the longest chain, bounded by the number of tables so a `Buffer` pointing at itself cannot spin. `IStorage::flushBufferedRowsBeforeShutdown` returns the number of buffers it flushed and is a no-op for everything except `Buffer`, and the per-database prepare pass keeps running afterwards for whatever arrived in the meantime.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117834
Closes: https://github.com/ClickHouse/ClickHouse/issues/117845
Related: https://github.com/ClickHouse/ClickHouse/issues/116803

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a graceful shutdown silently discarding the rows of a `Buffer` table whose destination lives in another database or is another `Buffer` table.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118985&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118985](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118985+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1092` (included in `26.9` and later)
<!-- ch-version-info:end -->