### PR TITLE
Use `simdutf::validate_ascii` in `isValidASCII`

### DIFF
--- a/src/Functions/isValidASCII.cpp
+++ b/src/Functions/isValidASCII.cpp
@@ -10,6 +10,12 @@
 #include <Common/Exception.h>
 #include <base/types.h>
 
+#include "config.h"
+
+#if USE_SIMDUTF
+#    include <simdutf.h>
+#endif
+
 namespace DB
 {
 
@@ -23,11 +29,17 @@ namespace
 
 UInt8 isValidASCII(const UInt8 * data, UInt64 len)
 {
+#if USE_SIMDUTF
+    /// Hand-written SIMD kernels with runtime dispatch. The plain OR-reduction below is vectorized with
+    /// 32-bit lanes by clang 23 (the accumulator is promoted to int), which quarters its throughput.
+    return simdutf::validate_ascii(reinterpret_cast<const char *>(data), len);
+#else
     /// https://lemire.me/blog/2025/12/20/performance-trick-optimistic-vs-pessimistic-checks/
     UInt8 res = 0;
     for (UInt64 i = 0; i < len; ++i)
         res |= data[i];
     return res <= 0x7F;
+#endif
 }
 
 }

--- a/src/Functions/isValidASCII.cpp
+++ b/src/Functions/isValidASCII.cpp
@@ -115,8 +115,7 @@ private:
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             size_t current_offset = offsets[i];
-            /// Exclude the terminating zero byte, so that empty strings take the fast path.
-            size_t string_size = current_offset - prev_offset - 1;
+            size_t string_size = current_offset - prev_offset;
             result_data[i] = isValidASCII(chars.data() + prev_offset, string_size);
             prev_offset = current_offset;
         }

--- a/src/Functions/isValidASCII.cpp
+++ b/src/Functions/isValidASCII.cpp
@@ -30,6 +30,9 @@ namespace
 UInt8 isValidASCII(const UInt8 * data, UInt64 len)
 {
 #if USE_SIMDUTF
+    /// The dispatched call is not free, so do not pay for it on empty strings.
+    if (len == 0)
+        return 1;
     /// Hand-written SIMD kernels with runtime dispatch. The plain OR-reduction below is vectorized with
     /// 32-bit lanes by clang 23 (the accumulator is promoted to int), which quarters its throughput.
     return simdutf::validate_ascii(reinterpret_cast<const char *>(data), len);
@@ -112,7 +115,8 @@ private:
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             size_t current_offset = offsets[i];
-            size_t string_size = current_offset - prev_offset;
+            /// Exclude the terminating zero byte, so that empty strings take the fast path.
+            size_t string_size = current_offset - prev_offset - 1;
             result_data[i] = isValidASCII(chars.data() + prev_offset, string_size);
             prev_offset = current_offset;
         }

--- a/tests/queries/0_stateless/05153_is_valid_ascii_simd_boundaries.reference
+++ b/tests/queries/0_stateless/05153_is_valid_ascii_simd_boundaries.reference
@@ -1,0 +1,28 @@
+all ascii, every length up to 300
+300	300
+one high byte at every position, every length up to 200
+20100	20100
+20100	20100
+boundary bytes 0x00 and 0x7F are ascii at every position
+20100	20100
+per-row results do not bleed into neighbours
+1
+0
+0
+1
+0
+0
+1
+0
+0
+1
+0
+1
+0
+1
+0
+fixed string
+64	64
+10	10
+1
+0

--- a/tests/queries/0_stateless/05153_is_valid_ascii_simd_boundaries.sql
+++ b/tests/queries/0_stateless/05153_is_valid_ascii_simd_boundaries.sql
@@ -1,0 +1,27 @@
+-- Non-constant inputs whose lengths cross the 16, 32 and 64 byte SIMD block sizes,
+-- with the offending byte at every possible position, to exercise the vectorized
+-- kernel, its scalar tail and the per-row boundaries.
+
+SELECT 'all ascii, every length up to 300';
+SELECT count(), countIf(isValidASCII(repeat('a', number)) = 1) FROM numbers(300);
+
+SELECT 'one high byte at every position, every length up to 200';
+SELECT count(), countIf(isValidASCII(concat(repeat('a', pos), '\x80', repeat('a', len - pos - 1))) = 0)
+FROM (SELECT number AS len FROM numbers(1, 200)) ARRAY JOIN range(len) AS pos;
+
+SELECT count(), countIf(isValidASCII(concat(repeat('a', pos), '\xFF', repeat('a', len - pos - 1))) = 0)
+FROM (SELECT number AS len FROM numbers(1, 200)) ARRAY JOIN range(len) AS pos;
+
+SELECT 'boundary bytes 0x00 and 0x7F are ascii at every position';
+SELECT count(), countIf(isValidASCII(concat(repeat('a', pos), '\x00', repeat('\x7F', len - pos - 1))) = 1)
+FROM (SELECT number AS len FROM numbers(1, 200)) ARRAY JOIN range(len) AS pos;
+
+SELECT 'per-row results do not bleed into neighbours';
+SELECT isValidASCII(if(number % 3 = 0, repeat('a', 100), concat(repeat('a', 99), 'é'))) FROM numbers(9);
+SELECT isValidASCII(if(number % 2 = 0, '', 'ä')) FROM numbers(6);
+
+SELECT 'fixed string';
+SELECT count(), countIf(isValidASCII(toFixedString(concat(repeat('a', number), '\x80', repeat('a', 63 - number)), 64)) = 0) FROM numbers(64);
+SELECT count(), countIf(isValidASCII(toFixedString(repeat('a', 64), 64)) = 1) FROM numbers(10);
+SELECT isValidASCII(toFixedString(materialize('ab'), 64));
+SELECT isValidASCII(toFixedString(materialize('a\x80'), 64));


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117346

Use the hand-written SIMD kernels from simdutf (with runtime dispatch) in `isValidASCII` instead of relying on the autovectorizer. Split out of https://github.com/ClickHouse/ClickHouse/pull/117346, where it showed a ~10x improvement in the `isValidASCII` performance test on aarch64.

Clang 23 vectorizes the plain OR-reduction over bytes with 32-bit lanes and a `zext` per load instead of 8-bit lanes, because the accumulator is promoted to `int` and the new InstSimplify fold `zext(trunc nuw X) -> X` keeps the loop-carried value wide (https://github.com/llvm/llvm-project/issues/222142). The simdutf kernel does not depend on the autovectorizer and is faster with the current compiler as well. The plain loop is kept for builds without simdutf.

Performance report (clang 23 branch): https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117346&sha=9577e299b7171e516629113c47e715e2ad8de6cd&name_0=PR

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up function `isValidASCII` by using SIMD kernels from simdutf.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119062&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119062](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119062+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1163` (included in `26.9` and later)
<!-- ch-version-info:end -->