### PR TITLE
Fix join-order conflict detector Code 717 on degenerate predicates and cross products

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/conflictDetector.cpp
+++ b/src/Processors/QueryPlan/Optimizations/conflictDetector.cpp
@@ -25,8 +25,8 @@ struct NormOp
     Category category = Category::Join;
     UInt32 left = 0;
     UInt32 right = 0;
-    /// Relations the ON predicate rejects nulls on (swap-invariant: it is a set of relation ids,
-    /// unaffected by the left/right normalisation). Used to resolve the footnoted matrix entries.
+    /// Relations the ON predicate rejects nulls on (swap-invariant: a set of relation ids, unaffected
+    /// by left/right normalisation). Resolves the conditional, null-rejection-dependent matrix entries.
     UInt32 nr_rels = 0;
     JoinKind kind = JoinKind::Inner;
     JoinStrictness strictness = JoinStrictness::All;
@@ -60,17 +60,18 @@ NormOp normalize(const ConflictOpMask & op)
     }
 }
 
-/// The property matrices of the paper (Tables 1-3), transcribed directly. Rows and columns are
-/// indexed by `Category` in the order {Join, LeftOuter, FullOuter, Semi, Anti}.
+/// The reorderability property matrices, indexed by `Category` in the order
+/// {Join, LeftOuter, FullOuter, Semi, Anti}.
 using PropRow = UInt8[NUM_CATEGORIES];
 
-/// Table 1: comm(op). Commutative operators (inner/cross and full outer).
+/// comm(op): is the operator commutative? Only inner/cross and full outer are.
 constexpr UInt8 COMM[NUM_CATEGORIES] =
 {
     /* Join */ 1, /* LeftOuter */ 0, /* FullOuter */ 1, /* Semi */ 0, /* Anti */ 0,
 };
 
-/// Table 2: assoc(op_a, op_b). Not symmetric -- op_a selects the row, op_b the column.
+/// assoc(op_a, op_b): does `(e1 op_a e2) op_b e3` equal `e1 op_a (e2 op_b e3)`? Not symmetric --
+/// op_a selects the row, op_b the column.
 constexpr PropRow ASSOC[NUM_CATEGORIES] =
 {
     /*                  Join LeftOuter FullOuter Semi Anti */
@@ -81,7 +82,7 @@ constexpr PropRow ASSOC[NUM_CATEGORIES] =
     /* Anti      */ {    0,      0,        0,      0,   0 },
 };
 
-/// Table 3, left component: l-asscom(op_a, op_b). Symmetric.
+/// l-asscom(op_a, op_b): does `(e1 op_a e2) op_b e3` equal `(e1 op_b e3) op_a e2`? Symmetric.
 constexpr PropRow L_ASSCOM[NUM_CATEGORIES] =
 {
     /*                  Join LeftOuter FullOuter Semi Anti */
@@ -92,7 +93,7 @@ constexpr PropRow L_ASSCOM[NUM_CATEGORIES] =
     /* Anti      */ {    1,      1,        0,      1,   1 },
 };
 
-/// Table 3, right component: r-asscom(op_a, op_b). Symmetric.
+/// r-asscom(op_a, op_b): does `e1 op_a (e2 op_b e3)` equal `e2 op_b (e1 op_a e3)`? Symmetric.
 constexpr PropRow R_ASSCOM[NUM_CATEGORIES] =
 {
     /*                  Join LeftOuter FullOuter Semi Anti */
@@ -113,16 +114,13 @@ bool isFreelyReorderable(Category c)
     return comm(c) && assoc(c, c) && lAsscom(c, c) && rAsscom(c, c);
 }
 
-/// Aware variants of assoc / l-asscom / r-asscom. When the base matrix entry is a
-/// conflict, the null-rejection-dependent (footnoted) entries of Tables 2-3 may still upgrade it to
-/// "holds". Each footnote asks whether one or both operators' predicates reject nulls on a specific
-/// operand of the transformation (`nr(op) & operand != 0`). The caller passes the exact operand
-/// mask because it depends on the nesting geometry (which operand is shared), which differs between
-/// the left-subtree and right-subtree traversals -- see the call sites for the mapping.
+/// Null-rejection-aware variants of assoc / l-asscom / r-asscom. When the plain matrix entry is a
+/// conflict, some entries still hold if one or both operators reject nulls on a specific shared
+/// operand. The caller passes that operand mask, since which operand is shared depends on the nesting.
 
-/// assoc(row, col) with `shared` = A(E2), the operand shared by the two operators in Eqv. 1.
-/// Footnoted cells (Table 2): (LeftOuter|FullOuter, LeftOuter) needs col's predicate null-rejecting
-/// on `shared`. (FullOuter, FullOuter) needs both operators' predicates null-rejecting on `shared`.
+/// assoc(row, col) with `shared` = the operand common to both operators. Conditional entries:
+/// (LeftOuter|FullOuter, LeftOuter) holds if col rejects nulls on `shared`; (FullOuter, FullOuter)
+/// holds if both do.
 bool assocHolds(const NormOp & row, const NormOp & col, UInt32 shared)
 {
     if (assoc(row.category, col.category))
@@ -136,10 +134,9 @@ bool assocHolds(const NormOp & row, const NormOp & col, UInt32 shared)
     return false;
 }
 
-/// l-asscom(row, col) for Eqv. 2, where `e1` is the shared operand (left of `row`) and `e3` is the
-/// operand `col` brings in. Footnoted cells (Table 3, left component): (LeftOuter, FullOuter) needs
-/// row's predicate null-rejecting on `e1`; (FullOuter, LeftOuter) needs col's predicate on `e3`;
-/// (FullOuter, FullOuter) needs both predicates on `e1`.
+/// l-asscom(row, col); `e1` is row's left (shared) operand, `e3` the operand col brings in.
+/// Conditional entries: (LeftOuter, FullOuter) needs row null-rejecting on `e1`; (FullOuter,
+/// LeftOuter) needs col on `e3`; (FullOuter, FullOuter) needs both on `e1`.
 bool lAsscomHolds(const NormOp & row, const NormOp & col, UInt32 e1, UInt32 e3)
 {
     if (lAsscom(row.category, col.category))
@@ -153,9 +150,8 @@ bool lAsscomHolds(const NormOp & row, const NormOp & col, UInt32 e1, UInt32 e3)
     return false;
 }
 
-/// r-asscom(row, col) for Eqv. 3, where `e3` is the shared operand (right of `col`). The only
-/// footnoted cell (Table 3, right component) is (FullOuter, FullOuter): both predicates must reject
-/// nulls on `e3`.
+/// r-asscom(row, col); `e3` is col's right (shared) operand. The only conditional entry,
+/// (FullOuter, FullOuter), needs both predicates null-rejecting on `e3`.
 bool rAsscomHolds(const NormOp & row, const NormOp & col, UInt32 e3)
 {
     if (rAsscom(row.category, col.category))
@@ -183,13 +179,10 @@ computeConflictOperators(const std::vector<ConflictOpMask> & ops, ConflictDetect
 
     /// For each operator b we walk every operator a in b's subtrees and consult the reorderability
     /// matrices. CD-A and CD-C differ only in how a detected conflict is recorded:
-    ///   - CD-A (Section 5.2): widen b's TES by the offending relations (an unconditioned
-    ///     containment) -- coarse but simple.
-    ///   - CD-C (Section 5.4): keep b's required set at SES and instead emit a conflict rule
-    ///     T1 -> T2 (a conditioned containment), narrowed to the predicate-referenced tables. This
-    ///     keeps valid reorderings CD-A's widening would forbid, making CD-C complete.
-    /// Both read only static subtree relation sets and the property matrices, so operators may be
-    /// processed in any order (no bottom-up traversal is needed).
+    ///   - CD-A: widen b's required set by the offending relations (unconditioned) -- coarse but simple.
+    ///   - CD-C: keep b's required set minimal and emit a conflict rule T1 -> T2 (conditioned),
+    ///     narrowed to the predicate-referenced tables, keeping valid reorderings CD-A would forbid.
+    /// Both read only static subtree relation sets and the matrices, so operators go in any order.
     for (size_t j = 0; j < n; ++j)
     {
         const NormOp & b = norm[j];
@@ -198,11 +191,10 @@ computeConflictOperators(const std::vector<ConflictOpMask> & ops, ConflictDetect
         const UInt32 b_rel = b_left | b_right;
         const UInt32 nel = ops[j].nel;
 
-        /// CalcSES for a non-degenerate predicate with no dependent operators: the ON-clause
-        /// relations, restricted to this operator's own relations. CD-C keeps `required` == SES.
+        /// Base required set: the ON-clause relations restricted to this operator's own relations.
         const UInt32 ses = nel & b_rel;
-        UInt32 tes = ses;                  /// CD-A widens this
-        std::vector<ConflictRule> rules;   /// CD-C fills this
+        UInt32 tes = ses;                  /// CD-A widens this; CD-C leaves it
+        std::vector<ConflictRule> rules;   /// CD-C fills this; CD-A leaves it empty
 
         for (size_t i = 0; i < n; ++i)
         {
@@ -210,16 +202,15 @@ computeConflictOperators(const std::vector<ConflictOpMask> & ops, ConflictDetect
                 continue;
             const NormOp & a = norm[i];
             const UInt32 a_rel = a.left | a.right;
-            const UInt32 fta = ops[i].nel;  /// FT(a): tables referenced by a's predicate
+            const UInt32 fta = ops[i].nel;  /// tables referenced by a's predicate
 
-            /// a is in STO(left(b)) iff all of a's relations lie in b's left subtree, and in
-            /// STO(right(b)) iff they lie in b's right subtree. In a tree the two subtrees are
-            /// disjoint, so at most one holds; ancestors and disjoint operators satisfy neither.
+            /// a lies entirely in b's left subtree iff all its relations are in b_left, and in the
+            /// right subtree iff in b_right. The two subtrees are disjoint, so at most one holds;
+            /// ancestors and disjoint operators satisfy neither.
             if ((a_rel & ~b_left) == 0)
             {
-                /// Left-nesting (Eqv. 1/2 with a below-left of b). For assoc the shared operand is
-                /// A(E2) = right(a); for l-asscom the shared operand is e1 = left(a) and the operand
-                /// b brings in is e3 = right(b).
+                /// a nested in b's left subtree. For assoc the shared operand is a's right; for
+                /// l-asscom the shared operand is a's left and b brings in b's right.
                 if (!assocHolds(a, b, a.right))
                 {
                     if (cdc) rules.push_back({a.right, (a.left & fta) ? (a.left & fta) : a.left});
@@ -233,8 +224,8 @@ computeConflictOperators(const std::vector<ConflictOpMask> & ops, ConflictDetect
             }
             else if ((a_rel & ~b_right) == 0)
             {
-                /// Right-nesting (Eqv. 1/3 with a below-right of b). For assoc(b, a) the shared
-                /// operand is A(E2) = left(a); for r-asscom(b, a) the shared operand is e3 = right(a).
+                /// a nested in b's right subtree. For assoc(b, a) the shared operand is a's left;
+                /// for r-asscom(b, a) it is a's right.
                 if (!assocHolds(b, a, a.left))
                 {
                     if (cdc) rules.push_back({a.left, (a.right & fta) ? (a.right & fta) : a.right});
@@ -248,8 +239,8 @@ computeConflictOperators(const std::vector<ConflictOpMask> & ops, ConflictDetect
             }
         }
 
-        /// The required set is the split of TES (CD-A) or SES (CD-C) over the operator's
-        /// (left-canonical) input sides, which is what the validity test compares against S1 and S2.
+        /// Split the required set over the operator's (left-canonical) input sides -- what the
+        /// validity test compares against S1 and S2.
         const UInt32 required = cdc ? ses : tes;
         ConflictOperator desc;
         desc.relations = b_rel;

--- a/src/Processors/QueryPlan/Optimizations/conflictDetector.cpp
+++ b/src/Processors/QueryPlan/Optimizations/conflictDetector.cpp
@@ -259,6 +259,9 @@ computeConflictOperators(const std::vector<ConflictOpMask> & ops, ConflictDetect
         desc.nel = nel;
         desc.kind = b.kind;
         desc.strictness = b.strictness;
+        /// The predicate references at most one input side (a one-sided predicate, or none at all
+        /// for a cross product), so the required sets alone cannot orient the operator.
+        desc.degenerate = ((nel & b_left) == 0) || ((nel & b_right) == 0);
         desc.freely_reorderable = isFreelyReorderable(b.category);
         desc.rules = std::move(rules);
 

--- a/src/Processors/QueryPlan/Optimizations/conflictDetector.h
+++ b/src/Processors/QueryPlan/Optimizations/conflictDetector.h
@@ -70,6 +70,10 @@ struct ConflictOperator
     UInt32 nel = 0;            /// ON-clause relations, used to locate the operator at a split boundary
     JoinKind kind = JoinKind::Inner;
     JoinStrictness strictness = JoinStrictness::All;
+    /// True when the ON predicate references relations on at most one input side (a one-sided
+    /// predicate, or none at all for a cross product). Then the required sets cannot orient the
+    /// operator, so the validity test checks each input subtree lands on its own side instead.
+    bool degenerate = false;
     /// True for plain inner/cross/comma joins (comm + assoc among themselves): they impose no join
     /// kind. False for outer/semi/anti/full joins, which pin orientation and fix the kind.
     bool freely_reorderable = true;

--- a/src/Processors/QueryPlan/Optimizations/conflictDetector.h
+++ b/src/Processors/QueryPlan/Optimizations/conflictDetector.h
@@ -8,29 +8,22 @@
 namespace DB
 {
 
-/** Table-driven conflict detectors for join reordering, from
-  * Moerkotte et al. "On the Correct and Complete Enumeration of the Core Search Space"
-  * (SIGMOD 2013)
+/** Table-driven conflict detectors that decide which join reorderings preserve results when the
+  * plan mixes inner joins with outer and semi/anti joins (not all reorderings are valid then).
   *
   * Two detectors share this module (select with `ConflictDetector`):
-  *   - CD-A: *correct* but not *complete*. For each operator it computes one Total Eligibility Set
-  *     (TES), widened from the operator's SES by every descendant it does not associate with. Its
-  *     validity test is the unconditioned containment `L-TES ⊆ S1 ∧ R-TES ⊆ S2`.
-  *   - CD-C: *correct and complete* -- it generates exactly the core search space. Its TES stays at
-  *     SES; conflicts are recorded as *conflict rules* `T1 → T2` (a conditioned containment: "if any
-  *     table of T1 is present, all of T2 must be too"). CD-C keeps valid reorderings that CD-A's
-  *     coarse TES widening throws away.
+  *   - CD-A: correct but incomplete. Each operator gets one required set, widened to forbid every
+  *     potentially-invalid reordering -- simple, but it also rejects some valid ones.
+  *   - CD-C: correct and complete. The required set stays minimal, and conflicts are recorded as
+  *     rules `T1 -> T2` ("if any table of T1 is joined, all of T2 must be too"), keeping the valid
+  *     reorderings CD-A's coarse widening discards.
   *
-  * Both are exposed through one descriptor (`ConflictOperator`) and one validity test:
-  *     required_left ⊆ S1 ∧ required_right ⊆ S2   (or the mirrored orientation)
-  *   AND every conflict rule obeyed.
-  * For CD-A, `required_*` is the split TES and `rules` is empty, so the test reduces to CD-A's plain
-  * TES containment. For CD-C, `required_*` is the split SES and `rules` carries the conflict rules.
-  * This is why non-commutative outer and semi/anti joins can be reordered correctly: their required
-  * relations are pinned, and orientation is decided per operator rather than assumed symmetric.
-  *
-  * The properties are looked up in four static matrices encoding `comm`, `assoc`, `l-asscom`, and
-  * `r-asscom`. The null-rejection-dependent entries are resolved from each operator's `nr_rels`.
+  * Both use one descriptor (`ConflictOperator`) and one validity test:
+  *     required_left subseteq S1  AND  required_right subseteq S2   (or the mirrored orientation),
+  *   AND every conflict rule obeyed. CD-A has empty rule sets, so its test reduces to the containment.
+  * Pinning the required relations per side (instead of assuming symmetry) is what lets
+  * non-commutative outer and semi/anti joins reorder correctly. Reorderability comes from four static
+  * matrices (comm, assoc, l-asscom, r-asscom); their null-rejection-dependent entries use `nr_rels`.
   */
 enum class ConflictDetector : UInt8
 {
@@ -43,16 +36,15 @@ struct ConflictOpMask
     UInt32 left = 0;
     UInt32 right = 0;
     UInt32 nel = 0;
-    /// Relations on whose attributes this operator's ON predicate rejects nulls (Definition 1 of
-    /// the paper): the predicate is false/unknown whenever all of that relation's columns are null.
-    /// Always a subset of `nel`. Resolves the null-rejection-dependent matrix entries.
-    /// An equi-join predicate rejects nulls on both of its sides.
+    /// Relations on whose attributes this operator's ON predicate rejects nulls: it is false or
+    /// unknown whenever all of that relation's columns are null. A subset of `nel` (an equi-join
+    /// predicate rejects nulls on both sides). Resolves the null-rejection-dependent matrix entries.
     UInt32 nr_rels = 0;
     JoinKind kind = JoinKind::Inner;
     JoinStrictness strictness = JoinStrictness::All;
 };
 
-/// A CD-B/CD-C conflict rule: if any table of `t1` is in the joined set, all of `t2` must be too.
+/// A conflict rule: if any table of `t1` is in the joined set, all of `t2` must be too.
 struct ConflictRule
 {
     UInt32 t1 = 0;
@@ -62,11 +54,11 @@ struct ConflictRule
 /// Per-operator descriptor consumed by DPsub's validity check (`isValidJoinOrderMaskConflict`).
 struct ConflictOperator
 {
-    UInt32 relations = 0;      /// T(left) | T(right): every relation under this operator, T: the set of relations in a subtree
-    UInt32 left_relations = 0; /// T(left): the (left-canonical) preserved-side subtree. Used to orient a degenerate
-                               /// (predicate-less) operator, whose empty required_* sets cannot decide the side.
-    UInt32 required_left = 0;  /// relations required on the operator's left input  (TES ∩ T(left) for CD-A, SES ∩ T(left) for CD-C)
-    UInt32 required_right = 0; /// relations required on the operator's right input
+    UInt32 relations = 0;      /// every relation under this operator (left subtree | right subtree)
+    UInt32 left_relations = 0; /// the (left-canonical) preserved-side subtree; used to orient a
+                               /// degenerate operator whose empty required_* sets cannot pick a side
+    UInt32 required_left = 0;  /// relations that must be present on the operator's left input
+    UInt32 required_right = 0; /// relations that must be present on the operator's right input
     UInt32 nel = 0;            /// ON-clause relations, used to locate the operator at a split boundary
     JoinKind kind = JoinKind::Inner;
     JoinStrictness strictness = JoinStrictness::All;

--- a/src/Processors/QueryPlan/Optimizations/joinEnum.h
+++ b/src/Processors/QueryPlan/Optimizations/joinEnum.h
@@ -2,6 +2,7 @@
 
 #include <bit>
 #include <concepts>
+#include <optional>
 #include <vector>
 #include <Common/logger_useful.h>
 #include <base/types.h>
@@ -123,6 +124,59 @@ void EnumCcpSub<TConsumer, TDPTable, TQueryGraph>::initDPTable(TDPTable & dp_tab
         dp_table[right_mask].estimated_rows = query_graph.relation_stats[relations[1]].estimated_rows;
         dp_table[right_mask].sel = 1.0; // selectivity of a base relation is trivially 1.0
         dp_table[right_mask].column_stats = query_graph.relation_stats[relations[1]].column_stats;
+    }
+
+    /// A join whose ON clause references only one input side (or none -- a cross product) adds no
+    /// binary edge, so its two subtrees are never linked and DPsub cannot assemble the full set.
+    /// Seed one connectivity link per such operator so its relation set is reachable; the validity
+    /// check still gates every ordering (and rejects a split no operator legitimately spans).
+    ///
+    /// Only the conflict-detector path carries the per-operator subtree sets needed to keep these
+    /// reachable cross-product orderings correct; the per-relation baseline leaves them disconnected.
+    /// This runs once, outside the per-csg-cmp hot loop.
+    if (!(query_graph.use_conflict_detector_a || query_graph.use_conflict_detector_c))
+        return;
+
+    for (const auto & op : query_graph.conflict_ops)
+    {
+        UInt left = 0;
+        UInt right = 0;
+        UInt nel = 0;
+        std::optional<size_t> rep_left;
+        std::optional<size_t> rep_right;
+        for (auto b : op.left)
+        {
+            left |= (static_cast<UInt>(1) << b);
+            if (!rep_left)
+                rep_left = b;
+        }
+        for (auto b : op.right)
+        {
+            right |= (static_cast<UInt>(1) << b);
+            if (!rep_right)
+                rep_right = b;
+        }
+        for (auto b : op.nel)
+            nel |= (static_cast<UInt>(1) << b);
+
+        if (!rep_left || !rep_right)
+            continue;
+        /// Non-degenerate: the predicate already spans both sides, so a binary edge connects them.
+        if ((nel & left) && (nel & right))
+            continue;
+
+        const UInt left_mask = static_cast<UInt>(1) << *rep_left;
+        const UInt right_mask = static_cast<UInt>(1) << *rep_right;
+
+        dp_table[left_mask].neighbor |= right_mask;
+        dp_table[left_mask].estimated_rows = query_graph.relation_stats[*rep_left].estimated_rows;
+        dp_table[left_mask].sel = 1.0;
+        dp_table[left_mask].column_stats = query_graph.relation_stats[*rep_left].column_stats;
+
+        dp_table[right_mask].neighbor |= left_mask;
+        dp_table[right_mask].estimated_rows = query_graph.relation_stats[*rep_right].estimated_rows;
+        dp_table[right_mask].sel = 1.0;
+        dp_table[right_mask].column_stats = query_graph.relation_stats[*rep_right].column_stats;
     }
 }
 

--- a/src/Processors/QueryPlan/Optimizations/joinOrder.h
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.h
@@ -82,7 +82,7 @@ struct RelationStats
 /// One binary join operator captured verbatim from the original (pre-flattening) join tree.
 /// Used only by the optional conflict detector for DPsub (CD-A or CD-C; see conflictDetector.h).
 ///   - `left` / `right`: the relation sets of the operator's two input subtrees;
-///   - `nel`: the relations referenced by the operator's ON clause (its SES);
+///   - `nel`: the relations referenced by the operator's ON clause;
 ///   - `kind`: the operator's join kind.
 /// Relation ids are in the final (global) QueryGraph numbering.
 struct ConflictJoinOp
@@ -90,9 +90,8 @@ struct ConflictJoinOp
     BitSet left;
     BitSet right;
     BitSet nel;
-    /// Relations on whose attributes the ON predicate rejects nulls (Definition 1 of the paper);
-    /// a subset of `nel`. Enables the null-rejection-dependent reorderability entries.
-    /// See `ConflictOpMask::nr_rels`.
+    /// Relations on whose attributes the ON predicate rejects nulls; a subset of `nel`. Enables the
+    /// null-rejection-dependent reorderability entries. See `ConflictOpMask::nr_rels`.
     BitSet nr_rels;
     JoinKind kind = JoinKind::Inner;
     /// Strictness distinguishes plain joins (All) from semi/anti joins, which the detectors model as

--- a/src/Processors/QueryPlan/Optimizations/joinOrderDPSub.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrderDPSub.cpp
@@ -282,7 +282,9 @@ DPSubJoinOrderOptimizer::isValidJoinOrderMaskConflict(UInt32 left_mask, UInt32 r
         const bool nel_within = subset_of(op.nel, combined);
         const bool nel_crosses = (op.nel & left_mask) && (op.nel & right_mask);
         const bool rel_crosses = (op.relations & left_mask) && (op.relations & right_mask);
-        const bool involved = (nel_within && nel_crosses) || (op.nel == 0 && rel_crosses && within);
+        /// A degenerate operator (one-sided or absent predicate) has no crossing predicate, so it is
+        /// located by its relation set crossing the split with all of its relations present.
+        const bool involved = (nel_within && nel_crosses) || (op.degenerate && rel_crosses && within);
         if (!involved)
             continue;
         any_involved = true;
@@ -303,13 +305,14 @@ DPSubJoinOrderOptimizer::isValidJoinOrderMaskConflict(UInt32 left_mask, UInt32 r
         bool mirrored = subset_of(op.required_left, right_mask) && subset_of(op.required_right, left_mask);
 
         /// A one-sided/cross-product operator has an empty required side, so the containment above
-        /// cannot orient it. Require each input subtree on its own side instead: this orients it and
-        /// stops a relation being pulled across (an invalid cross join). Rare -- gated by the flag.
+        /// cannot orient it. Require each whole input subtree on its own side instead: this orients
+        /// it and rejects a fragmented split that pulls part of a subtree across the outer-join
+        /// boundary (an invalid plan). Rare -- gated by the flag.
         if (op.degenerate)
         {
             const UInt32 right_relations = op.relations & ~op.left_relations;
-            forward = forward && (op.left_relations & left_mask) && (right_relations & right_mask);
-            mirrored = mirrored && (op.left_relations & right_mask) && (right_relations & left_mask);
+            forward = forward && subset_of(op.left_relations, left_mask) && subset_of(right_relations, right_mask);
+            mirrored = mirrored && subset_of(op.left_relations, right_mask) && subset_of(right_relations, left_mask);
         }
 
         if (!forward && !mirrored)
@@ -334,10 +337,11 @@ DPSubJoinOrderOptimizer::isValidJoinOrderMaskConflict(UInt32 left_mask, UInt32 r
         strictness = op.strictness;
     }
 
-    /// No operator is applied across this split. A connected query always has one, so this only
-    /// happens when the split is reachable solely through the synthetic cross-product connectivity
-    /// yet no operator legitimately spans it -- reject rather than invent an inner join.
-    if (!any_involved)
+    /// No operator is applied across this split. A real predicate always maps to an operator, so the
+    /// only legitimate no-operator split is a transitive inner join (two sides tied by a column
+    /// equivalence, no direct predicate). Anything else reaching here is the synthetic cross-product
+    /// connectivity with no operator spanning it -- reject rather than invent an inner join.
+    if (!any_involved && !query_graph.areTransitivelyConnected(BitSet::fromUInt(left_mask), BitSet::fromUInt(right_mask)))
         return std::nullopt;
 
     return std::make_pair(kind, strictness);

--- a/src/Processors/QueryPlan/Optimizations/joinOrderDPSub.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrderDPSub.cpp
@@ -259,46 +259,33 @@ std::optional<JoinKind> DPSubJoinOrderOptimizer::isValidJoinOrderMask(UInt32 lef
 std::optional<std::pair<JoinKind, JoinStrictness>>
 DPSubJoinOrderOptimizer::isValidJoinOrderMaskConflict(UInt32 left_mask, UInt32 right_mask) const
 {
-    /// Unified `applicable` for CD-A (Section 5.2) and CD-C (Section 5.4). The enumerator proposes
-    /// each connected, non-overlapping (left_mask, right_mask) split once. We look at every operator
-    /// whose ON predicate is applied across this split and require it to be `applicable`:
-    ///   required_left(op) subseteq S1  AND  required_right(op) subseteq S2  (forward, or mirrored),
-    ///   AND every conflict rule T1 -> T2 obeyed: T1 met by S implies T2 subseteq S.
-    /// For CD-A the required set is the widened TES and there are no rules; for CD-C it is the SES
-    /// plus conflict rules. Every crossing operator -- inner joins included -- must pass, because a
-    /// conflict between a nested operator and its parent is recorded in the *parent's* descriptor,
-    /// and that parent may itself be an inner join. The single non-inner operator that crosses (if
-    /// any) fixes the resulting join kind/strictness; two of them cannot share one binary node, so
-    /// the split is rejected. If none crosses, the step is a plain inner join.
+    /// Decide whether this (left_mask, right_mask) split is a legal join and what kind/strictness it
+    /// produces. Every operator applied across the split must pass: its required-left relations must
+    /// sit in S1 and required-right in S2 (or mirrored), and each conflict rule T1 -> T2 must hold
+    /// (if any table of T1 is joined, all of T2 must be too). Inner operators are checked too, since
+    /// a nested operator's conflict with its parent is recorded on the parent, which may be inner.
+    /// The single non-inner operator that crosses fixes the kind; two cannot share one node.
     const UInt32 combined = left_mask | right_mask;
     auto subset_of = [](const UInt32 a, const UInt32 b) { return (a & ~b) == 0; };
 
     JoinKind kind = JoinKind::Inner;
     JoinStrictness strictness = JoinStrictness::All;
     bool have_non_inner = false;
+    bool any_involved = false;
 
     for (const auto & op : dpsub_data.conflict_operators)
     {
-        /// The operator is applied at this boundary when its ON predicate (NEL) spans the split.
-        /// Using the operator's *relation set* to detect crossing is wrong: an ancestor's
-        /// relation set is a superset of this subset, and an operator already applied inside a
-        /// child no longer has a crossing predicate. The relation-set cross is a fallback only
-        /// for degenerate (predicate-less) operators (empty NEL, e.g. an ON-TRUE join).
+        /// The operator is applied here when its ON-clause relations (nel) span the split and are all
+        /// present: a predicate that still references a not-yet-joined relation belongs to a higher
+        /// node. A predicate-less operator falls back to its relation set straddling the split.
         const bool within = subset_of(op.relations, combined);
-        /// The predicate can only be applied at this node when every relation it references is
-        /// present. Otherwise it belongs to a higher node (a relation it needs is not joined yet).
-        /// Without this, an ancestor operator whose ON clause happens to reference two relations that
-        /// end up on opposite sides of a *lower* split -- e.g. an inner join `... AND t1.z = t3.z`
-        /// sitting above `t2 LEFT JOIN t1`, whose `nel` spans {t1,t2,t3} -- is wrongly treated as
-        /// crossing the {t1}|{t2} split, and its required set (which includes the not-yet-joined t3)
-        /// can satisfy neither orientation, rejecting every ordering of {t1,t2} and failing to find
-        /// any valid join order.
         const bool nel_within = subset_of(op.nel, combined);
         const bool nel_crosses = (op.nel & left_mask) && (op.nel & right_mask);
         const bool rel_crosses = (op.relations & left_mask) && (op.relations & right_mask);
         const bool involved = (nel_within && nel_crosses) || (op.nel == 0 && rel_crosses && within);
         if (!involved)
             continue;
+        any_involved = true;
 
         /// Conflict rules (CD-C; empty for CD-A). A rule T1 -> T2 is disobeyed when some table of T1
         /// is already in the joined set S but not all of T2 is -- that ordering would apply this
@@ -314,6 +301,17 @@ DPSubJoinOrderOptimizer::isValidJoinOrderMaskConflict(UInt32 left_mask, UInt32 r
         /// predicate, both non-empty, so at most one orientation can hold.
         bool forward = subset_of(op.required_left, left_mask) && subset_of(op.required_right, right_mask);
         bool mirrored = subset_of(op.required_left, right_mask) && subset_of(op.required_right, left_mask);
+
+        /// A one-sided/cross-product operator has an empty required side, so the containment above
+        /// cannot orient it. Require each input subtree on its own side instead: this orients it and
+        /// stops a relation being pulled across (an invalid cross join). Rare -- gated by the flag.
+        if (op.degenerate)
+        {
+            const UInt32 right_relations = op.relations & ~op.left_relations;
+            forward = forward && (op.left_relations & left_mask) && (right_relations & right_mask);
+            mirrored = mirrored && (op.left_relations & right_mask) && (right_relations & left_mask);
+        }
+
         if (!forward && !mirrored)
             return std::nullopt;
 
@@ -326,25 +324,21 @@ DPSubJoinOrderOptimizer::isValidJoinOrderMaskConflict(UInt32 left_mask, UInt32 r
             return std::nullopt;
         have_non_inner = true;
 
-        /// For a non-degenerate predicate the two required sides are non-empty and disjoint, so
-        /// exactly one orientation holds. A degenerate (predicate-less, e.g. ON TRUE) operator has
-        /// empty required sets, so both orientations pass and the required-set test cannot tell which
-        /// side is preserved. Break the tie by the operator's original subtree placement: its
-        /// (left-canonical) preserved subtree `left_relations` must land on the preserving side.
-        /// Fail closed if it is split across both sides: do not guess and risk flipping the
-        /// preserved side (see `reverseJoinKind`, which flips Left<->Right / the semi/anti preserved
-        /// side while `buildPhysicalPlan` keeps the child order).
+        /// A non-inner operator whose orientation is still ambiguous (both sides admissible) would
+        /// have its preserved side guessed; fail closed instead (see `reverseJoinKind`, which flips
+        /// Left<->Right / the semi/anti preserved side while `buildPhysicalPlan` keeps the child order).
         if (forward && mirrored)
-        {
-            if (subset_of(op.left_relations, right_mask))
-                forward = false;
-            else if (!subset_of(op.left_relations, left_mask))
-                return std::nullopt;
-        }
+            return std::nullopt;
 
         kind = forward ? op.kind : reverseJoinKind(op.kind);
         strictness = op.strictness;
     }
+
+    /// No operator is applied across this split. A connected query always has one, so this only
+    /// happens when the split is reachable solely through the synthetic cross-product connectivity
+    /// yet no operator legitimately spans it -- reject rather than invent an inner join.
+    if (!any_involved)
+        return std::nullopt;
 
     return std::make_pair(kind, strictness);
 }

--- a/src/Processors/QueryPlan/Optimizations/joinOrderDPSub.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrderDPSub.cpp
@@ -375,9 +375,8 @@ const std::vector<JoinActionRef *> & DPSubJoinOrderOptimizer::collectJoinEdgesMa
         if (dpsub_data.edge_pinned[i] && (dpsub_data.edge_pin_mask[i] & ~joined))
             continue;
 
-        /// Works much like Extended Eligibility List (EEL) in case of outerjoins:
-        /// encoding relations that must be present for the predicate to be applicable (in `pin` mask)
-        /// For innerjoins its just the sources of the predicate, i.e., NEL, here pin is empty.
+        /// For an outer join the `pin` mask encodes relations that must be present for the predicate
+        /// to be applicable; for an inner join it is just the predicate's source relations (pin empty).
         /// For a single-table conjunct of an outer join's ON
         /// clause (e.g. `t2.value = 'x'` in `... LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'x'`),
         /// `sources` is only `{t2}` but the pin is `{t3}`: the predicate belongs to the ON condition of

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -889,8 +889,8 @@ static BitSet strictOnRelations(const ActionsDAG::Node * node, const JoinExpress
 }
 
 /// Relations R such that the boolean `node` is false or unknown when all of R's columns are NULL
-/// (null-rejecting, Definition 1 of the paper). Conservative: when unsure it returns a subset of
-/// the true answer, which only widens a TES downstream and so keeps CD-A correct.
+/// (null-rejecting). Conservative: when unsure it returns a subset of the true answer, which only
+/// tightens the reordering constraints downstream and so stays correct.
 static BitSet predicateNullRejectingRelations(const ActionsDAG::Node * node, const JoinExpressionActions & actions)
 {
     if (node->type == ActionsDAG::ActionType::ALIAS && !node->children.empty())

--- a/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.reference
+++ b/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.reference
@@ -4,3 +4,7 @@ dpsub	1	1	1
 cdc	1	1	1
 cda	1	1	1
 cross cdc	2
+four-table noopt	1
+four-table cdc	1
+transitive off	3
+transitive cdc	3

--- a/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.reference
+++ b/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.reference
@@ -1,0 +1,6 @@
+noopt	1	1	1
+greedy	1	1	1
+dpsub	1	1	1
+cdc	1	1	1
+cda	1	1	1
+cross cdc	2

--- a/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.sql
+++ b/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.sql
@@ -39,3 +39,51 @@ SELECT 'cross cdc', count() FROM t1 CROSS JOIN t2 JOIN t3 ON t1.k = t3.k AND t2.
 DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
+
+-- A degenerate outer join sitting above non-trivial left and right subtrees: the detector must place
+-- each whole subtree on its own side and not accept a fragmented split. Four tables, so the degenerate
+-- LEFT JOIN's inputs are multi-relation.
+DROP TABLE IF EXISTS t0;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+CREATE TABLE t0 (k UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t1 (k UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t2 (k UInt64, a UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t3 (k UInt64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t0 SELECT number FROM numbers(6);
+INSERT INTO t1 SELECT number FROM numbers(6);
+INSERT INTO t2 SELECT number, number FROM numbers(6);
+INSERT INTO t3 SELECT number FROM numbers(6);
+
+SELECT 'four-table noopt', count() FROM t0 JOIN t1 ON t0.k = t1.k LEFT JOIN t2 ON t2.a = 3 JOIN t3 ON t2.k = t3.k AND t0.k = t3.k
+    SETTINGS query_plan_optimize_join_order_limit = 0;
+SELECT 'four-table cdc', count() FROM t0 JOIN t1 ON t0.k = t1.k LEFT JOIN t2 ON t2.a = 3 JOIN t3 ON t2.k = t3.k AND t0.k = t3.k
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_c = 1;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+
+-- With a conflict detector on, transitively-connected splits (inferred from column equivalences) must
+-- still be planned, i.e. the detector must not shrink the transitive-predicate search space.
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
+DROP TABLE IF EXISTS c;
+CREATE TABLE a (k UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE b (k UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE c (k UInt64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO a VALUES (1), (2), (3);
+INSERT INTO b VALUES (1), (2), (3);
+INSERT INTO c VALUES (1), (2), (3);
+SET enable_join_transitive_predicates = 1;
+
+SELECT 'transitive off', count() FROM a JOIN b ON a.k = b.k JOIN c ON b.k = c.k
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub';
+SELECT 'transitive cdc', count() FROM a JOIN b ON a.k = b.k JOIN c ON b.k = c.k
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_c = 1;
+
+DROP TABLE a;
+DROP TABLE b;
+DROP TABLE c;

--- a/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.sql
+++ b/tests/queries/0_stateless/05138_conflict_detector_degenerate_predicate.sql
@@ -1,0 +1,41 @@
+-- Enabling a join-order conflict detector must not make a plannable query unplannable. A join whose
+-- ON clause references relations on only one input side is a degenerate predicate / cross product
+-- (paper "On the Correct and Complete Enumeration of the Core Search Space", Section 6.2): it
+-- contributes no binary join edge, so DPsub's enumerator must still be able to connect its two
+-- subtrees. Regression test for https://github.com/ClickHouse/ClickHouse/issues/118938, where
+-- `t1 LEFT JOIN t2 ON t2.a = 5 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k` planned fine with no
+-- reordering, with greedy, and with plain dpsub, but returned Code 717 as soon as a detector was on.
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+
+CREATE TABLE t1 (k UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t2 (k UInt64, a UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t3 (k UInt64) ENGINE = MergeTree ORDER BY k;
+
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t2 VALUES (1, 5), (2, 7);
+INSERT INTO t3 VALUES (0), (1), (2), (3);
+
+SET enable_analyzer = 1, query_plan_optimize_join_order_randomize = 0, query_plan_optimize_join_order_limit = 10;
+
+-- Degenerate predicate on the null-supplying side (t2.a = 5). All four configurations must agree.
+SELECT 'noopt', t1.k, t2.k, t3.k FROM t1 LEFT JOIN t2 ON t2.a = 5 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k ORDER BY ALL
+    SETTINGS query_plan_optimize_join_order_limit = 0;
+SELECT 'greedy', t1.k, t2.k, t3.k FROM t1 LEFT JOIN t2 ON t2.a = 5 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k ORDER BY ALL
+    SETTINGS query_plan_optimize_join_order_algorithm = 'greedy';
+SELECT 'dpsub', t1.k, t2.k, t3.k FROM t1 LEFT JOIN t2 ON t2.a = 5 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k ORDER BY ALL
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub';
+SELECT 'cdc', t1.k, t2.k, t3.k FROM t1 LEFT JOIN t2 ON t2.a = 5 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k ORDER BY ALL
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_c = 1;
+SELECT 'cda', t1.k, t2.k, t3.k FROM t1 LEFT JOIN t2 ON t2.a = 5 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k ORDER BY ALL
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1;
+
+-- A pure cross product feeding an inner join must plan under a detector too.
+SELECT 'cross cdc', count() FROM t1 CROSS JOIN t2 JOIN t3 ON t1.k = t3.k AND t2.k = t3.k
+    SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_c = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/118938
Related: https://github.com/ClickHouse/ClickHouse/issues/118520
Related: https://github.com/ClickHouse/ClickHouse/pull/118494

Follow-up to #118494. A join whose `ON` clause references relations on only one input side -- or none at all, a cross product -- contributes no binary join edge. The DPsub enumerator links subtrees only through such edges, so it never formed the operator's relation set and reported `Code: 717` ("Failed to find a valid join order") once a conflict detector was enabled, for queries that plan fine with no reordering, with `greedy`, and with plain `dpsub`:

```sql
SELECT * FROM t1
LEFT JOIN t2 ON t2.a = 5
JOIN t3 ON t1.k = t3.k AND t2.k = t3.k
SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub',
         query_plan_optimize_join_order_use_conflict_detector_c = 1;
```

For the conflict-detector path only, the enumerator seeds a synthetic connectivity link between a representative relation of each such operator's two subtrees so its relation set is reachable (a one-time setup, outside the per-csg-cmp hot loop). The validity check keeps the reordering correct: a degenerate operator has an empty required side, so it must instead place each input subtree on its own side (this orients it and prevents a relation from being pulled across into an invalid cross join), and a split that no operator legitimately spans is rejected rather than turned into an inner join. Non-degenerate operators are unaffected -- they skip these checks behind a precomputed flag, so enumeration stays fast.

Verified with `05138_conflict_detector_degenerate_predicate`, the existing conflict-detector tests, the core-search-space evaluation harness (correct + complete), and a differential SQL fuzz extended to generate degenerate predicates (dpsub+CD agrees with `greedy` and the no-reorder baseline).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119035&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119035](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119035+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
