### PR TITLE
Do not treat a NULL inside a tuple key as a NULL key

### DIFF
--- a/src/DataTypes/NullableUtils.cpp
+++ b/src/DataTypes/NullableUtils.cpp
@@ -95,22 +95,15 @@ ColumnPtr extractNestedColumnsAndNullMap(ColumnRawPtrs & key_columns, ConstNullM
             /// Top-level Nullable(...) always contributes to the combined null map
             addNullMap(column_nullable);
 
-            const IColumn * nested_column = &column_nullable->getNestedColumn();
-            column = nested_column;
-
-            /// Special case: Nullable(Tuple(...))
-            /// If the nested column is a tuple, also fold in null maps of nullable tuple elements
-            if (const auto * tuple = checkAndGetColumn<ColumnTuple>(nested_column))
-            {
-                const auto & tuple_columns = tuple->getColumns();
-                for (const auto & element : tuple_columns)
-                {
-                    if (const auto * elem_nullable = checkAndGetColumn<ColumnNullable>(element.get()))
-                    {
-                        addNullMap(elem_nullable);
-                    }
-                }
-            }
+            /** Only the top-level null map says whether the key of a row is NULL. The null maps of the
+              * elements of a `Nullable(Tuple(Nullable(T), ...))` used to be folded in as well, which
+              * made a row whose tuple merely *contains* a NULL a NULL key: the hash-family joins
+              * dropped it, while the merge algorithms - which compare the nested tuples - kept it, so
+              * the result of a join depended on `join_algorithm`, and `IN` never matched such a row.
+              * The NULLs of the elements are part of the key and are compared as any other value,
+              * exactly as they are for a `Tuple(Nullable(T), ...)` that is not wrapped in `Nullable`.
+              */
+            column = &column_nullable->getNestedColumn();
         }
     }
 

--- a/tests/queries/0_stateless/05174_nullable_tuple_join_key_with_null_element.reference
+++ b/tests/queries/0_stateless/05174_nullable_tuple_join_key_with_null_element.reference
@@ -1,0 +1,14 @@
+every algorithm sees the same rows
+hash	2
+parallel_hash	2
+grace_hash	2
+full_sorting_merge	2
+partial_merge	2
+a top-level Nullable wrap of a key that is never NULL changes nothing
+unwrapped	2
+wrapped	2
+a NULL key still joins nothing, and is not the same key as a tuple of NULL
+null key	0
+in a set	0
+in a set	1
+in a set	\N

--- a/tests/queries/0_stateless/05174_nullable_tuple_join_key_with_null_element.sql
+++ b/tests/queries/0_stateless/05174_nullable_tuple_join_key_with_null_element.sql
@@ -1,0 +1,31 @@
+-- A `Nullable(Tuple(Nullable(T)))` join key that is not NULL at the top level but contains a NULL
+-- element was treated as a NULL key by the hash-family algorithms and as an ordinary key by the merge
+-- ones, so the row count of a join depended on `join_algorithm`. The null maps of the tuple's elements
+-- were folded into the key's null map; only the top level says whether the key of a row is NULL.
+
+SET enable_nullable_tuple_type = 1;
+
+DROP TABLE IF EXISTS t_null_tuple_key;
+CREATE TABLE t_null_tuple_key (t Nullable(Tuple(Nullable(Int64)))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_null_tuple_key VALUES (tuple(1)), (tuple(NULL)), (NULL);
+
+SELECT 'every algorithm sees the same rows';
+SELECT 'hash', count() FROM t_null_tuple_key AS a INNER JOIN t_null_tuple_key AS b ON a.t = b.t SETTINGS join_algorithm = 'hash';
+SELECT 'parallel_hash', count() FROM t_null_tuple_key AS a INNER JOIN t_null_tuple_key AS b ON a.t = b.t SETTINGS join_algorithm = 'parallel_hash';
+SELECT 'grace_hash', count() FROM t_null_tuple_key AS a INNER JOIN t_null_tuple_key AS b ON a.t = b.t SETTINGS join_algorithm = 'grace_hash';
+SELECT 'full_sorting_merge', count() FROM t_null_tuple_key AS a INNER JOIN t_null_tuple_key AS b ON a.t = b.t SETTINGS join_algorithm = 'full_sorting_merge';
+SELECT 'partial_merge', count() FROM t_null_tuple_key AS a INNER JOIN t_null_tuple_key AS b ON a.t = b.t SETTINGS join_algorithm = 'partial_merge';
+
+SELECT 'a top-level Nullable wrap of a key that is never NULL changes nothing';
+SELECT 'unwrapped', count() FROM (SELECT tuple(CAST(1, 'Nullable(Int64)')) AS t UNION ALL SELECT tuple(CAST(NULL, 'Nullable(Int64)'))) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'Nullable(Int64)')) AS t UNION ALL SELECT tuple(CAST(NULL, 'Nullable(Int64)'))) AS b ON a.t = b.t
+SETTINGS join_algorithm = 'hash';
+SELECT 'wrapped', count() FROM (SELECT tuple(CAST(1, 'Nullable(Int64)')) AS t UNION ALL SELECT tuple(CAST(NULL, 'Nullable(Int64)'))) AS a
+INNER JOIN (SELECT tuple(CAST(1, 'Nullable(Int64)')) AS t UNION ALL SELECT tuple(CAST(NULL, 'Nullable(Int64)'))) AS b ON toNullable(a.t) = toNullable(b.t)
+SETTINGS join_algorithm = 'hash';
+
+SELECT 'a NULL key still joins nothing, and is not the same key as a tuple of NULL';
+SELECT 'null key', count() FROM t_null_tuple_key AS a INNER JOIN t_null_tuple_key AS b ON a.t = b.t WHERE a.t IS NULL SETTINGS join_algorithm = 'hash';
+SELECT 'in a set', t IN (SELECT tuple(CAST(NULL, 'Nullable(Int64)'))) FROM t_null_tuple_key ORDER BY isNull(t), t;
+
+DROP TABLE t_null_tuple_key;


### PR DESCRIPTION
For a `Nullable(Tuple(Nullable(T)))` join key that is never NULL at the top level, the hash-family algorithms treated any row whose tuple contains a NULL *element* as a NULL key and dropped it, while the merge algorithms compare the nested tuples and kept it. The same query on the same data returned a different row count depending only on `join_algorithm` (`hash` / `parallel_hash` / `grace_hash` = 1, `full_sorting_merge` / `partial_merge` = 2), and wrapping a key in `toNullable` - a value-wise no-op there - was enough to change the result.

`extractNestedColumnsAndNullMap` folded the null maps of the tuple's elements into the key's null map. Only the top level says whether the key of a row is NULL; the NULLs of the elements are part of the key and are compared as any other value, exactly as they are for a `Tuple(Nullable(T))` that is not wrapped in `Nullable`. A row whose key really is NULL still joins nothing, and it is not the same key as a tuple of NULLs.

The same extraction is used by `IN` with a subquery, which had the mirror defect: such a row matched nothing there either.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118816

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed the hash-family join algorithms treating a non-NULL `Nullable(Tuple(...))` key that contains a NULL element as a NULL key, which made the result of a join depend on the `join_algorithm` setting. `IN` with a subquery over such a key was affected in the same way.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119081&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119081](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119081+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1101` (included in `26.9` and later)
<!-- ch-version-info:end -->