### PR TITLE
Fix `TRUNCATE` of an `Alias` table over a `MergeTree` blocking on concurrent readers

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -13,7 +13,6 @@
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Storages/IStorage.h>
-#include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/StorageMaterializedView.h>
 #include <Common/NamedCollections/NamedCollectionsFactory.h>
 #include <Common/escapeForFileName.h>
@@ -332,7 +331,9 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
             /// MergeTree removes its data under its own locks, but the storage still must not be
             /// dropped or moved to another database meanwhile, the same as for ALTER TABLE ... DROP PARTITION.
             /// For the rest of tables types exclusive lock is needed
-            if (std::dynamic_pointer_cast<MergeTreeData>(table))
+            /// An `Alias` runs the truncate on its target, so the exemption follows the target:
+            /// `isMergeTree()` resolves it, and is false while it is missing or not loaded yet.
+            if (table->isMergeTree())
                 table_shared_lock = table->lockForShare(context_->getCurrentQueryId(), context_->getSettingsRef()[Setting::lock_acquire_timeout]);
             else
                 table_excl_lock = table->lockExclusively(context_->getCurrentQueryId(), context_->getSettingsRef()[Setting::lock_acquire_timeout]);

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -283,11 +283,24 @@ void StorageAlias::truncate(
     const ASTPtr & query,
     const StorageMetadataPtr & /*metadata_snapshot*/,
     ContextPtr local_context,
-    TableExclusiveLockHolder & table_lock_holder)
+    TableExclusiveLockHolder & /*table_lock_holder*/)
 {
     auto target_storage = getTargetTable(TargetAccess{local_context, AccessType::TRUNCATE});
+
+    /// The target is what executes the truncate, so it carries the lock its own engine needs, and the
+    /// caller's holder is the alias's, not the target's. A MergeTree removes its data under its own
+    /// locks; every other engine needs its readers excluded while its data goes away.
+    TableExclusiveLockHolder target_excl_lock;
+    TableLockHolder target_shared_lock;
+    if (target_storage->isMergeTree())
+        target_shared_lock = target_storage->lockForShare(
+            local_context->getCurrentQueryId(), local_context->getSettingsRef()[Setting::lock_acquire_timeout]);
+    else
+        target_excl_lock = target_storage->lockExclusively(
+            local_context->getCurrentQueryId(), local_context->getSettingsRef()[Setting::lock_acquire_timeout]);
+
     auto target_metadata = target_storage->getInMemoryMetadataPtr(local_context, false);
-    target_storage->truncate(query, target_metadata, local_context, table_lock_holder);
+    target_storage->truncate(query, target_metadata, local_context, target_excl_lock);
 }
 
 bool StorageAlias::optimize(

--- a/tests/queries/0_stateless/05153_alias_truncate_lock.reference
+++ b/tests/queries/0_stateless/05153_alias_truncate_lock.reference
@@ -1,0 +1,25 @@
+-- fixture
+al_a	Alias
+al_b	Alias
+al_c	Alias
+al_d_inner	Alias
+al_d_outer	Alias
+al_f	Alias
+al_g	Alias
+al_h	Alias
+mem_c	Memory
+mem_g	Memory
+mt_a	MergeTree
+mt_d	MergeTree
+mt_e	MergeTree
+mt_h	MergeTree
+rmt_b	ReplicatedMergeTree
+-- arms
+A_alias_to_mergetree blocked=0 rows_after=0
+B_alias_to_replicated_mergetree blocked=0 rows_after=0
+C_alias_to_memory blocked=1 rows_after=300
+D_alias_chain_to_mergetree blocked=0 rows_after=0
+E_direct_mergetree blocked=0 rows_after=0
+G_direct_reader_of_memory_target blocked=1 rows_after=300
+H_direct_reader_of_mergetree_target blocked=0 rows_after=0
+F_dangling_alias err=UNKNOWN_TABLE

--- a/tests/queries/0_stateless/05153_alias_truncate_lock.sh
+++ b/tests/queries/0_stateless/05153_alias_truncate_lock.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-replicated-database, no-shared-merge-tree, memory-engine
+# no-replicated-database: there TRUNCATE is enqueued as a DDL entry instead of taking the lock these
+#                         arms measure, so every arm would report blocked=0 regardless of the fix.
+# no-shared-merge-tree, memory-engine: the fixture assertion pins each engine name, and the
+#                         ReplicatedMergeTree -> SharedMergeTree and Memory -> MergeTree test-runner
+#                         replacements rewrite two of them.
+#
+# TRUNCATE through an Alias must choose its lock on, and take it on, the storage that executes the
+# truncate. Each arm starts a reader, then issues TRUNCATE with a 3s lock_acquire_timeout and reports
+# whether that reader blocked it.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE mt_a  (id UInt64) ENGINE = MergeTree ORDER BY id;
+    CREATE TABLE rmt_b (id UInt64)
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/rmt_b', 'r1') ORDER BY id;
+    CREATE TABLE mem_c (id UInt64) ENGINE = Memory;
+    CREATE TABLE mt_d  (id UInt64) ENGINE = MergeTree ORDER BY id;
+    CREATE TABLE mt_e  (id UInt64) ENGINE = MergeTree ORDER BY id;
+    CREATE TABLE mem_g (id UInt64) ENGINE = Memory;
+    CREATE TABLE mt_h  (id UInt64) ENGINE = MergeTree ORDER BY id;
+
+    INSERT INTO mt_a  SELECT number FROM numbers(300);
+    INSERT INTO rmt_b SELECT number FROM numbers(300);
+    INSERT INTO mem_c SELECT number FROM numbers(300);
+    INSERT INTO mt_d  SELECT number FROM numbers(300);
+    INSERT INTO mt_e  SELECT number FROM numbers(300);
+    INSERT INTO mem_g SELECT number FROM numbers(300);
+    INSERT INTO mt_h  SELECT number FROM numbers(300);
+"
+
+# al_d_outer is created while al_d_inner is still absent: an Alias whose target already resolves to
+# an Alias is rejected at creation, an Alias to a missing name is not.
+$CLICKHOUSE_CLIENT -q "
+    CREATE TABLE al_a       ENGINE = Alias(currentDatabase(), 'mt_a');
+    CREATE TABLE al_b       ENGINE = Alias(currentDatabase(), 'rmt_b');
+    CREATE TABLE al_c       ENGINE = Alias(currentDatabase(), 'mem_c');
+    CREATE TABLE al_d_outer ENGINE = Alias(currentDatabase(), 'al_d_inner');
+    CREATE TABLE al_d_inner ENGINE = Alias(currentDatabase(), 'mt_d');
+    CREATE TABLE al_f       ENGINE = Alias(currentDatabase(), 'no_such_table');
+    CREATE TABLE al_g       ENGINE = Alias(currentDatabase(), 'mem_g');
+    CREATE TABLE al_h       ENGINE = Alias(currentDatabase(), 'mt_h');
+"
+
+# Without this an arm could report the expected value while probing a plain table instead of an alias.
+echo '-- fixture'
+$CLICKHOUSE_CLIENT -q "SELECT name, engine FROM system.tables WHERE database = currentDatabase() ORDER BY name"
+
+# arm <label> <reader table> <truncate target> <count table>
+arm() {
+    local label="$1" reader_table="$2" truncate_target="$3" count_table="$4"
+    local query_id="${CLICKHOUSE_DATABASE}_${label}"
+
+    $CLICKHOUSE_CLIENT --query_id "${query_id}" -q "
+        SELECT sum(sleepEachRow(0.2)) FROM ${reader_table}
+        SETTINGS max_block_size = 1, max_threads = 1,
+                 function_sleep_max_microseconds_per_block = 100000000
+    " > /dev/null 2>&1 &
+    local reader_pid=$!
+
+    # read_rows > 0 means the storage read has begun, which happens after the reader's share lock is
+    # taken, so this handshake cannot report a reader that does not yet hold the lock.
+    local started=0
+    for _ in {1..200}; do
+        if [ "$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.processes WHERE query_id = '${query_id}' AND read_rows > 0")" = "1" ]; then
+            started=1
+            break
+        fi
+        sleep 0.1
+    done
+    if [ "${started}" != "1" ]; then
+        echo "${label} ERROR reader did not start"
+        $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '${query_id}' SYNC" > /dev/null 2>&1
+        wait "${reader_pid}" 2>/dev/null
+        return
+    fi
+
+    local err
+    err=$($CLICKHOUSE_CLIENT -q "TRUNCATE TABLE ${truncate_target} SETTINGS lock_acquire_timeout = 3" 2>&1)
+    local blocked=0
+    if echo "${err}" | grep -q "WRITE locking attempt on .* has timed out.*Possible deadlock avoided"; then
+        blocked=1
+    elif [ -n "${err}" ]; then
+        echo "${label} UNEXPECTED $(echo "${err}" | head -1)"
+    fi
+
+    $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '${query_id}' SYNC" > /dev/null 2>&1
+    wait "${reader_pid}" 2>/dev/null
+
+    echo "${label} blocked=${blocked} rows_after=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${count_table}")"
+}
+
+echo '-- arms'
+#   label                                reader      truncate    count
+arm A_alias_to_mergetree                 al_a        al_a        mt_a
+arm B_alias_to_replicated_mergetree      al_b        al_b        rmt_b
+arm C_alias_to_memory                    al_c        al_c        mem_c
+arm D_alias_chain_to_mergetree           al_d_outer  al_d_outer  mt_d
+arm E_direct_mergetree                   mt_e        mt_e        mt_e
+arm G_direct_reader_of_memory_target     mem_g       al_g        mem_g
+arm H_direct_reader_of_mergetree_target  mt_h        al_h        mt_h
+
+# F has no reader: an alias whose target cannot be resolved must still fail to resolve, not time out
+# waiting for a lock.
+F_ERR=$($CLICKHOUSE_CLIENT -q "TRUNCATE TABLE al_f SETTINGS lock_acquire_timeout = 3" 2>&1)
+if echo "$F_ERR" | grep -q "UNKNOWN_TABLE"; then
+    echo "F_dangling_alias err=UNKNOWN_TABLE"
+else
+    echo "F_dangling_alias err=UNEXPECTED $(echo "$F_ERR" | head -1)"
+fi


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113634
Related: https://github.com/ClickHouse/ClickHouse/pull/103044
Related: https://github.com/ClickHouse/ClickHouse/pull/112915
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `TRUNCATE TABLE` of an `Alias` table whose target is a `MergeTree` failing with `DEADLOCK_AVOIDED` when the alias is being read concurrently, while the same statement against the target table succeeds immediately. The lock for `TRUNCATE` is now chosen and taken on the table that executes the truncate, so an `Alias` follows its target's engine.

### Description

Reported by a review bot on #113634: https://github.com/ClickHouse/ClickHouse/pull/113634#discussion_r3969692773

`TRUNCATE` of a `MergeTree` is exempt from the table's exclusive lock, so it does not wait for readers; `InterpreterDropQuery` decided that with `dynamic_pointer_cast<MergeTreeData>` on the catalog object. A `StorageAlias` holds only its target's name, so the cast always failed and the alias's own exclusive `drop_lock` was taken. A reader of the alias holds that same object's share lock, since `lockForShare`/`lockExclusively` are non-virtual. So `TRUNCATE TABLE <alias>` waited for the reader and then failed with `Code: 473 DEADLOCK_AVOIDED`, leaving the data in place.

The same decision was wrong twice:

- The interpreter now asks `table->isMergeTree()`, the virtual `StorageAlias` already answers by resolving its target. It has two overrides tree-wide, so for every other storage this is the old cast, and it resolves with `tryGetTargetTable()`, so a missing or not-yet-loaded target answers `false` and keeps today's exclusive lock.
- `StorageAlias::truncate` forwarded the *alias's* holder to the target and locked nothing on it, though `IStorage::truncate` is documented as having to be called under one. It now resolves the target once, applies the same rule to it, locks it, and passes that holder down, as #103044 does for `alter`.

That lock is the callee's precondition and parity with the direct statement, not a lifetime mechanism; #112915 owns the use-after-free separately and no longer touches this file.

Behaviour change: a `TRUNCATE` through an alias whose target is a **non**-MergeTree engine now waits for that target's own readers, as `TRUNCATE <target>` already did. That previous success was racy.

Four of the new test's arms fail on unpatched master. It also covers `ReplicatedMergeTree`, an alias chain, a dangling alias, and an alias to `Memory`, which must stay blocked, so this is no blanket lock removal.

Not fixed here: `alias -> not-yet-loaded target` under `lazy_load_tables`, which #113634 and #113389 own.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119105&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119105](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119105+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.230` (included in `26.10` and later)
<!-- ch-version-info:end -->