### PR TITLE
Fix wrong results when a JOIN USING key resolves to an alias named like a virtual column

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -5269,7 +5269,8 @@ void QueryAnalyzer::resolveCrossJoin(QueryTreeNodePtr & cross_join_node, Identif
     }
 }
 
-static bool getColumnsFromTableExpression(const QueryTreeNodePtr & root_table_expression, NameSet & existing_columns)
+static bool getColumnsFromTableExpression(
+    const QueryTreeNodePtr & root_table_expression, NameSet & existing_columns, VirtualsKind virtuals_kind = VirtualsKind::None)
 {
     std::stack<const IQueryTreeNode *> nodes_to_process;
     nodes_to_process.push(root_table_expression.get());
@@ -5286,7 +5287,9 @@ static bool getColumnsFromTableExpression(const QueryTreeNodePtr & root_table_ex
                 const auto * table_node = table_expression->as<TableNode>();
                 chassert(table_node);
 
-                auto get_column_options = GetColumnsOptions(GetColumnsOptions::All).withSubcolumns();
+                auto get_column_options = GetColumnsOptions(GetColumnsOptions::All)
+                                              .withSubcolumns()
+                                              .withVirtuals(virtuals_kind, VirtualsMaterializationPlace::All);
                 for (const auto & column : table_node->getStorageSnapshot()->getColumns(get_column_options))
                     existing_columns.insert(column.name);
 
@@ -5297,7 +5300,9 @@ static bool getColumnsFromTableExpression(const QueryTreeNodePtr & root_table_ex
                 const auto * table_function_node = table_expression->as<TableFunctionNode>();
                 chassert(table_function_node);
 
-                auto get_column_options = GetColumnsOptions(GetColumnsOptions::AllPhysical).withSubcolumns();
+                auto get_column_options = GetColumnsOptions(GetColumnsOptions::AllPhysical)
+                                              .withSubcolumns()
+                                              .withVirtuals(virtuals_kind, VirtualsMaterializationPlace::All);
                 for (const auto & column : table_function_node->getStorageSnapshot()->getColumns(get_column_options))
                     existing_columns.insert(column.name);
 
@@ -5587,8 +5592,9 @@ void QueryAnalyzer::resolveJoin(QueryTreeNodePtr & join_node, IdentifierResolveS
             if (resolved_nodes.size() == 1)
             {
                 /// Added column should not conflict with existing column names
+                /// Virtual columns are resolvable names for this source too, so the new name must avoid them as well
                 NameSet existing_columns;
-                if (!getColumnsFromTableExpression(left_table_expression, existing_columns))
+                if (!getColumnsFromTableExpression(left_table_expression, existing_columns, VirtualsKind::All))
                     return nullptr;
 
                 NameAndTypePair column_name_type(identifier_full_name_, resolved_nodes.front()->getResultType());

--- a/tests/queries/0_stateless/05153_join_using_projection_alias_virtual_column.reference
+++ b/tests/queries/0_stateless/05153_join_using_projection_alias_virtual_column.reference
@@ -1,0 +1,13 @@
+fixture-discriminates	1
+alias-is-key-table	1
+alias-is-key-merge-engine	1
+alias-is-key-merge-function	1
+raw-virtual-not-key-table	0
+raw-virtual-not-key-merge-engine	0
+raw-virtual-not-key-merge-function	0
+ordinary-column-collision	1
+subquery-left-side	1
+natural-join-ignores-virtuals	1
+bare-virtual-using-key	1
+compatibility-setting-off	0
+synthesized-column-renamed	1

--- a/tests/queries/0_stateless/05153_join_using_projection_alias_virtual_column.sql
+++ b/tests/queries/0_stateless/05153_join_using_projection_alias_virtual_column.sql
@@ -1,0 +1,64 @@
+-- Regression test: with analyzer_compatibility_join_using_top_level_identifier, a JOIN USING key that
+-- resolves to a SELECT-list alias must not keep the name of a VIRTUAL column of the left table
+-- expression. The synthesized column used to collide with the virtual column on the same source, so
+-- the raw virtual value silently became the join key instead of the aliased expression.
+
+DROP TABLE IF EXISTS t_src;
+DROP TABLE IF EXISTS t_mg;
+DROP TABLE IF EXISTS t_up;
+DROP TABLE IF EXISTS t_raw;
+DROP TABLE IF EXISTS t_ord0;
+DROP TABLE IF EXISTS t_ord1;
+DROP TABLE IF EXISTS t_nat;
+
+CREATE TABLE t_src (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t_src VALUES (1);
+CREATE TABLE t_mg (x UInt64) ENGINE = Merge(currentDatabase(), '^t_src$');
+
+-- The right-hand fixtures are derived from the actual virtual value, so no part name is hard-coded:
+-- t_up holds it uppercased (what the aliased expression yields), t_raw holds it verbatim (what an
+-- un-renamed virtual column yields). A join can match at most one of them.
+CREATE TABLE t_up (`_part` String) ENGINE = Memory;
+CREATE TABLE t_raw (`_part` String) ENGINE = Memory;
+INSERT INTO t_up SELECT upper(_part) FROM t_src;
+INSERT INTO t_raw SELECT _part FROM t_src;
+
+CREATE TABLE t_ord0 (`_t` String) ENGINE = Memory;
+CREATE TABLE t_ord1 (`_t` String) ENGINE = Memory;
+INSERT INTO t_ord0 SELECT _part FROM t_src;
+INSERT INTO t_ord1 SELECT upper(_part) FROM t_src;
+
+-- t_nat shares no named column with t_src, so a NATURAL JOIN of the two must be a cross join.
+-- PARTITION BY gives it a different part name, so if virtual columns ever entered the NATURAL JOIN
+-- name intersection the join would match on `_part` instead and return no rows.
+CREATE TABLE t_nat (y UInt64) ENGINE = MergeTree PARTITION BY y ORDER BY y;
+INSERT INTO t_nat VALUES (1);
+
+SET enable_analyzer = 1;
+SET analyzer_compatibility_join_using_top_level_identifier = 1;
+
+-- The two fixtures must differ, otherwise every assertion below is degenerate.
+SELECT 'fixture-discriminates', upper(_part) != _part FROM t_src;
+
+-- The aliased expression must be the join key. Each of the three table-expression kinds
+-- (table, Merge engine, merge() table function) used to return 0 rows here.
+SELECT 'alias-is-key-table', count() FROM (SELECT upper(a._part) AS _part FROM t_src AS a JOIN t_up USING (_part));
+SELECT 'alias-is-key-merge-engine', count() FROM (SELECT upper(m._part) AS _part FROM t_mg AS m JOIN t_up USING (_part));
+SELECT 'alias-is-key-merge-function', count() FROM (SELECT upper(m._part) AS _part FROM merge(currentDatabase(), '^t_src$') AS m JOIN t_up USING (_part));
+
+-- Converse of the above: the raw virtual value must NOT be the join key. These used to return 1 row.
+SELECT 'raw-virtual-not-key-table', count() FROM (SELECT upper(a._part) AS _part FROM t_src AS a JOIN t_raw USING (_part));
+SELECT 'raw-virtual-not-key-merge-engine', count() FROM (SELECT upper(m._part) AS _part FROM t_mg AS m JOIN t_raw USING (_part));
+SELECT 'raw-virtual-not-key-merge-function', count() FROM (SELECT upper(m._part) AS _part FROM merge(currentDatabase(), '^t_src$') AS m JOIN t_raw USING (_part));
+
+-- Paths that were already correct must not move.
+SELECT 'ordinary-column-collision', count() FROM (SELECT upper(o._t) AS _t FROM t_ord0 AS o JOIN t_ord1 USING (_t));
+SELECT 'subquery-left-side', count() FROM (SELECT upper(s._part) AS _part FROM (SELECT _part FROM t_src) AS s JOIN t_up USING (_part));
+SELECT 'natural-join-ignores-virtuals', count() FROM (SELECT * FROM t_src NATURAL JOIN t_nat);
+SELECT 'bare-virtual-using-key', count() FROM (SELECT x FROM t_src AS a JOIN t_raw USING (_part));
+SELECT 'compatibility-setting-off', count() FROM (SELECT upper(a._part) AS _part FROM t_src AS a JOIN t_up USING (_part)) SETTINGS analyzer_compatibility_join_using_top_level_identifier = 0;
+
+-- Mechanism: the synthesized column is renamed away from the virtual name.
+SELECT 'synthesized-column-renamed', count() > 0 FROM (
+    EXPLAIN QUERY TREE SELECT upper(a._part) AS _part FROM t_src AS a JOIN t_up USING (_part)
+) WHERE explain ILIKE '%column_name: __part%';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/118734


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong results when `analyzer_compatibility_join_using_top_level_identifier = 1` and a `JOIN ... USING` key resolves to a `SELECT`-list alias whose name is a virtual column of the left table expression, such as `SELECT upper(t._part) AS _part FROM t JOIN r USING (_part)`. The raw virtual column value was silently used as the join key instead of the aliased expression, with no exception and no diagnostic.


### Description

Returns no rows where it must return one, silently:

```sql
CREATE TABLE p0 (x UInt64) ENGINE = MergeTree ORDER BY x;
CREATE TABLE p1 (`_part` String) ENGINE = Memory;
INSERT INTO p0 VALUES (1);
INSERT INTO p1 VALUES ('ALL_1_1_0');
SET analyzer_compatibility_join_using_top_level_identifier = 1;
SELECT upper(a._part) AS _part FROM p0 AS a JOIN p1 USING (_part);
```

Resolving a `USING` key from the SELECT list creates a synthetic column at the left table
expression, which `QueryAnalyzer` renames (`_part` to `__part`) when that name is already taken
there. The census feeding that rename never asked for virtual columns, while
`initializeTableExpressionData` registers a table expression's columns with
`withVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::All)`. The census was therefore a
strict subset of the names registrable for the same source: the rename never fired, the synthetic
column and the physical virtual column both rendered `__table1._part`, and `hasColumn()` in
`CollectTableExpressionData` kept the physical one. The raw virtual value became the join key
while the projection still displayed the aliased expression. `67b1de6dcfaf` and #118734 widen this
same census for `ALIAS` columns; virtuals are the remaining kind, and the failure is silent here
rather than a `LOGICAL_ERROR` because the two columns are de-duplicated instead of colliding.

The census now requests virtuals with the options registration itself uses, at the de-confliction
call site only. The parameter defaults to `VirtualsKind::None`, so both `NATURAL JOIN` censuses
keep today's behaviour: widening those would make `NATURAL JOIN` match on `_part`/`_table`/`_path`,
a far larger change. Measured: widening them too flips exactly the new test's
`natural-join-ignores-virtuals` line and nothing else.

PR #118734 adds a `Kind` parameter to this same helper, orthogonal to the `VirtualsKind` parameter
added here, so whichever of the two merges first the other is a mechanical rebase.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119102&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119102](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119102+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
