### PR TITLE
Build the zstd decoders without loop unrolling

### DIFF
--- a/contrib/zstd-cmake/CMakeLists.txt
+++ b/contrib/zstd-cmake/CMakeLists.txt
@@ -146,3 +146,16 @@ add_library(_zstd ${Sources} ${Headers})
 add_library(ch_contrib::zstd ALIAS _zstd)
 target_include_directories(_zstd BEFORE PUBLIC ${LIBRARY_DIR})
 target_compile_options(_zstd PRIVATE -fno-sanitize=undefined)
+
+# Loop unrolling makes the decoders slower: on ClickBench column data, ZSTD_decompressSequences
+# built by clang at -O3 retires 10-12% more instructions and spends 7-9% more cycles with the
+# unroller on than off (the per-sequence copies are short, so the unrolled bodies mostly run
+# their remainders). The compressor does not benefit from the flag, so only the decoders get it.
+set_source_files_properties(
+        "${LIBRARY_DIR}/common/entropy_common.c"
+        "${LIBRARY_DIR}/common/fse_decompress.c"
+        "${LIBRARY_DIR}/decompress/huf_decompress.c"
+        "${LIBRARY_DIR}/decompress/zstd_ddict.c"
+        "${LIBRARY_DIR}/decompress/zstd_decompress_block.c"
+        "${LIBRARY_DIR}/decompress/zstd_decompress.c"
+        PROPERTIES COMPILE_OPTIONS "-fno-unroll-loops")


### PR DESCRIPTION
`ZSTD_decompressSequences` retires 54% (ClickBench) to 58% (TPC-H SF10) of all instructions of a warm-cache benchmark pass. On raw frames extracted from the hits `URL` and `UserID` columns, the bundled zstd built by clang at `-O3` needs 12% more instructions and 9% more cycles to decompress than the same source built with `-fno-unroll-loops`, and matches a gcc `-O2` build only with the flag: the per-sequence copies are short, so the unrolled bodies mostly run their remainders. Compression does not benefit from the flag (+2.5..3.8% instructions), so only the decoder sources get it.

TPC-H SF10 (22 queries, 32 threads, min of 2 interleaved rounds): instructions -8.5%, cycles -6.2%, wall time -4.3% (Q06 -12%, Q01 -11%, Q15 -8%). ClickBench (43 queries): instructions -6.4%, cycles -2.6%, wall time -1.8% (Q23 -11%). All query results identical.

Related: https://github.com/ClickHouse/ClickHouse/pull/119047

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Build the bundled zstd decoder with `-fno-unroll-loops`, which speeds up decompression of `ZSTD`-compressed columns: up to 4% lower wall time on TPC-H SF10 and up to 12% on individual queries.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119104&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119104](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119104+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
