### PR TITLE
Do not stream server warnings to the clients in 04335_distributed_plan_cancel

### DIFF
--- a/tests/queries/0_stateless/04335_distributed_plan_cancel.sh
+++ b/tests/queries/0_stateless/04335_distributed_plan_cancel.sh
@@ -8,6 +8,11 @@
 
 set -e
 
+# Cancelling is what this test does, and a worker task that outlives the initiator's bounded wait for a
+# terminal state is reported at Warning. The runner fails a test whose stderr is not empty, and the line
+# can arrive on any of this test's clients, so keep only Error and above for all of them.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=error
+
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/118390

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

`04335_distributed_plan_cancel` fails with `Reason: having stderror:` on runs whose output is correct. Since #118390 merged (2026-09-09 05:40 UTC), public CI has 24 such runs out of 766 `llvm_coverage` runs of this test (3.1%), 0 of 1708 non-coverage runs, 3 of them on master ([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=10bec7b88102f257d9888b1aa4ffb6f3aeb3cbc0&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%203%2F3%29)); the first is 19 minutes after that merge. They are green only because a flaky-labelled failure is force-greened on coverage lanes; any other lane reds.

#118390 added the two remote arms, so `TaskTracker::cancel()` is now reachable from a stateless test. Its teardown waits a bounded 3 s per cancelled task (`waitForTaskTerminal`, 10 polls x 300 ms) for the task to leave `Running`. On an instrumented build that overruns, and the initiator correctly reports at Warning that it left the task for the worker to reclaim. `clickhouse-test` runs clients with `--send_logs_level=warning`, so the line reaches a client's stderr, and the runner fails any test whose stderr is not empty.

I lowered the level in the test rather than demoting the warning, because the warning is real: for a task that has started, `forgetTask` is the only thing that erases the worker's `tasks` entry, and this branch skips it. `error` rather than `none` or `fatal` keeps the Error-level reports on the same teardown path streaming, so the test still reddens on a genuine teardown failure.

Whole-file, because the emitter is not one client: with the timeout forced, 7 lines arrived on the `KILL QUERY ... SYNC` client, which reds the test, and 3 on the cancelled `SELECT`, in one run.

Validation: with the timeout forced the test fails without this change and passes with it, and `system.text_log` shows the warning still logged. 20/20 pinned, 50/50 randomized, siblings pass.

Not fixed here: the worker-side entry stays until restart. That is a separate question about the teardown's wait budget.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119101&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119101](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119101+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
