### PR TITLE
Do not index absolute symbols as addresses

### DIFF
--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -591,8 +591,10 @@ void collectSymbolsFromMachOImage(
         /// Skip debug symbols (STABS entries)
         if (sym.n_type & N_STAB)
             continue;
-        /// Skip undefined symbols
-        if ((sym.n_type & N_TYPE) == N_UNDF)
+        /// The value of a symbol is an address only when the symbol is defined in a section. For the other
+        /// types it is a constant: an absolute symbol (N_ABS) holds a value such as a bit mask and an
+        /// indirect symbol (N_INDR) holds a string table index.
+        if ((sym.n_type & N_TYPE) != N_SECT)
             continue;
         /// Skip symbols with no address
         if (sym.n_value == 0)

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -107,6 +107,18 @@ namespace
 /// https://stackoverflow.com/questions/32088140/multiple-string-tables-in-elf-object
 
 
+/// The value of a symbol is an address only when the symbol is defined relative to a section. A reserved
+/// section index means the value is a constant instead: for example, the control-flow-integrity type-id
+/// globals `__typeid__*` are absolute symbols whose value is a bit mask.
+bool symbolValueIsAddress(uint16_t section_index)
+{
+    static constexpr uint16_t shn_undef = 0;
+    static constexpr uint16_t shn_abs = 0xfff1;
+    static constexpr uint16_t shn_common = 0xfff2;
+    return section_index != shn_undef && section_index != shn_abs && section_index != shn_common;
+}
+
+
 /// Based on the code of musl-libc and the answer of Kanalpiroge on
 /// https://stackoverflow.com/questions/15779185/list-all-the-functions-symbols-on-the-fly-in-c-code-on-a-linux-architecture
 /// It does not extract all the symbols (but only public - exported and used for dynamic linking),
@@ -235,6 +247,9 @@ void collectSymbolsFromProgramHeaders(
                     if (!sym_name)
                         continue;
 
+                    if (!symbolValueIsAddress(elf_sym[sym_index].shndx))
+                        continue;
+
                     SymbolIndex::Symbol symbol{};
                     symbol.offset_begin = reinterpret_cast<const void *>(
                         elf_sym[sym_index].value);
@@ -294,6 +309,7 @@ void collectSymbolsFromELFSymbolTable(
     {
         if (!symbol_table_entry->name
             || !symbol_table_entry->value
+            || !symbolValueIsAddress(symbol_table_entry->shndx)
             || strings + symbol_table_entry->name >= elf.end())
             continue;
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117449

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`system.symbols` no longer lists symbols whose value is not an address, such as absolute symbols: their `address_begin`/`address_end` were meaningless. On builds compiled with ThinLTO, `-fwhole-program-vtables` emits the control-flow-integrity type-id globals (`__typeid__*`) as absolute symbols whose value is a bit mask rather than an address, and those were indexed as if they were offsets into the binary, inflating `max(address_end)` by a factor of about 1.7 million.

### Description

`Stateless tests (amd_release, parallel, 1/2)` is red on every master commit since #117449 merged, on `05076_error_trace_file_offsets`, which prints `1 0` instead of `1 1`. It reproduces 45/45 with and without randomized settings. Report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=baa509a920113525f109868c2448414d963e5252&name_0=MasterCI

`SymbolIndex` copies `Elf64_Sym::st_value` into `Symbol::offset_begin`/`offset_end` without checking that the symbol is defined relative to a section. When `st_shndx` is a reserved index, the value is a constant rather than an address. `-fwhole-program-vtables` is enabled for every ThinLTO build and emits `__typeid__*` as absolute symbols holding a bit mask, so on `amd_release` `max(address_end) FROM system.symbols` reads 1162219258676258 instead of 685204737 (505 such symbols; `amd_debug` has none). The test bounds captured stack frames by that value, so the raw runtime addresses it looks for stop exceeding it.

A section-relative definition is now required in all three places that turn a symbol table entry into an offset: the two ELF collectors, and the Mach-O one, which requires `N_SECT` instead of only rejecting `N_UNDF`. Each build's bound is again its largest real symbol offset, so `05076` and `03172_error_log_table_not_empty` need no change.

Validated by injecting one `SHN_ABS` symbol into a debug binary: unfixed, `05076` fails 10/10 with exactly the CI diff; fixed, it passes 10/10. `02911_system_symbols` and `03565_system_stack_trace_works` also pass, and `05076` and `03172` pass 50 randomized runs each.

`Stateless tests (amd_release, *)` runs only in MasterCI, so this PR's own CI cannot show the failing arm going green; it does so after merge. The `Fast test (arm_darwin)` red on `05076` is a separate defect, covered by #119145; that build disables ThinLTO, so `__typeid__*` cannot exist in it.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119136&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119136](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119136+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

