### PR TITLE
Keep `03251_insert_sparse_all_formats` out of the flaky check

### DIFF
--- a/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
+++ b/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-msan, no-azure-blob-storage, no-random-settings
+# Tags: no-fasttest, long, no-msan, no-azure-blob-storage, no-random-settings, no-flaky-check
 # no-azure-blob-storage: too slow
 # no-msan: it is too slow
-# no-random-settings: this test is already slow, and randomized settings make it slower
+# no-random-settings: serial loop over every I/O format on debug sits at the 600s per-test timeout; randomized query settings amplify wall-time ~3x and tip it over
+# no-flaky-check: any PR adding a format touches the reference file, and dozens of parallel debug reruns of this near-timeout loop over every I/O format spuriously hit the 600s limit
 
 set -e
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/104424

`03251_insert_sparse_all_formats` loops serially over every I/O format and already sits close to the 600s per-test timeout on debug builds. The flaky check reruns a test dozens of times in parallel whenever a pull request touches it, and every pull request that adds a format touches its reference file, so those reruns land on the timeout rather than on a real failure. The test is tagged `no-flaky-check`.

The `no-random-settings` rationale is spelled out at the same time: randomized query settings amplify the wall time of this loop roughly threefold.

Split out of https://github.com/ClickHouse/ClickHouse/pull/104424, which adds a format and therefore hits this.

@vdimir @alexey-milovidov

### Changelog category (leave one):
- CI Fix or Improvement

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118990&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118990](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118990+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1277` (included in `26.9` and later)
<!-- ch-version-info:end -->