### PR TITLE
Apply the `broken` prefix to the part's own directory name

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -178,9 +178,15 @@ String DataPartStorageOnDiskBase::getPartDirForPrefix(const String & prefix, boo
       */
     const String part_dir_name = fs::path(part_dir).filename();
 
-    /// During RESTORE temporary part directories are created with names like "tmp_restore_all_2_2_0-XXXXXXXX".
-    /// To detach such a directory we need to rename it replacing "tmp_restore_" with a specified prefix,
-    /// and a random suffix with an attempt number.
+    /** That name can still be a temporary rename of the part rather than the part's own name, and a
+      * temporary marker has to be dropped rather than prefixed: a detached directory must remain a name
+      * `DetachedPartInfo::parseDetachedPartName` can parse, or `system.detached_parts` reports it with a
+      * `NULL` `reason` and `partition_id` while partition-scoped `DROP DETACHED` and `ATTACH PARTITION`
+      * skip it - the part becomes impossible to inspect or to get rid of. RESTORE names its temporary
+      * directories "tmp_restore_all_2_2_0-XXXXXXXX", where the random suffix goes away together with the
+      * prefix; the `ATTACH_PART` candidate above is `attaching_<name>`, so its quarantined directory has
+      * to become a plain `broken_<name>`.
+      */
     String part_name;
     if (detached && part_dir_name.starts_with("tmp_restore_"))
     {
@@ -188,6 +194,10 @@ String DataPartStorageOnDiskBase::getPartDirForPrefix(const String & prefix, boo
         size_t endpos = part_name.find('-');
         if (endpos != String::npos)
             part_name.erase(endpos, String::npos);
+    }
+    else if (detached && part_dir_name.starts_with("attaching_"))
+    {
+        part_name = part_dir_name.substr(strlen("attaching_"));
     }
 
     if (!part_name.empty())

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -169,13 +169,22 @@ String DataPartStorageOnDiskBase::getPartDirForPrefix(const String & prefix, boo
     if (!prefix.empty() && !prefix.ends_with("_"))
         res += "_";
 
+    /** The part's directory is usually a bare name, but it can be a relative path: the `ATTACH_PART`
+      * executor builds its candidate part with `detached/attaching_<name>` so that it can read the
+      * candidate straight out of `detached/`. Prefixing that whole path names a directory inside a
+      * `broken_detached/` subdirectory that nothing ever creates, so the quarantine rename of a broken
+      * detached part failed with ENOENT and the part kept its valid name in `detached/` - failing every
+      * later attach the same way. Only the last component is the part's own directory name.
+      */
+    const String part_dir_name = fs::path(part_dir).filename();
+
     /// During RESTORE temporary part directories are created with names like "tmp_restore_all_2_2_0-XXXXXXXX".
     /// To detach such a directory we need to rename it replacing "tmp_restore_" with a specified prefix,
     /// and a random suffix with an attempt number.
     String part_name;
-    if (detached && part_dir.starts_with("tmp_restore_"))
+    if (detached && part_dir_name.starts_with("tmp_restore_"))
     {
-        part_name = part_dir.substr(strlen("tmp_restore_"));
+        part_name = part_dir_name.substr(strlen("tmp_restore_"));
         size_t endpos = part_name.find('-');
         if (endpos != String::npos)
             part_name.erase(endpos, String::npos);
@@ -184,7 +193,7 @@ String DataPartStorageOnDiskBase::getPartDirForPrefix(const String & prefix, boo
     if (!part_name.empty())
         res += part_name;
     else
-        res += part_dir;
+        res += part_dir_name;
 
     if (try_no)
         res += DetachedPartInfo::TRY_N_SUFFIX + DB::toString(try_no);

--- a/tests/integration/test_broken_detached_part_quarantine/test.py
+++ b/tests/integration/test_broken_detached_part_quarantine/test.py
@@ -69,8 +69,24 @@ def test_broken_detached_part_is_renamed_with_broken_prefix(started_cluster):
     detached = node2.query(
         "SELECT name FROM system.detached_parts WHERE database = currentDatabase() AND table = 't' ORDER BY name"
     ).split()
-    assert any(name.startswith("broken") for name in detached), detached
     assert "all_0_0_0" not in detached, detached
+
+    # The quarantined directory has to be a plain `broken_<part>`, not `broken_attaching_<part>`: the
+    # temporary `attaching_` marker makes the name unparsable, and then `reason` and `partition_id` are
+    # `NULL` here and the partition-scoped `DROP DETACHED` below cannot see the part at all.
+    quarantined = node2.query(
+        "SELECT name, reason, partition_id FROM system.detached_parts "
+        "WHERE database = currentDatabase() AND table = 't' AND startsWith(name, 'broken') ORDER BY name"
+    )
+    assert quarantined == "broken_all_0_0_0\tbroken\tall\n", quarantined
+
+    node2.query("ALTER TABLE t DROP DETACHED PARTITION ALL SETTINGS allow_drop_detached = 1")
+    assert (
+        node2.query(
+            "SELECT count() FROM system.detached_parts WHERE database = currentDatabase() AND table = 't'"
+        )
+        == "0\n"
+    )
 
     for node in [node1, node2]:
         node.query("DROP TABLE t SYNC")

--- a/tests/integration/test_broken_detached_part_quarantine/test.py
+++ b/tests/integration/test_broken_detached_part_quarantine/test.py
@@ -1,0 +1,77 @@
+"""A broken part in `detached/` must be renamed out of the way by the `ATTACH_PART` executor.
+
+The executor builds its candidate part with a `detached/attaching_<name>` directory so it can read
+the candidate out of `detached/`. Prefixing that whole path aimed the quarantine rename at
+`detached/broken_detached/attaching_<name>`, a directory nothing creates, so the rename failed and the
+torn part kept its valid name - failing every later attach the same way.
+"""
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", with_zookeeper=True, stay_alive=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True, stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        # The torn part is deliberately unreadable, and loading it raises a `LOGICAL_ERROR` that this
+        # test exists to see handled.
+        cluster.shutdown(ignore_logical_errors=True)
+
+
+def test_broken_detached_part_is_renamed_with_broken_prefix(started_cluster):
+    for replica, node in [("r1", node1), ("r2", node2)]:
+        node.query(
+            "CREATE TABLE t (id UInt64, a UInt32, b UInt32, c UInt32) "
+            f"ENGINE = ReplicatedMergeTree('/clickhouse/tables/t_broken_detached', '{replica}') ORDER BY id "
+            "SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0"
+        )
+
+    node1.query("INSERT INTO t SELECT number, number, number, number FROM numbers(1000)")
+    node2.query("SYSTEM SYNC REPLICA t")
+    assert node2.query("SELECT count() FROM t") == "1000\n"
+
+    node2.stop_clickhouse()
+
+    # The on-disk state a kill during `DETACH PARTITION` leaves behind: a hard-linked clone of the part
+    # whose column files are missing, with `checksums.txt` kept so the log entry's checksum matches.
+    part_path = node2.exec_in_container(
+        ["bash", "-c", "find /var/lib/clickhouse/store -type d -name all_0_0_0 | head -1"],
+        user="root",
+    ).strip()
+    assert part_path, "the part directory was not found"
+    node2.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"cd {part_path}/.. && mkdir -p detached && cp -al all_0_0_0 detached/all_0_0_0 && "
+            "rm detached/all_0_0_0/columns.txt detached/all_0_0_0/serialization.json "
+            "detached/all_0_0_0/metadata_version.txt detached/all_0_0_0/b.* detached/all_0_0_0/c.*",
+        ],
+        user="root",
+    )
+
+    node1.query("SYSTEM DROP REPLICA 'r2' FROM TABLE t")
+    node2.start_clickhouse()
+    node2.query("SYSTEM RESTORE REPLICA t")
+    node2.query("SYSTEM SYNC REPLICA t")
+
+    # The rows come back either way (the entry falls back to fetching from `r1`), but the torn part must
+    # not keep its valid name: the next attach would parse it again and fail again.
+    assert node2.query("SELECT count() FROM t") == "1000\n"
+
+    detached = node2.query(
+        "SELECT name FROM system.detached_parts WHERE database = currentDatabase() AND table = 't' ORDER BY name"
+    ).split()
+    assert any(name.startswith("broken") for name in detached), detached
+    assert "all_0_0_0" not in detached, detached
+
+    for node in [node1, node2]:
+        node.query("DROP TABLE t SYNC")

--- a/tests/integration/test_broken_detached_part_quarantine/test.py
+++ b/tests/integration/test_broken_detached_part_quarantine/test.py
@@ -21,9 +21,7 @@ def started_cluster():
         cluster.start()
         yield cluster
     finally:
-        # The torn part is deliberately unreadable, and loading it raises a `LOGICAL_ERROR` that this
-        # test exists to see handled.
-        cluster.shutdown(ignore_logical_errors=True)
+        cluster.shutdown()
 
 
 def test_broken_detached_part_is_renamed_with_broken_prefix(started_cluster):
@@ -41,7 +39,9 @@ def test_broken_detached_part_is_renamed_with_broken_prefix(started_cluster):
     node2.stop_clickhouse()
 
     # The on-disk state a kill during `DETACH PARTITION` leaves behind: a hard-linked clone of the part
-    # whose column files are missing, with `checksums.txt` kept so the log entry's checksum matches.
+    # that is missing data files, with `checksums.txt` kept so the log entry's checksum matches. Data
+    # files are what is removed here: a missing `columns.txt` makes the load raise a `LOGICAL_ERROR`
+    # instead, which the sanitizer builds turn into an abort.
     part_path = node2.exec_in_container(
         ["bash", "-c", "find /var/lib/clickhouse/store -type d -name all_0_0_0 | head -1"],
         user="root",
@@ -52,8 +52,7 @@ def test_broken_detached_part_is_renamed_with_broken_prefix(started_cluster):
             "bash",
             "-c",
             f"cd {part_path}/.. && mkdir -p detached && cp -al all_0_0_0 detached/all_0_0_0 && "
-            "rm detached/all_0_0_0/columns.txt detached/all_0_0_0/serialization.json "
-            "detached/all_0_0_0/metadata_version.txt detached/all_0_0_0/b.* detached/all_0_0_0/c.*",
+            "rm detached/all_0_0_0/b.* detached/all_0_0_0/c.*",
         ],
         user="root",
     )


### PR DESCRIPTION
When the replication queue executes an `ATTACH_PART` entry, `attachPartHelperFoundValidPart` looks for a local candidate in `detached/` whose checksums match, and quarantines it with `renameToDetached("broken", ...)` if it turns out to be unreadable. That rename could never succeed: the candidate part is built with `part_dir = detached/attaching_<name>`, so `getPartDirForPrefix` produced `broken_detached/attaching_<name>` and `getRelativePathForDetachedPart` prepended `detached/` once more. The destination was `detached/broken_detached/attaching_<name>`, inside a directory nothing ever creates, and `fs::rename` failed with `ENOENT`.

So the quarantine was dead code on that path: the torn directory kept its valid name in `detached/`, every later `ATTACH_PART` (and every manual `ALTER TABLE ... ATTACH PARTITION`) re-parsed it and failed the same way, and when `detached/broken_detached/` happened to exist the part was buried there instead - `system.detached_parts` then listing `broken_detached` as if it were a part.

Only the last component of the part's directory is its own name, so the prefix is applied to that. A part whose directory is a bare name - every other caller - is unaffected.

That alone would land the part in `detached/broken_attaching_<name>`, which is not a detached part name either: `DetachedPartInfo::parseDetachedPartName` reads it as the known prefix `broken` plus a part name `attaching_<name>` that does not parse, so `valid_name` is false - `system.detached_parts` reports `NULL` for `reason`, `partition_id` and the block numbers, and both `ALTER TABLE ... DROP DETACHED PARTITION` and `ATTACH PARTITION` skip the entry, leaving a part that can be neither inspected nor removed. `attaching_` is a temporary marker held only for the duration of the load, so it is dropped rather than prefixed - exactly like the `tmp_restore_` prefix directly above it - and the quarantined directory is a plain `broken_<name>`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116825
Related: https://github.com/ClickHouse/ClickHouse/issues/116628

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a broken part in `detached/` never being renamed with the `broken_` prefix by the `ATTACH_PART` executor, which left it occupying a valid part name and failing every later attach attempt.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118999&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118999](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118999+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1331` (included in `26.9` and later)
<!-- ch-version-info:end -->