### PR TITLE
Do not evaluate the PromQL whole-metric id range for every row

### DIFF
--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -372,11 +372,11 @@ namespace
         auto select_as_subquery = make_intrusive<ASTSubquery>(std::move(select_query_from_tags_table));
         conditions.push_back(makeASTFunction("in", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID), std::move(select_as_subquery)));
 
-        /// For a whole-metric selector over a metric-clustered id layout two more conditions are
-        /// added: <raw id column> >= tuple(hash(metric_name), min) AND <raw id column> <= tuple(
-        /// hash(metric_name), max). They are a superset of the `id IN <set>` condition above, so
-        /// the returned rows do not change; their purpose is to give the primary-key index
-        /// analysis a continuous key range instead of the large set (see readImpl).
+        /// For a whole-metric selector over a metric-clustered id layout one more condition is
+        /// added: indexHint(<raw id column> >= tuple(hash(metric_name), min) AND <raw id column>
+        /// <= tuple(hash(metric_name), max)). `indexHint` keeps it out of the row-level filter, so
+        /// its only purpose is to give the primary-key index analysis a continuous key range
+        /// instead of the large set (see readImpl).
         for (auto & condition : whole_metric_id_range_conditions)
             conditions.push_back(std::move(condition));
 
@@ -773,15 +773,21 @@ namespace
                 std::vector<String>{data_table_id.database_name, data_table_id.table_name, TimeSeriesColumnNames::ID});
         };
 
-        ASTs conditions;
-        conditions.push_back(makeASTFunction(
+        ASTs range_conditions;
+        range_conditions.push_back(makeASTFunction(
             "greaterOrEquals",
             make_qualified_id(),
             makeASTFunction("tuple", first_component->clone(), std::move(min_max_second_component->first))));
-        conditions.push_back(makeASTFunction(
+        range_conditions.push_back(makeASTFunction(
             "lessOrEquals",
             make_qualified_id(),
             makeASTFunction("tuple", std::move(first_component), std::move(min_max_second_component->second))));
+
+        /// Wrapped in `indexHint` so the range reaches index analysis but is not evaluated per row:
+        /// the `id IN <set>` condition the caller keeps is the exact filter, and on this path every
+        /// id of that set is inside the range (that is what the probe establishes).
+        ASTs conditions;
+        conditions.push_back(makeASTFunction("indexHint", makeASTForLogicalAnd(std::move(range_conditions))));
         return conditions;
     }
 }

--- a/tests/performance/promql_selector_id_range_row_cost.xml
+++ b/tests/performance/promql_selector_id_range_row_cost.xml
@@ -1,0 +1,47 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!--
+        Benchmarks the row-level cost of the whole-metric primary-key range that PromQL selectors
+        emit over a metric-clustered id layout (id = Tuple(sipHash64(metric_name), hash of tags)).
+
+        promql_selector_pk_range.xml measures index analysis and is built for it (tiny granules and
+        a 5m lookback, so a query touches few rows). This one is the opposite shape: one metric,
+        default index granularity, and a window covering every sample, so nothing can be pruned and
+        the filter runs over every row read.
+
+        The range accepts every row the `id IN <set>` condition beside it accepts, so it is a
+        row-level no-op that still costs two Tuple(UInt64, UUID) comparisons per row. The
+        label-filtered selector emits no range and is the control: it must not regress.
+    -->
+
+    <create_query>
+        CREATE TABLE promql_row_cost_ts ENGINE = TimeSeries
+        SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
+        TAGS INNER COLUMNS (id Tuple(UInt64, UUID))
+    </create_query>
+
+    <!-- 12800 series of one metric, 4096 samples each at 15s: 52.4M rows in the samples table.
+         The samples share one 17-hour window, which keeps the default recent-samples target
+         (partitioned by 5-hour interval) under max_partitions_per_insert_block. -->
+    <fill_query>
+        INSERT INTO promql_row_cost_ts (metric_name, tags, time_series)
+        SELECT
+            'rowcost_metric',
+            map('instance', toString(number), 'dc', toString(number % 8)),
+            arrayMap(step -> (toDateTime64(1000000 + step * 15, 3), toFloat64(step % 977)), range(4096))
+        FROM numbers_mt(12800)
+    </fill_query>
+
+    <!-- whole-metric selectors over the full window: every row is read and filtered -->
+    <query>SELECT sum(value) FROM timeSeriesSelector('promql_row_cost_ts', 'rowcost_metric', 1000000, 1061440) SETTINGS max_threads = 4 FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_row_cost_ts', 'sum(rowcost_metric)', 1000000, 1061440, 10000) SETTINGS max_threads = 4 FORMAT Null</query>
+
+    <!-- label-filtered selector: no range is emitted, the id set is the only filter (control) -->
+    <query>SELECT sum(value) FROM timeSeriesSelector('promql_row_cost_ts', 'rowcost_metric{{dc="0"}}', 1000000, 1061440) SETTINGS max_threads = 4 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_row_cost_ts</drop_query>
+</test>

--- a/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.reference
+++ b/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.reference
@@ -6,6 +6,8 @@
 1970-01-01 00:02:30.000	10
 1970-01-01 00:04:10.000	20
 1	1
+-- the range is an index condition only: it is not part of any row-level filter
+1	1	1
 -- whole-metric-by-data selector (a matcher every series passes): the range is still emitted
 1970-01-01 00:01:40.000	1
 1970-01-01 00:03:20.000	2
@@ -59,3 +61,6 @@
 1970-01-01 00:01:40.000	1
 1970-01-01 00:02:30.000	10
 1
+-- the index-only range still drops the part that holds another metric
+3	2
+1	1

--- a/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.sql
+++ b/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.sql
@@ -9,9 +9,13 @@
 -- excluded from primary-key index analysis (`use_index_for_in_with_subqueries_max_values = 1`): index
 -- analysis then works on the continuous range instead of running a generic exclusion search with the
 -- whole set. The `id IN <set>` condition always stays in the WHERE, so the returned rows never change.
--- The range conditions contain the max-UUID literal. The checks below look for it in the
+-- The range is wrapped in `indexHint`, so it reaches index analysis without being evaluated per
+-- row. The range conditions contain the max-UUID literal. The checks below look for it in the
 -- `Condition:` line of `EXPLAIN indexes = 1`, that is, in what primary-key index analysis actually
 -- received, rather than anywhere in the plan text.
+-- `Condition: true` cannot tell an always-true atom from an unknown one (`KeyCondition` describes
+-- both as `True`), so the part-pruning check on `ts_prune` below is what detects a range that
+-- reaches index analysis but no longer constrains the read.
 
 SET allow_experimental_time_series_table = 1;
 SET session_timezone = 'UTC';
@@ -21,6 +25,7 @@ DROP TABLE IF EXISTS ts_plain;
 DROP TABLE IF EXISTS ts_custom_gen;
 DROP TABLE IF EXISTS ts_altered_gen;
 DROP TABLE IF EXISTS ts_u64;
+DROP TABLE IF EXISTS ts_prune;
 
 -- The metric-clustered layout: id = tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(tags))).
 -- Inner target tables (their names contain dots and the table UUID - the qualified references of the
@@ -39,6 +44,15 @@ SELECT timestamp, value FROM timeSeriesSelector(ts_clustered, 'foo', 0, 1000) OR
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range, plan LIKE '%IN subquery%' AS keeps_id_set
 FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo', 0, 1000)));
+
+SELECT '-- the range is an index condition only: it is not part of any row-level filter';
+
+SELECT
+    countIf(explain ILIKE '%Condition:%' AND explain ILIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%') > 0 AS range_in_index_condition,
+    countIf(explain ILIKE '%filter column:%' AND explain ILIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%') = 0 AS range_not_row_level,
+    -- control for the check above: filter descriptions are printed and this pattern does match them
+    countIf(explain ILIKE '%filter column:%' AND explain ILIKE '%timestamp%') > 0 AS filter_lines_present
+FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo', 0, 1000));
 
 SELECT '-- whole-metric-by-data selector (a matcher every series passes): the range is still emitted';
 
@@ -140,6 +154,31 @@ SELECT timestamp, value FROM timeSeriesSelector(ts_u64, 'foo', 0, 1000) ORDER BY
 SELECT plan LIKE '%18446744073709551615%' AS has_id_range
 FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_u64, 'foo', 0, 1000)));
 
+SELECT '-- the index-only range still drops the part that holds another metric';
+
+-- Two parts, one metric each: `max_bytes_to_merge_at_max_space_in_pool = 1` keeps them apart.
+-- `foo` has two series, so its id set holds two values and
+-- `use_index_for_in_with_subqueries_max_values = 1` excludes it from index analysis: the range is
+-- then the only condition that can drop the `bar` part, which `id_set_not_in_index_analysis`
+-- asserts rather than assumes.
+CREATE TABLE ts_prune ENGINE = TimeSeries TAGS INNER COLUMNS (id Tuple(UInt64, UUID))
+SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
+    SETTINGS max_bytes_to_merge_at_max_space_in_pool = 1;
+
+INSERT INTO ts_prune (metric_name, tags, time_series) VALUES
+    ('foo', map('env', 'prod'), [(toDateTime64(100, 3), 1.)]),
+    ('foo', map('env', 'dev'), [(toDateTime64(100, 3), 2.)]);
+INSERT INTO ts_prune (metric_name, tags, time_series) VALUES
+    ('bar', map('env', 'prod'), [(toDateTime64(100, 3), 4.)]);
+
+SELECT sum(value), count() FROM timeSeriesSelector(ts_prune, 'foo', 0, 1000);
+
+SELECT
+    countIf(explain LIKE '%Parts: 1/2%') > 0 AS prunes_the_other_metrics_part,
+    countIf(explain ILIKE '%Condition:%' AND explain ILIKE '%element set%') = 0 AS id_set_not_in_index_analysis
+FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_prune, 'foo', 0, 1000));
+
+DROP TABLE ts_prune;
 DROP TABLE ts_u64;
 DROP TABLE ts_altered_gen;
 DROP TABLE ts_custom_gen;

--- a/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.sql
+++ b/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.sql
@@ -9,7 +9,9 @@
 -- excluded from primary-key index analysis (`use_index_for_in_with_subqueries_max_values = 1`): index
 -- analysis then works on the continuous range instead of running a generic exclusion search with the
 -- whole set. The `id IN <set>` condition always stays in the WHERE, so the returned rows never change.
--- The range conditions contain the max-UUID literal, which is used below to detect the emission.
+-- The range conditions contain the max-UUID literal. The checks below look for it in the
+-- `Condition:` line of `EXPLAIN indexes = 1`, that is, in what primary-key index analysis actually
+-- received, rather than anywhere in the plan text.
 
 SET allow_experimental_time_series_table = 1;
 SET session_timezone = 'UTC';
@@ -36,14 +38,14 @@ SELECT '-- whole-metric selector: same rows as a filtered read, and the WHERE ca
 SELECT timestamp, value FROM timeSeriesSelector(ts_clustered, 'foo', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range, plan LIKE '%IN subquery%' AS keeps_id_set
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo', 0, 1000)));
 
 SELECT '-- whole-metric-by-data selector (a matcher every series passes): the range is still emitted';
 
 SELECT timestamp, value FROM timeSeriesSelector(ts_clustered, 'foo{env=~".*"}', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo{env=~".*"}', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo{env=~".*"}', 0, 1000)));
 
 SELECT '-- partial-metric selector (a matcher filters some series out): falls back to the id set only';
 
@@ -51,14 +53,14 @@ SELECT timestamp, value FROM timeSeriesSelector(ts_clustered, 'foo{env="prod"}',
 SELECT timestamp, value FROM timeSeriesSelector(ts_clustered, 'foo{env!=""}', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo{env="prod"}', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, 'foo{env="prod"}', 0, 1000)));
 
 SELECT '-- regex matcher on the metric name: falls back';
 
 SELECT timestamp, value FROM timeSeriesSelector(ts_clustered, '{__name__=~"foo|bar", env="dev"}', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, '{__name__=~"foo|bar"}', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_clustered, '{__name__=~"foo|bar"}', 0, 1000)));
 
 SELECT '-- selector with no series in the time range: empty result either way';
 
@@ -89,7 +91,7 @@ INSERT INTO ts_plain (metric_name, tags, time_series) VALUES
 SELECT timestamp, value FROM timeSeriesSelector(ts_plain, 'foo', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_plain, 'foo', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_plain, 'foo', 0, 1000)));
 
 SELECT '-- custom id generator: no structural guarantee, no id range, same results';
 
@@ -103,7 +105,7 @@ INSERT INTO ts_custom_gen (metric_name, tags, time_series) VALUES
 SELECT timestamp, value FROM timeSeriesSelector(ts_custom_gen, 'foo', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_custom_gen, 'foo', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_custom_gen, 'foo', 0, 1000)));
 
 SELECT '-- id_generator changed after ingestion: old series ids are outside the range, the probe detects them and falls back';
 
@@ -123,7 +125,7 @@ INSERT INTO ts_altered_gen (metric_name, tags, time_series) VALUES
 SELECT timestamp, value FROM timeSeriesSelector(ts_altered_gen, 'foo', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_altered_gen, 'foo', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_altered_gen, 'foo', 0, 1000)));
 
 SELECT '-- Tuple(UInt64, UInt64) id layout: the range is emitted with the max-UInt64 literal';
 
@@ -136,7 +138,7 @@ INSERT INTO ts_u64 (metric_name, tags, time_series) VALUES
 SELECT timestamp, value FROM timeSeriesSelector(ts_u64, 'foo', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%18446744073709551615%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_u64, 'foo', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_u64, 'foo', 0, 1000)));
 
 DROP TABLE ts_u64;
 DROP TABLE ts_altered_gen;

--- a/tests/queries/0_stateless/04891_timeseries_lowcardinality_id.sql
+++ b/tests/queries/0_stateless/04891_timeseries_lowcardinality_id.sql
@@ -43,7 +43,7 @@ SELECT '-- whole-metric selector: results and the emitted id range';
 SELECT timestamp, value FROM timeSeriesSelector(ts_lc, 'foo', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range, plan LIKE '%IN subquery%' AS keeps_id_set
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_lc, 'foo', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_lc, 'foo', 0, 1000)));
 
 SELECT '-- partial selector: results, no id range';
 
@@ -51,7 +51,7 @@ SELECT timestamp, value FROM timeSeriesSelector(ts_lc, 'foo{env="prod"}', 0, 100
 SELECT timestamp, value FROM timeSeriesSelector(ts_lc, 'foo{env!=""}', 0, 1000) ORDER BY value, timestamp;
 
 SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%' AS has_id_range
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector(ts_lc, 'foo{env="prod"}', 0, 1000)));
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan FROM (EXPLAIN indexes = 1 SELECT sum(value) FROM timeSeriesSelector(ts_lc, 'foo{env="prod"}', 0, 1000)));
 
 SELECT '-- prometheus query evaluation over the dictionary-encoded ids';
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/119011
Related: https://github.com/ClickHouse/ClickHouse/pull/118116


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

A PromQL selector matching a whole metric on a `TimeSeries` table no longer evaluates, for every row it reads, the primary-key range on `id` that it adds for index analysis. That range accepts every row the exact `id IN <set>` condition beside it accepts, so it is now wrapped in `indexHint`: pruning and query results are unchanged, and two `Tuple(UInt64, UUID)` comparisons per row disappear. Measured 23.7% faster on a 105M-row whole-metric query; label-filtered selectors emit no such range and are unaffected.

### Description

When a selector matches every series of a metric, `tryMakeWholeMetricIDRangeConditions` adds `id >= tuple(hash(metric), min) AND id <= tuple(hash(metric), max)`, and `readImpl` sets `use_index_for_in_with_subqueries_max_values = 1` so index analysis uses that range instead of an exclusion search over the id set (#114131).

`WHERE` is the only place the generating layer can put something `KeyCondition` reads, and a plain conjunct there is both an index condition and a row filter. Here the range is a superset of the `id IN <set>` condition beside it, so evaluating it per row cannot change the result. `indexHint` expresses "index only": `FunctionIndexHint` returns 1 without evaluating its argument, while `RPNBuilder` reads the wrapped expression back out, so the RPN `KeyCondition` gets is unchanged. The analyzer already uses it this way for conditions it derives itself (`optimize_and_compare_chain`). Its documented warning that it cannot speed up a query is about wrapping a condition whose row filter is needed for correctness.

Two release builds as two servers, arms interleaved query by query, 105M samples in one metric, `max_threads = 4`, 20 paired rounds: 500 ms to 382 ms, paired geometric-mean ratio 0.7626, 95% CI [0.7543, 0.7709]. The label-filtered control moves -1.4% [-2.5%, -0.3%], the floor between two separately linked binaries emitting identical SQL. Results and `read_rows` identical in every pair. The reporter's aarch64 numbers are in the issue; I did not reproduce them.

The first commit is test-only and passes on master unchanged. `EXPLAIN actions = 1` renders the hint with its arguments elided, so the ten sites detecting the range by its max-UUID literal now read it from the `Condition:` line of `EXPLAIN indexes = 1`, what `KeyCondition` received. A part-pruning assertion covers `Condition: true`, which that output cannot distinguish. The new performance test measures the scan-bound shape with a fallback control.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119092&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119092](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119092+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1122` (included in `26.9` and later)
<!-- ch-version-info:end -->