### PR TITLE
Update contrib/sysroot: FreeBSD 14.5, Debian-based riscv64/loongarch64, drop unused files

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -48,9 +48,9 @@ CROSS_BUILTIN_TARGETS = [
     ("powerpc64le-unknown-linux-gnu", "Linux"),
     ("riscv64-unknown-linux-gnu", "Linux"),
     ("loongarch64-unknown-linux-gnu", "Linux"),
-    ("x86_64-pc-freebsd13", "FreeBSD"),
-    ("aarch64-unknown-freebsd13", "FreeBSD"),
-    ("powerpc64le-unknown-freebsd13", "FreeBSD"),
+    ("x86_64-pc-freebsd14", "FreeBSD"),
+    ("aarch64-unknown-freebsd14", "FreeBSD"),
+    ("powerpc64le-unknown-freebsd14", "FreeBSD"),
 ]
 
 

--- a/cmake/freebsd/toolchain-aarch64.cmake
+++ b/cmake/freebsd/toolchain-aarch64.cmake
@@ -3,9 +3,9 @@ include_guard(GLOBAL)
 
 set (CMAKE_SYSTEM_NAME "FreeBSD")
 set (CMAKE_SYSTEM_PROCESSOR "aarch64")
-set (CMAKE_C_COMPILER_TARGET "aarch64-unknown-freebsd13")
-set (CMAKE_CXX_COMPILER_TARGET "aarch64-unknown-freebsd13")
-set (CMAKE_ASM_COMPILER_TARGET "aarch64-unknown-freebsd13")
+set (CMAKE_C_COMPILER_TARGET "aarch64-unknown-freebsd14")
+set (CMAKE_CXX_COMPILER_TARGET "aarch64-unknown-freebsd14")
+set (CMAKE_ASM_COMPILER_TARGET "aarch64-unknown-freebsd14")
 set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/freebsd-aarch64")
 
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)  # disable linkage check - it doesn't work in CMake

--- a/cmake/freebsd/toolchain-ppc64le.cmake
+++ b/cmake/freebsd/toolchain-ppc64le.cmake
@@ -3,9 +3,9 @@ include_guard(GLOBAL)
 
 set (CMAKE_SYSTEM_NAME "FreeBSD")
 set (CMAKE_SYSTEM_PROCESSOR "ppc64le")
-set (CMAKE_C_COMPILER_TARGET "powerpc64le-unknown-freebsd13")
-set (CMAKE_CXX_COMPILER_TARGET "powerpc64le-unknown-freebsd13")
-set (CMAKE_ASM_COMPILER_TARGET "powerpc64le-unknown-freebsd13")
+set (CMAKE_C_COMPILER_TARGET "powerpc64le-unknown-freebsd14")
+set (CMAKE_CXX_COMPILER_TARGET "powerpc64le-unknown-freebsd14")
+set (CMAKE_ASM_COMPILER_TARGET "powerpc64le-unknown-freebsd14")
 set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/freebsd-powerpc64le")
 
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)  # disable linkage check - it doesn't work in CMake

--- a/cmake/freebsd/toolchain-x86_64.cmake
+++ b/cmake/freebsd/toolchain-x86_64.cmake
@@ -3,9 +3,9 @@ include_guard(GLOBAL)
 
 set (CMAKE_SYSTEM_NAME "FreeBSD")
 set (CMAKE_SYSTEM_PROCESSOR "x86_64")
-set (CMAKE_C_COMPILER_TARGET "x86_64-pc-freebsd13")
-set (CMAKE_CXX_COMPILER_TARGET "x86_64-pc-freebsd13")
-set (CMAKE_ASM_COMPILER_TARGET "x86_64-pc-freebsd13")
+set (CMAKE_C_COMPILER_TARGET "x86_64-pc-freebsd14")
+set (CMAKE_CXX_COMPILER_TARGET "x86_64-pc-freebsd14")
+set (CMAKE_ASM_COMPILER_TARGET "x86_64-pc-freebsd14")
 set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/freebsd-x86_64")
 
 # dprintf is used in a patched version of replxx

--- a/cmake/linux/toolchain-riscv64.cmake
+++ b/cmake/linux/toolchain-riscv64.cmake
@@ -9,9 +9,10 @@ set (CMAKE_C_COMPILER_TARGET "riscv64-linux-gnu")
 set (CMAKE_CXX_COMPILER_TARGET "riscv64-linux-gnu")
 set (CMAKE_ASM_COMPILER_TARGET "riscv64-linux-gnu")
 
-set (TOOLCHAIN_PATH "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/linux-riscv64")
+set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/linux-riscv64")
 
-set (CMAKE_SYSROOT "${TOOLCHAIN_PATH}")
+# The sysroot has the Debian layout: GCC startup objects and libgcc.a live under usr/lib/gcc.
+set (TOOLCHAIN_PATH "${CMAKE_SYSROOT}/usr")
 
 # Make sure to ignore global clang configuration files which could influence the
 # build environment using --no-default-config

--- a/contrib/liburing-cmake/CMakeLists.txt
+++ b/contrib/liburing-cmake/CMakeLists.txt
@@ -30,7 +30,14 @@ set (LIBURING_COMPAT_HEADER "${LIBURING_COMPAT_INCLUDE_DIR}/liburing/compat.h")
 
 set (LIBURING_CONFIG_HAS_KERNEL_RWF_T    FALSE)
 set (LIBURING_CONFIG_HAS_KERNEL_TIMESPEC FALSE)
-set (LIBURING_CONFIG_HAS_OPEN_HOW        FALSE)
+# glibc >= 2.43 includes <linux/openat2.h> from <fcntl.h>, so when the kernel headers of the sysroot
+# provide `struct open_how` (Linux >= 5.6), the fallback definition in compat.h would be a redefinition.
+# Build-time probes are forbidden (cmake/block_build_time_checks.cmake); the sysroot is known statically.
+if (EXISTS "${CMAKE_SYSROOT}/usr/include/linux/openat2.h")
+    set (LIBURING_CONFIG_HAS_OPEN_HOW    TRUE)
+else ()
+    set (LIBURING_CONFIG_HAS_OPEN_HOW    FALSE)
+endif ()
 set (LIBURING_CONFIG_HAS_STATX           FALSE)
 set (LIBURING_CONFIG_HAS_GLIBC_STATX     FALSE)
 set (LIBURING_CONFIG_HAS_DISCARD_CMD     FALSE)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/sysroot/pull/46

**Merge order:** the `ClickHouse/sysroot` pull request above must be merged first. This PR points the
submodule at its head commit, and the cmake changes here only work with the new sysroot layout.

Bumps `contrib/sysroot` and adapts the build to it:

- FreeBSD sysroots are now 14.5-RELEASE (13.x is end-of-life), so the target triples in
  `cmake/freebsd/toolchain-*.cmake` and `ci/jobs/build_toolchain.py` become `*-freebsd14`.
  Resulting binaries require FreeBSD 14 or newer.
- `linux-riscv64` is rebuilt from Debian 13 packages (glibc 2.41, kernel headers 6.12) and has the
  Debian layout, so `cmake/linux/toolchain-riscv64.cmake` passes `--gcc-toolchain=<sysroot>/usr`.
  riscv64 binaries now reference glibc symbols up to `GLIBC_2.38` (previously 2.32); riscv64 has no
  glibc-compatibility layer or compatibility check.
- `linux-loongarch64` is rebuilt from Debian sid (glibc 2.43, kernel headers 7.1). glibc 2.43 includes
  `linux/openat2.h` from `fcntl.h`, which made the fallback `struct open_how` in `contrib/liburing-cmake`
  a redefinition; `LIBURING_CONFIG_HAS_OPEN_HOW` is now derived from the presence of that header in the
  sysroot (no build-time probe).
- `linux-s390x` and `linux-aarch64` lost unused files and debug info; `linux-x86_64`, `linux-aarch64`,
  `linux-s390x`, `linux-powerpc64le` keep their glibc versions (they define the glibc floor of the
  release binaries, see `ci/jobs/compatibility_check.py`).
- The sysroot README now documents provenance and the update procedure for every sysroot.

Verified locally by building `programs/clickhouse` for s390x, riscv64, loongarch64, FreeBSD x86_64 and
aarch64; the aarch64 binary still caps at `GLIBC_2.17`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cross-compilation sysroots updated: FreeBSD builds now target FreeBSD 14 (13 is end-of-life), riscv64 and loongarch64 builds use current Debian glibc and kernel headers. Unused files were removed from the sysroot submodule.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119049&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119049](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119049+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1269` (included in `26.9` and later)
<!-- ch-version-info:end -->