### PR TITLE
Move two lightweight-update test rendezvous out of IProcessor::work()

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -311,7 +311,6 @@ static struct InitFiu
     ONCE(database_iceberg_gcs) \
     REGULAR(rmt_delay_execute_drop_range) \
     REGULAR(rmt_delay_commit_part) \
-    PAUSEABLE_ONCE(rmt_pause_before_commit_local_part) \
     ONCE(local_object_storage_network_error_during_remove) \
     REGULAR(lightweight_show_tables) \
     REGULAR(smt_part_update_duplicated_part) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -212,6 +212,7 @@ static struct InitFiu
     REGULAR(claim_inject_stale_part_dir) \
     PAUSEABLE(infinite_sleep) \
     PAUSEABLE(async_insert_flush_pause_in_executor) \
+    PAUSEABLE_ONCE(completed_pipeline_pause_before_teardown) \
     PAUSEABLE(system_replicas_schedule_requests_pause) \
     PAUSEABLE(stop_moving_part_before_swap_with_active) \
     REGULAR(replicated_merge_tree_all_replicas_stale) \

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -1,8 +1,25 @@
 #include <QueryPipeline/BlockIO.h>
+#include <Common/CurrentThread.h>
+#include <Common/FailPoint.h>
 #include <Interpreters/ProcessList.h>
+
+#include <string_view>
 
 namespace DB
 {
+
+namespace FailPoints
+{
+extern const char completed_pipeline_pause_before_teardown[];
+}
+
+namespace
+{
+
+constexpr std::string_view completed_pipeline_pause_before_teardown_query_id_prefix
+    = "completed_pipeline_pause_failpoint_";
+
+}
 
 void BlockIO::resetPipeline(bool cancel)
 {
@@ -69,6 +86,13 @@ void BlockIO::onFinish(std::chrono::system_clock::time_point finish_time)
     /// in `PipelineExecutor`) and read it until the pipeline is finalized below, so releasing it here would
     /// be a data race. It is released a bit later instead — the extra hold is brief and harmless.
     releaseQuerySlot();
+
+    /// The teardown below releases the table locks the interpreter moved into the pipeline's
+    /// resources, and a patch sink's lightweight update lock: after it, neither is held.
+    if (pipeline.completed() && FailPointInjection::hasAnyFailPointBeenRegistered()
+        && CurrentThread::getQueryId().starts_with(completed_pipeline_pause_before_teardown_query_id_prefix))
+        FailPointInjection::pauseFailPoint(FailPoints::completed_pipeline_pause_before_teardown);
+
     if (finalize_query_pipeline)
     {
         const QueryPipelineFinalizedInfo query_pipeline_finalized_info = finalize_query_pipeline(std::move(pipeline));

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -75,7 +75,6 @@ namespace FailPoints
     extern const char replicated_merge_tree_insert_retry_pause[];
     extern const char replicated_merge_tree_restore_attach_retry[];
     extern const char rmt_delay_commit_part[];
-    extern const char rmt_pause_before_commit_local_part[];
     extern const char rmt_dedup_conflict_part_name_missing[];
     extern const char merge_tree_sink_on_start_random_sleep[];
 }
@@ -871,10 +870,6 @@ std::vector<DeduplicationHash> ReplicatedMergeTreeSink::commitPart(
 
     auto sleep_before_commit_for_tests = [&] ()
     {
-        /// The parts have been renamed but not committed yet, and the caller still holds the
-        /// table lock it took for the whole pipeline.
-        FailPointInjection::pauseFailPoint(FailPoints::rmt_pause_before_commit_local_part);
-
         auto sleep_before_commit_local_part_in_replicated_table_ms = (*storage.getSettings())[MergeTreeSetting::sleep_before_commit_local_part_in_replicated_table_ms];
         if (sleep_before_commit_local_part_in_replicated_table_ms.totalMilliseconds())
         {

--- a/tests/queries/0_stateless/03100_lwu_57_lock_acquire_timeout.sh
+++ b/tests/queries/0_stateless/03100_lwu_57_lock_acquire_timeout.sh
@@ -2,8 +2,8 @@
 # Tags: long, no-replicated-database, no-parallel
 # long: the lock holds put this at about a minute.
 # no-replicated-database - path in zookeeper differs with replicated database
-# no-parallel: the `infinite_sleep` and `patch_parts_lock_pause_before_cas` failpoints are
-#   server-global, so a concurrent test would park at them or clear them while this one waits.
+# no-parallel: the `completed_pipeline_pause_before_teardown` and `patch_parts_lock_pause_before_cas`
+#   failpoints are server-global, so a concurrent test would clear them while this one waits.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -15,9 +15,14 @@ set -e
 # database for every test, so tagging by database alone would let one run match another's rows.
 run_id="lwu57-$CLICKHOUSE_DATABASE-$RANDOM$RANDOM"
 
+FP=completed_pipeline_pause_before_teardown
+# Only a query whose id starts with this can park at the failpoint, so unrelated pipelines cannot
+# consume the one-shot arm.
+QID_PREFIX=completed_pipeline_pause_failpoint_
+
 function cleanup()
 {
-    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT infinite_sleep" 2>/dev/null || true
+    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP" 2>/dev/null || true
     $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT patch_parts_lock_pause_before_cas" 2>/dev/null || true
     wait || true
     $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_lwu_timeout_sync SYNC; DROP TABLE IF EXISTS t_lwu_timeout_auto SYNC; DROP TABLE IF EXISTS t_lwu_cas SYNC; DROP TABLE IF EXISTS t_lwu_cancel SYNC; DROP TABLE IF EXISTS t_lwu_plain_sync SYNC; DROP TABLE IF EXISTS t_lwu_plain_auto SYNC" 2>/dev/null || true
@@ -57,10 +62,10 @@ function wait_for_lock_held()
     exit 2
 }
 
-# Starts an update that takes the lock and then parks inside `sleep` at the `infinite_sleep`
-# failpoint, holding the lock until release_holder is called. The hold does not begin expiring before
-# the waiter starts, so how long a waiter blocks is chosen by this test rather than raced against a
-# fixed sleep.
+# Starts an update that takes the lightweight update lock, then parks on the query thread with its
+# pipeline finished but not yet torn down, holding the lock until release_holder is called. The hold
+# does not begin expiring before the waiter starts, so how long a waiter blocks is chosen by this
+# test rather than raced against a fixed sleep.
 function start_parked_holder()
 {
     local table_name=$1
@@ -68,21 +73,39 @@ function start_parked_holder()
     # A plain MergeTree keeps the lock in process memory, so there is no node to count.
     local in_keeper=${3:-1}
 
-    $CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT infinite_sleep"
+    holder_qid="${QID_PREFIX}${CLICKHOUSE_DATABASE}_${RANDOM}${RANDOM}"
 
-    $CLICKHOUSE_CLIENT --query "
+    $CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT $FP"
+
+    # Everything below reads the armed state as evidence, so an unarmed run would be vacuous.
+    if [[ "$($CLICKHOUSE_CLIENT --query "SELECT enabled FROM system.fail_points WHERE name = '$FP'")" != 1 ]]
+    then
+        echo "Failed to arm the pause for a $mode holder on $table_name" >&2
+        exit 2
+    fi
+
+    $CLICKHOUSE_CLIENT --query_id "$holder_qid" --query "
         SET enable_lightweight_update = 1;
-        UPDATE $table_name SET s = 'xx' WHERE id = 2 AND sleep(0.001) = 0
+        UPDATE $table_name SET s = 'xx' WHERE id = 2
         SETTINGS update_parallel_mode = '$mode';
     " &
 
-    if ! $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT infinite_sleep PAUSE"
+    if ! $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT $FP PAUSE"
     then
         echo "Failed to park a $mode holder of the lightweight update lock on $table_name" >&2
         exit 2
     fi
 
-    # The pause is reached after the lock is taken, so this must already hold.
+    # The wait returns at once when nothing is parked. The failpoint is one-shot and only a query
+    # whose id carries the prefix can consume it, so a zero here is this holder having parked.
+    if [[ "$($CLICKHOUSE_CLIENT --query "SELECT enabled FROM system.fail_points WHERE name = '$FP'")" != 0 ]]
+    then
+        echo "No prefixed query parked for a $mode holder on $table_name" >&2
+        exit 2
+    fi
+
+    # The lock is taken before the pipeline runs and released only when the pipeline is torn down, so
+    # it must be held at the pause.
     if [[ "$in_keeper" == "1" ]]
     then
         wait_for_lock_held "$table_name" "$mode"
@@ -93,7 +116,7 @@ function start_parked_holder()
 # started themselves, so that a waiter can be waited for separately from the holder.
 function release_holder()
 {
-    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT infinite_sleep"
+    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT $FP"
 }
 
 # Blocks until the query tagged $1 is inside the wait for the lock rather than about to enter it.

--- a/tests/queries/0_stateless/04905_lwu_drop_race_table_lock.sh
+++ b/tests/queries/0_stateless/04905_lwu_drop_race_table_lock.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest, no-parallel, no-replicated-database, no-shared-merge-tree
 # Tag no-fasttest: relies on a failpoint (libfiu).
-# Tag no-parallel: the test waits on a server-global pauseable failpoint, so a concurrent copy's
-#   sink could satisfy this copy's wait and this copy's resume could release that sink.
-#   FailPointInjection::{enable,disable}FailPoint take only a name, so it cannot be scoped.
+# Tag no-parallel: the test waits on a server-global pauseable failpoint, so a concurrent copy
+#   could disarm this copy's park. FailPointInjection::{enable,disable}FailPoint take only a name.
 # Tag no-replicated-database: the test needs its own Memory database, which a Replicated database
 #   run cannot host, and DROP must reach the synchronous exclusive-lock path.
-# Tag no-shared-merge-tree: the failpoint this test parks on is in the ReplicatedMergeTree sink,
-#   which a SharedMergeTree table does not go through.
+# Tag no-shared-merge-tree: the substitution replaces the engine, and this asserts on the lock a
+#   ReplicatedMergeTree lightweight update holds.
 
 set -e
 
@@ -15,10 +14,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-FP=rmt_pause_before_commit_local_part
+FP=completed_pipeline_pause_before_teardown
+# Only a query whose id starts with this can park at the failpoint, so unrelated pipelines cannot
+# consume the one-shot arm.
+QID_PREFIX=completed_pipeline_pause_failpoint_
 
-# The failpoint is server-global, so leaving it enabled would park the sink of every later test.
-# This has to survive the test failing or being killed part-way through.
+# Disabling is also what releases a parked query, so this has to survive the test failing or being
+# killed part-way through.
 function cleanup()
 {
     ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT ${FP}" < /dev/null 2>/dev/null || true
@@ -49,15 +51,17 @@ function setup_table()
     " < /dev/null
 }
 
-# The DROP has to land between the patch-part rename and the commit. The sink parks there and stays
+# The DROP has to land while the update still holds the table lock it took for its pipeline. The
+# update parks once that pipeline has finished, before the teardown releases the lock, and stays
 # parked until this function resumes it, so the window is held open instead of being a timed one the
 # drop could miss.
 function race_with_drop()
 {
     local arm=$1
     shift
-    local qid="${CLICKHOUSE_DATABASE_1}_${arm}_${RANDOM}${RANDOM}"
-    local drop_qid="${qid}_drop"
+    local qid="${QID_PREFIX}${CLICKHOUSE_DATABASE_1}_${arm}_${RANDOM}${RANDOM}"
+    # Deliberately unprefixed: the drop must reach the table lock rather than park.
+    local drop_qid="${CLICKHOUSE_DATABASE_1}_${arm}_drop_${RANDOM}${RANDOM}"
 
     ${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT ${FP}" < /dev/null
 
@@ -66,32 +70,34 @@ function race_with_drop()
     if [ "$(${CLICKHOUSE_CLIENT} --query "
         SELECT enabled FROM system.fail_points WHERE name = '${FP}'
         SETTINGS enable_parallel_replicas = 0" < /dev/null 2>/dev/null)" != 1 ]; then
-        echo "$arm: the commit hook was not armed"
+        echo "$arm: the pause was not armed"
         return
     fi
 
     ${CLICKHOUSE_CLIENT} --query_id "$qid" "$@" < /dev/null > /dev/null 2>&1 &
     local updater=$!
 
-    # Returns once the sink has parked, so the update still holds the lock it took for the pipeline.
-    # An update that never reaches the hook would otherwise wait here forever.
+    # Returns once the update has parked with its pipeline finished but not yet torn down, so the
+    # share lock it moved into the pipeline's resources is still held. An update that raised instead
+    # of finishing never parks, because a failed query is torn down without reaching the pause, so a
+    # timeout here is as likely to be a broken update as a broken rendezvous.
     # shellcheck disable=SC2086 # CLICKHOUSE_CLIENT carries arguments and must word-split
     if ! timeout 60 ${CLICKHOUSE_CLIENT} --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" < /dev/null; then
         ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT ${FP}" < /dev/null 2>/dev/null || true
         wait "$updater" 2>/dev/null || true
-        echo "$arm: the sink never reached the commit hook"
+        echo "$arm: the update never finished its pipeline and parked"
         return
     fi
 
     # The wait above returns at once when nothing is parked, so it does not by itself establish that
-    # the sink reached the hook. The failpoint is one-shot, so it reports itself disabled only after
-    # something fired it.
+    # the update parked. The failpoint is one-shot and only a query carrying the prefix can consume
+    # it, so it reports itself disabled only after this arm's update fired it.
     if [ "$(${CLICKHOUSE_CLIENT} --query "
         SELECT enabled FROM system.fail_points WHERE name = '${FP}'
         SETTINGS enable_parallel_replicas = 0" < /dev/null 2>/dev/null)" != 0 ]; then
         ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT ${FP}" < /dev/null 2>/dev/null || true
         wait "$updater" 2>/dev/null || true
-        echo "$arm: the sink never parked at the commit hook"
+        echo "$arm: nothing parked after a pipeline ran"
         return
     fi
 
@@ -99,7 +105,7 @@ function race_with_drop()
         DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE_1}.t SYNC" < /dev/null > /dev/null 2>&1 &
     local dropper=$!
 
-    # The sink is still parked, so the drop reaches the table lock and blocks on it while the
+    # The update is still parked, so the drop reaches the table lock and blocks on it while the
     # window is held open.
     sleep 2
 
@@ -113,7 +119,7 @@ function race_with_drop()
 
     # The lock wait is charged to the statement that blocked, so a non-zero value here is this
     # drop's own wait on this table and no other writer can supply it. A drop that reached the lock
-    # only after the commit released it reports zero and never covered the race.
+    # only after the teardown released it reports zero and never covered the race.
     local waited
     waited=$(${CLICKHOUSE_CLIENT} --query "
         SYSTEM FLUSH LOGS query_log;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110334
Related: https://github.com/ClickHouse/ClickHouse/pull/119030
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Test-only change: two lightweight-update tests no longer park a pipeline worker thread inside `IProcessor::work()`.


### Description

Follows a review request on #110334 (https://github.com/ClickHouse/ClickHouse/pull/110334#discussion_r3963236383): no test should park a `PipelineExecutor` worker inside `IProcessor::work()` (`IProcessor.h`: synchronous work must only use CPU), and to audit the tests I committed over the last four months. Part 2 of 2; part 1 is #119030.

Two were left. `04905_lwu_drop_race_table_lock` parked in the ReplicatedMergeTree sink's commit path, reached from `ExceptionKeepingTransform::work()`. `03100_lwu_57_lock_acquire_timeout` parked inside `sleep()` at `infinite_sleep`, before its bound check and before its sliced, cancellation-polling wait loop, so it held a worker unboundedly and un-cancellably.

Both want a rendezvous while a lightweight update's locks are held. Those locks are taken once while the pipeline is built (the table share lock into the pipeline's resources, the lightweight update lock into the patch sink) and released only by the teardown, so both are still held in `BlockIO::onFinish`, on the query thread, with no `work()` frame. One `PAUSEABLE_ONCE` failpoint goes there, after `releaseQuerySlot()`.

Every query whose pipeline is completed reaches `onFinish`, including plain `SELECT`s (`PullingAsyncPipelineExecutor` completes the pipeline it runs), and failpoints are keyed by name only. So the pause is gated on a query-id prefix outside the `fiu` evaluation, as `QueryMetricLog::finishQuery` already is.

Two costs. 04905 no longer lands the DROP between the patch-part rename and the commit, only after it; since the locks are released only by that teardown, held there implies held throughout, so the assertion does not weaken, but the interleaving is gone. And this is a test hook in `BlockIO`, which is query plumbing; the alternatives are `TCPHandler` (native protocol only) and the end of `CompletedPipelineExecutor::execute()` (a step earlier, still holding the query slot). Either is a one-line move leaving both tests unchanged, so say the word if you prefer one.

Neither reference file changes. `rmt_pause_before_commit_local_part` had no other user and goes; `infinite_sleep` stays for 04095.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119069&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119069](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119069+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
