### PR TITLE
Fix a logical error when a setting holding a `disk(...)` value is assigned twice

### DIFF
--- a/src/Parsers/FieldFromAST.cpp
+++ b/src/Parsers/FieldFromAST.cpp
@@ -13,6 +13,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
 Field createFieldFromAST(ASTPtr ast)
@@ -23,6 +24,17 @@ Field createFieldFromAST(ASTPtr ast)
 [[noreturn]] void FieldFromASTImpl::throwNotImplemented(std::string_view method) const
 {
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Method {} not implemented for {}", method, getTypeName());
+}
+
+bool FieldFromASTImpl::operator == (const CustomTypeImpl & rhs) const
+{
+    if (std::string_view(getTypeName()) != std::string_view(rhs.getTypeName()))
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Comparing custom types with different type names: {} and {}",
+            getTypeName(), rhs.getTypeName());
+
+    /// Compare the unmasked text: masking rewrites every credential to `[HIDDEN]`, so two values
+    /// differing only in a credential would compare equal.
+    return toString(/*show_secrets=*/ true) == rhs.toString(/*show_secrets=*/ true);
 }
 
 bool FieldFromASTImpl::isSecret() const

--- a/src/Parsers/FieldFromAST.h
+++ b/src/Parsers/FieldFromAST.h
@@ -21,7 +21,7 @@ struct FieldFromASTImpl : public CustomType::CustomTypeImpl
     bool operator <= (const CustomTypeImpl &) const override { throwNotImplemented("<="); }
     bool operator > (const CustomTypeImpl &) const override { throwNotImplemented(">"); }
     bool operator >= (const CustomTypeImpl &) const override { throwNotImplemented(">="); }
-    bool operator == (const CustomTypeImpl &) const override { throwNotImplemented("=="); }
+    bool operator == (const CustomTypeImpl & rhs) const override;
 
     ASTPtr ast;
 };

--- a/tests/queries/0_stateless/05153_reassign_ast_valued_custom_setting.reference
+++ b/tests/queries/0_stateless/05153_reassign_ast_valued_custom_setting.reference
@@ -1,0 +1,5 @@
+1	1
+1
+1
+identical value accepted under readonly
+1

--- a/tests/queries/0_stateless/05153_reassign_ast_valued_custom_setting.sh
+++ b/tests/queries/0_stateless/05153_reassign_ast_valued_custom_setting.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A custom setting (enabled by `custom_settings_prefixes`) can hold an AST rather than a literal, e.g.
+# `custom_x = disk(type = 's3', ...)`. Assigning such a setting a second time compares the new value
+# with the one the session already holds, and both sides being AST-valued is the only way to reach
+# that comparison. `custom_x` lives for the lifetime of an HTTP session, so every statement below runs
+# in one session.
+
+SESSION="05153_$CLICKHOUSE_DATABASE"
+
+# A successful SET writes nothing, so no request below is redirected: an exception body would land in
+# the output and no longer match the reference.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=$SESSION" \
+    --data-binary "SET custom_x = disk(type = 's3', name = 'c05153first', secret_access_key = 'c05153secret')"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=$SESSION" \
+    --data-binary "SET custom_x = disk(type = 's3', name = 'c05153second', secret_access_key = 'c05153secret')"
+
+# The second value wins. `name` is one of the arguments the credential masker leaves visible.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=$SESSION" \
+    --data-binary "SELECT
+        position(value, 'c05153second') > 0,
+        position(value, 'c05153first') = 0
+    FROM system.settings WHERE name = 'custom_x'"
+
+# Re-assigning the identical value is accepted too.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=$SESSION" \
+    --data-binary "SET custom_x = disk(type = 's3', name = 'c05153second', secret_access_key = 'c05153secret')"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=$SESSION" \
+    --data-binary "SELECT position(value, 'c05153second') > 0 FROM system.settings WHERE name = 'custom_x'"
+
+# A nested SETTINGS clause is clamped against the session value rather than refused, which reaches the
+# same comparison through a different caller. The inner scope sees the nested value.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=$SESSION" \
+    --data-binary "SELECT * FROM (
+        SELECT position(value, 'c05153nested') > 0
+        FROM system.settings WHERE name = 'custom_x'
+        SETTINGS custom_x = disk(type = 's3', name = 'c05153nested')
+    )"
+
+# Under `readonly = 1` a setting change is refused, but an assignment the constraint check judges
+# unchanged returns before that check (`SettingsConstraints.cpp:362`), so the comparison's verdict is
+# observable: an exact repeat stays silent, while a value differing only in its credential is refused.
+# `readonly = 1` also refuses the settings the test runner appends to the URL, so this session's URL
+# carries nothing but the session id.
+RO_SESSION="05153_ro_$CLICKHOUSE_DATABASE"
+RO_URL="${CLICKHOUSE_URL%%\?*}?session_id=$RO_SESSION"
+
+${CLICKHOUSE_CURL} -sS "$RO_URL" \
+    --data-binary "SET custom_x = disk(type = 's3', name = 'c05153ro', secret_access_key = 'c05153secret')"
+${CLICKHOUSE_CURL} -sS "$RO_URL" --data-binary "SET readonly = 1"
+
+${CLICKHOUSE_CURL} -sS "$RO_URL" \
+    --data-binary "SET custom_x = disk(type = 's3', name = 'c05153ro', secret_access_key = 'c05153secret')"
+echo 'identical value accepted under readonly'
+
+${CLICKHOUSE_CURL} -sS "$RO_URL" \
+    --data-binary "SET custom_x = disk(type = 's3', name = 'c05153ro', secret_access_key = 'c05153other')" 2>&1 \
+    | grep -c "Cannot modify 'custom_x' setting in readonly mode"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a logical error (`Method == not implemented for AST`) raised by a `SET` of a custom setting that already held an AST value such as `disk(type = 's3', ...)`. Assigning such a setting a second time in one session, or clamping a nested `SETTINGS` clause against it, reached a comparison that was never implemented. `FieldFromASTImpl` now implements equality over the formatted value.


### Description

**What breaks.** A custom setting (`custom_settings_prefixes`, `SQL_` by default) may hold an AST rather than a literal. Assigning it twice in one session raised `LOGICAL_ERROR: Method == not implemented for AST`. Two requests against a server with the shipped configuration are enough:

```sql
SET SQL_x = disk(type = 'local', path = '/tmp/a');
SET SQL_x = disk(type = 'local', path = '/tmp/b');
```

On a release build the second statement returns `Code: 49` instead of aborting, since a `LOGICAL_ERROR` aborts only in debug and sanitizer builds. It is also reachable through a nested `SETTINGS SQL_x = disk(...)` clause, clamped against the session value (`QueryTreeBuilder` -> `SettingsConstraints::clamp`).

**Root cause.** `Field::operator==` short-circuits on the type tag and dispatches to `CustomType::operator==` only when both operands are `CustomType`. An AST-valued setting is a designed, long-lived value in the custom-settings map of `Settings`, so a second AST assignment supplies that pair, and the unchanged-value test at `SettingsConstraints.cpp:362` asserted instead of answering.

**Change.** `FieldFromASTImpl::operator ==` type-checks its operand and compares the unmasked formatted value. This mirrors `AggregateFunctionStateData::operator==` and agrees with `FieldVisitorHash`, which already defines a `CustomType`'s identity as its type name plus the unmasked text.

**Validation.** New test `05153_reassign_ast_valued_custom_setting`: the server aborts on it without this change; it passes 50/50 with randomized settings. Found by `Stress test (arm_release)` on #113565, a bystander ([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=113565&sha=cc75c21e35d4eb8d89869903a165c8c16e5e7b02&name_0=PR)). No matching open issue.

**Residual.** `<`, `<=`, `>` and `>=` still assert, since no caller needs an order over an AST. Reaching one needs a `CustomType` constraint bound, which no input produces: `ParserSettingsProfileElement` accepts only `ParserLiteral`, and the configuration route ends in `Field::restoreFromDump`, which cannot restore a `CustomType`.

Behaviour change: on the clamping path an identical AST value re-assigned is now recognised as unchanged and dropped, where it previously aborted. The `SET` path is unaffected.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118993&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118993](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118993+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
