### PR TITLE
Bump `zxc` from 0.13.1 to 0.14.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -413,7 +413,7 @@
 	url = https://github.com/ClickHouse/geometry.hpp
 [submodule "contrib/zxc"]
 	path = contrib/zxc
-	url = https://github.com/ClickHouse/zxc
+	url = https://github.com/hellobertrand/zxc
 [submodule "contrib/libucontext"]
 	path = contrib/libucontext
 	url = https://github.com/kaniini/libucontext

--- a/contrib/zxc-cmake/CMakeLists.txt
+++ b/contrib/zxc-cmake/CMakeLists.txt
@@ -33,9 +33,14 @@ set(ZXC_CORE_SOURCES
 # emitted symbols (e.g. zxc_compress_chunk_wrapper_avx2). zxc_dispatch.c declares
 # these suffixed symbols unconditionally per architecture, so the exact set of
 # variants below must match what the dispatcher expects for each target:
-#   x86-64  -> _default, _sse2, _avx2, _avx512
-#   aarch64 -> _default, _neon
+#   x86-64  -> _default, _avx2, _avx512
+#   aarch64 -> _default only (NEON is the AArch64 baseline)
 #   other   -> _default only
+# SSE2 is the x86-64 baseline and NEON the AArch64 one, so `_default` already
+# compiles those code paths; zxc dropped the dedicated `_sse2` and `_neon`
+# variants in v0.14.0 and the dispatcher no longer references them. The
+# remaining `_neon32` variant is for 32-bit ARM, which ClickHouse does not
+# target.
 set(ZXC_VARIANT_OBJECTS "")
 
 macro(zxc_add_variant suffix)
@@ -54,11 +59,14 @@ macro(zxc_add_variant suffix)
 endmacro()
 
 if (OS_DARWIN AND ARCH_AMD64)
-    # zxc's x86-64 runtime dispatch calls `__builtin_cpu_init` /
+    # Historically zxc's x86-64 runtime dispatch called `__builtin_cpu_init` /
     # `__builtin_cpu_supports`, which reference compiler-rt's `__cpu_model`. That
-    # symbol is not linked into ClickHouse's macOS cross-build, so linking fails
-    # with "undefined ___cpu_model". macOS builds are for local development only,
-    # so restrict zxc to its portable scalar core there.
+    # symbol is not linked into ClickHouse's macOS cross-build, so linking failed
+    # with "undefined ___cpu_model". Since v0.14.0 the dispatcher issues `CPUID`
+    # and `XGETBV` directly and no longer needs `__cpu_model`, so this is now a
+    # conservative restriction rather than a required one: macOS builds are for
+    # local development only and are never test-run in CI, so there is nothing
+    # to gain from the x86 SIMD variants there. Lifting it is a separate change.
     set(ZXC_FORCE_SCALAR TRUE)
 elseif (SANITIZE STREQUAL "memory")
     # clang's MemorySanitizer has no precise shadow model for the x86 byte-shuffle
@@ -67,7 +75,7 @@ elseif (SANITIZE STREQUAL "memory")
     # that the shuffle discards still poisons the logical result. zxc's SIMD
     # kernels deliberately do speculative 16/32-byte loads whose tail lanes fall
     # into malloc'ed scratch buffers or not-yet-written output and are then
-    # discarded by such shuffles (e.g. `zxc_decode_copy_overlap_run`,
+    # discarded by such shuffles (e.g. `zxc_decode_copy_overlap_run32`,
     # `zxc_pivco_merge`), which triggers false `use-of-uninitialized-value`
     # reports. The scalar core branches only on initialized bytes, so build only
     # that under MSan. (AArch64 NEON `tbl` gets a precise shadow, but keep all
@@ -90,16 +98,16 @@ if (ZXC_FORCE_SCALAR)
         target_compile_definitions(${_tgt} PRIVATE ZXC_DISABLE_SIMD)
     endforeach()
 elseif (ARCH_AMD64)
-    # SSE2/AVX2 flags are redundant with the x86-64-v3 baseline but harmless;
+    # The AVX2 flags are redundant with the x86-64-v3 baseline but harmless;
     # AVX512 is NOT in the baseline, so those flags are required for that variant
-    # (only ever entered at runtime on AVX-512 capable CPUs).
-    zxc_add_variant(_sse2   -msse2)
-    zxc_add_variant(_avx2   -mavx2 -mfma -mbmi -mbmi2 -mlzcnt)
+    # (only ever entered at runtime on AVX-512 capable CPUs). The flag sets must
+    # stay in sync with `zxc_detect_cpu_features`, which admits a CPU to the AVX2
+    # and AVX-512 tiers only after proving BMI1, BMI2 and LZCNT as well. Note
+    # that it does not probe FMA, so `-mfma` must not be added here: the
+    # compiler would be free to emit FMA instructions into a variant that runs
+    # on any AVX2 CPU.
+    zxc_add_variant(_avx2   -mavx2 -mbmi -mbmi2 -mlzcnt)
     zxc_add_variant(_avx512 -mavx512f -mavx512bw -mavx512vbmi -mavx512vbmi2 -mbmi -mbmi2 -mlzcnt)
-elseif (ARCH_AARCH64)
-    # NEON is guaranteed by ClickHouse's armv8.2-a+simd baseline; no extra flags
-    # (adding -march=armv8-a would downgrade below the baseline).
-    zxc_add_variant(_neon)
 endif ()
 
 add_library(_zxc ${ZXC_CORE_SOURCES} ${ZXC_VARIANT_OBJECTS})


### PR DESCRIPTION
Bumps `zxc` to v0.14.0 (from v0.13.1 + 3 commits), which changes the compressed file format to version 8, reworks runtime CPU dispatch and changes the set of per-ISA variants.

### ClickHouse-side changes
- `contrib/zxc-cmake/CMakeLists.txt`:
  - drop the `_sse2` and `_neon` variants — `_default` covers those baselines and the dispatcher no longer declares the symbols;
  - drop `-mfma` from `_avx2` — detection gates that tier on AVX2/BMI1/BMI2/LZCNT and never probes FMA;
  - update the variant-set documentation and the MSan symbol name to `zxc_decode_copy_overlap_run32`.

### Behaviour changes
- Compatibility warning: the file format moves v7 → v8 and the decoder rejects older versions, so data already written with `CODEC(ZXC)` becomes unreadable (`CANNOT_DECOMPRESS`). The codec is experimental and gated behind `enable_zxc_codec`, which defaults to `false`.
- Slightly better compression ratio at the same levels; levels 1..7 and the codec's API are unchanged.

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update the `zxc` library to v0.14.0, which changes the compressed block format of the experimental `ZXC` codec. Data written with `CODEC(ZXC)` by earlier versions cannot be read by the new version and fails with `CANNOT_DECOMPRESS`. If you used the experimental `ZXC` codec, re-encode the affected columns to a different codec before upgrading, or re-insert the data after the upgrade.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119097&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119097](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119097+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
