### PR TITLE
Keep the database qualification of a parameterized view reference across an AST round-trip

### DIFF
--- a/src/Analyzer/TableFunctionNode.cpp
+++ b/src/Analyzer/TableFunctionNode.cpp
@@ -168,12 +168,18 @@ ASTPtr TableFunctionNode::toASTImpl(const ConvertToASTOptions & options) const
     /// database, so qualify it from `storage_id`. Only a 2-part result is resolvable as a
     /// parameterized view, so a dotted database name is left alone.
     if (const auto * storage_view = storage ? storage->as<StorageView>() : nullptr;
-        storage_view && storage_view->isParameterizedView() && storage_id.hasDatabase()
-        && Identifier{table_function_name}.getPartsSize() == 1)
+        storage_view && storage_view->isParameterizedView())
     {
-        const auto database_name = storage_id.getDatabaseName();
-        if (Identifier{database_name}.getPartsSize() == 1)
-            table_function_ast->name = database_name + "." + storage_id.getTableName();
+        if (storage_id.hasDatabase() && Identifier{table_function_name}.getPartsSize() == 1)
+        {
+            const auto database_name = storage_id.getDatabaseName();
+            if (Identifier{database_name}.getPartsSize() == 1)
+                table_function_ast->name = database_name + "." + storage_id.getTableName();
+        }
+
+        /// Keep the qualification parseable: one quoted `db.view` token re-parses as a single name.
+        if (Identifier{table_function_ast->name}.getPartsSize() == 2)
+            table_function_ast->setIsCompoundName(true);
     }
 
     const auto & arguments = getArguments();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3136,22 +3136,41 @@ static bool findIdentifier(const ASTFunction * function)
 StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const ASTSelectQuery * select_query_hint)
 {
     ASTFunction * function = assert_cast<ASTFunction *>(table_expression.get());
-    String database_name = getCurrentDatabase();
-    String table_name = function->name;
 
-    if (function->isCompoundName())
+    /// `isCompoundName` says whether the parser saw the dot outside backticks, and that bit does not
+    /// survive an AST round-trip: a compound name formats back as one quoted token (`db.view`) and
+    /// re-parses as a single part. Try both readings, preferring the one the parser saw.
+    std::vector<std::pair<String, String>> candidates;
+    candidates.reserve(2);
     {
+        if (!function->isCompoundName())
+            candidates.emplace_back(getCurrentDatabase(), function->name);
+
         std::vector<std::string> parts;
         splitInto<'.'>(parts, function->name);
-
         if (parts.size() == 2)
+            candidates.emplace_back(parts[0], parts[1]);
+
+        /// Compound but not two parts: not resolvable as `database.table`.
+        if (candidates.empty())
+            candidates.emplace_back(getCurrentDatabase(), function->name);
+    }
+
+    String database_name = candidates.front().first;
+    String table_name = candidates.front().second;
+
+    StoragePtr table;
+    for (const auto & [candidate_database, candidate_table] : candidates)
+    {
+        table = DatabaseCatalog::instance().tryGetTable({candidate_database, candidate_table}, getQueryContext());
+        if (table)
         {
-            database_name = std::move(parts[0]);
-            table_name = std::move(parts[1]);
+            database_name = candidate_database;
+            table_name = candidate_table;
+            break;
         }
     }
 
-    StoragePtr table = DatabaseCatalog::instance().tryGetTable({database_name, table_name}, getQueryContext());
     if (table)
     {
         if (table.get()->isView() && table->as<StorageView>() && table->as<StorageView>()->isParameterizedView())

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -39,6 +39,34 @@ namespace ErrorCodes
 }
 
 
+namespace
+{
+
+/// A compound name (`database.view`, only for a parameterized-view table function) needs its parts
+/// quoted separately: one quoted token would re-parse as a single identifier.
+void writeFunctionName(WriteBuffer & ostr, const String & name, bool is_compound_name)
+{
+    if (!is_compound_name)
+    {
+        ostr << backQuoteIfNeed(name);
+        return;
+    }
+
+    std::string_view rest = name;
+    while (true)
+    {
+        const size_t dot = rest.find('.');
+        ostr << backQuoteIfNeed(rest.substr(0, dot));
+        if (dot == std::string_view::npos)
+            break;
+        ostr << '.';
+        rest.remove_prefix(dot + 1);
+    }
+}
+
+}
+
+
 boost::intrusive_ptr<ASTFunction> makeASTLambda(std::initializer_list<String> param_names, ASTPtr && body)
 {
     auto tuple = makeASTFunction("tuple");
@@ -515,7 +543,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
         std::string nl_or_nothing = settings.one_line ? "" : "\n";
         std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
         if (!name.empty())
-            ostr << backQuoteIfNeed(name);
+            writeFunctionName(ostr, name, isCompoundName());
         ostr << "(";
         ostr << nl_or_nothing;
         FormatStateStacked frame_nested = frame;
@@ -994,7 +1022,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
 
     /// Empty names are used rarely, to format queries with an extra pair of parentheses for external databases.
     if (!name.empty())
-        ostr << backQuoteIfNeed(name);
+        writeFunctionName(ostr, name, isCompoundName());
 
     if (parameters)
     {

--- a/tests/queries/0_stateless/05153_parameterized_view_qualified_name.reference
+++ b/tests/queries/0_stateless/05153_parameterized_view_qualified_name.reference
@@ -1,0 +1,9 @@
+--- enable_analyzer = 1
+2
+2
+--- enable_analyzer = 0
+2
+2
+--- formatting
+SELECT * FROM db.pv(p = 2)
+CREATE VIEW db.outer_view (`x` UInt64) AS SELECT * FROM db.pv(p = 3)

--- a/tests/queries/0_stateless/05153_parameterized_view_qualified_name.sh
+++ b/tests/queries/0_stateless/05153_parameterized_view_qualified_name.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DB="${CLICKHOUSE_DATABASE}"
+
+$CLICKHOUSE_CLIENT --multiquery "
+CREATE TABLE t (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t SELECT arrayJoin([1, 2, 3]);
+CREATE VIEW pv AS SELECT x FROM t WHERE x = {p:UInt64};
+"
+
+# A database-qualified reference to a parameterized view must resolve both when the dot qualifies
+# the name and when the whole name arrives inside one quoted identifier: an AST round-trip (view
+# metadata, `ON CLUSTER` DDL, a query shipped to another server) collapses `db.pv` into the single
+# quoted token `db.pv`.
+for analyzer in 1 0; do
+    echo "--- enable_analyzer = $analyzer"
+    $CLICKHOUSE_CLIENT --enable_analyzer "$analyzer" -q "SELECT * FROM ${DB}.pv(p = 2)"
+    $CLICKHOUSE_CLIENT --enable_analyzer "$analyzer" -q "SELECT * FROM \`${DB}.pv\`(p = 2)"
+done
+
+# Formatting keeps the qualification: the database and the view are quoted separately, so the
+# reference does not degrade into a reference to a table named `db.pv` on the way through metadata.
+echo "--- formatting"
+$CLICKHOUSE_CLIENT -q "SELECT replaceAll(formatQuerySingleLine('SELECT * FROM ${DB}.pv(p = 2)'), '${DB}', 'db')"
+$CLICKHOUSE_CLIENT -q "CREATE VIEW outer_view AS SELECT * FROM ${DB}.pv(p = 3)"
+$CLICKHOUSE_CLIENT -q "SELECT replaceAll(create_table_query, '${DB}', 'db') FROM system.tables WHERE database = currentDatabase() AND name = 'outer_view'"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

A qualified parameterized view reference `db.view(params)` was formatted back as the single
quoted token `` `db.view`(params) ``, because `ASTFunction` keeps only a boolean saying that
the parser saw the dot outside backticks, and that bit does not survive format-and-parse.
Storing a view, `ON CLUSTER` DDL and shipping a query fragment to a replica all go through
such a round-trip, so `CREATE VIEW v AS SELECT * FROM db.pv(p = 1)` was stored with the
qualification collapsed. The analyzer tolerates the collapsed spelling because it always
splits the name on the dot, but `Context::executeTableFunction` only split it when the
parser had flagged the name as compound, so on the old analyzer the reference resolved to
a table literally named `db.pv` and failed with `UNKNOWN_FUNCTION`.

`ASTFunction::formatImpl` now quotes the parts of a compound name separately, so the
reference round-trips unchanged, and `Context::executeTableFunction` considers both readings
of a dotted name — `database`.`table`, and the literal name in the current database —
preferring the one the parser saw, which repairs views whose metadata already carries the
collapsed spelling. `TableFunctionNode::toASTImpl` marks a qualified parameterized-view name
as compound so fragments sent to replicas format the same way.

Related: https://github.com/ClickHouse/ClickHouse/issues/87267


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A database-qualified reference to a parameterized view, such as `SELECT * FROM db.pv(p = 1)`, is no longer stored with its qualification collapsed into a single quoted identifier, and such a collapsed reference in existing metadata now resolves again instead of failing with `Unknown table function db.pv`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119027&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119027](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119027+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
