### PR TITLE
Bump `double-conversion` from v3.3.0 to v3.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -326,7 +326,7 @@
 	url = https://github.com/ClickHouse/openssl.git
 [submodule "contrib/double-conversion"]
 	path = contrib/double-conversion
-	url = https://github.com/ClickHouse/double-conversion.git
+	url = https://github.com/google/double-conversion
 [submodule "contrib/mongo-cxx-driver"]
 	path = contrib/mongo-cxx-driver
 	url = https://github.com/mongodb/mongo-cxx-driver.git


### PR DESCRIPTION
Bumps `double-conversion` to upstream `v3.4.0`; the only change ClickHouse compiles is an initialisation fix in `double-to-string.cc` (`decimal_point` is now zero-initialised, silencing a maybe-uninitialized warning) plus documentation comments — no API or source-list changes.

### ClickHouse-side changes
- `.gitmodules` — submodule URL moved to `https://github.com/google/double-conversion`, because the fork carries no ClickHouse patches and `v3.4.0` is not reachable from it.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `double-conversion` to v3.4.0.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.116` (included in `26.10` and later)
<!-- ch-version-info:end -->