### PR TITLE
Keep the filter column distinct when resolving a planner-only NOT NULL filter

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/resolvePlannerOnlyFilters.cpp
+++ b/src/Processors/QueryPlan/Optimizations/resolvePlannerOnlyFilters.cpp
@@ -229,6 +229,11 @@ void resolvePlannerOnlyFilters(QueryPlan::Node & node, const QueryPlanOptimizati
         new_filter = &new_actions_dag.addFunction(func_and, std::move(new_conjuncts), {});
     }
 
+    /// collectFilterConjuncts unwraps aliases, so the surviving conjunct can be a column of the output header.
+    /// The step removes its filter column by name, which would erase that column and break the parent step.
+    if (filter->getOutputHeader()->has(new_filter->result_name))
+        new_filter = &new_actions_dag.addAlias(*new_filter, "__filter" + new_filter->result_name);
+
     new_actions_dag.addOrReplaceInOutputs(*new_filter);
     new_actions_dag.removeUnusedActions(/*allow_remove_inputs=*/false);
 

--- a/tests/queries/0_stateless/05153_planner_only_filter_keeps_output_column.reference
+++ b/tests/queries/0_stateless/05153_planner_only_filter_keeps_output_column.reference
@@ -1,0 +1,4 @@
+1	alpha	beta
+1	alpha	beta
+left	right
+left	right

--- a/tests/queries/0_stateless/05153_planner_only_filter_keeps_output_column.sql
+++ b/tests/queries/0_stateless/05153_planner_only_filter_keeps_output_column.sql
@@ -1,0 +1,44 @@
+-- A NOT NULL filter derived from a join condition is resolved into the filter step below the join.
+-- When the conjunct that survives that rewrite names a column of the step's own output header, the
+-- column must still reach the join: the join's expressions hold an input node for it.
+
+-- One side carries the bare filter column.
+SELECT is_active, name, label
+FROM (SELECT 'alpha' AS name, toNullable('k1') AS join_key, 1 AS is_active) AS left_side
+INNER JOIN (SELECT 'k1' AS join_key, 'beta' AS label) AS right_side
+    ON left_side.join_key = right_side.join_key
+WHERE is_active AND (label != name)
+SETTINGS query_plan_filter_push_down = 1, query_plan_merge_filters = 1,
+         query_plan_convert_outer_join_to_inner_join = 1,
+         query_plan_derive_not_null_filters_from_joins = 1,
+         query_plan_optimize_join_order_limit = 10;
+
+-- Same query without the join reorder, which reaches the broken plan at execution instead.
+SELECT is_active, name, label
+FROM (SELECT 'alpha' AS name, toNullable('k1') AS join_key, 1 AS is_active) AS left_side
+INNER JOIN (SELECT 'k1' AS join_key, 'beta' AS label) AS right_side
+    ON left_side.join_key = right_side.join_key
+WHERE is_active AND (label != name)
+SETTINGS query_plan_filter_push_down = 1, query_plan_merge_filters = 1,
+         query_plan_convert_outer_join_to_inner_join = 1,
+         query_plan_derive_not_null_filters_from_joins = 1,
+         query_plan_optimize_join_order_limit = 0;
+
+-- Both sides carry a column of that name, so both lose one.
+SELECT left_value, right_value
+FROM (SELECT toNullable('k1') AS join_key, 1 AS is_active, 'left' AS left_value) AS left_side
+NATURAL INNER JOIN (SELECT 'k1' AS join_key, 1 AS is_active, 'right' AS right_value) AS right_side
+WHERE is_active AND (left_value != right_value)
+SETTINGS query_plan_filter_push_down = 1, query_plan_merge_filters = 1,
+         query_plan_convert_outer_join_to_inner_join = 1,
+         query_plan_derive_not_null_filters_from_joins = 1,
+         query_plan_optimize_join_order_limit = 10;
+
+SELECT left_value, right_value
+FROM (SELECT toNullable('k1') AS join_key, 1 AS is_active, 'left' AS left_value) AS left_side
+NATURAL INNER JOIN (SELECT 'k1' AS join_key, 1 AS is_active, 'right' AS right_value) AS right_side
+WHERE is_active AND (left_value != right_value)
+SETTINGS query_plan_filter_push_down = 1, query_plan_merge_filters = 1,
+         query_plan_convert_outer_join_to_inner_join = 1,
+         query_plan_derive_not_null_filters_from_joins = 1,
+         query_plan_optimize_join_order_limit = 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114817
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog: this fixes a master-only regression that was never part of a release.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/114817 (an unreleased regression from it).

`resolvePlannerOnlyFilters` rebuilds a `FilterStep` with `remove_filter = true`, using a surviving
conjunct's `result_name` as the filter column. `collectFilterConjuncts` unwraps aliases, so that
conjunct can be a column of the step's own output header: push-down had wrapped that predicate in a
`__filter<name>` alias so the removal could not hit the stream column (`ActionsDAG.cpp:3768-3779`),
and the unwrap discards that protection. `FilterTransform` then erases the column, and since the pass
replaces `node.step`, no `updateInputHeader` reaches the parent `JoinStepLogical`, whose
expressions still hold an input node for it. Nor can it be pruned, being a join output.

I re-establish the alias at the rebuild site when the chosen filter node's name collides with the
output header, the same idiom and reason as `ActionsDAG.cpp:3774-3779`.

Reproducer, on defaults:

```sql
SELECT deleted, b, c
FROM (SELECT 'v' AS b, toNullable('x') AS a, 1 AS deleted) AS q
INNER JOIN (SELECT 'x' AS a, 'w' AS c) AS s ON q.a = s.a
WHERE deleted AND (c != b);
```

A debug build aborts with `Input nodes size mismatch in dag` (`JoinExpressionActions.cpp:138`, from
`chooseJoinOrder`). With the join reorder off the query is instead rejected with
`NOT_FOUND_COLUMN_IN_BLOCK`, and a `NATURAL JOIN` variant with `UNKNOWN_IDENTIFIER`, so release builds
are affected too. All three return the correct rows after the change. A Nullable join key is required:
it makes the join condition null-rejecting, which produces the marker.

Validation: the new test reddens without the change and passes with it (two scenarios, each with the
join reorder on and off, asserting result rows), plus 50 runs on default randomization and 50 with a
forced join-order seed. Eight of the nine stateless tests #114817 touched pass with no reference
change; the ninth sets `query_plan_derive_not_null_filters_from_joins = 0`, so it returns before the
changed branch.

<details>
<summary>Where it shows up in CI</summary>

Example report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=118979&sha=ef26353f73160ecf71c7681c5d618d448637f813&name_0=PR

```sql
SELECT toDateTime(check_start_time) AS t, pull_request_number AS pr, check_name
FROM default.checks
WHERE position(test_name, 'Input nodes size mismatch in dag') > 0
  AND check_start_time > now() - INTERVAL 30 DAY
  AND test_status IN ('FAIL','ERROR')
ORDER BY t FORMAT TabSeparatedWithNames
```

```
t                     pr      check_name
2026-08-16 07:39:41   110210  AST fuzzer (amd_debug, targeted, old_compatibility)
2026-08-18 05:34:39   111844  AST fuzzer (amd_debug, targeted, old_compatibility)
2026-09-09 12:31:43   118979  Stress test (arm_msan)
2026-09-09 14:12:23   109235  Stress test (arm_tsan)
2026-09-09 14:21:59   118056  AST fuzzer (arm_asan_ubsan)
2026-09-09 15:20:24   103044  BuzzHouse (amd_debug)
2026-09-09 19:00:12   119042  AST fuzzer (amd_debug, targeted)
```

#114817 merged at 08:08 UTC on 2026-09-09. Five rows followed the same day, on five check flavours and
two architectures, every one on an unrelated PR. The two August rows share only the message text, whose
hash forms the failure id; that older shape was fixed by #110227. The query behind the 14:21:59 row was
captured and reproduces this mechanism locally.

This does not touch `src/Interpreters/JoinExpressionActions.cpp`, so it does not overlap my open #108787.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119106&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119106](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119106+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
