### PR TITLE
Remove stale `Unneeded` references from `IProcessor`

### DIFF
--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -148,9 +148,6 @@ public:
         /// All work is done (all data is processed or all output are closed), nothing more to do.
         Finished,
 
-        /// No one needs data on output ports.
-        /// Unneeded,
-
         /// You may call 'work' method and processor will do some work synchronously.
         Ready,
 
@@ -169,7 +166,7 @@ public:
       *
       * It may access input and output ports,
       *  indicate the need for work by another processor by returning NeedData or PortFull,
-      *  or indicate the absence of work by returning Finished or Unneeded,
+      *  or indicate that processing has finished by returning `Finished`,
       *  it may pull data from input ports and push data to output ports.
       *
       * The method is not thread-safe and must be called from a single thread in one moment of time,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119038&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119038](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119038+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1105` (included in `26.9` and later)
<!-- ch-version-info:end -->