### PR TITLE
Lazy materialization and row selection support for Vortex

### DIFF
--- a/rust/workspace/vortex/include/vortex_ffi.h
+++ b/rust/workspace/vortex/include/vortex_ffi.h
@@ -195,6 +195,9 @@ struct FFI_VortexScanOptions
     const uint64_t* row_selection_begin;
     uint64_t row_selection_len;
 
+    /// If true, prepend a row_idx() column to output
+    bool row_index_column;
+
     /// The number of splits that may be in flight at once: being read, being decoded, or already
     /// handed over and not yet released. 0 selects the default. This is what keeps the scan from
     /// running ahead of the caller; the reads underneath are bounded separately by

--- a/rust/workspace/vortex/include/vortex_ffi.h
+++ b/rust/workspace/vortex/include/vortex_ffi.h
@@ -191,6 +191,10 @@ struct FFI_VortexScanOptions
     /// The row range `[row_range_begin, row_range_end)`. Both zero means the whole file.
     uint64_t row_range_begin;
     uint64_t row_range_end;
+
+    const uint64_t* row_selection_begin;
+    uint64_t row_selection_len;
+
     /// The number of splits that may be in flight at once: being read, being decoded, or already
     /// handed over and not yet released. 0 selects the default. This is what keeps the scan from
     /// running ahead of the caller; the reads underneath are bounded separately by

--- a/rust/workspace/vortex/src/lib.rs
+++ b/rust/workspace/vortex/src/lib.rs
@@ -848,7 +848,7 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
                     let row_idx_struct = pack([(name, row_idx())], Nullability::NonNullable);
                     projection = Some(merge([row_idx_struct, projection.unwrap_or_else(root)]));
                     let mut fields = Vec::with_capacity(schema.fields.len() + 1);
-                    fields[0] = Arc::new(Field::new(name, DataType::UInt64, false));
+                    fields.push(Arc::new(Field::new(name, DataType::UInt64, false)));
                     fields.extend_from_slice(&schema.fields);
                     schema = Arc::new(Schema::new(fields));
                 }

--- a/rust/workspace/vortex/src/lib.rs
+++ b/rust/workspace/vortex/src/lib.rs
@@ -28,7 +28,7 @@ use std::task::{Context, Poll, Waker};
 use arrow_array::cast::AsArray;
 use arrow_array::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_array::{Array, RecordBatch, StructArray};
-use arrow_schema::{Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use async_task::Runnable;
 use concurrent_queue::ConcurrentQueue;
 use futures::future::BoxFuture;
@@ -39,12 +39,13 @@ use vortex::arrow::ArrowSessionExt;
 use vortex::buffer::{Alignment, Buffer, ByteBufferMut};
 use vortex::dtype::{FieldName, Nullability};
 use vortex::error::{vortex_err, VortexResult};
-use vortex::expr::{get_item, is_null, lit, not, root, select, Expression};
+use vortex::expr::{get_item, is_null, lit, merge, not, pack, root, select, Expression};
 use vortex::extension::datetime::{Date, TimeUnit, Timestamp, TimestampOptions};
 use vortex::file::{OpenOptionsSessionExt, VortexFile, WriteOptionsSessionExt};
 use vortex::io::runtime::{AbortHandle, AbortHandleRef, Executor, Handle, Task};
 use vortex::io::session::RuntimeSessionExt;
 use vortex::io::{CoalesceConfig, IoBuf, VortexReadAt, VortexWrite};
+use vortex::layout::layouts::row_idx::row_idx;
 use vortex::scalar::Scalar;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::Operator;
@@ -645,6 +646,9 @@ pub struct FFI_VortexScanOptions {
     // 0 means the whole file
     pub row_selection_len: u64,
 
+    // If true, prepend a row_idx() column to output
+    pub row_index_column: bool,
+
     /// The number of splits that may be in flight at once: being read, being decoded, or already
     /// handed over and not yet released. 0 selects the default. This is what keeps the scan from
     /// running ahead of the caller; the reads underneath are bounded separately by
@@ -806,6 +810,8 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
             if !options.is_null() {
                 let options = &*options;
 
+                let mut projection: Option<Expression> = None;
+
                 if !options.columns.is_null() {
                     let mut names = Vec::with_capacity(options.num_columns as usize);
                     for i in 0..options.num_columns {
@@ -828,15 +834,34 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
                         .iter()
                         .map(|name| FieldName::from(name.as_str()))
                         .collect();
+                    projection = Some(select(field_names, root()));
+                    schema = Arc::new(Schema::new(fields));
+                }
+
+                if options.row_index_column {
+                    let name = "_row_index";
+                    if schema.field_with_name(name).is_ok() {
+                        return Err(format!(
+                            "the row index column name '{name}' collides with a projected column"
+                        ));
+                    }
+                    let row_idx_struct = pack([(name, row_idx())], Nullability::NonNullable);
+                    projection = Some(merge([row_idx_struct, projection.unwrap_or_else(root)]));
+                    let mut fields = Vec::with_capacity(schema.fields.len() + 1);
+                    fields[0] = Arc::new(Field::new(name, DataType::UInt64, false));
+                    fields.extend_from_slice(&schema.fields);
+                    schema = Arc::new(Schema::new(fields));
+                }
+
+                if let Some(projection) = projection {
                     // `with_projection` and `with_filter` take an expression already bound to
                     // the file's type, which is where a column that is not in the file or a
                     // comparison of two types that cannot be compared is now caught.
                     builder = builder.with_projection(
-                        select(field_names, root())
+                        projection
                             .bind(reader.file.dtype())
                             .map_err(|e| e.to_string())?,
                     );
-                    schema = Arc::new(Schema::new(fields));
                 }
 
                 if !options.filter.is_null() {
@@ -1860,6 +1885,7 @@ mod tests {
             row_range_end: 0,
             row_selection_begin: ptr::null(),
             row_selection_len: 0,
+            row_index_column: false,
             max_splits_in_flight: 0,
         }
     }
@@ -1940,20 +1966,28 @@ mod tests {
             0
         );
         let file_schema = Schema::try_from(&ffi_schema).expect("schema");
-        if options.columns.is_null() {
-            return Arc::new(file_schema);
+        let mut fields: Vec<Field> = if options.columns.is_null() {
+            file_schema
+                .fields()
+                .iter()
+                .map(|field| field.as_ref().clone())
+                .collect()
+        } else {
+            (0..options.num_columns as usize)
+                .map(|i| {
+                    let name = unsafe { CStr::from_ptr(*options.columns.add(i)) }
+                        .to_str()
+                        .expect("utf-8 name");
+                    file_schema
+                        .field_with_name(name)
+                        .expect("a column of the file")
+                        .clone()
+                })
+                .collect()
+        };
+        if options.row_index_column {
+            fields.insert(0, Field::new("_row_index", DataType::UInt64, false));
         }
-        let fields: Vec<Field> = (0..options.num_columns as usize)
-            .map(|i| {
-                let name = unsafe { CStr::from_ptr(*options.columns.add(i)) }
-                    .to_str()
-                    .expect("utf-8 name");
-                file_schema
-                    .field_with_name(name)
-                    .expect("a column of the file")
-                    .clone()
-            })
-            .collect();
         Arc::new(Schema::new(fields))
     }
 

--- a/rust/workspace/vortex/src/lib.rs
+++ b/rust/workspace/vortex/src/lib.rs
@@ -36,7 +36,7 @@ use futures::{FutureExt, StreamExt};
 use vortex::array::buffer::BufferHandle;
 use vortex::array::VortexSessionExecute;
 use vortex::arrow::ArrowSessionExt;
-use vortex::buffer::{Alignment, ByteBufferMut};
+use vortex::buffer::{Alignment, Buffer, ByteBufferMut};
 use vortex::dtype::{FieldName, Nullability};
 use vortex::error::{vortex_err, VortexResult};
 use vortex::expr::{get_item, is_null, lit, not, root, select, Expression};
@@ -49,6 +49,8 @@ use vortex::scalar::Scalar;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::Operator;
 use vortex::scalar_fn::ScalarFnVTableExt;
+use vortex::scan::selection::Selection;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex::session::VortexSession;
 use vortex::VortexSessionDefault;
 
@@ -638,6 +640,11 @@ pub struct FFI_VortexScanOptions {
     /// The row range `[row_range_begin, row_range_end)`. Both zero means the whole file.
     pub row_range_begin: u64,
     pub row_range_end: u64,
+
+    pub row_selection_begin: *const u64,
+    // 0 means the whole file
+    pub row_selection_len: u64,
+
     /// The number of splits that may be in flight at once: being read, being decoded, or already
     /// handed over and not yet released. 0 selects the default. This is what keeps the scan from
     /// running ahead of the caller; the reads underneath are bounded separately by
@@ -850,6 +857,17 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
                     }
                     builder =
                         builder.with_row_range(options.row_range_begin..options.row_range_end);
+                }
+
+                if options.row_selection_len != 0 {
+                    let slice = std::slice::from_raw_parts(
+                        options.row_selection_begin,
+                        options.row_selection_len as usize,
+                    );
+                    let buffer = Buffer::copy_from(slice);
+                    let buffer = StrictSortedBuffer::new_unchecked(buffer);
+                    let selection = Selection::IncludeByIndex(buffer);
+                    builder = builder.with_selection(selection);
                 }
 
                 if options.max_splits_in_flight != 0 {
@@ -1474,6 +1492,7 @@ mod tests {
     use arrow_array::ffi::to_ffi;
     use arrow_array::{Int64Array, StringArray};
     use arrow_schema::{DataType, Field};
+    use std::ptr;
     use std::sync::atomic::AtomicBool;
     use std::sync::Condvar;
 
@@ -1839,6 +1858,8 @@ mod tests {
             filter: std::ptr::null(),
             row_range_begin: 0,
             row_range_end: 0,
+            row_selection_begin: ptr::null(),
+            row_selection_len: 0,
             max_splits_in_flight: 0,
         }
     }

--- a/rust/workspace/vortex/src/lib.rs
+++ b/rust/workspace/vortex/src/lib.rs
@@ -865,7 +865,7 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
                         options.row_selection_len as usize,
                     );
                     let buffer = Buffer::copy_from(slice);
-                    let buffer = StrictSortedBuffer::new_unchecked(buffer);
+                    let buffer = StrictSortedBuffer::try_new(buffer).map_err(|e| e.to_string())?;
                     let selection = Selection::IncludeByIndex(buffer);
                     builder = builder.with_selection(selection);
                 }

--- a/src/Formats/FormatFilterInfo.h
+++ b/src/Formats/FormatFilterInfo.h
@@ -116,6 +116,9 @@ struct FormatFilterInfo
     /// return exactly these rows; with `FormatSettings::parquet::preserve_order` they are returned
     /// in this exact order. Supported by Parquet and Vortex.
     std::shared_ptr<const PaddedPODArray<UInt64>> rows_to_read;
+
+    // True if someone will use ChunkInfoRowNumbers downstream
+    bool need_row_numbers = false;
 private:
     /// For lazily initializing the fields above.
     std::once_flag init_flag;

--- a/src/Formats/FormatFilterInfo.h
+++ b/src/Formats/FormatFilterInfo.h
@@ -114,7 +114,7 @@ struct FormatFilterInfo
     /// Lazy materialization: if set, read only the rows with these row numbers and skip everything
     /// else. Sorted, unique, absolute (pre-filtering) row indexes within the file. The format must
     /// return exactly these rows; with `FormatSettings::parquet::preserve_order` they are returned
-    /// in this exact order. Only supported by the Parquet format.
+    /// in this exact order. Supported by Parquet and Vortex.
     std::shared_ptr<const PaddedPODArray<UInt64>> rows_to_read;
 private:
     /// For lazily initializing the fields above.

--- a/src/Processors/Formats/Impl/Parquet/ReadManager.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ReadManager.cpp
@@ -1155,17 +1155,20 @@ ReadManager::ReadResult ReadManager::read()
     Chunk chunk(std::move(output_columns), row_subgroup.filter.rows_pass);
     BlockMissingValues block_missing_values = std::move(row_subgroup.block_missing_values);
 
-    auto row_numbers_info = std::make_shared<ChunkInfoRowNumbers>(
-        row_subgroup.start_row_idx + row_group.start_global_row_idx);
-    if (row_subgroup.filter.rows_pass != row_subgroup.filter.rows_total)
+    if (reader.format_filter_info && reader.format_filter_info->need_row_numbers)
     {
-        chassert(row_subgroup.filter.rows_pass > 0);
-        chassert(!row_subgroup.filter.filter.empty());
-        chassert(countBytesInFilter(row_subgroup.filter.filter) == chunk.getNumRows());
+        auto row_numbers_info = std::make_shared<ChunkInfoRowNumbers>(
+            row_subgroup.start_row_idx + row_group.start_global_row_idx);
+        if (row_subgroup.filter.rows_pass != row_subgroup.filter.rows_total)
+        {
+            chassert(row_subgroup.filter.rows_pass > 0);
+            chassert(!row_subgroup.filter.filter.empty());
+            chassert(countBytesInFilter(row_subgroup.filter.filter) == chunk.getNumRows());
 
-        row_numbers_info->applied_filter = std::move(row_subgroup.filter.filter);
+            row_numbers_info->applied_filter = std::move(row_subgroup.filter.filter);
+        }
+        chunk.getChunkInfos().add(std::move(row_numbers_info));
     }
-    chunk.getChunkInfos().add(std::move(row_numbers_info));
 
     /// This is a terrible hack to make progress indication kind of work.
     ///

--- a/src/Processors/Formats/Impl/ParquetV3BlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetV3BlockInputFormat.cpp
@@ -136,7 +136,8 @@ Chunk ParquetV3BlockInputFormat::read()
 
 
         auto chunk = getChunkForCount(size_t(file_metadata.num_rows));
-        chunk.getChunkInfos().add(std::make_shared<ChunkInfoRowNumbers>(0));
+        if (format_filter_info && format_filter_info->need_row_numbers)
+            chunk.getChunkInfos().add(std::make_shared<ChunkInfoRowNumbers>(0));
 
         reported_count = true;
         return chunk;

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
@@ -14,6 +14,7 @@
 #include <base/scope_guard.h>
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
+#include <Common/assert_cast.h>
 #include <Common/ProfileEvents.h>
 #include <Common/setThreadName.h>
 #include <Common/threadPoolCallbackRunner.h>
@@ -48,6 +49,26 @@ using namespace Vortex;
 /// still making progress. Finding it idle this many times in a row means it never will again.
 static constexpr auto PROGRESS_CHECK_PERIOD = std::chrono::seconds(1);
 static constexpr size_t IDLE_CHECKS_BEFORE_STUCK = 3;
+
+// Convert Vortex's row_idx() column into ChunkInfoRowNumbers
+static std::shared_ptr<ChunkInfoRowNumbers> convertToRowNumbers(const arrow::Array & row_index_column)
+{
+    const auto & values = assert_cast<const arrow::UInt64Array &>(row_index_column);
+    const size_t num_rows = values.length();
+    if (num_rows == 0)
+        return std::make_shared<ChunkInfoRowNumbers>(0);
+
+    const UInt64 first = values.Value(0);
+    const UInt64 last = values.Value(num_rows - 1);
+    if (last - first + 1 == num_rows)
+        return std::make_shared<ChunkInfoRowNumbers>(first);
+
+    // TODO(myrrc): this is very inefficient
+    auto info = std::make_shared<ChunkInfoRowNumbers>(first, IColumnFilter(last - first + 1, 0));
+    for (size_t i = 0; i < num_rows; ++i)
+        (*info->applied_filter)[values.Value(i) - first] = 1;
+    return info;
+}
 
 /// The C entry points the library calls. An exception escaping one of them would unwind into Rust,
 /// so everything they reach is `noexcept`.
@@ -236,7 +257,17 @@ int32_t VortexBlockInputFormat::onChunk(::ArrowArray * array, UInt64 split_index
 
             ArrowColumnToCHColumn::checkRecordBatchValidityBitmaps(**batch);
 
-            auto table = arrow::Table::FromRecordBatches({*batch});
+            std::shared_ptr<ChunkInfoRowNumbers> row_numbers_info;
+            auto data_batch = *batch;
+            if (row_index_column)
+            {
+                row_numbers_info = convertToRowNumbers(*data_batch->column(0));
+                auto removed = data_batch->RemoveColumn(0);
+                throwFromArrowStatusIfFailed(removed.status());
+                data_batch = *removed;
+            }
+
+            auto table = arrow::Table::FromRecordBatches({data_batch});
             throwFromArrowStatusIfFailed(table.status());
 
             auto converter = takeConverter();
@@ -246,6 +277,8 @@ int32_t VortexBlockInputFormat::onChunk(::ArrowArray * array, UInt64 split_index
             BlockMissingValues * missing_values_ptr
                 = format_settings.defaults_for_omitted_fields ? &delivered_chunk.missing_values : nullptr;
             delivered_chunk.chunk = converter->arrowTableToCHChunk(*table, (*table)->num_rows(), nullptr, missing_values_ptr);
+            if (row_numbers_info)
+                delivered_chunk.chunk.getChunkInfos().add(std::move(row_numbers_info));
         }
 
         {
@@ -462,6 +495,10 @@ void VortexBlockInputFormat::prepareReader()
     options.columns = column_name_pointers.data();
     options.num_columns = column_name_pointers.size();
     options.filter = plan.filter.get();
+
+    row_index_column = false;
+    options.row_index_column = format_filter_info && format_filter_info->need_row_numbers;
+
     /// Splits allowed in flight at once: being read, decoded, or queued for `read`. Two per
     /// decoding thread leaves each thread something to decode while the next split is still being
     /// read. The limit is low because it counts splits and not bytes, and the decoded chunks of a
@@ -477,7 +514,9 @@ void VortexBlockInputFormat::prepareReader()
     /// will be imported with has to exist beforehand: the file schema projected to the requested
     /// columns, the same way the library projects it.
     arrow::FieldVector scan_fields;
-    scan_fields.reserve(plan.column_names.size());
+    scan_fields.reserve(plan.column_names.size() + 1);
+    if (row_index_column)
+        scan_fields.push_back(arrow::field("_row_index", arrow::uint64(), /* nullable */ false));
     for (const auto & name : plan.column_names)
         scan_fields.push_back(file_schema->GetFieldByName(name));
     scan_schema = arrow::schema(std::move(scan_fields));

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
@@ -496,8 +496,8 @@ void VortexBlockInputFormat::prepareReader()
     options.num_columns = column_name_pointers.size();
     options.filter = plan.filter.get();
 
-    row_index_column = false;
-    options.row_index_column = format_filter_info && format_filter_info->need_row_numbers;
+    row_index_column = format_filter_info && format_filter_info->need_row_numbers;
+    options.row_index_column = row_index_column;
 
     /// Splits allowed in flight at once: being read, decoded, or queued for `read`. Two per
     /// decoding thread leaves each thread something to decode while the next split is still being

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
@@ -435,14 +435,11 @@ void VortexBlockInputFormat::prepareReader()
     if (!reader)
         return;
 
-    if (need_only_count)
-        return;
-
     const VortexScanPlan plan = planVortexScan(getPort().getHeader(), *file_schema, format_filter_info.get(), format_settings, log);
 
-    if (plan.column_names.empty())
+    if (need_only_count || plan.column_names.empty())
     {
-        pending_rows_without_columns = vortex_ffi_reader_row_count(reader);
+        pending_rows_without_columns = plan.rows_to_read ? plan.rows_to_read->size() : vortex_ffi_reader_row_count(reader);
         return;
     }
 
@@ -454,12 +451,14 @@ void VortexBlockInputFormat::prepareReader()
 
     FFI_VortexScanOptions options{};
 
-    if (plan.rows_to_read) {
+    preserve_order |= format_settings.vortex.preserve_order;
+
+    if (plan.rows_to_read)
+    {
         options.row_selection_begin = plan.rows_to_read->begin();
         options.row_selection_len = plan.rows_to_read->size();
+        preserve_order = true;
     }
-    options.row_range_begin = 0;
-    options.row_range_end = 0;
 
     options.columns = column_name_pointers.data();
     options.num_columns = column_name_pointers.size();
@@ -573,7 +572,7 @@ Chunk VortexBlockInputFormat::read()
         if (!delivered.empty())
         {
             auto it = delivered.begin();
-            if (!format_settings.vortex.preserve_order || it->first == next_split_index)
+            if (!preserve_order || it->first == next_split_index)
             {
                 const UInt64 split_index = it->first;
                 DeliveredChunk delivered_chunk = std::move(it->second);
@@ -669,8 +668,7 @@ Chunk VortexBlockInputFormat::read()
         }
         lock.lock();
 
-        const bool nothing_deliverable
-            = delivered.empty() || (format_settings.vortex.preserve_order && delivered.begin()->first != next_split_index);
+        const bool nothing_deliverable = delivered.empty() || (preserve_order && delivered.begin()->first != next_split_index);
         if (idle_checks >= IDLE_CHECKS_BEFORE_STUCK && nothing_deliverable && !scan_finished && !background_exception && !is_stopped)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Deadlock in the Vortex reader (thread pool)");
     }

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
@@ -453,6 +453,14 @@ void VortexBlockInputFormat::prepareReader()
         column_name_pointers.push_back(name.c_str());
 
     FFI_VortexScanOptions options{};
+
+    if (plan.rows_to_read) {
+        options.row_selection_begin = plan.rows_to_read->begin();
+        options.row_selection_len = plan.rows_to_read->size();
+    }
+    options.row_range_begin = 0;
+    options.row_range_end = 0;
+
     options.columns = column_name_pointers.data();
     options.num_columns = column_name_pointers.size();
     options.filter = plan.filter.get();

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
@@ -451,13 +451,12 @@ void VortexBlockInputFormat::prepareReader()
 
     FFI_VortexScanOptions options{};
 
-    preserve_order |= format_settings.vortex.preserve_order;
+    preserve_order = format_settings.vortex.preserve_order || plan.rows_to_read;
 
     if (plan.rows_to_read)
     {
         options.row_selection_begin = plan.rows_to_read->begin();
         options.row_selection_len = plan.rows_to_read->size();
-        preserve_order = true;
     }
 
     options.columns = column_name_pointers.data();

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.h
@@ -209,6 +209,7 @@ private:
 
     std::atomic<int> is_stopped{0};
     bool preserve_order = false;
+    bool row_index_column = false;
 };
 
 class VortexSchemaReader final : public ISchemaReader

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.h
@@ -173,7 +173,7 @@ private:
     std::condition_variable delivery_cv;
     /// Finished chunks waiting for `read`, keyed by the position of their split in the file.
     std::map<UInt64, DeliveredChunk> delivered TSA_GUARDED_BY(delivery_mutex);
-    /// Which split `read` hands out next while `input_format_vortex_preserve_order` is on.
+    /// Which split `read` hands out next while "preserve_order" is true.
     UInt64 next_split_index TSA_GUARDED_BY(delivery_mutex) = 0;
     /// The scan reported that it reached the end. Stays false when it was cancelled instead.
     bool scan_finished TSA_GUARDED_BY(delivery_mutex) = false;

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.h
@@ -208,6 +208,7 @@ private:
     const LoggerPtr log = getLogger("VortexBlockInputFormat");
 
     std::atomic<int> is_stopped{0};
+    bool preserve_order = false;
 };
 
 class VortexSchemaReader final : public ISchemaReader

--- a/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.cpp
@@ -121,9 +121,12 @@ VortexScanPlan planVortexScan(
         add_column_name(Nested::extractTableName(column.name));
     }
 
+    if (filter_info) {
+        plan.rows_to_read = filter_info->rows_to_read.get();
+    }
+
     if (!plan.column_names.empty() && format_settings.vortex.filter_push_down && filter_info && filter_info->hasFilter())
     {
-        plan.rows_to_read = filter_info->rows_to_read.get();
         plan.filter = buildFilter(header, file_schema, *filter_info, format_settings, plan);
         ProfileEvents::increment(ProfileEvents::VortexFilterPushdownConjunctsPushed, plan.filter_conjuncts_pushed);
         ProfileEvents::increment(

--- a/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.cpp
@@ -123,6 +123,7 @@ VortexScanPlan planVortexScan(
 
     if (!plan.column_names.empty() && format_settings.vortex.filter_push_down && filter_info && filter_info->hasFilter())
     {
+        plan.rows_to_read = filter_info->rows_to_read.get();
         plan.filter = buildFilter(header, file_schema, *filter_info, format_settings, plan);
         ProfileEvents::increment(ProfileEvents::VortexFilterPushdownConjunctsPushed, plan.filter_conjuncts_pushed);
         ProfileEvents::increment(

--- a/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.cpp
@@ -121,9 +121,8 @@ VortexScanPlan planVortexScan(
         add_column_name(Nested::extractTableName(column.name));
     }
 
-    if (filter_info) {
+    if (filter_info)
         plan.rows_to_read = filter_info->rows_to_read.get();
-    }
 
     if (!plan.column_names.empty() && format_settings.vortex.filter_push_down && filter_info && filter_info->hasFilter())
     {

--- a/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.h
+++ b/src/Processors/Formats/Impl/Vortex/VortexScanPlanner.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Common/PODArray.h>
 #include "config.h"
 
 #if USE_VORTEX
@@ -42,6 +43,9 @@ struct VortexScanPlan
     /// and skips the statistics zones it excludes; ClickHouse reapplies the full condition to the
     /// result, so this may keep more rows than the condition - never fewer.
     VortexExpressionPtr filter;
+
+    // Row selection to read. If present, set to FilterInfo's rows_to_read.
+    const PaddedPODArray<UInt64, 4096>* rows_to_read = nullptr;
 
     /// How much of the WHERE condition the filter carries, for logs and `ProfileEvents`.
     size_t filter_conjuncts_total = 0;

--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
@@ -128,6 +128,10 @@ void ReadFromObjectStorageStep::initializePipeline(QueryPipelineBuilder & pipeli
         configuration->getColumnMapperForCurrentSchema(storage_snapshot->metadata, context),
         query_info.row_level_filter,
         query_info.prewhere_info);
+    // Delete transforms in data lakes need row numbers
+    format_filter_info->need_row_numbers = lazy_row_index_registry != nullptr
+        || VirtualColumnUtils::hasRowDependentVirtualColumns(info.requested_virtual_columns)
+        || configuration->isDataLakeConfiguration();
 
     for (size_t i = 0; i < num_streams; ++i)
     {

--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
@@ -79,7 +79,8 @@ void ReadFromObjectStorageStep::applyFilters(ActionDAGNodes added_filter_nodes)
     if (!filter_actions_dag)
         return;
 
-    if (boost::iequals(configuration->format, "Parquet") || boost::iequals(configuration->format, "ORC"))
+    if (boost::iequals(configuration->format, "Parquet") || boost::iequals(configuration->format, "ORC")
+        || boost::iequals(configuration->format, "Vortex"))
         prepareEagerKeyConditionSets(
             filter_actions_dag,
             storage_snapshot, info.source_header,
@@ -198,8 +199,8 @@ bool ReadFromObjectStorageStep::canUseLazyMaterialization() const
 
     /// The global row index requires per-row file row numbers (ChunkInfoRowNumbers), and the lazy
     /// branch requires reading an explicit set of rows (FormatFilterInfo::rows_to_read).
-    /// Only the Parquet reader supports both.
-    if (!boost::iequals(configuration->format, "Parquet"))
+    /// Only the Parquet and Vortex readers support both.
+    if (!boost::iequals(configuration->format, "Parquet") && !boost::iequals(configuration->format, "Vortex"))
         return false;
 
     /// Data lakes can have per-file formats, deletes, and schema evolution; the configuration

--- a/src/Processors/Sources/LazyReadFromObjectStorageSource.cpp
+++ b/src/Processors/Sources/LazyReadFromObjectStorageSource.cpp
@@ -224,6 +224,7 @@ IProcessor::PipelineUpdate LazyReadFromObjectStorageSource::updatePipeline()
     /// would restore the original row order incorrectly.
     FormatSettings modified_format_settings = format_settings ? *format_settings : getFormatSettings(context);
     modified_format_settings.parquet.preserve_order = true;
+    modified_format_settings.vortex.preserve_order = true;
 
     auto parser_shared_resources = std::make_shared<FormatParserSharedResources>(context->getSettingsRef(), /*num_streams_=*/ 1);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -361,6 +361,8 @@ static void writeDataFiles(
             settings,
             /*num_streams_=*/1);
 
+        auto input_format_filter_info = std::make_shared<FormatFilterInfo>(nullptr, context, nullptr, nullptr, nullptr);
+        input_format_filter_info->need_row_numbers = delete_file_transform != nullptr;
         auto input_format = FormatFactory::instance().getInput(
             data_file->data_object_info->getFileFormat().value_or(write_format),
             *read_buffer,
@@ -369,7 +371,7 @@ static void writeDataFiles(
             8192,
             format_settings,
             parser_shared_resources,
-            std::make_shared<FormatFilterInfo>(nullptr, context, nullptr, nullptr, nullptr),
+            input_format_filter_info,
             true /* is_remote_fs */,
             chooseCompressionMethod(data_file->data_object_info->getPath(), toContentEncodingName(write_compression_method)),
             false);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -1381,10 +1381,12 @@ bool IcebergMetadata::shouldReloadSchemaForConsistency(ContextPtr) const
 
 void IcebergMetadata::modifyFormatSettings(FormatSettings & format_settings, const Context & local_context) const
 {
-    if (!local_context.getSettingsRef()[Setting::use_roaring_bitmap_iceberg_positional_deletes].value)
+    if (!local_context.getSettingsRef()[Setting::use_roaring_bitmap_iceberg_positional_deletes].value) { 
         /// IcebergStreamingPositionDeleteTransform requires increasing row numbers from both the
         /// data reader and the deletes reader.
         format_settings.parquet.preserve_order = true;
+        format_settings.vortex.preserve_order = true;
+    }
 }
 
 void IcebergMetadata::addDeleteTransformers(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -250,10 +250,10 @@ bool ManifestFileIterator::ManifestFileEntriesHandle::areAllDataFilesEligibleFor
 
     for (const auto & file : *data_files)
     {
-        /// Only the Parquet reader provides physical row numbers (ChunkInfoRowNumbers)
+        /// Only Parquet and Vortex readers provide physical row numbers (ChunkInfoRowNumbers)
         /// for the main read and positional re-reads (FormatFilterInfo::rows_to_read)
         /// for the lazy read.
-        if (Poco::toUpper(file->parsed_entry->file_format) != "PARQUET")
+        if (std::string format = Poco::toUpper(file->parsed_entry->file_format); format != "PARQUET" && format != "VORTEX")
             return false;
 
         /// Schema evolution forces reading all physical columns as well.

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -112,6 +112,8 @@ void IcebergPositionDeleteTransform::initializeDeleteSources()
             return std::shared_ptr<const ActionsDAG>();
         }();
 
+        auto delete_format_filter_info = std::make_shared<FormatFilterInfo>(actions_dag_ptr, context, nullptr, nullptr, nullptr);
+        delete_format_filter_info->need_row_numbers = true;
         auto delete_format = FormatFactory::instance().getInput(
             format,
             *delete_read_buffers.back(),
@@ -120,7 +122,7 @@ void IcebergPositionDeleteTransform::initializeDeleteSources()
             context->getSettingsRef()[DB::Setting::max_block_size],
             format_settings,
             parser_shared_resources,
-            std::make_shared<FormatFilterInfo>(actions_dag_ptr, context, nullptr, nullptr, nullptr),
+            delete_format_filter_info,
             true /* is_remote_fs */,
             compression_method);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -1325,6 +1325,9 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             return format_filter_info;
         }();
 
+        if (filter_info && filter_info != format_filter_info)
+            filter_info->need_row_numbers = format_filter_info->need_row_numbers;
+
         if (object_info->rows_to_read)
         {
             /// Lazy materialization: read only the specified rows of this file. The set of rows
@@ -1336,6 +1339,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
                 filter_info ? filter_info->row_level_filter : nullptr,
                 filter_info ? filter_info->prewhere_info : nullptr);
             filter_info_with_rows->rows_to_read = object_info->rows_to_read;
+            filter_info_with_rows->need_row_numbers = true;
             filter_info = filter_info_with_rows;
         }
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -2432,6 +2432,8 @@ void ReadFromFile::initializePipeline(QueryPipelineBuilder & pipeline, const Bui
 
     auto parser_shared_resources = std::make_shared<FormatParserSharedResources>(ctx->getSettingsRef(), num_streams);
     auto format_filter_info = std::make_shared<FormatFilterInfo>(filter_actions_dag, ctx, nullptr, query_info.row_level_filter, query_info.prewhere_info);
+    format_filter_info->need_row_numbers
+        = lazy_row_index_registry != nullptr || VirtualColumnUtils::hasRowDependentVirtualColumns(info.requested_virtual_columns);
 
     for (size_t i = 0; i < num_streams; ++i)
     {
@@ -2561,6 +2563,7 @@ public:
                 /// so the deferred columns are read without any filtering expressions.
                 auto format_filter_info = std::make_shared<FormatFilterInfo>(nullptr, getContext(), nullptr, nullptr, nullptr);
                 format_filter_info->rows_to_read = file.rows;
+                format_filter_info->need_row_numbers = true;
 
                 if (object_with_metadata)
                 {

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -2238,7 +2238,7 @@ bool ReadFromFile::canUseLazyMaterialization() const
 
     /// The global row index requires per-row file row numbers (ChunkInfoRowNumbers), and the lazy
     /// branch requires reading an explicit set of rows (FormatFilterInfo::rows_to_read).
-    /// Only Parquet and Vortex readers supports both.
+    /// Only the Parquet and Vortex readers support both.
     if (!boost::iequals(storage->format_name, "Parquet")
         && !boost::iequals(storage->format_name, "Vortex"))
         return false;

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -2238,8 +2238,9 @@ bool ReadFromFile::canUseLazyMaterialization() const
 
     /// The global row index requires per-row file row numbers (ChunkInfoRowNumbers), and the lazy
     /// branch requires reading an explicit set of rows (FormatFilterInfo::rows_to_read).
-    /// Only the Parquet reader supports both.
-    if (!boost::iequals(storage->format_name, "Parquet"))
+    /// Only Parquet and Vortex readers supports both.
+    if (!boost::iequals(storage->format_name, "Parquet")
+        && !boost::iequals(storage->format_name, "Vortex"))
         return false;
 
     /// A file descriptor (e.g. stdin) is consumed by the main read and cannot be reopened.
@@ -2554,6 +2555,7 @@ public:
                 /// LazyMaterializingTransform would restore the original row order incorrectly.
                 FormatSettings format_settings = storage->format_settings ? *storage->format_settings : getFormatSettings(getContext());
                 format_settings.parquet.preserve_order = true;
+                format_settings.vortex.preserve_order = true;
 
                 /// There is no filter and no prewhere here: the surviving rows are known exactly,
                 /// so the deferred columns are read without any filtering expressions.

--- a/src/Storages/VirtualColumnUtils.cpp
+++ b/src/Storages/VirtualColumnUtils.cpp
@@ -527,7 +527,7 @@ void addRequestedFileLikeStorageVirtualsToChunk(
         }
         else if (virtual_column.name == "_row_number")
         {
-#if USE_PARQUET
+#if USE_PARQUET || USE_VORTEX
             auto chunk_info = chunk.getChunkInfos().get<ChunkInfoRowNumbers>();
             if (chunk_info)
             {
@@ -548,7 +548,7 @@ void addRequestedFileLikeStorageVirtualsToChunk(
                 chunk.addColumn(virtual_column.type->createColumnConstWithDefaultValue(chunk.getNumRows())->convertToFullColumnIfConst());
             }
 #else
-            // If Parquet format is not used, we don't have row numbers info, so _row_number = NULL.
+            // If Parquet or Vortex are not used, we don't have row numbers info, so _row_number = NULL.
             chunk.addColumn(virtual_column.type->createColumnConstWithDefaultValue(chunk.getNumRows())->convertToFullColumnIfConst());
 #endif
         }
@@ -576,7 +576,7 @@ void addRequestedFileLikeStorageVirtualsToChunk(
         else if (virtual_column.name == "_row_id")
         {
             std::vector<UInt64> row_positions;
-#if USE_PARQUET
+#if USE_PARQUET || USE_VORTEX
             if (auto chunk_info = chunk.getChunkInfos().get<ChunkInfoRowNumbers>(); chunk_info && virtual_values.first_row_id)
             {
                 const auto & applied_filter = chunk_info->applied_filter;

--- a/tests/queries/0_stateless/05056_vortex_lazy_materialization.reference
+++ b/tests/queries/0_stateless/05056_vortex_lazy_materialization.reference
@@ -1,0 +1,113 @@
+-- query_plan_optimize_lazy_materialization_for_file = 1
+-- simple ORDER BY ... LIMIT
+0	val_0
+1	val_1
+2	val_2
+3	val_3
+4	val_4
+-- ORDER BY ... DESC LIMIT across files
+2999	val_2999	[0,1,2,3]
+2998	val_2998	[0,1,2]
+2997	val_2997	[0,1]
+2996	val_2996	[0]
+2995	val_2995	[]
+2994	val_2994	[0,1,2,3]
+2993	val_2993	[0,1,2]
+-- with a filter (moved to PREWHERE)
+2995	val_2995
+2978	val_2978
+2961	val_2961
+2944	val_2944
+-- a preserved PREWHERE expression stays on the main branch
+1	val_0
+2	val_1
+3	val_2
+-- expressions on lazy columns are applied after the LIMIT
+18	VAL_2900
+19	VAL_2901
+20	VAL_2902
+-- sorting by a column with duplicate values
+0	val_0
+0	val_17
+0	val_34
+0	val_51
+0	val_68
+-- virtual columns together with lazy columns
+data_1.vortex	998	998	val_998
+data_1.vortex	999	999	val_999
+data_2.vortex	0	1000	val_1000
+-- the number of lazy read steps in the plan
+1
+-- lazily read columns are shown in EXPLAIN
+Lazily read columns: s, arr
+-- a non-Vortex file stays on the single-pass plan
+0
+99	val_99
+98	val_98
+-- an archive entry stays on the single-pass plan
+0
+999	val_999
+998	val_998
+-- a FIFO stays on the single-pass plan
+0
+-- the File engine takes the lazy path as well
+1
+999	engine_999	[]
+998	engine_998	[0,1]
+997	engine_997	[0]
+-- query_plan_optimize_lazy_materialization_for_file = 0
+-- simple ORDER BY ... LIMIT
+0	val_0
+1	val_1
+2	val_2
+3	val_3
+4	val_4
+-- ORDER BY ... DESC LIMIT across files
+2999	val_2999	[0,1,2,3]
+2998	val_2998	[0,1,2]
+2997	val_2997	[0,1]
+2996	val_2996	[0]
+2995	val_2995	[]
+2994	val_2994	[0,1,2,3]
+2993	val_2993	[0,1,2]
+-- with a filter (moved to PREWHERE)
+2995	val_2995
+2978	val_2978
+2961	val_2961
+2944	val_2944
+-- a preserved PREWHERE expression stays on the main branch
+1	val_0
+2	val_1
+3	val_2
+-- expressions on lazy columns are applied after the LIMIT
+18	VAL_2900
+19	VAL_2901
+20	VAL_2902
+-- sorting by a column with duplicate values
+0	val_0
+0	val_17
+0	val_34
+0	val_51
+0	val_68
+-- virtual columns together with lazy columns
+data_1.vortex	998	998	val_998
+data_1.vortex	999	999	val_999
+data_2.vortex	0	1000	val_1000
+-- the number of lazy read steps in the plan
+0
+-- lazily read columns are shown in EXPLAIN
+-- a non-Vortex file stays on the single-pass plan
+0
+99	val_99
+98	val_98
+-- an archive entry stays on the single-pass plan
+0
+999	val_999
+998	val_998
+-- a FIFO stays on the single-pass plan
+0
+-- the File engine takes the lazy path as well
+0
+999	engine_999	[]
+998	engine_998	[0,1]
+997	engine_997	[0]

--- a/tests/queries/0_stateless/05056_vortex_lazy_materialization.sh
+++ b/tests/queries/0_stateless/05056_vortex_lazy_materialization.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Tags: no-fasttest
 # - no-fasttest: reads Vortex files
 
@@ -10,7 +11,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # sorting and filtering are read only for the `n` rows that survive the `LIMIT`.
 # The whole battery is run with the optimization enabled and disabled; the results must match.
 
-LOCAL_DIR=$(mktemp -d "${CLICKHOUSE_TMP}/04838_lazy_mat_file_XXXXXX")
+LOCAL_DIR=$(mktemp -d "${CLICKHOUSE_TMP}/05056_lazy_mat_file_XXXXXX")
 trap 'rm -rf "${LOCAL_DIR}"' EXIT
 
 LOCAL=(${CLICKHOUSE_LOCAL} --path "${LOCAL_DIR}")

--- a/tests/queries/0_stateless/05056_vortex_lazy_materialization.sh
+++ b/tests/queries/0_stateless/05056_vortex_lazy_materialization.sh
@@ -1,0 +1,98 @@
+# Tags: no-fasttest
+# - no-fasttest: reads Vortex files
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Lazy materialization for reading local Vortex files with the `file` table function and the
+# `File` table engine: for `ORDER BY ... LIMIT n` queries, the columns that are not needed for
+# sorting and filtering are read only for the `n` rows that survive the `LIMIT`.
+# The whole battery is run with the optimization enabled and disabled; the results must match.
+
+LOCAL_DIR=$(mktemp -d "${CLICKHOUSE_TMP}/04838_lazy_mat_file_XXXXXX")
+trap 'rm -rf "${LOCAL_DIR}"' EXIT
+
+LOCAL=(${CLICKHOUSE_LOCAL} --path "${LOCAL_DIR}")
+
+DATA_DIR="${LOCAL_DIR}/user_files"
+mkdir -p "$DATA_DIR"
+
+"${LOCAL[@]}" --query "
+    INSERT INTO FUNCTION file('${DATA_DIR}/data_1.vortex', Vortex)
+    SELECT number AS k, number % 17 AS f, concat('val_', toString(number)) AS s, range(number % 5) AS arr
+    FROM numbers(0, 1000)
+    SETTINGS engine_file_truncate_on_insert = 1;
+
+    INSERT INTO FUNCTION file('${DATA_DIR}/data_2.vortex', Vortex)
+    SELECT number AS k, number % 17 AS f, concat('val_', toString(number)) AS s, range(number % 5) AS arr
+    FROM numbers(1000, 1000)
+    SETTINGS engine_file_truncate_on_insert = 1;
+
+    INSERT INTO FUNCTION file('${DATA_DIR}/data_3.vortex', Vortex)
+    SELECT number AS k, number % 17 AS f, concat('val_', toString(number)) AS s, range(number % 5) AS arr
+    FROM numbers(2000, 1000)
+    SETTINGS engine_file_truncate_on_insert = 1;
+
+    INSERT INTO FUNCTION file('${DATA_DIR}/data.csv', CSVWithNames)
+    SELECT number AS k, concat('val_', toString(number)) AS s
+    FROM numbers(0, 100)
+    SETTINGS engine_file_truncate_on_insert = 1;
+"
+
+(
+    cd "$DATA_DIR" || exit 1
+    zip -0 -q archive.zip data_1.vortex
+)
+
+FIFO_PATH="${DATA_DIR}/data.vortex.fifo"
+mkfifo "$FIFO_PATH"
+
+TABLE_FN="file('${DATA_DIR}/data_{1,2,3}.vortex', Vortex)"
+
+QUERIES="
+SELECT '-- simple ORDER BY ... LIMIT';
+SELECT k, s FROM ${TABLE_FN} ORDER BY k LIMIT 5;
+SELECT '-- ORDER BY ... DESC LIMIT across files';
+SELECT k, s, arr FROM ${TABLE_FN} ORDER BY k DESC LIMIT 7;
+SELECT '-- with a filter (moved to PREWHERE)';
+SELECT k, s FROM ${TABLE_FN} WHERE f = 3 ORDER BY k DESC LIMIT 4;
+SELECT '-- a preserved PREWHERE expression stays on the main branch';
+SELECT f + 1, s FROM ${TABLE_FN} WHERE f + 1 > 0 ORDER BY k LIMIT 3;
+SELECT '-- expressions on lazy columns are applied after the LIMIT';
+SELECT length(s) + f AS x, upper(s) FROM ${TABLE_FN} ORDER BY intDiv(k, 100) DESC, k LIMIT 3;
+SELECT '-- sorting by a column with duplicate values';
+SELECT f, s FROM ${TABLE_FN} ORDER BY f, k LIMIT 5;
+SELECT '-- virtual columns together with lazy columns';
+SELECT _file, _row_number, k, s FROM ${TABLE_FN} ORDER BY k LIMIT 3 OFFSET 998;
+SELECT '-- the number of lazy read steps in the plan';
+SELECT countIf(explain LIKE '%LazilyReadFromFile%') FROM (EXPLAIN SELECT s FROM ${TABLE_FN} ORDER BY k LIMIT 3);
+SELECT '-- lazily read columns are shown in EXPLAIN';
+SELECT trim(explain) FROM (EXPLAIN actions = 1 SELECT k, s, arr FROM ${TABLE_FN} ORDER BY k LIMIT 3) WHERE explain LIKE '%Lazily read columns%';
+SELECT '-- a non-Vortex file stays on the single-pass plan';
+SELECT countIf(explain LIKE '%LazilyReadFromFile%') FROM (EXPLAIN SELECT s FROM file('${DATA_DIR}/data.csv', CSVWithNames) ORDER BY k LIMIT 3);
+SELECT k, s FROM file('${DATA_DIR}/data.csv', CSVWithNames) ORDER BY k DESC LIMIT 2;
+SELECT '-- an archive entry stays on the single-pass plan';
+SELECT countIf(explain LIKE '%LazilyReadFromFile%') FROM (EXPLAIN SELECT s FROM file('${DATA_DIR}/archive.zip :: data_1.vortex', Vortex) ORDER BY k LIMIT 3);
+SELECT k, s FROM file('${DATA_DIR}/archive.zip :: data_1.vortex', Vortex) ORDER BY k DESC LIMIT 2;
+SELECT '-- a FIFO stays on the single-pass plan';
+SELECT countIf(explain LIKE '%LazilyReadFromFile%') FROM (EXPLAIN SELECT s FROM file('${FIFO_PATH}', Vortex, 'k UInt64, s String') ORDER BY k LIMIT 3);
+SELECT '-- the File engine takes the lazy path as well';
+CREATE TABLE t_lazy_mat_file (k UInt64, f UInt64, s String, arr Array(UInt64)) ENGINE = File(Vortex);
+INSERT INTO t_lazy_mat_file SELECT number, number % 17, concat('engine_', toString(number)), range(number % 3) FROM numbers(1000);
+SELECT countIf(explain LIKE '%LazilyReadFromFile%') FROM (EXPLAIN SELECT s FROM t_lazy_mat_file ORDER BY k LIMIT 3);
+SELECT k, s, arr FROM t_lazy_mat_file ORDER BY k DESC LIMIT 3;
+DROP TABLE t_lazy_mat_file;
+"
+
+# `enable_analyzer` is pinned because lazy materialization requires the analyzer
+# (see `QueryPlanOptimizationSettings`), and some CI configurations run with the old analyzer.
+for enabled in 1 0; do
+    echo "-- query_plan_optimize_lazy_materialization_for_file = $enabled"
+    "${LOCAL[@]}" \
+        --enable_analyzer=1 \
+        --query_plan_optimize_lazy_materialization=1 \
+        --query_plan_max_limit_for_lazy_materialization=0 \
+        --query_plan_optimize_lazy_materialization_for_file="$enabled" \
+        --query "$QUERIES"
+done


### PR DESCRIPTION
Add "_row_index" virtual column for Vortex which serves as basis for lazy materialization. Caveat: due to the way ChunkInfoRowNumbers is implemented, adding row numbers iterates the row numbers column fully.

As a result, adding it blindly to the scan is a performance regression. Introduce FormatFilterInfo::need_row_numbers which tells the scan we need this column. Change Parquet reader to use this flag as well. rows_to_read is not sufficient for this: first scan (before the deferred refetch) needs to collect row numbers but can't supply rows_to_read yet.

Add a lazy materialization test, copycat of Parquet's lazy materialization test, sans JSON which isn't supported in Vortex.