### PR TITLE
Do not park a pipeline worker thread inside IProcessor::work in failpoint tests

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -369,8 +369,8 @@ static struct InitFiu
     PAUSEABLE_ONCE(limit_by_sorted_stream_transform_mid_loop_pause) \
     PAUSEABLE_ONCE(limit_by_transform_mid_loop_pause) \
     ONCE(aggregating_in_order_transform_cancel_mid_loop) \
-    PAUSEABLE_ONCE(mysql_output_format_mid_loop_pause) \
-    PAUSEABLE_ONCE(postgresql_output_format_mid_loop_pause) \
+    ONCE(mysql_output_format_cancel_mid_loop) \
+    ONCE(postgresql_output_format_cancel_mid_loop) \
     ONCE(hash_join_throw_after_data_release) \
     ONCE(stored_columns_index_throw_on_add) \
     REGULAR(smt_force_takeover_predicate_true) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -157,7 +157,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(smt_select_sequential_consistency_before_keeper_fence) \
     PAUSEABLE_ONCE(smt_select_sequential_consistency_after_keeper_get) \
     PAUSEABLE_ONCE(delta_lake_metadata_iterate_pause) \
-    PAUSEABLE_ONCE(delta_lake_write_commit_pause) \
+    ONCE(delta_lake_write_cancel_in_commit_window) \
     PAUSEABLE_ONCE(query_metric_log_pause_before_finish) \
     PAUSEABLE_ONCE(replicated_table_remove_zk_before_get_children) \
     PAUSEABLE_ONCE(replicated_table_remove_zk_before_final_multi) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -368,7 +368,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(limit_by_transform_after_loop_pause) \
     PAUSEABLE_ONCE(limit_by_sorted_stream_transform_mid_loop_pause) \
     PAUSEABLE_ONCE(limit_by_transform_mid_loop_pause) \
-    PAUSEABLE_ONCE(aggregating_in_order_transform_mid_loop_pause) \
+    ONCE(aggregating_in_order_transform_cancel_mid_loop) \
     PAUSEABLE_ONCE(mysql_output_format_mid_loop_pause) \
     PAUSEABLE_ONCE(postgresql_output_format_mid_loop_pause) \
     ONCE(hash_join_throw_after_data_release) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -44,8 +44,7 @@ static struct InitFiu
     REGULAR(replicated_sends_sleep_before_file_send) \
     REGULAR(use_delayed_remote_source) \
     ONCE(remote_query_executor_cancel_before_send) \
-    PAUSEABLE_ONCE(remote_query_executor_receive_packet_pause) \
-    PAUSEABLE_ONCE(remote_query_executor_finish_drain_pause) \
+    ONCE(remote_query_executor_cancel_and_drain_in_receive_window) \
     PAUSEABLE_ONCE(distributed_sink_pause_before_push) \
     ONCE(connection_stale_on_establish) \
     REGULAR(cluster_discovery_faults) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -197,6 +197,7 @@ static struct InitFiu
     REGULAR(refresh_mv_force_scheduling_feature_flags_missing) \
     REGULAR(refresh_mv_force_coordination_version_conflict) \
     REGULAR(refresh_mv_force_coordination_running_znode_lost) \
+    PAUSEABLE_ONCE(refresh_mv_pause_after_executor_published) \
     PAUSEABLE(refresh_mv_pause_before_exchange) \
     PAUSEABLE(refresh_mv_pause_after_interrupt_check) \
     REGULAR(refresh_mv_skip_execution) \

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -29,7 +29,7 @@ namespace ErrorCodes
 
 namespace FailPoints
 {
-extern const char mysql_output_format_mid_loop_pause[];
+extern const char mysql_output_format_cancel_mid_loop[];
 }
 
 MySQLOutputFormat::MySQLOutputFormat(WriteBuffer & out_, SharedHeader header_, const FormatSettings & settings_)
@@ -95,7 +95,15 @@ void MySQLOutputFormat::consume(Chunk chunk)
                 throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
 
             if (row == 5)
-                FailPointInjection::pauseFailPoint(FailPoints::mysql_output_format_mid_loop_pause);
+            {
+                /// This runs inside `IProcessor::work()`, which must only use CPU and never wait, so
+                /// the hook cancels the query the same way `KILL QUERY` does instead of blocking:
+                /// the check above then observes the cancellation on the next row.
+                fiu_do_on(FailPoints::mysql_output_format_cancel_mid_loop, {
+                    if (auto query_context = CurrentThread::tryGetQueryContext())
+                        query_context->killCurrentQuery();
+                });
+            }
 
             ProtocolText::ResultSetRow row_packet(serializations, data_types, chunk.getColumns(), row);
             packet_endpoint->sendPacket(row_packet, false);

--- a/src/Processors/Formats/Impl/PostgreSQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/PostgreSQLOutputFormat.cpp
@@ -1,10 +1,12 @@
 #include <Processors/Formats/Impl/PostgreSQLOutputFormat.h>
 
 #include <Columns/IColumn.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/logger_useful.h>
 #include <Formats/FormatFactory.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/ProcessList.h>
 
 #include <Processors/Port.h>
@@ -19,7 +21,7 @@ namespace ErrorCodes
 
 namespace FailPoints
 {
-extern const char postgresql_output_format_mid_loop_pause[];
+extern const char postgresql_output_format_cancel_mid_loop[];
 }
 
 PostgreSQLOutputFormat::PostgreSQLOutputFormat(WriteBuffer & out_, SharedHeader header_, const FormatSettings & settings_)
@@ -67,7 +69,15 @@ void PostgreSQLOutputFormat::consume(Chunk chunk)
             throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
 
         if (i == 5)
-            FailPointInjection::pauseFailPoint(FailPoints::postgresql_output_format_mid_loop_pause);
+        {
+            /// This runs inside `IProcessor::work()`, which must only use CPU and never wait, so the
+            /// hook cancels the query the same way `KILL QUERY` does instead of blocking: the
+            /// check above then observes the cancellation on the next row.
+            fiu_do_on(FailPoints::postgresql_output_format_cancel_mid_loop, {
+                if (auto query_context = CurrentThread::tryGetQueryContext())
+                    query_context->killCurrentQuery();
+            });
+        }
 
         const Columns & columns = chunk.getColumns();
         VectorWithMemoryTracking<std::shared_ptr<PostgreSQLProtocol::Messaging::ISerializable>> row;

--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -9,6 +9,7 @@
 #include <Common/logger_useful.h>
 #include <Common/formatReadable.h>
 #include <Common/MemoryTracker.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/sortBlock.h>
 #include <base/range.h>
 
@@ -17,7 +18,7 @@ namespace DB
 
 namespace FailPoints
 {
-extern const char aggregating_in_order_transform_mid_loop_pause[];
+extern const char aggregating_in_order_transform_cancel_mid_loop[];
 }
 
 AggregatingInOrderTransform::AggregatingInOrderTransform(
@@ -174,7 +175,15 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
         }
 
         if (interval_index == 5)
-            FailPointInjection::pauseFailPoint(FailPoints::aggregating_in_order_transform_mid_loop_pause);
+        {
+            /// This runs inside `IProcessor::work()`, which must only use CPU and never wait, so the
+            /// hook cancels the query the same way `KILL QUERY` does instead of blocking: the
+            /// check above then observes the cancellation on the next interval.
+            fiu_do_on(FailPoints::aggregating_in_order_transform_cancel_mid_loop, {
+                if (auto query_context = CurrentThread::tryGetQueryContext())
+                    query_context->killCurrentQuery();
+            });
+        }
         ++interval_index;
 
         /// Find the first position of new (not current) key in current chunk

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -75,8 +75,7 @@ namespace ErrorCodes
 namespace FailPoints
 {
     extern const char remote_query_executor_cancel_before_send[];
-    extern const char remote_query_executor_receive_packet_pause[];
-    extern const char remote_query_executor_finish_drain_pause[];
+    extern const char remote_query_executor_cancel_and_drain_in_receive_window[];
 }
 
 ThrottlerPtr getThrottler(const ContextPtr & context)
@@ -652,14 +651,10 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::read()
                 return ReadResult(Block());
         }
 
-        /// Parks the reader in the window this fix is about: `was_cancelled` has just been checked
-        /// and the mutex released, so a parallel `onUpdatePorts` can cancel and drain these
-        /// connections before `receivePacket` below runs.
-        fiu_do_on(FailPoints::remote_query_executor_receive_packet_pause, {
-            in_receive_packet_window = true;
-            FailPointInjection::notifyPauseAndWaitForResume(FailPoints::remote_query_executor_receive_packet_pause);
-            in_receive_packet_window = false;
-        });
+        /// `was_cancelled` was checked and `was_cancelled_mutex` released above, so a parallel
+        /// `onUpdatePorts` -> `finish` can cancel and drain these connections before `receivePacket`
+        /// below runs. `finish()` takes that mutex itself, which is not held at this point.
+        fiu_do_on(FailPoints::remote_query_executor_cancel_and_drain_in_receive_window, { finish(); });
 
         auto packet = connections->receivePacket();
 
@@ -1068,11 +1063,6 @@ void RemoteQueryExecutor::finish()
                 break;
         }
     }
-
-    /// Reached only with this executor's own reader parked above, i.e. with its connections
-    /// cancelled and fully drained - the state that reader will observe when it wakes.
-    if (in_receive_packet_window)
-        FailPointInjection::pauseFailPoint(FailPoints::remote_query_executor_finish_drain_pause);
 }
 
 void RemoteQueryExecutor::cancel()

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -300,12 +300,6 @@ private:
       */
     bool finished = false;
 
-    /** Test-only. True only while this executor's reading thread is parked at the
-      * `remote_query_executor_receive_packet_pause` failpoint, so that the drain pause in
-      * `finish` cannot be satisfied by a sibling shard. False unless the failpoints are enabled.
-      */
-    std::atomic_bool in_receive_packet_window = false;
-
     /** Cancel query request was sent to all replicas because data is not needed anymore
       * This behaviour may occur when:
       * - data size is already satisfactory (when using LIMIT, for example)

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -95,6 +95,11 @@ namespace FailPoints
     /// refresh is already in flight cancels the local refresh before giving up coordination,
     /// instead of leaving Keeper thinking the refresh is still running.
     extern const char refresh_mv_force_scheduling_feature_flags_missing[];
+    /// Pauses the refresh thread after the executor is published to execution.executor and
+    /// executor_mutex is released, but before it starts, so a test can cancel a refresh that has a
+    /// live executor to interrupt. This is the refresh (BackgroundSchedulePool) thread, not a
+    /// pipeline worker: no IProcessor::work() frame exists yet, so nothing waits inside work().
+    extern const char refresh_mv_pause_after_executor_published[];
     /// Pauses the refresh thread after the insert pipeline finished but before the target-table
     /// exchange, so a test can deterministically hit the post-insert window where the executor is
     /// already gone and only the interrupt_execution flag can stop the exchange.
@@ -1389,6 +1394,8 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(int32_t root_znode_versi
                     std::unique_lock exec_lock(execution.executor_mutex);
                     execution.executor = nullptr;
                 });
+
+                FailPointInjection::pauseFailPoint(FailPoints::refresh_mv_pause_after_executor_published);
 
                 executor.execute();
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakePartitionedSink.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakePartitionedSink.cpp
@@ -2,6 +2,7 @@
 
 #if USE_DELTA_KERNEL_RS
 #include <Common/logger_useful.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/ArenaUtils.h>
@@ -42,7 +43,7 @@ namespace Setting
 
 namespace FailPoints
 {
-    extern const char delta_lake_write_commit_pause[];
+    extern const char delta_lake_write_cancel_in_commit_window[];
 }
 
 namespace
@@ -423,10 +424,13 @@ void DeltaLakePartitionedSink::onFinish()
 
     LOG_TEST(log, "Written {} data files", total_data_files_count);
 
-    /// Test-only hook: pause inside the commit window (after the data files are
-    /// finalized, before commit) so a test can inject an external cancel and
-    /// check that a late cancel does not delete committed files.
-    FailPointInjection::pauseFailPoint(FailPoints::delta_lake_write_commit_pause);
+    /// Test-only hook for the commit window: the data files are finalized and the commit below has
+    /// not run yet. `onFinish` runs inside `IProcessor::work()`, which must only use CPU and never
+    /// wait, so the hook cancels the query the same way `KILL QUERY` does instead of blocking.
+    fiu_do_on(FailPoints::delta_lake_write_cancel_in_commit_window, {
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            query_context->killCurrentQuery();
+    });
 
     try
     {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakeSink.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakeSink.cpp
@@ -3,6 +3,7 @@
 
 #if USE_DELTA_KERNEL_RS
 #include <Common/logger_useful.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Interpreters/Context.h>
@@ -21,7 +22,7 @@ namespace Setting
 
 namespace FailPoints
 {
-    extern const char delta_lake_write_commit_pause[];
+    extern const char delta_lake_write_cancel_in_commit_window[];
 }
 
 DeltaLakeSink::DeltaLakeSink(
@@ -126,10 +127,13 @@ void DeltaLakeSink::onFinish()
         files.emplace_back(std::move(file_location), file_size, written_rows, Map{});
     }
 
-    /// Test-only hook: pause inside the commit window (after the data files are
-    /// finalized, before commit) so a test can inject an external cancel and
-    /// check that a late cancel does not delete committed files.
-    FailPointInjection::pauseFailPoint(FailPoints::delta_lake_write_commit_pause);
+    /// Test-only hook for the commit window: the data files are finalized and the commit below has
+    /// not run yet. `onFinish` runs inside `IProcessor::work()`, which must only use CPU and never
+    /// wait, so the hook cancels the query the same way `KILL QUERY` does instead of blocking.
+    fiu_do_on(FailPoints::delta_lake_write_cancel_in_commit_window, {
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            query_context->killCurrentQuery();
+    });
 
     try
     {

--- a/tests/integration/test_aggregating_in_order_transform_kill_query/test.py
+++ b/tests/integration/test_aggregating_in_order_transform_kill_query/test.py
@@ -1,5 +1,3 @@
-import concurrent.futures
-import threading
 import uuid
 
 import pytest
@@ -11,7 +9,7 @@ node1 = cluster.add_instance(
     "node1",
 )
 
-FAULT_NAME = "aggregating_in_order_transform_mid_loop_pause"
+FAULT_NAME = "aggregating_in_order_transform_cancel_mid_loop"
 
 # A `MergeTree` table sorted on the GROUP BY key is required: `buildInputOrderInfo` only
 # accepts `ReadFromMergeTree` / `ReadFromMerge` / `ReadFromObjectStorageStep`, so a `numbers`
@@ -37,43 +35,30 @@ def started_cluster():
         cluster.shutdown()
 
 
+def failpoint_enabled():
+    return node1.query(
+        f"SELECT enabled FROM system.fail_points WHERE name = '{FAULT_NAME}'"
+    ).strip()
+
+
 def test_kill_query_mid_loop(started_cluster):
     query_id = str(uuid.uuid4())
 
+    # The failpoint cancels the query in place, the same way `KILL QUERY` does, so the query runs
+    # on this thread and no `SYSTEM WAIT FAILPOINT ... PAUSE` parks a pipeline worker inside
+    # `IProcessor::work()`.
     node1.query(f"SYSTEM ENABLE FAILPOINT {FAULT_NAME}")
-
-    thread_error = [None]
-
-    def execute_query():
-        try:
-            _, error = node1.query_and_get_answer_with_error(QUERY, query_id=query_id)
-            assert "DB::Exception: Query was cancelled" in error
-        except Exception as e:
-            thread_error[0] = e
-
-    query_thread = threading.Thread(target=execute_query)
-    query_thread.start()
-
     try:
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        wait_future = pool.submit(
-            node1.query,
-            f"SYSTEM WAIT FAILPOINT {FAULT_NAME} PAUSE",
-        )
-        done, _ = concurrent.futures.wait([wait_future], timeout=60)
-        if not done:
-            pool.shutdown(wait=False, cancel_futures=True)
-            assert False, f"Failpoint {FAULT_NAME} not triggered within 60 s"
-        pool.shutdown(wait=False)
-        wait_future.result()
+        assert failpoint_enabled() == "1"
 
-        node1.http_query(f"KILL QUERY WHERE query_id='{query_id}'")
+        _, error = node1.query_and_get_answer_with_error(QUERY, query_id=query_id)
+        assert "DB::Exception: Query was cancelled" in error
+
+        # `enabled` went 1 -> 0 with no DISABLE in between, which only a fire can do; `0` on its
+        # own is also what an un-armed failpoint reads.
+        assert failpoint_enabled() == "0"
     finally:
         node1.query(f"SYSTEM DISABLE FAILPOINT {FAULT_NAME}")
-
-    query_thread.join()
-    if thread_error[0] is not None:
-        raise thread_error[0]
 
     result = node1.query(
         f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"

--- a/tests/integration/test_mysql_protocol/test_kill_query.py
+++ b/tests/integration/test_mysql_protocol/test_kill_query.py
@@ -1,6 +1,3 @@
-import concurrent.futures
-import threading
-
 import pymysql
 import pytest
 
@@ -8,12 +5,12 @@ from helpers.cluster import ClickHouseCluster
 
 MYSQL_PORT = 9001
 
-FAULT_NAME = "mysql_output_format_mid_loop_pause"
+FAULT_NAME = "mysql_output_format_cancel_mid_loop"
 
 ROW_COUNT = 10
 
-# The row index `MySQLOutputFormat::consume` parks on when the failpoint is enabled.
-PAUSE_AT_ROW = 5
+# The row index `MySQLOutputFormat::consume` cancels the query on when the failpoint is enabled.
+CANCEL_AT_ROW = 5
 
 # `max_block_size` equal to the row count clamps `numbers` to one stream, so the whole result
 # arrives as one chunk and only the per-row cancellation check can leave the row loop early.
@@ -38,92 +35,78 @@ def started_cluster():
         cluster.shutdown()
 
 
+def failpoint_enabled():
+    return node.query(
+        f"SELECT enabled FROM system.fail_points WHERE name = '{FAULT_NAME}'",
+        user="default",
+        password="123",
+    ).strip()
+
+
 def test_kill_query_during_output(started_cluster):
-    """A query killed while its rows are being written to the MySQL wire must stop writing
+    """A query cancelled while its rows are being written to the MySQL wire must stop writing
     them and fail with `QUERY_WAS_CANCELLED`. Reporting the cancellation is not enough: the
     rest of the result set must not reach the client first."""
 
-    thread_error = [None]
     client_error = [None]
     rows_seen = [0]
 
-    def execute_query():
-        try:
-            conn = pymysql.connections.Connection(
-                host=started_cluster.get_instance_ip("node"),
-                port=MYSQL_PORT,
-                user="default",
-                password="123",
-                database="default",
-            )
-            try:
-                # An unbuffered cursor, so the rows that reached the client can be counted
-                # instead of being discarded when the error arrives.
-                with conn.cursor(pymysql.cursors.SSCursor) as cur:
-                    cur.execute(SELECT_FROM_NUMBERS)
-                    for _ in cur:
-                        rows_seen[0] += 1
-                raise AssertionError("the killed query returned a complete result set")
-            # Only a driver error is an expected outcome, so the assertion above stays a
-            # failure instead of being recorded as the error the test looks for.
-            except pymysql.err.Error as e:
-                client_error[0] = repr(e)
-            finally:
-                conn.close()
-        except Exception as e:
-            thread_error[0] = e
-
+    # The failpoint cancels the query in place, the same way `KILL QUERY` does, so the query runs
+    # on this thread and no `SYSTEM WAIT FAILPOINT ... PAUSE` parks a pipeline worker inside
+    # `IProcessor::work()`.
     node.query(f"SYSTEM ENABLE FAILPOINT {FAULT_NAME}", user="default", password="123")
-
-    query_thread = threading.Thread(target=execute_query)
-    query_thread.start()
-
     try:
-        # `SYSTEM WAIT FAILPOINT ... PAUSE` blocks, so it needs its own thread to keep a
-        # failpoint that never fires a failure rather than a hang.
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        wait_future = pool.submit(
-            node.query,
-            f"SYSTEM WAIT FAILPOINT {FAULT_NAME} PAUSE",
+        assert failpoint_enabled() == "1"
+
+        conn = pymysql.connections.Connection(
+            host=started_cluster.get_instance_ip("node"),
+            port=MYSQL_PORT,
             user="default",
             password="123",
+            database="default",
         )
-        done, _ = concurrent.futures.wait([wait_future], timeout=60)
-        if not done:
-            pool.shutdown(wait=False, cancel_futures=True)
-            assert False, f"Failpoint {FAULT_NAME} not triggered within 60 s"
-        pool.shutdown(wait=False)
-        wait_future.result()
+        try:
+            # An unbuffered cursor, so the rows that reached the client can be counted
+            # instead of being discarded when the error arrives.
+            with conn.cursor(pymysql.cursors.SSCursor) as cur:
+                cur.execute(SELECT_FROM_NUMBERS)
+                for _ in cur:
+                    rows_seen[0] += 1
+            raise AssertionError("the cancelled query returned a complete result set")
+        # Only a driver error is an expected outcome, so the assertion above stays a
+        # failure instead of being recorded as the error the test looks for.
+        except pymysql.err.Error as e:
+            client_error[0] = repr(e)
+        finally:
+            conn.close()
 
-        # The output loop is parked, so the query is registered and its server-assigned id is
-        # unambiguous. The MySQL protocol gives the client no way to supply one.
-        query_id = node.query(
-            "SELECT query_id FROM system.processes WHERE query LIKE 'SELECT toString(number)%'",
-            user="default",
-            password="123",
-        ).strip()
-        assert query_id, "the paused query is not in system.processes"
-
-        # `SYNC` would wait for a query that cannot finish until the failpoint is released.
-        node.query(
-            f"KILL QUERY WHERE query_id='{query_id}'", user="default", password="123"
-        )
+        # `enabled` went 1 -> 0 with no DISABLE in between, which only a fire can do; `0` on its
+        # own is also what an un-armed failpoint reads.
+        assert failpoint_enabled() == "0"
     finally:
         node.query(
             f"SYSTEM DISABLE FAILPOINT {FAULT_NAME}", user="default", password="123"
         )
 
-    query_thread.join()
-    if thread_error[0] is not None:
-        raise thread_error[0]
-
     assert client_error[0] is not None, "the client did not observe an error"
     assert "Query was cancelled" in client_error[0], client_error[0]
 
-    # Rows up to and including the parked one are already on their way and the next per-row
-    # check ends the loop, so the count is exact. Without that check the whole chunk is
+    # Rows up to and including the one the cancel fired on are already on their way and the next
+    # per-row check ends the loop, so the count is exact. Without that check the whole chunk is
     # written and the client receives all ROW_COUNT rows before the same cancellation error.
-    assert rows_seen[0] == PAUSE_AT_ROW + 1, rows_seen[0]
+    assert rows_seen[0] == CANCEL_AT_ROW + 1, rows_seen[0]
+
+    # The MySQL protocol gives the client no way to supply a query id, and the query is gone from
+    # `system.processes` by now, so recover the server-assigned one from the log.
+    node.query("SYSTEM FLUSH LOGS query_log", user="default", password="123")
+    query_id = node.query(
+        """SELECT query_id FROM system.query_log
+           WHERE query LIKE 'SELECT toString(number)%' AND type = 'ExceptionWhileProcessing'
+           ORDER BY event_time_microseconds DESC LIMIT 1""",
+        user="default",
+        password="123",
+    ).strip()
+    assert query_id, "the cancelled query is not in system.query_log"
 
     result = node.query(
         f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'",
@@ -134,8 +117,8 @@ def test_kill_query_during_output(started_cluster):
 
     cancel_log = node.grep_in_log(query_id)
     assert "QUERY_WAS_CANCELLED" in cancel_log
-    # A second line would mean the failpoint parked in a later chunk, so the first one held
-    # at most PAUSE_AT_ROW rows and the bound above would be measuring the chunk size rather
+    # A second line would mean the failpoint fired in a later chunk, so the first one held
+    # at most CANCEL_AT_ROW rows and the bound above would be measuring the chunk size rather
     # than the cancellation.
     chunks = cancel_log.count("Consume a chunk")
     assert chunks == 1, f"expected a single chunk, got {chunks}"

--- a/tests/integration/test_postgresql_protocol/test_kill_query.py
+++ b/tests/integration/test_postgresql_protocol/test_kill_query.py
@@ -1,6 +1,3 @@
-import concurrent.futures
-import threading
-
 import psycopg2
 import pytest
 
@@ -8,12 +5,12 @@ from helpers.cluster import ClickHouseCluster
 
 server_port = 5433
 
-FAULT_NAME = "postgresql_output_format_mid_loop_pause"
+FAULT_NAME = "postgresql_output_format_cancel_mid_loop"
 
 ROW_COUNT = 10
 
-# The row index `PostgreSQLOutputFormat::consume` parks on when the failpoint is enabled.
-PAUSE_AT_ROW = 5
+# The row index `PostgreSQLOutputFormat::consume` cancels the query on when the failpoint is enabled.
+CANCEL_AT_ROW = 5
 
 # `max_block_size` equal to the row count clamps `numbers` to one stream, so the whole result
 # arrives as one chunk and only the per-row cancellation check can leave the row loop early.
@@ -38,86 +35,72 @@ def started_cluster():
         cluster.shutdown()
 
 
+def failpoint_enabled():
+    return node.query(
+        f"SELECT enabled FROM system.fail_points WHERE name = '{FAULT_NAME}'",
+        user="default",
+        password="123",
+    ).strip()
+
+
 def test_kill_query_during_output(started_cluster):
-    """A query killed while its rows are being written to the PostgreSQL wire must stop
+    """A query cancelled while its rows are being written to the PostgreSQL wire must stop
     writing them and fail with `QUERY_WAS_CANCELLED`. Reporting the cancellation is not
     enough: the rest of the result set must not reach the client first."""
 
-    thread_error = [None]
     client_error = [None]
 
-    def execute_query():
-        try:
-            conn = psycopg2.connect(
-                host=started_cluster.get_instance_ip("node"),
-                port=server_port,
-                user="default",
-                password="123",
-                dbname="default",
-            )
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(SELECT_FROM_NUMBERS)
-                    for _ in cur:
-                        pass
-                raise AssertionError("the killed query returned a complete result set")
-            # Only a driver error is an expected outcome, so the assertion above stays a
-            # failure instead of being recorded as the error the test looks for.
-            except psycopg2.Error as e:
-                client_error[0] = repr(e)
-            finally:
-                conn.close()
-        except Exception as e:
-            thread_error[0] = e
-
+    # The failpoint cancels the query in place, the same way `KILL QUERY` does, so the query runs
+    # on this thread and no `SYSTEM WAIT FAILPOINT ... PAUSE` parks a pipeline worker inside
+    # `IProcessor::work()`.
     node.query(f"SYSTEM ENABLE FAILPOINT {FAULT_NAME}", user="default", password="123")
-
-    query_thread = threading.Thread(target=execute_query)
-    query_thread.start()
-
     try:
-        # `SYSTEM WAIT FAILPOINT ... PAUSE` blocks, so it needs its own thread to keep a
-        # failpoint that never fires a failure rather than a hang.
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        wait_future = pool.submit(
-            node.query,
-            f"SYSTEM WAIT FAILPOINT {FAULT_NAME} PAUSE",
+        assert failpoint_enabled() == "1"
+
+        conn = psycopg2.connect(
+            host=started_cluster.get_instance_ip("node"),
+            port=server_port,
             user="default",
             password="123",
+            dbname="default",
         )
-        done, _ = concurrent.futures.wait([wait_future], timeout=60)
-        if not done:
-            pool.shutdown(wait=False, cancel_futures=True)
-            assert False, f"Failpoint {FAULT_NAME} not triggered within 60 s"
-        pool.shutdown(wait=False)
-        wait_future.result()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(SELECT_FROM_NUMBERS)
+                for _ in cur:
+                    pass
+            raise AssertionError("the cancelled query returned a complete result set")
+        # Only a driver error is an expected outcome, so the assertion above stays a
+        # failure instead of being recorded as the error the test looks for.
+        except psycopg2.Error as e:
+            client_error[0] = repr(e)
+        finally:
+            conn.close()
 
-        # The output loop is parked, so the query is registered and its server-assigned id is
-        # unambiguous. The PostgreSQL protocol gives the client no way to supply one.
-        query_id = node.query(
-            "SELECT query_id FROM system.processes WHERE query LIKE 'SELECT toString(number)%'",
-            user="default",
-            password="123",
-        ).strip()
-        assert query_id, "the paused query is not in system.processes"
-
-        # `SYNC` would wait for a query that cannot finish until the failpoint is released.
-        node.query(
-            f"KILL QUERY WHERE query_id='{query_id}'", user="default", password="123"
-        )
+        # `enabled` went 1 -> 0 with no DISABLE in between, which only a fire can do; `0` on its
+        # own is also what an un-armed failpoint reads.
+        assert failpoint_enabled() == "0"
     finally:
         node.query(
             f"SYSTEM DISABLE FAILPOINT {FAULT_NAME}", user="default", password="123"
         )
 
-    query_thread.join()
-    if thread_error[0] is not None:
-        raise thread_error[0]
-
     # The handler sends an `ErrorResponse` and then tears the connection down without a
     # following `ReadyForQuery`, so `psycopg2` reports the connection loss rather than the
     # server's message. The message is therefore not asserted; the bytes below are.
     assert client_error[0] is not None, "the client did not observe an error"
+
+    node.query("SYSTEM FLUSH LOGS", user="default", password="123")
+    # The PostgreSQL protocol gives the client no way to supply a query id, and the query is gone
+    # from `system.processes` by now, so recover the server-assigned one from the log.
+    query_id = node.query(
+        """SELECT query_id FROM system.query_log
+           WHERE query LIKE 'SELECT toString(number)%' AND type = 'ExceptionWhileProcessing'
+           ORDER BY event_time_microseconds DESC LIMIT 1""",
+        user="default",
+        password="123",
+    ).strip()
+    assert query_id, "the cancelled query is not in system.query_log"
 
     result = node.query(
         f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'",
@@ -126,10 +109,9 @@ def test_kill_query_during_output(started_cluster):
     )
     assert int(result.strip()) == 0
 
-    node.query("SYSTEM FLUSH LOGS", user="default", password="123")
     # Counts only bytes flushed while the query context was attached; the rows the loop
     # buffered reach the wire later, once the `QueryScope` has unwound. One row beyond the
-    # parked one overflows the 1 MiB socket buffer, so 0 bounds the loop at PAUSE_AT_ROW + 1.
+    # cancelled one overflows the 1 MiB socket buffer, so 0 bounds the loop at CANCEL_AT_ROW + 1.
     sent_bytes = node.query(
         "SELECT ProfileEvents['NetworkSendBytes'] FROM system.query_log "
         f"WHERE query_id='{query_id}' AND type = 'ExceptionWhileProcessing'",
@@ -140,8 +122,8 @@ def test_kill_query_during_output(started_cluster):
 
     cancel_log = node.grep_in_log(query_id)
     assert "QUERY_WAS_CANCELLED" in cancel_log
-    # A second line would mean the failpoint parked in a later chunk, so the first one held
-    # at most PAUSE_AT_ROW rows and the byte count above would be measuring the chunk size
+    # A second line would mean the failpoint fired in a later chunk, so the first one held
+    # at most CANCEL_AT_ROW rows and the byte count above would be measuring the chunk size
     # rather than the cancellation.
     chunks = cancel_log.count("Consume a chunk")
     assert chunks == 1, f"expected a single chunk, got {chunks}"

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4492,13 +4492,13 @@ def test_write_cancel_during_commit_keeps_data(started_cluster, partitioned):
     # ~DeltaLakePartitionedSink would see isCancelled() and cancelBuffers() would
     # unlink the just-committed files, leaving the Delta log pointing at missing
     # data (silent data loss). The fix clears the tracked sinks after a successful
-    # commit, so a late cancel has nothing to remove. This test pauses the
-    # committing thread inside the commit window via the delta_lake_write_commit_pause
-    # failpoint, KILLs the query while paused, lets the commit finish, then checks
-    # the committed rows survive. The two other write-failure tests cancel while
-    # consume() is still running, so they never reach the commit window.
+    # commit, so a late cancel has nothing to remove. This test uses the
+    # delta_lake_write_cancel_in_commit_window failpoint, which cancels the query in
+    # place inside the commit window exactly as KILL QUERY does, so nothing parks a
+    # pipeline worker inside IProcessor::work(). The two other write-failure tests
+    # cancel while consume() is still running, so they never reach the commit window.
     instance = started_cluster.instances["node1"]
-    failpoint = "delta_lake_write_commit_pause"
+    failpoint = "delta_lake_write_cancel_in_commit_window"
     table_name = randomize_table_name("test_write_commit_race")
     result_file = f"/var/lib/clickhouse/user_files/{table_name}_data"
 
@@ -4518,58 +4518,33 @@ def test_write_cancel_during_commit_keeps_data(started_cluster, partitioned):
         f"SETTINGS output_format_parquet_compression_method = 'none'"
     )
 
-    query_id = str(uuid.uuid4())
+    def failpoint_enabled():
+        return instance.query(
+            f"SELECT enabled FROM system.fail_points WHERE name = '{failpoint}'"
+        ).strip()
 
-    # PAUSEABLE_ONCE failpoint blocks the committing thread inside onFinish(),
-    # after the data files are finalized and before delta commit.
+    # ONCE failpoint: cancels the query inside onFinish(), after the data files are
+    # finalized and before the delta commit.
     instance.query(f"SYSTEM ENABLE FAILPOINT {failpoint}")
-
-    # An assertion raised inside a thread does not fail the test (pytest only turns
-    # it into a PytestUnhandledThreadExceptionWarning), so hand the worker's
-    # exception back to the main thread and re-raise it there. Without this the test
-    # could pass its row/file checks while the cancellation silently never happened.
-    insert_error = []
-
-    def run_insert():
-        # A valid INSERT (no throwIf): reaches onFinish and pauses in the commit
-        # window. max_block_size = 1 opens an inner sink per partition.
-        try:
-            _, error = instance.query_and_get_answer_with_error(
-                f"INSERT INTO {table_name} "
-                f"SELECT number::Int32, (number % 2)::Int32 "
-                f"FROM numbers(6) SETTINGS max_block_size = 1",
-                query_id=query_id,
-            )
-            # The KILL lands while paused, so the client sees QUERY_WAS_CANCELLED even
-            # though the commit itself completes.
-            assert "QUERY_WAS_CANCELLED" in error, f"unexpected insert error: {error}"
-        except BaseException as e:  # noqa: BLE001
-            insert_error.append(e)
-
-    insert_thread = threading.Thread(target=run_insert)
-    insert_thread.start()
     try:
-        # Wait until the committing thread has paused in the commit window. Bounded,
-        # so a failpoint that is never reached fails the test instead of hanging
-        # until the pytest session timeout.
-        instance.query(f"SYSTEM WAIT FAILPOINT {failpoint} PAUSE", timeout=60)
+        assert failpoint_enabled() == "1"
 
-        # KILL while paused: flips isCancelled() on the sink asynchronously. ASYNC
-        # (not SYNC) because the query is blocked at the failpoint, so a SYNC kill
-        # would deadlock with the notify below.
-        instance.query(f"KILL QUERY WHERE query_id='{query_id}' ASYNC")
-        # Give the executor cancel-watch thread time to propagate the cancel.
-        time.sleep(1)
-        # Let the commit proceed now that isCancelled() is (racily) set.
-        instance.query(f"SYSTEM NOTIFY FAILPOINT {failpoint}")
+        # A valid INSERT (no throwIf): reaches onFinish and cancels itself in the
+        # commit window. max_block_size = 1 opens an inner sink per partition.
+        _, error = instance.query_and_get_answer_with_error(
+            f"INSERT INTO {table_name} "
+            f"SELECT number::Int32, (number % 2)::Int32 "
+            f"FROM numbers(6) SETTINGS max_block_size = 1"
+        )
+        # The cancel lands in the commit window, so the client sees QUERY_WAS_CANCELLED
+        # even though the commit itself completes.
+        assert "QUERY_WAS_CANCELLED" in error, f"unexpected insert error: {error}"
+
+        # `enabled` went 1 -> 0 with no DISABLE in between, which only a fire can do;
+        # `0` on its own is also what an un-armed failpoint reads.
+        assert failpoint_enabled() == "0"
     finally:
         instance.query(f"SYSTEM DISABLE FAILPOINT {failpoint}")
-        insert_thread.join()
-
-    # Surface a worker-thread failure (e.g. the INSERT was never cancelled, which
-    # would make the checks below vacuous).
-    if insert_error:
-        raise insert_error[0]
 
     # Server stays alive after the cancelled-during-commit write.
     assert "1" == instance.query("SELECT 1").strip()

--- a/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.reference
+++ b/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.reference
@@ -1,1 +1,3 @@
+armed 1
+parked 0
 <1: cancel during refresh records an exception>	1	1	1

--- a/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.reference
+++ b/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.reference
@@ -1,3 +1,4 @@
 armed 1
 parked 0
+read_rows_at_park 0
 <1: cancel during refresh records an exception>	1	1	1

--- a/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.sh
+++ b/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.sh
@@ -69,6 +69,11 @@ echo "parked $(enabled)"
 # The WAIT is keyed on the failpoint name, not on this view, so confirm OUR refresh is the parked one.
 wait_status c Running
 
+# The park is before `executor.execute()`, so the refresh cannot have read anything yet.
+# `execution.progress` is reset at the top of `executeRefreshUnlocked`, and the refresh thread is
+# parked, so this is stable: a park moved to after `execute()` would read 1 for this one-row source.
+echo "read_rows_at_park $($CLICKHOUSE_CLIENT -q "select read_rows from refreshes where view = 'c' -- $LINENO" | xargs)"
+
 # The refresh is parked, so the cancel cannot be outrun; disabling the failpoint resumes it.
 $CLICKHOUSE_CLIENT -q "
     system cancel view c;

--- a/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.sh
+++ b/tests/queries/0_stateless/04162_system_cancel_view_during_refresh.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # Tags: atomic-database, memory-engine, no-parallel
 
-# Uses `SYSTEM ENABLE FAILPOINT infinite_sleep`, which is server-global and would park every
-# other sleeping query on the server, so it cannot run concurrently with other tests.
+# Uses `SYSTEM ENABLE FAILPOINT refresh_mv_pause_after_executor_published`, which is server-global
+# and would park every other refresh on the server, so it cannot run concurrently with other tests.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
+
+FP="refresh_mv_pause_after_executor_published"
 
 # Set session timezone to UTC to make all DateTime formatting and parsing use UTC, because refresh
 # scheduling is done in UTC.
@@ -25,14 +27,10 @@ wait_status() {
     done
 }
 
-# Helper: wait until the refresh is running AND has read at least one row, so that a cancellation
-# issued right after has a concrete pipeline to interrupt (see 04105_system_pause_view).
-wait_running_with_progress() {
-    local view_name=$1
-    while [ "`$CLICKHOUSE_CLIENT -q "select status = 'Running' and read_rows > 0 from refreshes where view = '$view_name' -- $LINENO" | xargs`" != '1' ]
-    do
-        sleep 0.1
-    done
+# `enabled` is read while the refresh is parked, before the DISABLE that resumes it, so 1 then 0 can
+# only happen through a fire; `enabled = 0` alone would also be what an un-armed failpoint reads.
+enabled() {
+    $CLICKHOUSE_CLIENT -q "select enabled from system.fail_points where name = '$FP' settings max_rows_to_read = 0"
 }
 
 # ---------------------------------------------------------------------------
@@ -40,34 +38,41 @@ wait_running_with_progress() {
 # ---------------------------------------------------------------------------
 
 # The disable below is the resume mechanism and only runs on the happy path; this trap covers an
-# early exit, which would otherwise leave the failpoint parking every later sleep in the run.
+# early exit, which would otherwise leave the failpoint parking every later refresh in the run.
 trap '
-    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT infinite_sleep" 2>/dev/null || true
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT '"$FP"'" 2>/dev/null || true
 ' EXIT
 
-# The cancel must reach a live `PipelineExecutor`, so park the refresh at `infinite_sleep`, which
-# `sleepEachRow` hits inside `executor.execute()`.
+# The cancel must reach a live `PipelineExecutor`, so park the refresh thread right after it
+# published the executor and released `executor_mutex`, which is where `interruptExecution` can
+# take that mutex and cancel it. Parking there instead of inside the pipeline keeps the wait off
+# every `IProcessor::work()` frame: no worker has started yet.
 $CLICKHOUSE_CLIENT -q "
     create table src (x Int64) engine Memory;
     insert into src select * from numbers(1);
     create materialized view c refresh every 1 year settings refresh_retries = 0 (x Int64) engine Memory empty as
-        select x + sleepEachRow(0) as x from src settings max_block_size = 1, max_threads = 1;
-    system enable failpoint infinite_sleep;
-    system refresh view c;"
+        select x from src;
+    system enable failpoint $FP;"
 
-if ! timeout 60 $CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT infinite_sleep PAUSE"
+echo "armed $(enabled)"
+
+$CLICKHOUSE_CLIENT -q "system refresh view c;"
+
+if ! timeout 60 $CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT $FP PAUSE"
 then
-    echo "FAIL: refresh did not reach the infinite_sleep failpoint"
+    echo "FAIL: refresh did not reach the $FP failpoint"
     exit 1
 fi
 
+echo "parked $(enabled)"
+
 # The WAIT is keyed on the failpoint name, not on this view, so confirm OUR refresh is the parked one.
-wait_running_with_progress c
+wait_status c Running
 
 # The refresh is parked, so the cancel cannot be outrun; disabling the failpoint resumes it.
 $CLICKHOUSE_CLIENT -q "
     system cancel view c;
-    system disable failpoint infinite_sleep;"
+    system disable failpoint $FP;"
 
 wait_status c Scheduled
 

--- a/tests/queries/0_stateless/04512_distributed_limit_no_more_packets_race.reference
+++ b/tests/queries/0_stateless/04512_distributed_limit_no_more_packets_race.reference
@@ -1,1 +1,5 @@
+armed_0 1
+consumed_0 0
+armed_1 1
+consumed_1 0
 ok

--- a/tests/queries/0_stateless/04512_distributed_limit_no_more_packets_race.sh
+++ b/tests/queries/0_stateless/04512_distributed_limit_no_more_packets_race.sh
@@ -1,39 +1,40 @@
 #!/usr/bin/env bash
 # Tags: no-parallel, shard
-# Tag no-parallel: uses global PAUSEABLE failpoints, which concurrent instances would share.
+# Tag no-parallel: uses a global failpoint, which concurrent instances would share - one query
+#   would consume another's arming, and the injected cancel would land in an unrelated query.
 # Tag shard: uses a two-shards Distributed table.
 
 # Regression test for a race in the synchronous distributed-read path: `RemoteQueryExecutor::read`
-# checks `was_cancelled`, releases the mutex, then calls `receivePacket`, while a LIMIT closing the
-# output port makes another thread cancel and drain the same connections. The reader then used to
-# throw LOGICAL_ERROR "No more packets are available.".
+# checks `was_cancelled`, releases the mutex, then calls `receivePacket`, while another pipeline
+# thread's `onUpdatePorts` -> `finish` cancels and drains the same connections. The reader then used
+# to throw LOGICAL_ERROR "No more packets are available.".
 #
-# Two failpoints replace timing: fp1 parks the reader in that window, fp2 parks the same executor's
-# `finish` once it has cancelled and drained, so the reader is only released after the cancel the
-# fix depends on. The query runs under both `use_hedged_requests` values because the fix touches
+# The defect is a state, not an interleaving: the reader only has to reach `receivePacket` with the
+# connections cancelled and drained. So the failpoint runs that same `finish()` inline, on the
+# reading thread, instead of parking it there and cancelling from outside - a park inside
+# `IProcessor::work()` would break the contract in `src/Processors/IProcessor.h`.
+#
+# The query runs under both `use_hedged_requests` values because the fix touches both
 # `HedgedConnections` and `MultiplexedConnections`; `async_socket_for_remote=0` picks the sync path.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-FP_RECV="remote_query_executor_receive_packet_pause"
-FP_DRAIN="remote_query_executor_finish_drain_pause"
+FP="remote_query_executor_cancel_and_drain_in_receive_window"
 
 function cleanup()
 {
-    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP_RECV" 2>/dev/null ||:
-    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP_DRAIN" 2>/dev/null ||:
-    wait 2>/dev/null ||:
-    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.src" 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP" 2>/dev/null ||:
     $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.dist" 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.src" 2>/dev/null ||:
 }
 trap cleanup EXIT
 
 $CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.src;
     CREATE TABLE ${CLICKHOUSE_DATABASE}.src (x UInt64) ENGINE = MergeTree ORDER BY x;
-    INSERT INTO ${CLICKHOUSE_DATABASE}.src SELECT number FROM numbers(100000);
+    INSERT INTO ${CLICKHOUSE_DATABASE}.src SELECT number FROM numbers(1000);
     DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.dist;
     CREATE TABLE ${CLICKHOUSE_DATABASE}.dist AS ${CLICKHOUSE_DATABASE}.src
         ENGINE = Distributed(test_cluster_two_shards, ${CLICKHOUSE_DATABASE}, src);
@@ -42,71 +43,43 @@ $CLICKHOUSE_CLIENT --query "
 failed=0
 err="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}.err"
 
-# Fail loudly if a failpoint is not available: a run that proceeds un-armed proves nothing.
-function arm()
+# `enabled` is read before and after the query with no DISABLE in between, so 1 then 0 can only
+# happen through a fire - the ONCE failpoint disarms itself. `enabled = 0` alone would be vacuous
+# because an un-armed failpoint reads 0 too. Reading `system.fail_points` does not consume a
+# failpoint (03916 regression-tests that); `max_rows_to_read = 0` guards against randomisation.
+function enabled()
 {
-    if ! $CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT $1" 2>"$err"; then
-        echo "cannot arm failpoint $1:"
-        cat "$err"
-        failed=1
-        return 1
-    fi
+    $CLICKHOUSE_CLIENT --query "
+        SELECT enabled FROM system.fail_points WHERE name = '$FP' SETTINGS max_rows_to_read = 0"
 }
 
 for use_hedged_requests in 0 1; do
-    arm "$FP_RECV" || break
-    arm "$FP_DRAIN" || break
+    # Fail loudly if the failpoint is not available: a run that proceeds un-armed proves nothing.
+    if ! $CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT $FP" 2>"$err"; then
+        echo "cannot arm failpoint $FP:"
+        cat "$err"
+        failed=1
+        break
+    fi
+    echo "armed_$use_hedged_requests $(enabled)"
 
-    query_id="${CLICKHOUSE_TEST_UNIQUE_NAME}_${use_hedged_requests}"
-    # LIMIT 1 without ORDER BY: the sibling shard delivers a row and closes the output port,
-    # triggering `finish` to drain the parked source's executor.
-    # Parallel replicas force `use_hedged_requests` off, which would run both iterations
-    # against MultiplexedConnections and leave the HedgedConnections branch untested.
-    $CLICKHOUSE_CLIENT \
-        --query_id "$query_id" \
+    # No LIMIT: with the cancel injected in place, a LIMIT could satisfy itself and cancel both
+    # executors before either reader entered the loop, so the failpoint would not fire at all.
+    # Parallel replicas force `use_hedged_requests` off, which would leave HedgedConnections
+    # untested; `prefer_localhost_replica=0` makes both shards go through RemoteQueryExecutor.
+    if ! $CLICKHOUSE_CLIENT \
         --use_hedged_requests="$use_hedged_requests" --enable_parallel_replicas=0 \
-        --async_socket_for_remote=0 --max_block_size=1 --prefer_localhost_replica=0 \
-        --query "SELECT x FROM ${CLICKHOUSE_DATABASE}.dist LIMIT 1 FORMAT Null" 2>"$err" &
-    QPID=$!
-
-    # A failed wait would leave the interleaving unsynchronized, and the plain LIMIT query could
-    # then succeed and log the cancellation, so check both.
-    sync_ok=1
-    for fp in "$FP_RECV" "$FP_DRAIN"; do
-        if ! $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT $fp PAUSE" 2>"$err"; then
-            echo "wait for failpoint $fp failed:"
-            cat "$err"
-            failed=1
-            sync_ok=0
-        fi
-    done
-
-    # Release the reader onto the drained, cancelled connections, then release `finish`.
-    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP_RECV"
-    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP_DRAIN"
-
-    # The query must succeed: without the fix a debug build aborts the server, while a release
-    # build returns the LOGICAL_ERROR to the client, which the exit status below turns into a
-    # failure independently of the output diff (a bare "if ! wait" is not itself an assertion).
-    if ! wait "$QPID"; then
+        --async_socket_for_remote=0 --prefer_localhost_replica=0 \
+        --query "SELECT x FROM ${CLICKHOUSE_DATABASE}.dist FORMAT Null" 2>"$err"
+    then
+        # Without the fix a debug build aborts the server on the LOGICAL_ERROR and a release build
+        # returns it to the client, so this covers both.
         echo "query under use_hedged_requests=$use_hedged_requests failed:"
         cat "$err"
         failed=1
     fi
 
-    # Positive control: prove the cancel path this test exists for actually ran, so the query
-    # cannot pass by never reaching it. Only meaningful when the synchronization above held.
-    [ "$sync_ok" -eq 1 ] || continue
-    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS text_log"
-    cancelled=$($CLICKHOUSE_CLIENT --query "
-        SELECT count() > 0 FROM system.text_log
-        WHERE query_id = '$query_id' AND event_date >= yesterday()
-          AND message LIKE '%Cancelling query because enough data has been read%'
-        SETTINGS max_rows_to_read = 0")
-    if [ "$cancelled" != "1" ]; then
-        echo "cancellation was not logged for use_hedged_requests=$use_hedged_requests"
-        failed=1
-    fi
+    echo "consumed_$use_hedged_requests $(enabled)"
 done
 
 rm -f "$err"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110334
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to the review request on https://github.com/ClickHouse/ClickHouse/pull/110334#discussion_r3963228345.

Seven `PAUSEABLE` failpoints sat at sites reachable from `IProcessor::work()`, so
`SYSTEM WAIT FAILPOINT ... PAUSE` blocked a `PipelineExecutor` worker on an unbounded condvar until
the test cancelled from outside and released it. `src/Processors/IProcessor.h` states that synchronous
`work()` must only use CPU, no sleep, IO wait or network wait, and a parked `work()` holds a
thread-pool slot for as long as the test takes to act.

Each rendezvous is replaced by injecting, on the same thread, the exact action the external actor
performed, so nothing waits inside `work()`:

* `04512_distributed_limit_no_more_packets_race`: the defect is a state, not an interleaving, so one
  non-blocking `ONCE` failpoint runs `finish()` inline in `RemoteQueryExecutor::read()` (what
  `RemoteSource::onUpdatePorts()` calls). Deletes both `PAUSEABLE_ONCE` failpoints, the second pause
  site and the `in_receive_packet_window` member.
* Four `KILL QUERY` tests (`AggregatingInOrderTransform`, the MySQL and PostgreSQL output formats,
  both DeltaLake sinks): the failpoint calls `Context::killCurrentQuery()`, which is what
  `KILL QUERY` itself reaches, at the same point.
* `04162_system_cancel_view_during_refresh`: its `infinite_sleep` rendezvous is a duration, not an
  action, so it moves off the pipeline. A new `refresh_mv_pause_after_executor_published` parks the
  refresh (`BackgroundSchedulePool`) thread after the executor is published and `executor_mutex`
  released, but before it starts, which is where `interruptExecution` can cancel it. The two existing
  `refresh_mv_pause_*` failpoints could not be reused: both sit after `executor.execute()` returned,
  where `execution.executor` is already cleared.

Every test keeps its existing oracles and gains a bracketed `system.fail_points` `enabled` 1 -> 0
check, so a run in which the failpoint never fired fails instead of passing. Net: 6 `PAUSEABLE_ONCE`
registrations removed, 5 `ONCE` and 1 `PAUSEABLE_ONCE` added; tests lose ~200 lines of pause protocol.

<details><summary>Audit of the tests I committed since 2026-05-08 (the second half of the ask)</summary>

Criterion: tests of mine that **arm** a `PAUSE` failpoint, then whether the paused C++ site is
reachable from a `work()` / `tryGenerate()` / `onFinish()` / `onUpdatePorts()` frame.

105 pauseable failpoints registered; 74 armed by some test; 64 test files arm one; **15 of those
carry a commit of mine since 2026-05-08**; **9 failpoints in 8 of them have an in-`work()` site**.

| failpoint | test | disposition |
|---|---|---|
| `remote_query_executor_receive_packet_pause` | 04512 | fixed here (deleted) |
| `remote_query_executor_finish_drain_pause` | 04512 | fixed here (deleted) |
| `aggregating_in_order_transform_mid_loop_pause` | `test_aggregating_in_order_transform_kill_query` | fixed here |
| `mysql_output_format_mid_loop_pause` | `test_mysql_protocol/test_kill_query.py` | fixed here |
| `postgresql_output_format_mid_loop_pause` | `test_postgresql_protocol/test_kill_query.py` | fixed here |
| `delta_lake_write_commit_pause` | `test_storage_delta` (both sinks) | fixed here |
| `infinite_sleep` | 04162 | fixed here |
| `infinite_sleep` | `03100_lwu_57_lock_acquire_timeout` | follow-up PR |
| `rmt_pause_before_commit_local_part` | `04905_lwu_drop_race_table_lock` | follow-up PR |
| `replicated_merge_tree_insert_retry_pause` | `03916_system_fault_injection_points` | armed, never reached: no park occurs |

The two follow-up ones need a query-thread rendezvous on the lightweight-update lock path: two new
production failpoints plus a 582-line test, so a separate review. The relocation was found for both.
The remaining 6 of the 15 arm a `PAUSE` failpoint whose site I traced to a non-pipeline thread
(`runWritingJob` pool, `initializePipeline`, SchedulePool streaming tasks, the RefreshTask thread).

Coverage note, unchanged here: 04512 exercises only the synchronous read path
(`async_socket_for_remote=0`), as the merged test did.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119030&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119030](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119030+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
