### PR TITLE
Do not let a setting masking rule throw

### DIFF
--- a/src/Databases/DataLake/DataLakeConstants.h
+++ b/src/Databases/DataLake/DataLakeConstants.h
@@ -3,6 +3,7 @@
 #include <unordered_set>
 #include <Core/Types.h>
 #include <Core/Field.h>
+#include <optional>
 
 namespace DataLake
 {
@@ -18,7 +19,7 @@ static constexpr auto FAKE_TABLE_ENGINE_NAME_FOR_UNREADABLE_TABLES = "Other";
 
 static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
 
-using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+using ValueMaskingFunc = std::function<std::optional<std::string>(const DB::Field &)>;
 static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
 {
     /// Catalog credentials

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -30,7 +30,7 @@ namespace ErrorCodes
 
 /// Each engine namespace declares its own identical `ValueMaskingFunc` alias, hence the spelled-out
 /// type. Unrelated to `CoreSettings::ValueMaskingFunc`, which rewrites a value string in place.
-using EngineSettingsToHide = std::unordered_map<String, std::function<std::string(const Field &)>>;
+using EngineSettingsToHide = std::unordered_map<String, std::function<std::optional<std::string>(const Field &)>>;
 
 /// The table and database engine settings whose value is a secret, and how each one is masked.
 ///

--- a/src/Storages/Kafka/Kafka_fwd.h
+++ b/src/Storages/Kafka/Kafka_fwd.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Core/Types.h>
 #include <Core/Field.h>
+#include <optional>
 
 namespace Kafka
 {
@@ -8,7 +9,7 @@ namespace Kafka
 static constexpr auto TABLE_ENGINE_NAME = "Kafka";
 static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
 
-using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+using ValueMaskingFunc = std::function<std::optional<std::string>(const DB::Field &)>;
 static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
 {
     {"kafka_sasl_password", DEFAULT_MASKING_RULE},

--- a/src/Storages/NATS/NATS_fwd.h
+++ b/src/Storages/NATS/NATS_fwd.h
@@ -2,6 +2,7 @@
 #include <Core/Types.h>
 #include <Core/Field.h>
 #include <Common/maskURIPassword.h>
+#include <optional>
 
 namespace NATS
 {
@@ -9,7 +10,7 @@ namespace NATS
 static constexpr auto TABLE_ENGINE_NAME = "NATS";
 static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
 
-using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+using ValueMaskingFunc = std::function<std::optional<std::string>(const DB::Field &)>;
 static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
 {
     {"nats_password", DEFAULT_MASKING_RULE},
@@ -17,9 +18,14 @@ static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
     {"nats_credential_file", DEFAULT_MASKING_RULE},
     {"nats_credentials", DEFAULT_MASKING_RULE},
     {"nats_server_list", DEFAULT_MASKING_RULE},
-    {"nats_url", [](const DB::Field & value)
+    {"nats_url", [](const DB::Field & value) -> std::optional<std::string>
     {
-        std::string masked_value = value.safeGet<std::string>();
+        /// A masking rule must not throw: it runs before the setting is validated, so the value
+        /// need not be a String. `SETTINGS nats_url = 4222` used to throw `BAD_GET` here, which
+        /// aborted the masking of every other setting in the same statement.
+        std::string masked_value;
+        if (!value.tryGet<std::string>(masked_value))
+            return {};
         DB::maskURIPassword(&masked_value);
         return fmt::format("'{}'", masked_value);
     }}

--- a/src/Storages/ObjectStorageQueue/AzureQueue_fwd.h
+++ b/src/Storages/ObjectStorageQueue/AzureQueue_fwd.h
@@ -2,6 +2,7 @@
 #include <Core/Types.h>
 #include <Core/Field.h>
 #include <Common/maskURIPassword.h>
+#include <optional>
 
 namespace AzureQueue
 {
@@ -9,12 +10,16 @@ namespace AzureQueue
 static constexpr auto TABLE_ENGINE_NAME = "AzureQueue";
 static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
 
-using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+using ValueMaskingFunc = std::function<std::optional<std::string>(const DB::Field &)>;
 static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
 {
-    {"after_processing_move_connection_string", [](const DB::Field & value)
+    {"after_processing_move_connection_string", [](const DB::Field & value) -> std::optional<std::string>
     {
-        std::string masked_value = value.safeGet<std::string>();
+        /// Not a String means there is nothing to mask; see the `nats_url` rule for why a rule
+        /// must not throw.
+        std::string masked_value;
+        if (!value.tryGet<std::string>(masked_value))
+            return {};
         DB::maskConnectionStringKey(masked_value, "AccountKey=");
         DB::maskConnectionStringKey(masked_value, "SharedAccessSignature=");
         return fmt::format("'{}'", masked_value);

--- a/src/Storages/ObjectStorageQueue/S3Queue_fwd.h
+++ b/src/Storages/ObjectStorageQueue/S3Queue_fwd.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Core/Types.h>
 #include <Core/Field.h>
+#include <optional>
 
 namespace S3Queue
 {
@@ -8,7 +9,7 @@ namespace S3Queue
 static constexpr auto TABLE_ENGINE_NAME = "S3Queue";
 static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
 
-using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+using ValueMaskingFunc = std::function<std::optional<std::string>(const DB::Field &)>;
 static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
 {
     {"after_processing_move_secret_access_key", DEFAULT_MASKING_RULE},

--- a/src/Storages/RabbitMQ/RabbitMQ_fwd.h
+++ b/src/Storages/RabbitMQ/RabbitMQ_fwd.h
@@ -2,6 +2,7 @@
 #include <Core/Types.h>
 #include <Core/Field.h>
 #include <Common/maskURIPassword.h>
+#include <optional>
 
 namespace RabbitMQ
 {
@@ -9,13 +10,17 @@ namespace RabbitMQ
 static constexpr auto TABLE_ENGINE_NAME = "RabbitMQ";
 static constexpr auto DEFAULT_MASKING_RULE = [](const DB::Field &){ return "'[HIDDEN]'"; };
 
-using ValueMaskingFunc = std::function<std::string(const DB::Field &)>;
+using ValueMaskingFunc = std::function<std::optional<std::string>(const DB::Field &)>;
 static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
 {
     {"rabbitmq_password", DEFAULT_MASKING_RULE},
-    {"rabbitmq_address", [](const DB::Field & value)
+    {"rabbitmq_address", [](const DB::Field & value) -> std::optional<std::string>
     {
-        std::string masked_value = value.safeGet<std::string>();
+        /// Not a String means there is nothing to mask; see the `nats_url` rule for why a rule
+        /// must not throw.
+        std::string masked_value;
+        if (!value.tryGet<std::string>(masked_value))
+            return {};
         DB::maskURIPassword(&masked_value);
         return fmt::format("'{}'", masked_value);
     }}

--- a/tests/queries/0_stateless/05153_settings_masking_non_string_value.reference
+++ b/tests/queries/0_stateless/05153_settings_masking_non_string_value.reference
@@ -1,0 +1,5 @@
+(UNKNOWN_SETTING)
+(UNKNOWN_SETTING)
+(UNKNOWN_SETTING)
+in query: SET nats_password = '[HIDDEN]', nats_url = 4222
+1	1

--- a/tests/queries/0_stateless/05153_settings_masking_non_string_value.sh
+++ b/tests/queries/0_stateless/05153_settings_masking_non_string_value.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Masking a setting value must never throw. `nats_url`, `rabbitmq_address` and
+# `after_processing_move_connection_string` hold a URL or a connection string whose credential is
+# masked in place, and masking runs before the setting is validated, so the value can be of any
+# type. Writing the port where the URL goes used to throw `BAD_GET` out of the masking, and the
+# server then logged the statement text raw, with every other credential in it in cleartext.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CANARY="c05153natspassword"
+
+# 1. A value of the wrong type reports the setting's own error, not one from the masking.
+for setting in nats_url rabbitmq_address after_processing_move_connection_string; do
+    $CLICKHOUSE_CLIENT -q "SET $setting = 4222" 2>&1 | grep -oE '\(UNKNOWN_SETTING\)|\(BAD_GET\)' | head -1
+done
+
+# 2. The credential next to the wrongly typed setting is still masked in what the server logs.
+# Only the server's own log line is checked: the `(query: ...)` line next to it is the client
+# echoing back what it sent, which is the text the user typed and is never masked.
+$CLICKHOUSE_CLIENT --send_logs_level=error -q "SET nats_password = '$CANARY', nats_url = 4222" 2>&1 |
+    grep -oE "in query: [^)]*" | head -1
+
+# 3. And in `system.query_log`, for the `SETTINGS` clause of a `CREATE TABLE` as well.
+QUERY_ID="05153_$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT --query_id="$QUERY_ID" --log_queries=1 -q \
+    "CREATE TABLE ${CLICKHOUSE_DATABASE}.events (a String) ENGINE = MergeTree ORDER BY a
+        SETTINGS nats_password = '$CANARY', nats_url = 4222" > /dev/null 2>&1
+
+for _ in {1..60}; do
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+    LOGGED=$($CLICKHOUSE_CLIENT -q "SELECT
+            position(query, '$CANARY') = 0,
+            position(query, 'nats_password = \'[HIDDEN]\'') > 0
+        FROM system.query_log
+        WHERE current_database = currentDatabase() AND query_id = '$QUERY_ID' AND type = 'ExceptionBeforeStart'")
+    [ -n "$LOGGED" ] && break
+    sleep 0.5
+done
+echo "$LOGGED"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/118950
Related: https://github.com/ClickHouse/ClickHouse/pull/117523

Follow-up to #117523.

The masking rules for `nats_url`, `rabbitmq_address` and `after_processing_move_connection_string` mask the credential inside a URL or a connection string, so they read the value with `safeGet<std::string>`. Masking runs before the setting is validated, so the value need not be a `String`: `SETTINGS nats_url = 4222` reached the rule and threw `BAD_GET`.

The throw escaped `hasSecretParts`/`formatForLogging`, and `executeQueryImpl` then fell back to logging the raw statement text. That put every other credential in the same statement into the server log in cleartext, so writing the port where the URL goes was enough to publish the `nats_password` next to it:

```sql
-- What the user meant
CREATE TABLE events (a String) ENGINE = NATS
SETTINGS nats_url = 'localhost:4222', nats_subjects = 'events',
         nats_format = 'JSONEachRow', nats_password = 'hunter2';

-- What they typed: the port instead of the URL
CREATE TABLE events (a String) ENGINE = NATS
SETTINGS nats_url = 4222, nats_subjects = 'events',
         nats_format = 'JSONEachRow', nats_password = 'hunter2';
```

Both statements fail, but the second one leaves `nats_password = 'hunter2'` in `system.query_log.query` and in the server log, while the first one correctly stores `nats_password = '[HIDDEN]'`.

A masking rule must not throw. The rules now return `std::optional<std::string>`, and the three that need the value as a string read it with `tryGet` and mask nothing when it is not a `String`. This is the guard `CoreSettings::renderSecretSettingValue` already has, for exactly this reason. The rules that hide the value whole are unchanged, so a non-`String` value for them is still masked.

Also checked, and clean: `FunctionSecretArgumentsFinderAST::tryGetString` already checks the field type before `safeGet`; `ASTSettingsProfileElement` routes through the guarded core function; `ASTAuthenticationData::hasSecretParts` decides from the authentication type without reading a value; dictionary `SOURCE(...)` masking is keyed on the argument name. Two sweeps found no remaining leak: 30 masked setting names against 10 value types, and 18 table function shapes with wrong types, `NULL` and non-literal arguments.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119028&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119028](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119028+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1116` (included in `26.9` and later)
- Backported to: `26.8.3.93`, `26.7.7.81`, `26.6.5.110`, `26.3.33.60`
<!-- ch-version-info:end -->