### PR TITLE
Enable full RELRO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,6 +648,15 @@ if (NOT OS_ANDROID AND OS_LINUX AND NOT ARCH_S390X AND NOT SANITIZE AND NOT ENAB
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,-no-pie")
 endif ()
 
+# Full RELRO (relocation read-only): '-z now' resolves all dynamic relocations at startup and '-z relro'
+# then maps the global offset table read-only, so an arbitrary write cannot redirect a call through it.
+# Resolving everything at startup costs nothing here because we link dynamically only against libc
+# and we forbid dlopen (see programs/main.cpp).
+# Not on Darwin: ld64 does not accept '-z' options.
+if (NOT OS_DARWIN)
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro,-z,now")
+endif ()
+
 if (ENABLE_TESTS)
     message (STATUS "Unit tests are enabled")
 else()


### PR DESCRIPTION
Link executables with `-z relro -z now`. All dynamic relocations are resolved at startup and the global offset table is mapped read-only afterwards. Previously only the linker default applied, which leaves the table writable for the lifetime of the process, so an arbitrary write could redirect a call through it.

Resolving everything at startup is free here: we link dynamically only against libc and we forbid `dlopen`.

Not enabled on Darwin, where `ld64` does not accept `-z` options.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Harden official builds by enabling full RELRO: the global offset table is now mapped read-only after startup.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119037&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119037](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119037+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1121` (included in `26.9` and later)
<!-- ch-version-info:end -->