### PR TITLE
Document Protobuf schema uploads for Kafka and Kinesis ClickPipes

### DIFF
--- a/docs/integrations/clickpipes/kafka/create-kafka-clickpipe.mdx
+++ b/docs/integrations/clickpipes/kafka/create-kafka-clickpipe.mdx
@@ -31,6 +31,8 @@ Fill out the form by providing your ClickPipe with a name, a description (option
 </Step>
 <Step title="Configure a schema registry (optional)" id="4-configure-your-schema-registry">
 A valid schema is required for Avro and Protobuf topics. See [Schema registries](/integrations/clickpipes/kafka/schema-registries) for more details on how to configure a schema registry.
+
+For Protobuf, you can instead leave **Schema registry** disabled and [upload a schema when selecting your topic](#7-select-your-topic).
 </Step>
 <Step title="Configure a reverse private endpoint (optional)" id="5-configure-reverse-private-endpoint">
 Configure a Reverse Private Endpoint to allow ClickPipes to connect to your Kafka cluster using AWS PrivateLink.
@@ -56,7 +58,9 @@ Make sure to whitelist [ClickPipes IP addresses](/integrations/clickpipes/networ
 </Note>
 </Step>
 <Step title="Select your topic" id="7-select-your-topic">
-Select your topic and the UI will display a sample document from the topic.
+Select your topic. If you aren't using a schema registry, select your data format under **Schema format**. For `Protobuf`, upload a `.proto` file or serialized `FileDescriptorSet` (maximum 768 KiB).
+
+The UI will then display a sample document from the topic.
 <Image img="/images/integrations/data-ingestion/clickpipes/cp_step3.webp" alt="Set your topic" size="md"/>
 </Step>
 <Step title="Configure your destination table" id="8-configure-your-destination-table">

--- a/docs/integrations/clickpipes/kafka/schema-registries.mdx
+++ b/docs/integrations/clickpipes/kafka/schema-registries.mdx
@@ -14,6 +14,8 @@ import { Image } from "/snippets/components/Image.jsx";
 
 ClickPipes supports integrating with a schema registry to decode Avro- and Protobuf-encoded record values and [structured Kafka keys](/integrations/clickpipes/kafka/reference#structured-message-keys).
 
+For Protobuf record values, you can also [upload a schema directly](/integrations/clickpipes/kafka/create-kafka-clickpipe#7-select-your-topic) without configuring a schema registry.
+
 ## Supported registries for Kafka ClickPipes {#supported-schema-registries}
 
 Kafka ClickPipes supports two families of schema registry:

--- a/docs/integrations/clickpipes/kinesis/overview.mdx
+++ b/docs/integrations/clickpipes/kinesis/overview.mdx
@@ -37,7 +37,7 @@ You have familiarized yourself with the [ClickPipes intro](/integrations/clickpi
 
 5. Select the Kinesis stream, **Data format**, and starting offset. For `Protobuf`, upload a `.proto` file or serialized `FileDescriptorSet` (maximum 768 KiB). No schema registry is required.
 
-   The UI will display a sample document from the selected stream. You can also enable Enhanced Fan-out for Kinesis streams to improve the performance and stability of your ClickPipe (More information on Enhanced Fan-out can be found [here](https://aws.amazon.com/blogs/aws/kds-enhanced-fanout))
+   The UI displays sample data from the selected stream. **Use Kinesis Enhanced Fan-Out** is enabled by default. See the [Amazon Kinesis documentation](https://docs.aws.amazon.com/streams/latest/dev/enhanced-consumers.html) for details.
 
 <Image img="/images/integrations/data-ingestion/clickpipes/cp_step3_kinesis.webp" alt="Set data format and topic" size="lg" border/>
 
@@ -168,13 +168,7 @@ If you have specific low-latency requirements, please [contact us](https://click
 
 ### Active Shards {#active-shards}
 
-We strongly recommend limiting the number concurrently active shards to match your throughput requirements.  For an "On Demand" Kinesis stream, AWS will automatically assign a matching number of shards based on throughput,
-but for "Provisioned" streams, provisioning too many shards can cause latency as described below, plus have increased costs because Kinesis pricing for such streams is on a "per shard" basis.
-
-If your producer application writes continuously to a large number of active shards, this can cause latency if your pipe isn't scaled high enough to efficiently process those shards.  Based on Kinesis throughput limits,
-ClickPipes assigns a specific number of "workers" per replica to read shard data.  For example, at the smallest size, a ClickPipes replica will have 4 of these worker threads.  If the producer is writing
-to more than 4 shards at the same time, data won't be processed from the "extra" shards until a worker thread is available.  In particular, if the pipe is using "enhanced fanout", each worker thread will subscribe to a
-single shard for 5 minutes, and is unavailable to read any other shard during that time.  This can cause latency "spikes" of 5 minute multiples.
+A large number of active shards can reduce ClickPipe throughput if the ClickPipe isn't [scaled](#scaling) to handle them.
 
 ### Scaling {#scaling}
 

--- a/docs/integrations/clickpipes/kinesis/overview.mdx
+++ b/docs/integrations/clickpipes/kinesis/overview.mdx
@@ -35,7 +35,9 @@ You have familiarized yourself with the [ClickPipes intro](/integrations/clickpi
 
 <Image img="/images/integrations/data-ingestion/clickpipes/cp_step2_kinesis.webp" alt="Fill out connection details" size="lg" border/>
 
-5. Select Kinesis Stream and starting offset. The UI will display a sample document from the selected source (Kafka topic, etc). You can also enable Enhanced Fan-out for Kinesis streams to improve the performance and stability of your ClickPipe (More information on Enhanced Fan-out can be found [here](https://aws.amazon.com/blogs/aws/kds-enhanced-fanout))
+5. Select the Kinesis stream, **Data format**, and starting offset. For `Protobuf`, upload a `.proto` file or serialized `FileDescriptorSet` (maximum 768 KiB). No schema registry is required.
+
+   The UI will display a sample document from the selected stream. You can also enable Enhanced Fan-out for Kinesis streams to improve the performance and stability of your ClickPipe (More information on Enhanced Fan-out can be found [here](https://aws.amazon.com/blogs/aws/kds-enhanced-fanout))
 
 <Image img="/images/integrations/data-ingestion/clickpipes/cp_step3_kinesis.webp" alt="Set data format and topic" size="lg" border/>
 
@@ -79,6 +81,7 @@ You have familiarized yourself with the [ClickPipes intro](/integrations/clickpi
 
 The supported formats are:
 - [JSON](/reference/formats/JSON/JSON)
+- [Protobuf](/reference/formats/Protobuf/Protobuf)
 
 ## Compression {#compression}
 


### PR DESCRIPTION
Document direct Protobuf schema uploads for Kafka and Kinesis ClickPipes, including the UI steps, accepted schema files, and size limit. Clarify that a schema registry is not required for direct uploads.

Local verification: whitespace checks passed and new link targets were verified. Full docs/style checks encountered missing dependencies and macOS tooling incompatibilities.

### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Document direct Protobuf schema uploads for Kafka and Kinesis ClickPipes.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119048&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119048](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119048+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1074` (included in `26.9` and later)
<!-- ch-version-info:end -->