### PR TITLE
Prune ARRAY JOIN nested subcolumns inside subqueries and CTEs

### DIFF
--- a/src/Analyzer/Passes/PruneArrayJoinColumnsPass.cpp
+++ b/src/Analyzer/Passes/PruneArrayJoinColumnsPass.cpp
@@ -5,8 +5,6 @@
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
-#include <Analyzer/QueryNode.h>
-#include <Analyzer/Utils.h>
 
 #include <Core/Settings.h>
 
@@ -16,8 +14,6 @@
 #include <Functions/FunctionFactory.h>
 
 #include <Interpreters/Context.h>
-
-#include <Common/UnorderedMapWithMemoryTracking.h>
 
 namespace DB
 {
@@ -45,50 +41,125 @@ struct ExpressionUsage
     /// Subcolumn names from the nested() first argument. Empty if not a nested() expression.
     std::vector<std::string> nested_subcolumn_names;
 
+    /// Filled after pruning: the column type of the ARRAY JOIN expression, which references must adopt.
+    DataTypePtr pruned_type;
+
+    /// Filled after pruning: old 1-based tupleElement index -> new 1-based index.
+    std::unordered_map<UInt64, UInt64> index_remap;
+
     bool hasNested() const { return !nested_subcolumn_names.empty(); }
 
     bool isUsed() const { return fully_used || !used_subcolumns.empty(); }
 };
 
-/// Key: (ArrayJoinNode raw ptr, column name) → ExpressionUsage.
-using ArrayJoinUsageMap = std::unordered_map<const IQueryTreeNode *, std::unordered_map<std::string, ExpressionUsage>>;
+struct ArrayJoinUsage
+{
+    ArrayJoinNode * array_join_node = nullptr;
 
-/// Set of ArrayJoinNode raw pointers that we are tracking.
-using ArrayJoinNodeSet = std::unordered_set<const IQueryTreeNode *>;
+    /// Keyed by the ARRAY JOIN column name.
+    std::unordered_map<std::string, ExpressionUsage> expressions;
+};
 
-/// Map: (ArrayJoinNode raw ptr, column name) → post-pruning column DataType.
-using UpdatedTypeMap = std::unordered_map<const IQueryTreeNode *, UnorderedMapWithMemoryTracking<std::string, DataTypePtr>>;
+/// Keyed by ArrayJoinNode raw pointer.
+using ArrayJoinUsageMap = std::unordered_map<const IQueryTreeNode *, ArrayJoinUsage>;
 
-/// Map: (ArrayJoinNode raw ptr, column name, old 1-based index) → new 1-based index.
-using IndexRemapMap = std::unordered_map<const IQueryTreeNode *, std::unordered_map<std::string, std::unordered_map<UInt64, UInt64>>>;
+/// Returns the usage entry of a ColumnNode that references a tracked ARRAY JOIN expression, or nullptr.
+ExpressionUsage * findReferencedExpression(const ColumnNode & column_node, ArrayJoinUsageMap & usage_map)
+{
+    auto source = column_node.getColumnSourceOrNull();
+    if (!source)
+        return nullptr;
 
-/// Visitor that marks which ARRAY JOIN expressions and nested subcolumns are used.
+    auto usage_it = usage_map.find(source.get());
+    if (usage_it == usage_map.end())
+        return nullptr;
+
+    auto expr_it = usage_it->second.expressions.find(column_node.getColumnName());
+    if (expr_it == usage_it->second.expressions.end())
+        return nullptr;
+
+    return &expr_it->second;
+}
+
+/// Collects every ARRAY JOIN node of the tree, including those inside subqueries, CTEs and UNION branches.
+class CollectArrayJoinNodesVisitor : public InDepthQueryTreeVisitorWithContext<CollectArrayJoinNodesVisitor>
+{
+public:
+    using Base = InDepthQueryTreeVisitorWithContext<CollectArrayJoinNodesVisitor>;
+
+    CollectArrayJoinNodesVisitor(ContextPtr context_, ArrayJoinUsageMap & usage_map_, std::unordered_set<const IQueryTreeNode *> & definition_nodes_)
+        : Base(std::move(context_))
+        , usage_map(usage_map_)
+        , definition_nodes(definition_nodes_)
+    {
+    }
+
+    void enterImpl(const QueryTreeNodePtr & node)
+    {
+        auto * array_join_node = node->as<ArrayJoinNode>();
+        if (!array_join_node)
+            return;
+
+        /// Unaligned ARRAY JOIN pads shorter arrays, so removing an array can change the number of result rows.
+        if (getSettings()[Setting::enable_unaligned_array_join])
+            return;
+
+        ArrayJoinUsage usage;
+        usage.array_join_node = array_join_node;
+
+        for (const auto & join_expr : array_join_node->getJoinExpressions().getNodes())
+        {
+            auto * column_node = join_expr->as<ColumnNode>();
+            if (!column_node || !column_node->hasExpression())
+                continue;
+
+            ExpressionUsage expr_usage;
+
+            auto * function_node = column_node->getExpression()->as<FunctionNode>();
+            if (function_node && function_node->getFunctionName() == "nested")
+            {
+                const auto & args = function_node->getArguments().getNodes();
+                if (args.size() >= 2)
+                {
+                    if (auto * names_constant = args[0]->as<ConstantNode>())
+                    {
+                        const auto & names_array = names_constant->getValue().safeGet<Array>();
+                        for (const auto & name : names_array)
+                            expr_usage.nested_subcolumn_names.push_back(name.safeGet<String>());
+                    }
+                }
+            }
+
+            definition_nodes.insert(join_expr.get());
+            usage.expressions[column_node->getColumnName()] = std::move(expr_usage);
+        }
+
+        if (!usage.expressions.empty())
+            usage_map[node.get()] = std::move(usage);
+    }
+
+private:
+    ArrayJoinUsageMap & usage_map;
+    std::unordered_set<const IQueryTreeNode *> & definition_nodes;
+};
+
+/// Marks which ARRAY JOIN expressions and nested subcolumns are referenced anywhere in the tree.
 class MarkUsedArrayJoinColumnsVisitor : public InDepthQueryTreeVisitorWithContext<MarkUsedArrayJoinColumnsVisitor>
 {
 public:
     using Base = InDepthQueryTreeVisitorWithContext<MarkUsedArrayJoinColumnsVisitor>;
 
-    MarkUsedArrayJoinColumnsVisitor(ContextPtr context_, ArrayJoinUsageMap & usage_map_, const ArrayJoinNodeSet & tracked_nodes_)
+    MarkUsedArrayJoinColumnsVisitor(ContextPtr context_, ArrayJoinUsageMap & usage_map_, const std::unordered_set<const IQueryTreeNode *> & definition_nodes_)
         : Base(std::move(context_))
         , usage_map(usage_map_)
-        , tracked_nodes(tracked_nodes_)
+        , definition_nodes(definition_nodes_)
     {
     }
 
-    bool needChildVisit(QueryTreeNodePtr & parent, QueryTreeNodePtr & child)
+    bool needChildVisit(QueryTreeNodePtr & parent, QueryTreeNodePtr & child [[maybe_unused]])
     {
-        /// Skip visiting the join expressions list of a tracked ARRAY JOIN node —
-        /// those are the expression definitions, not references.
-        if (tracked_nodes.contains(parent.get()))
-        {
-            auto * array_join_node = parent->as<ArrayJoinNode>();
-            if (array_join_node && child.get() == array_join_node->getJoinExpressionsNode().get())
-                return false;
-        }
-
-        /// If the parent is tupleElement whose first argument is a column from a tracked
-        /// ARRAY JOIN, skip visiting children — enterImpl already handles the tupleElement
-        /// by marking only the specific subcolumn.
+        /// tupleElement(array_join_column, ...) is handled as a whole in enterImpl:
+        /// visiting the column child would mark the expression as fully used.
         auto * function_node = parent->as<FunctionNode>();
         if (function_node && function_node->getFunctionName() == "tupleElement")
         {
@@ -97,8 +168,7 @@ public:
             {
                 if (auto * column_node = arguments[0]->as<ColumnNode>())
                 {
-                    auto source = column_node->getColumnSourceOrNull();
-                    if (source && tracked_nodes.contains(source.get()))
+                    if (findReferencedExpression(*column_node, usage_map))
                         return false;
                 }
             }
@@ -124,66 +194,55 @@ public:
             if (!column_node || !constant_node)
                 return;
 
-            auto source = column_node->getColumnSourceOrNull();
-            if (!source || !tracked_nodes.contains(source.get()))
+            auto * expr_usage = findReferencedExpression(*column_node, usage_map);
+            if (!expr_usage || expr_usage->fully_used)
                 return;
 
-            auto map_it = usage_map.find(source.get());
-            if (map_it == usage_map.end())
-                return;
-
-            auto expr_it = map_it->second.find(column_node->getColumnName());
-            if (expr_it == map_it->second.end() || expr_it->second.fully_used)
-                return;
-
-            if (expr_it->second.hasNested())
+            if (expr_usage->hasNested())
             {
                 const auto & value = constant_node->getValue();
                 if (value.getType() == Field::Types::String)
                 {
-                    expr_it->second.used_subcolumns.insert(value.safeGet<String>());
+                    expr_usage->used_subcolumns.insert(value.safeGet<String>());
                 }
                 else if (value.getType() == Field::Types::UInt64)
                 {
                     /// tupleElement uses 1-based indexing.
                     UInt64 index = value.safeGet<UInt64>();
-                    if (index >= 1 && index <= expr_it->second.nested_subcolumn_names.size())
-                        expr_it->second.used_subcolumns.insert(expr_it->second.nested_subcolumn_names[index - 1]);
+                    if (index >= 1 && index <= expr_usage->nested_subcolumn_names.size())
+                        expr_usage->used_subcolumns.insert(expr_usage->nested_subcolumn_names[index - 1]);
                     else
-                        expr_it->second.fully_used = true;
+                        expr_usage->fully_used = true;
                 }
                 else
                 {
-                    expr_it->second.fully_used = true;
+                    expr_usage->fully_used = true;
                 }
             }
             else
-                expr_it->second.fully_used = true;
+                expr_usage->fully_used = true;
 
             return;
         }
 
         /// Case 2: direct reference to an ARRAY JOIN column — mark fully used.
+        /// The ARRAY JOIN expression itself is a ColumnNode with the same name and source, but it is
+        /// the definition, not a reference. Its expression is still visited, because it may reference
+        /// columns of a preceding ARRAY JOIN or contain a subquery with its own ARRAY JOIN.
+        if (definition_nodes.contains(node.get()))
+            return;
+
         auto * column_node = node->as<ColumnNode>();
         if (!column_node)
             return;
 
-        auto source = column_node->getColumnSourceOrNull();
-        if (!source || !tracked_nodes.contains(source.get()))
-            return;
-
-        auto map_it = usage_map.find(source.get());
-        if (map_it == usage_map.end())
-            return;
-
-        auto expr_it = map_it->second.find(column_node->getColumnName());
-        if (expr_it != map_it->second.end())
-            expr_it->second.fully_used = true;
+        if (auto * expr_usage = findReferencedExpression(*column_node, usage_map))
+            expr_usage->fully_used = true;
     }
 
 private:
     ArrayJoinUsageMap & usage_map;
-    const ArrayJoinNodeSet & tracked_nodes;
+    const std::unordered_set<const IQueryTreeNode *> & definition_nodes;
 };
 
 /// Prune unused subcolumn arguments from a nested() function and build an index remap
@@ -191,9 +250,8 @@ private:
 void pruneNestedFunctionArguments(
     ColumnNode & column_node,
     FunctionNode & function_node,
-    const ExpressionUsage & expr_usage,
-    const ContextPtr & context,
-    std::unordered_map<UInt64, UInt64> & index_remap)
+    ExpressionUsage & expr_usage,
+    const ContextPtr & context)
 {
     auto & nested_args = function_node.getArguments().getNodes();
     const auto & subcolumn_names = expr_usage.nested_subcolumn_names;
@@ -217,7 +275,7 @@ void pruneNestedFunctionArguments(
 
     /// Build old 1-based index → new 1-based index remap.
     for (size_t new_idx = 0; new_idx < indices_to_keep.size(); ++new_idx)
-        index_remap[indices_to_keep[new_idx] + 1] = new_idx + 1;
+        expr_usage.index_remap[indices_to_keep[new_idx] + 1] = new_idx + 1;
 
     /// Build pruned names array and arguments.
     Array pruned_names_array;
@@ -246,22 +304,16 @@ void pruneNestedFunctionArguments(
     column_node.setColumnType(std::move(new_column_type));
 }
 
-/// Visitor that updates reference ColumnNode types, rewrites stale numeric tupleElement
+/// Updates reference ColumnNode types, rewrites stale numeric tupleElement
 /// indices, and re-resolves tupleElement functions after nested() arguments have been pruned.
 class UpdateArrayJoinReferenceTypesVisitor : public InDepthQueryTreeVisitorWithContext<UpdateArrayJoinReferenceTypesVisitor>
 {
 public:
     using Base = InDepthQueryTreeVisitorWithContext<UpdateArrayJoinReferenceTypesVisitor>;
 
-    UpdateArrayJoinReferenceTypesVisitor(
-        ContextPtr context_,
-        const UpdatedTypeMap & updated_types_,
-        const ArrayJoinNodeSet & tracked_nodes_,
-        const IndexRemapMap & index_remap_)
+    UpdateArrayJoinReferenceTypesVisitor(ContextPtr context_, ArrayJoinUsageMap & usage_map_)
         : Base(std::move(context_))
-        , updated_types(updated_types_)
-        , tracked_nodes(tracked_nodes_)
-        , index_remap(index_remap_)
+        , usage_map(usage_map_)
     {
     }
 
@@ -279,19 +331,9 @@ public:
         if (!column_node)
             return;
 
-        auto source = column_node->getColumnSourceOrNull();
-        if (!source || !tracked_nodes.contains(source.get()))
+        auto * expr_usage = findReferencedExpression(*column_node, usage_map);
+        if (!expr_usage || !expr_usage->pruned_type)
             return;
-
-        auto node_it = updated_types.find(source.get());
-        if (node_it == updated_types.end())
-            return;
-
-        auto type_it = node_it->second.find(column_node->getColumnName());
-        if (type_it == node_it->second.end())
-            return;
-
-        const auto & new_type = type_it->second;
 
         /// Rewrite numeric tupleElement index if pruning changed positions.
         auto * constant_node = arguments[1]->as<ConstantNode>();
@@ -301,118 +343,48 @@ public:
             if (value.getType() == Field::Types::UInt64)
             {
                 UInt64 old_index = value.safeGet<UInt64>();
-
-                auto remap_node_it = index_remap.find(source.get());
-                if (remap_node_it != index_remap.end())
-                {
-                    auto remap_col_it = remap_node_it->second.find(column_node->getColumnName());
-                    if (remap_col_it != remap_node_it->second.end())
-                    {
-                        auto remap_it = remap_col_it->second.find(old_index);
-                        if (remap_it != remap_col_it->second.end() && remap_it->second != old_index)
-                            arguments[1] = std::make_shared<ConstantNode>(remap_it->second);
-                    }
-                }
+                auto remap_it = expr_usage->index_remap.find(old_index);
+                if (remap_it != expr_usage->index_remap.end() && remap_it->second != old_index)
+                    arguments[1] = std::make_shared<ConstantNode>(remap_it->second);
             }
         }
 
-        if (column_node->getColumnType()->equals(*new_type))
+        if (column_node->getColumnType()->equals(*expr_usage->pruned_type))
             return;
 
-        column_node->setColumnType(new_type);
+        column_node->setColumnType(expr_usage->pruned_type);
 
         auto tuple_element_function = FunctionFactory::instance().get("tupleElement", getContext());
         function_node->resolveAsFunction(tuple_element_function->build(function_node->getArgumentColumns()));
     }
 
 private:
-    const UpdatedTypeMap & updated_types;
-    const ArrayJoinNodeSet & tracked_nodes;
-    const IndexRemapMap & index_remap;
+    ArrayJoinUsageMap & usage_map;
 };
 
 }
 
 void PruneArrayJoinColumnsPass::run(QueryTreeNodePtr & query_tree_node, ContextPtr context)
 {
-    auto * top_query_node = query_tree_node->as<QueryNode>();
-    if (!top_query_node)
-        return;
-
-    const auto & settings = context->getSettingsRef();
-    if (settings[Setting::enable_unaligned_array_join])
-        return;
-
     /// Step 1: Find all ARRAY JOIN nodes and build the usage map.
     ArrayJoinUsageMap usage_map;
-    ArrayJoinNodeSet tracked_nodes;
+    std::unordered_set<const IQueryTreeNode *> definition_nodes;
 
-    auto table_expressions = extractTableExpressions(top_query_node->getJoinTreeNodeTyped(), /*add_array_join=*/ true);
-    for (const auto & table_expr : table_expressions)
-    {
-        auto * array_join_node = table_expr->as<ArrayJoinNode>();
-        if (!array_join_node)
-            continue;
+    CollectArrayJoinNodesVisitor collector(context, usage_map, definition_nodes);
+    collector.visit(query_tree_node);
 
-        auto & expressions_usage = usage_map[table_expr.get()];
-
-        for (const auto & join_expr : array_join_node->getJoinExpressions().getNodes())
-        {
-            auto * column_node = join_expr->as<ColumnNode>();
-            if (!column_node || !column_node->hasExpression())
-                continue;
-
-            ExpressionUsage expr_usage;
-
-            auto * function_node = column_node->getExpression()->as<FunctionNode>();
-            if (function_node && function_node->getFunctionName() == "nested")
-            {
-                const auto & args = function_node->getArguments().getNodes();
-                if (args.size() >= 2)
-                {
-                    if (auto * names_constant = args[0]->as<ConstantNode>())
-                    {
-                        const auto & names_array = names_constant->getValue().safeGet<Array>();
-                        for (const auto & name : names_array)
-                            expr_usage.nested_subcolumn_names.push_back(name.safeGet<String>());
-                    }
-                }
-            }
-
-            expressions_usage[column_node->getColumnName()] = std::move(expr_usage);
-        }
-
-        if (!expressions_usage.empty())
-            tracked_nodes.insert(table_expr.get());
-    }
-
-    if (tracked_nodes.empty())
+    if (usage_map.empty())
         return;
 
     /// Step 2: Mark used expressions and subcolumns.
-    MarkUsedArrayJoinColumnsVisitor visitor(context, usage_map, tracked_nodes);
+    MarkUsedArrayJoinColumnsVisitor visitor(context, usage_map, definition_nodes);
     visitor.visit(query_tree_node);
 
     /// Step 3: Prune.
-    UpdatedTypeMap updated_types;
-    IndexRemapMap index_remap;
-
-    for (auto & [node_ptr, expressions_usage] : usage_map)
+    for (auto & [_, usage] : usage_map)
     {
-        /// Find the ArrayJoinNode among our table_expressions.
-        ArrayJoinNode * array_join_node = nullptr;
-        for (const auto & te : table_expressions)
-        {
-            if (te.get() == node_ptr)
-            {
-                array_join_node = te->as<ArrayJoinNode>();
-                break;
-            }
-        }
-        if (!array_join_node)
-            continue;
-
-        auto & join_expressions = array_join_node->getJoinExpressions().getNodes();
+        auto & expressions_usage = usage.expressions;
+        auto & join_expressions = usage.array_join_node->getJoinExpressions().getNodes();
 
         /// 3a: Remove entire unused ARRAY JOIN expressions.
         {
@@ -459,24 +431,24 @@ void PruneArrayJoinColumnsPass::run(QueryTreeNodePtr & query_tree_node, ContextP
             if (!function_node)
                 continue;
 
-            pruneNestedFunctionArguments(
-                *column_node, *function_node, expr_usage, context,
-                index_remap[node_ptr][column_node->getColumnName()]);
+            pruneNestedFunctionArguments(*column_node, *function_node, expr_usage, context);
         }
 
         /// Collect post-pruning types for step 3c.
-        auto & type_map = updated_types[node_ptr];
         for (const auto & join_expr : join_expressions)
         {
             auto * col_node = join_expr->as<ColumnNode>();
             if (!col_node)
                 continue;
-            type_map[col_node->getColumnName()] = col_node->getColumnType();
+
+            auto expr_it = expressions_usage.find(col_node->getColumnName());
+            if (expr_it != expressions_usage.end())
+                expr_it->second.pruned_type = col_node->getColumnType();
         }
     }
 
     /// 3c: Update types of reference ColumnNodes, rewrite numeric indices, and re-resolve tupleElement functions.
-    UpdateArrayJoinReferenceTypesVisitor type_updater(context, updated_types, tracked_nodes, index_remap);
+    UpdateArrayJoinReferenceTypesVisitor type_updater(context, usage_map);
     type_updater.visit(query_tree_node);
 }
 

--- a/src/Analyzer/Passes/PruneArrayJoinColumnsPass.h
+++ b/src/Analyzer/Passes/PruneArrayJoinColumnsPass.h
@@ -14,6 +14,10 @@ namespace DB
   *    function with ALL subcolumns as arguments. This pass removes arguments that
   *    are not referenced, so that only the needed subcolumns are read from storage.
   *
+  * ARRAY JOIN nodes are collected from the whole tree, so subqueries, CTEs and UNION
+  * branches are pruned as well. References are counted from the whole tree too, which
+  * covers correlated references and expressions of a subsequent ARRAY JOIN.
+  *
   * Example 1: SELECT b FROM t ARRAY JOIN a, b  =>  ARRAY JOIN b
   *
   * Example 2: Table has n.a, n.b, n.c.

--- a/tests/queries/0_stateless/05139_prune_array_join_columns_subquery.reference
+++ b/tests/queries/0_stateless/05139_prune_array_join_columns_subquery.reference
@@ -1,0 +1,257 @@
+-- subquery
+3
+4
+8
+QUERY id: 0
+  PROJECTION COLUMNS
+    n.b Int64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: n.b, result_type: Int64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, alias: __table1, is_subquery: 1
+      PROJECTION COLUMNS
+        n.b Int64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          FUNCTION id: 5, function_name: tupleElement, function_type: ordinary, result_type: Int64
+            ARGUMENTS
+              LIST id: 6, nodes: 2
+                COLUMN id: 7, column_name: __array_join_exp_1, result_type: Tuple(b Int64), source_id: 8
+                CONSTANT id: 9, constant_value: \'b\', constant_value_type: String
+      JOIN TREE
+        ARRAY_JOIN id: 8, is_left: 0
+          TABLE EXPRESSION
+            TABLE id: 10, alias: __table3, table_name: default.t_nested
+          JOIN EXPRESSIONS
+            LIST id: 11, nodes: 1
+              COLUMN id: 12, alias: __array_join_exp_1, column_name: __array_join_exp_1, result_type: Tuple(b Int64), source_id: 8
+                EXPRESSION
+                  FUNCTION id: 13, function_name: nested, function_type: ordinary, result_type: Array(Tuple(b Int64))
+                    ARGUMENTS
+                      LIST id: 14, nodes: 2
+                        CONSTANT id: 15, constant_value: Array_[\'b\'], constant_value_type: Array(String)
+                        COLUMN id: 16, column_name: n.b, result_type: Array(Int64), source_id: 10
+  ORDER BY
+    LIST id: 17, nodes: 1
+      SORT id: 18, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 19, column_name: n.b, result_type: Int64, source_id: 3
+          ReadFromMergeTree (default.t_nested)
+          Header: n.b Array(Int64)
+-- CTE
+3	5
+4	6
+8	9
+QUERY id: 0
+  PROJECTION COLUMNS
+    b Int64
+    c Int64
+  PROJECTION
+    LIST id: 1, nodes: 2
+      COLUMN id: 2, column_name: b, result_type: Int64, source_id: 3
+      COLUMN id: 4, column_name: c, result_type: Int64, source_id: 3
+  JOIN TREE
+    QUERY id: 3, alias: __table1, is_subquery: 1, is_cte: 1, cte_name: r
+      PROJECTION COLUMNS
+        b Int64
+        c Int64
+      PROJECTION
+        LIST id: 5, nodes: 2
+          FUNCTION id: 6, function_name: tupleElement, function_type: ordinary, result_type: Int64
+            ARGUMENTS
+              LIST id: 7, nodes: 2
+                COLUMN id: 8, column_name: __array_join_exp_1, result_type: Tuple(b Int64, c Int64), source_id: 9
+                CONSTANT id: 10, constant_value: \'b\', constant_value_type: String
+          FUNCTION id: 11, function_name: tupleElement, function_type: ordinary, result_type: Int64
+            ARGUMENTS
+              LIST id: 12, nodes: 2
+                COLUMN id: 13, column_name: __array_join_exp_1, result_type: Tuple(b Int64, c Int64), source_id: 9
+                CONSTANT id: 14, constant_value: \'c\', constant_value_type: String
+      JOIN TREE
+        ARRAY_JOIN id: 9, is_left: 0
+          TABLE EXPRESSION
+            TABLE id: 15, alias: __table3, table_name: default.t_nested
+          JOIN EXPRESSIONS
+            LIST id: 16, nodes: 1
+              COLUMN id: 17, alias: __array_join_exp_1, column_name: __array_join_exp_1, result_type: Tuple(b Int64, c Int64), source_id: 9
+                EXPRESSION
+                  FUNCTION id: 18, function_name: nested, function_type: ordinary, result_type: Array(Tuple(b Int64, c Int64))
+                    ARGUMENTS
+                      LIST id: 19, nodes: 3
+                        CONSTANT id: 20, constant_value: Array_[\'b\', \'c\'], constant_value_type: Array(String)
+                        COLUMN id: 21, column_name: n.b, result_type: Array(Int64), source_id: 15
+                        COLUMN id: 22, column_name: n.c, result_type: Array(Int64), source_id: 15
+  ORDER BY
+    LIST id: 23, nodes: 1
+      SORT id: 24, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 25, column_name: b, result_type: Int64, source_id: 3
+-- CTE referenced twice with different subcolumns
+15	20
+-- UNION ALL branches
+3
+4
+5
+6
+8
+9
+UNION id: 0, union_mode: UNION_ALL
+  QUERIES
+    LIST id: 1, nodes: 2
+      QUERY id: 2, alias: __table1
+        PROJECTION COLUMNS
+          x Int64
+        PROJECTION
+          LIST id: 3, nodes: 1
+            FUNCTION id: 4, function_name: tupleElement, function_type: ordinary, result_type: Int64
+              ARGUMENTS
+                LIST id: 5, nodes: 2
+                  COLUMN id: 6, column_name: __array_join_exp_1, result_type: Tuple(b Int64), source_id: 7
+                  CONSTANT id: 8, constant_value: \'b\', constant_value_type: String
+        JOIN TREE
+          ARRAY_JOIN id: 7, is_left: 0
+            TABLE EXPRESSION
+              TABLE id: 9, alias: __table3, table_name: default.t_nested
+            JOIN EXPRESSIONS
+              LIST id: 10, nodes: 1
+                COLUMN id: 11, alias: __array_join_exp_1, column_name: __array_join_exp_1, result_type: Tuple(b Int64), source_id: 7
+                  EXPRESSION
+                    FUNCTION id: 12, function_name: nested, function_type: ordinary, result_type: Array(Tuple(b Int64))
+                      ARGUMENTS
+                        LIST id: 13, nodes: 2
+                          CONSTANT id: 14, constant_value: Array_[\'b\'], constant_value_type: Array(String)
+                          COLUMN id: 15, column_name: n.b, result_type: Array(Int64), source_id: 9
+      QUERY id: 16, alias: __table4
+        PROJECTION COLUMNS
+          n.c Int64
+        PROJECTION
+          LIST id: 17, nodes: 1
+            FUNCTION id: 18, function_name: tupleElement, function_type: ordinary, result_type: Int64
+              ARGUMENTS
+                LIST id: 19, nodes: 2
+                  COLUMN id: 20, column_name: __array_join_exp_2, result_type: Tuple(c Int64), source_id: 21
+                  CONSTANT id: 22, constant_value: \'c\', constant_value_type: String
+        JOIN TREE
+          ARRAY_JOIN id: 21, is_left: 0
+            TABLE EXPRESSION
+              TABLE id: 23, alias: __table6, table_name: default.t_nested
+            JOIN EXPRESSIONS
+              LIST id: 24, nodes: 1
+                COLUMN id: 25, alias: __array_join_exp_2, column_name: __array_join_exp_2, result_type: Tuple(c Int64), source_id: 21
+                  EXPRESSION
+                    FUNCTION id: 26, function_name: nested, function_type: ordinary, result_type: Array(Tuple(c Int64))
+                      ARGUMENTS
+                        LIST id: 27, nodes: 2
+                          CONSTANT id: 28, constant_value: Array_[\'c\'], constant_value_type: Array(String)
+                          COLUMN id: 29, column_name: n.c, result_type: Array(Int64), source_id: 23
+-- view with unused projection column
+3
+4
+8
+          ReadFromMergeTree (default.t_nested)
+          Header: n.b Array(Int64)
+-- numeric tupleElement index inside subquery
+3	5
+4	6
+8	9
+-- LEFT ARRAY JOIN inside subquery
+0
+3
+4
+8
+-- ARRAY JOIN inside IN subquery, both scopes name the column n
+4
+8
+-- ARRAY JOIN inside IN subquery that is part of an outer ARRAY JOIN expression
+1
+2
+-- second ARRAY JOIN references a subcolumn of the first one
+103
+104
+108
+QUERY id: 0
+  PROJECTION COLUMNS
+    y Int64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: __array_join_exp_1, result_type: Int64, source_id: 3
+  JOIN TREE
+    ARRAY_JOIN id: 3, is_left: 0
+      TABLE EXPRESSION
+        ARRAY_JOIN id: 4, is_left: 0
+          TABLE EXPRESSION
+            TABLE id: 5, alias: __table3, table_name: default.t_nested
+          JOIN EXPRESSIONS
+            LIST id: 6, nodes: 1
+              COLUMN id: 7, alias: __array_join_exp_2, column_name: __array_join_exp_2, result_type: Tuple(b Int64), source_id: 4
+                EXPRESSION
+                  FUNCTION id: 8, function_name: nested, function_type: ordinary, result_type: Array(Tuple(b Int64))
+                    ARGUMENTS
+                      LIST id: 9, nodes: 2
+                        CONSTANT id: 10, constant_value: Array_[\'b\'], constant_value_type: Array(String)
+                        COLUMN id: 11, column_name: n.b, result_type: Array(Int64), source_id: 5
+      JOIN EXPRESSIONS
+        LIST id: 12, nodes: 1
+          COLUMN id: 13, alias: __array_join_exp_1, column_name: __array_join_exp_1, result_type: Int64, source_id: 3
+            EXPRESSION
+              FUNCTION id: 14, function_name: arrayMap, function_type: ordinary, result_type: Array(Int64)
+                ARGUMENTS
+                  LIST id: 15, nodes: 2
+                    LAMBDA id: 16
+                      ARGUMENTS id: 17
+                        ARGUMENT id: 0, name: x, type: UInt8
+                      EXPRESSION 
+                        FUNCTION id: 18, function_name: plus, function_type: ordinary, result_type: Int64
+                          ARGUMENTS
+                            LIST id: 19, nodes: 2
+                              COLUMN id: 20, column_name: x, result_type: UInt8, source_id: 17
+                              FUNCTION id: 21, function_name: tupleElement, function_type: ordinary, result_type: Int64
+                                ARGUMENTS
+                                  LIST id: 22, nodes: 2
+                                    COLUMN id: 23, column_name: __array_join_exp_2, result_type: Tuple(b Int64), source_id: 4
+                                    CONSTANT id: 24, constant_value: \'b\', constant_value_type: String
+                    CONSTANT id: 25, constant_value: Array_[UInt64_100], constant_value_type: Array(UInt8)
+-- whole tuple projected from the subquery: nothing to prune
+5
+6
+9
+QUERY id: 0
+  PROJECTION COLUMNS
+    n.c Int64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: getSubcolumn, function_type: ordinary, result_type: Int64
+        ARGUMENTS
+          LIST id: 3, nodes: 2
+            COLUMN id: 4, column_name: n, result_type: Tuple(a Int64, b Int64, c Int64), source_id: 5
+            CONSTANT id: 6, constant_value: \'c\', constant_value_type: String
+  JOIN TREE
+    QUERY id: 5, alias: __table1, is_subquery: 1
+      PROJECTION COLUMNS
+        n Tuple(a Int64, b Int64, c Int64)
+      PROJECTION
+        LIST id: 7, nodes: 1
+          COLUMN id: 8, column_name: __array_join_exp_1, result_type: Tuple(a Int64, b Int64, c Int64), source_id: 9
+      JOIN TREE
+        ARRAY_JOIN id: 9, is_left: 0
+          TABLE EXPRESSION
+            TABLE id: 10, alias: __table3, table_name: default.t_nested
+          JOIN EXPRESSIONS
+            LIST id: 11, nodes: 1
+              COLUMN id: 12, alias: __array_join_exp_1, column_name: __array_join_exp_1, result_type: Tuple(a Int64, b Int64, c Int64), source_id: 9
+                EXPRESSION
+                  FUNCTION id: 13, function_name: nested, function_type: ordinary, result_type: Array(Tuple(a Int64, b Int64, c Int64))
+                    ARGUMENTS
+                      LIST id: 14, nodes: 4
+                        CONSTANT id: 15, constant_value: Array_[\'a\', \'b\', \'c\'], constant_value_type: Array(String)
+                        COLUMN id: 16, column_name: n.a, result_type: Array(Int64), source_id: 10
+                        COLUMN id: 17, column_name: n.b, result_type: Array(Int64), source_id: 10
+                        COLUMN id: 18, column_name: n.c, result_type: Array(Int64), source_id: 10
+-- unused subcolumn with mismatched array sizes is not read, same as the top-level query
+1	3
+2	4
+7	8
+1	3
+2	4
+7	8

--- a/tests/queries/0_stateless/05139_prune_array_join_columns_subquery.sql
+++ b/tests/queries/0_stateless/05139_prune_array_join_columns_subquery.sql
@@ -1,0 +1,66 @@
+-- ARRAY JOIN of a Nested column inside a subquery, CTE, UNION branch or view must
+-- read only the referenced subcolumns, like the top-level query does.
+-- https://github.com/ClickHouse/clickhouse-private/issues/58384
+
+SET enable_analyzer = 1;
+SET explain_query_plan_default = 'legacy';
+SET enable_parallel_replicas = 0;
+SET serialize_query_plan = 0;
+
+DROP TABLE IF EXISTS t_nested;
+CREATE TABLE t_nested (`n.a` Array(Int64), `n.b` Array(Int64), `n.c` Array(Int64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nested VALUES ([1, 2], [3, 4], [5, 6]), ([], [], []), ([7], [8], [9]);
+
+SELECT '-- subquery';
+SELECT * FROM (SELECT n.b FROM t_nested ARRAY JOIN n) ORDER BY 1;
+EXPLAIN QUERY TREE SELECT * FROM (SELECT n.b FROM t_nested ARRAY JOIN n) ORDER BY 1;
+SELECT * FROM (EXPLAIN header = 1 SELECT count() FROM (SELECT n.b FROM t_nested ARRAY JOIN n)) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%Header: n.%';
+
+SELECT '-- CTE';
+WITH r AS (SELECT n.b AS b, n.c AS c FROM t_nested ARRAY JOIN n) SELECT b, c FROM r ORDER BY 1;
+EXPLAIN QUERY TREE WITH r AS (SELECT n.b AS b, n.c AS c FROM t_nested ARRAY JOIN n) SELECT b, c FROM r ORDER BY 1;
+
+SELECT '-- CTE referenced twice with different subcolumns';
+WITH r AS (SELECT n.a AS a, n.b AS b, n.c AS c FROM t_nested ARRAY JOIN n) SELECT (SELECT sum(b) FROM r), (SELECT sum(c) FROM r);
+
+SELECT '-- UNION ALL branches';
+SELECT * FROM (SELECT n.b AS x FROM t_nested ARRAY JOIN n UNION ALL SELECT n.c FROM t_nested ARRAY JOIN n) ORDER BY 1;
+EXPLAIN QUERY TREE SELECT n.b AS x FROM t_nested ARRAY JOIN n UNION ALL SELECT n.c FROM t_nested ARRAY JOIN n;
+
+SELECT '-- view with unused projection column';
+DROP VIEW IF EXISTS v_nested;
+CREATE VIEW v_nested AS SELECT n.a AS a, n.b AS b, n.c AS c FROM t_nested ARRAY JOIN n;
+SELECT b FROM v_nested ORDER BY 1;
+SELECT * FROM (EXPLAIN header = 1 SELECT count() FROM (SELECT b FROM v_nested)) WHERE explain LIKE '%ReadFromMergeTree%' OR explain LIKE '%Header: n.%';
+DROP VIEW v_nested;
+
+SELECT '-- numeric tupleElement index inside subquery';
+SELECT * FROM (SELECT tupleElement(n, 2), tupleElement(n, 3) FROM t_nested ARRAY JOIN n) ORDER BY 1;
+
+SELECT '-- LEFT ARRAY JOIN inside subquery';
+SELECT * FROM (SELECT n.b FROM t_nested LEFT ARRAY JOIN n) ORDER BY 1;
+
+SELECT '-- ARRAY JOIN inside IN subquery, both scopes name the column n';
+SELECT n.b FROM t_nested ARRAY JOIN n WHERE n.a IN (SELECT n.a FROM t_nested ARRAY JOIN n WHERE n.c > 5) ORDER BY 1;
+
+SELECT '-- ARRAY JOIN inside IN subquery that is part of an outer ARRAY JOIN expression';
+SELECT x FROM t_nested ARRAY JOIN arrayFilter(v -> v IN (SELECT n.b - 2 FROM t_nested ARRAY JOIN n), n.a) AS x ORDER BY 1;
+
+SELECT '-- second ARRAY JOIN references a subcolumn of the first one';
+SELECT y FROM t_nested ARRAY JOIN n ARRAY JOIN arrayMap(x -> x + n.b, [100]) AS y ORDER BY 1;
+EXPLAIN QUERY TREE SELECT y FROM t_nested ARRAY JOIN n ARRAY JOIN arrayMap(x -> x + n.b, [100]) AS y;
+
+SELECT '-- whole tuple projected from the subquery: nothing to prune';
+SELECT n.c FROM (SELECT n FROM t_nested ARRAY JOIN n) ORDER BY 1;
+EXPLAIN QUERY TREE SELECT n.c FROM (SELECT n FROM t_nested ARRAY JOIN n);
+
+DROP TABLE t_nested;
+
+SELECT '-- unused subcolumn with mismatched array sizes is not read, same as the top-level query';
+DROP TABLE IF EXISTS t_mismatch;
+CREATE TABLE t_mismatch (`n.a` Array(Int64), `n.b` Array(Int64), `n.c` Array(Int64)) ENGINE = MergeTree ORDER BY tuple() SETTINGS share_nested_offsets = 0;
+INSERT INTO t_mismatch VALUES ([1, 2], [3, 4], [5]), ([7], [8], [9, 10, 11]);
+SELECT n.a, n.b FROM t_mismatch ARRAY JOIN n ORDER BY 1;
+SELECT * FROM (SELECT n.a, n.b FROM t_mismatch ARRAY JOIN n) ORDER BY 1;
+SELECT * FROM (SELECT n.a, n.c FROM t_mismatch ARRAY JOIN n) ORDER BY 1; -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+DROP TABLE t_mismatch;


### PR DESCRIPTION
`PruneArrayJoinColumnsPass` rewrites `ARRAY JOIN nested_column` so that only the referenced subcolumns of the `Nested` column are read, but it only inspected the join tree of the top-level query. `ARRAY JOIN` inside a subquery, CTE, UNION branch or view kept reading every subcolumn, which is where the analyzer-migration replay wrapper `WITH result AS (...) SELECT ... FROM result` put the customer queries. On the reproducer from the issue the new analyzer read 86x more bytes and loaded 3x more mark files than the old one for the same selected marks. The pass now collects `ARRAY JOIN` nodes from the whole query tree; on the reproducer both analyzers read the same bytes and mark files.

The pass also skipped the join expressions of every tracked `ARRAY JOIN` when counting references, so a second `ARRAY JOIN` whose expression referenced a subcolumn of the first one (`ARRAY JOIN n ARRAY JOIN arrayMap(x -> x + n.b, [1])`) had `n` pruned to its first subcolumn and failed with `Tuple doesn't have element with name 'b'`. Only the definition column nodes are skipped now, so the expressions themselves are visited.

Semantics with mismatched array sizes inside a `Nested` prefix (reachable with `share_nested_offsets = 0`) become the same as for a top-level `ARRAY JOIN` and as in the old analyzer: an unreferenced subcolumn of a different length is not read and does not raise `SIZES_OF_ARRAYS_DONT_MATCH`; a referenced one still does.

Closes: https://github.com/ClickHouse/clickhouse-private/issues/58384

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`ARRAY JOIN` of a `Nested` column inside a subquery, CTE, UNION branch or view now reads only the referenced subcolumns, like a top-level `ARRAY JOIN` does. Fixed an exception `Tuple doesn't have element with name` when a second `ARRAY JOIN` referenced a subcolumn of a `Nested` column joined by the first one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119055&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119055](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119055+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
