### PR TITLE
Do not create or chown storage_configuration disk paths in Docker entrypoint

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -38,10 +38,6 @@ ERROR_LOG_DIR=""
 if [ -n "$ERROR_LOG_PATH" ]; then ERROR_LOG_DIR="$(dirname "$ERROR_LOG_PATH")"; fi
 FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=format_schema_path || true)"
 
-# There could be many disks declared in config
-readarray -t DISKS_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.path' || true)
-readarray -t DISKS_METADATA_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.metadata_path' || true)
-
 # A `filesystem_caches` entry is not a `storage_configuration` disk, so the paths above do not cover
 # it, and `FileCache::initialize` cannot create one under a directory the server does not own.
 # Absolute entries only: those are used verbatim, while a relative one is resolved by the server
@@ -87,13 +83,19 @@ function create_directory_and_do_chown() {
 }
 
 function manage_clickhouse_directories() {
+    # storage_configuration disk paths are deliberately not touched here: they are
+    # often external mounts, and creating a missing one (as root) would place an
+    # empty directory on the container's ephemeral filesystem, which the server
+    # would then silently fill with data that disappears with the container.
+    # The server creates local disk directories itself when it has permission,
+    # and otherwise fails loudly instead of losing data. filesystem_caches
+    # entries hold re-fillable cache data, not primary data, so preparing them
+    # is safe.
     for dir in "$ERROR_LOG_DIR" \
       "$LOG_DIR" \
       "$TMP_DIR" \
       "$USER_PATH" \
       "$FORMAT_SCHEMA_PATH" \
-      "${DISKS_PATHS[@]}" \
-      "${DISKS_METADATA_PATHS[@]}" \
       "${FILESYSTEM_CACHES_PATHS[@]}"
     do
         create_directory_and_do_chown "$dir"


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The Docker entrypoint no longer creates or recursively chowns `storage_configuration` disk directories (`disks.*.path` / `disks.*.metadata_path`). Previously, when an external mount was absent at container start, the entrypoint silently created an empty directory in its place on the container's ephemeral filesystem, and the server would then write data into it that disappeared with the container. Note: a mounted but root-owned disk is no longer chowned by the entrypoint either — the server starts with that disk read-only and rejects writes loudly until the operator fixes the volume ownership once. Closes #73949.

### Documentation entry for user-facing changes

Fixes #73949.

**Problem.** `manage_clickhouse_directories` in `docker/server/entrypoint.sh` ran an unconditional `mkdir -p` (+ `chown -R`) as root over every `storage_configuration.disks.*.path` and `.metadata_path`. When a configured external mount was absent at container start (maintenance, typo in the compose file, mount ordering), this fabricated an empty directory at that path on the container's ephemeral filesystem. The server then started normally, treated the disk as healthy, and wrote parts into it — all of which silently disappeared when the container was recreated. Reproduced on `clickhouse/clickhouse-server:26.8.2.7`: 100 000 rows inserted into a table on such a disk, then after a container recreate the table reports `count() = 0` with **zero** errors or warnings anywhere and the disk reported healthy.

**Why the entrypoint does not need to touch these directories.** `DiskLocal::setup()` already runs `fs::create_directories(disk_path)` at disk startup, as the `clickhouse` user, and disk startup marks the disk broken / fails loudly when that is not possible. Because that server-side creation runs unprivileged, ordinary Unix permissions distinguish the two cases: a legitimate first-boot path under the (chowned) data volume is created by the server itself, while a missing mount under a root-owned parent (e.g. `/mnt/...`) fails loudly. The entrypoint's root `mkdir -p` was precisely what defeated that protection.

**Change.** Pure deletion, per the direction in #73949 (reverts the disk-path part of #39121): the two `readarray` extractions are removed and disk paths are no longer part of the entrypoint's directory management. No new logic is added. Default paths (data dir, logs, tmp, user_files, format_schemas) keep today's behavior, so the standard first boot is unaffected.

**Behavior matrix** (all verified on `clickhouse/clickhouse-server:26.8.2.7`, entrypoint patched via bind mount):

| # | Scenario | Before | After |
|---|----------|--------|-------|
| 1 | `local` disk `/mnt/cold`, mount absent | dir fabricated on ephemeral FS, silent data loss on recreate (`count()=0`, no errors) | nothing is created; server: `Disk cold is marked as broken during startup ... create_directories: Permission denied`, then `Code: 481 PATH_ACCESS_DENIED` → fails fast at startup |
| 2 | same, with `skip_access_check=true` on the disk | same silent loss | server starts, `system.disks.is_broken = 1`, `INSERT` fails loudly with `NOT_ENOUGH_SPACE` — i.e. exactly the "mark it broken until the disk is reconnected" behavior requested in #73949, as an explicit opt-in for who prefers availability |
| 3 | standard first boot (fresh volume, `CLICKHOUSE_DB`, initdb scripts) | works | works, unchanged |
| 4 | `local` disk on a mounted but root-owned volume | recursively chowned by the entrypoint, transparently usable | **behavior change**: no chown; server starts with the disk read-only and `INSERT` fails loudly (`TABLE_IS_PERMANENTLY_READ_ONLY`) until the operator fixes the volume ownership once |
| 5 | `local` disk path under the data dir, not pre-created | created by entrypoint | created by the server itself, works |
| 6 | `s3` disk (MinIO) + `cache` disk on top, `metadata_path` and cache path not pre-created | works | works — the server creates both paths itself, first boot unaffected |

**Known limits of scope** (unchanged by this PR):
- With `CLICKHOUSE_RUN_AS_ROOT=1` the server itself runs as root and recreates the missing path, so this class of loss persists in that mode.
- A missing mount whose parent is writable by `clickhouse` (e.g. a path under `/tmp`) is still recreated by the server itself (verified). Fully closing that class would need a server-side guard (e.g. a per-disk marker file); happy to discuss as a follow-up.

**Rebase note**: rebased on master after 814b3a601 ("Prepare `filesystem_caches` directories in the server entrypoint") landed on the same lines. No semantic conflict: that change prepares `filesystem_caches` entries, which hold re-fillable cache data — creating those is safe and is kept as is; this PR removes only the `storage_configuration` disk paths, which hold primary data. The key scenarios (missing mount → loud failure at startup; standard first boot) were re-verified on the rebased script. Shellcheck status of the file is unchanged.
