### PR TITLE
Preserve input sorting for groupArrayInsertAt and stochastic regression

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.cpp
@@ -299,7 +299,8 @@ SELECT groupArrayInsertAt(number, 0) FROM numbers_mt(10) SETTINGS max_block_size
     FunctionDocumentation::Category category = FunctionDocumentation::Category::AggregateFunction;
     FunctionDocumentation documentation = {description, syntax, arguments, parameters, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction("groupArrayInsertAt", {createAggregateFunctionGroupArrayInsertAt, documentation});
+    AggregateFunctionProperties properties = {.is_order_dependent = true};
+    factory.registerFunction("groupArrayInsertAt", {createAggregateFunctionGroupArrayInsertAt, documentation, properties});
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionMLMethod.cpp
+++ b/src/AggregateFunctions/AggregateFunctionMLMethod.cpp
@@ -105,6 +105,8 @@ namespace
 void registerAggregateFunctionMLMethod(AggregateFunctionFactory & factory);
 void registerAggregateFunctionMLMethod(AggregateFunctionFactory & factory)
 {
+    AggregateFunctionProperties properties = {.is_order_dependent = true};
+
     // stochasticLinearRegression documentation
     FunctionDocumentation::Description description_linear = R"(
 This function implements stochastic linear regression.
@@ -269,7 +271,7 @@ SELECT length(stochasticLinearRegression(0.01)(target, x1, x2)) FROM train_data
     FunctionDocumentation::Category category_linear = FunctionDocumentation::Category::MachineLearning;
     FunctionDocumentation documentation_linear = {description_linear, syntax_linear, arguments_linear, {}, returned_value_linear, examples_linear, introduced_in_linear, category_linear};
 
-    factory.registerFunction("stochasticLinearRegression", {createAggregateFunctionMLMethod<FuncLinearRegression>, documentation_linear, {}});
+    factory.registerFunction("stochasticLinearRegression", {createAggregateFunctionMLMethod<FuncLinearRegression>, documentation_linear, properties});
 
     // stochasticLogisticRegression documentation
     FunctionDocumentation::Description description_logistic = R"(
@@ -441,7 +443,7 @@ evalMLMethod(model, x1, x2) AS result FROM test_data)
     FunctionDocumentation::Category category_logistic = FunctionDocumentation::Category::MachineLearning;
     FunctionDocumentation documentation_logistic = {description_logistic, syntax_logistic, arguments_logistic, {}, returned_value_logistic, examples_logistic, introduced_in_logistic, category_logistic};
 
-    factory.registerFunction("stochasticLogisticRegression", {createAggregateFunctionMLMethod<FuncLogisticRegression>, documentation_logistic, {}});
+    factory.registerFunction("stochasticLogisticRegression", {createAggregateFunctionMLMethod<FuncLogisticRegression>, documentation_logistic, properties});
 }
 
 LinearModelData::LinearModelData(

--- a/tests/queries/0_stateless/05161_group_array_insert_at_order_by.reference
+++ b/tests/queries/0_stateless/05161_group_array_insert_at_order_by.reference
@@ -1,0 +1,3 @@
+ascending	[0]
+descending	[2]
+0

--- a/tests/queries/0_stateless/05161_group_array_insert_at_order_by.sql
+++ b/tests/queries/0_stateless/05161_group_array_insert_at_order_by.sql
@@ -1,0 +1,14 @@
+SET max_threads = 1, query_plan_remove_redundant_sorting = 1;
+
+-- With a single input thread, `groupArrayInsertAt` keeps the first value at each
+-- position. Removing the subquery's `ORDER BY` must not change which value wins.
+SELECT 'ascending', groupArrayInsertAt(number, 0)
+FROM numbers(3);
+
+SELECT 'descending', groupArrayInsertAt(number, 0)
+FROM (SELECT number FROM numbers(3) ORDER BY number DESC);
+
+-- Verify that sort removal is active for an order-independent aggregate.
+SELECT countIf(explain LIKE '%Sorting%') AS sorting_steps
+FROM (EXPLAIN actions = 0, compact = 0, pretty = 0 SELECT sum(number)
+      FROM (SELECT number FROM numbers(3) ORDER BY number DESC));

--- a/tests/queries/0_stateless/05162_stochastic_regression_order_by.reference
+++ b/tests/queries/0_stateless/05162_stochastic_regression_order_by.reference
@@ -1,0 +1,5 @@
+linear ascending	1
+linear descending	1
+logistic ascending	1
+logistic descending	1
+0

--- a/tests/queries/0_stateless/05162_stochastic_regression_order_by.sql
+++ b/tests/queries/0_stateless/05162_stochastic_regression_order_by.sql
@@ -1,0 +1,25 @@
+SET max_threads = 1, query_plan_remove_redundant_sorting = 1;
+
+-- One-sample `SGD` batches and a zero feature isolate the order-dependent bias:
+-- targets -1 then 1 produce a positive bias, while 1 then -1 produce a negative bias.
+-- Query each function separately so one function's metadata cannot preserve the other's sort.
+SELECT 'linear ascending',
+    stochasticLinearRegression(0.5, 0, 1, 'SGD')(if(number = 0, -1, 1), 0)[2] > 0
+FROM numbers(2);
+
+SELECT 'linear descending',
+    stochasticLinearRegression(0.5, 0, 1, 'SGD')(if(number = 0, -1, 1), 0)[2] < 0
+FROM (SELECT number FROM numbers(2) ORDER BY number DESC);
+
+SELECT 'logistic ascending',
+    stochasticLogisticRegression(1, 0, 1, 'SGD')(if(number = 0, -1, 1), 0)[2] > 0
+FROM numbers(2);
+
+SELECT 'logistic descending',
+    stochasticLogisticRegression(1, 0, 1, 'SGD')(if(number = 0, -1, 1), 0)[2] < 0
+FROM (SELECT number FROM numbers(2) ORDER BY number DESC);
+
+-- Verify that sort removal is active for an order-independent aggregate.
+SELECT countIf(explain LIKE '%Sorting%') AS sorting_steps
+FROM (EXPLAIN actions = 0, compact = 0, pretty = 0 SELECT sum(number)
+      FROM (SELECT number FROM numbers(2) ORDER BY number DESC));


### PR DESCRIPTION
Splitting this from #115925.

---

`groupArrayInsertAt` keeps the first value at each position for single-threaded input, while `stochasticLinearRegression` and `stochasticLogisticRegression` depend on sample order. Their registrations did not set `is_order_dependent`, allowing redundant-sort removal to discard a subquery's `ORDER BY` and change the result.

Mark all three functions as order-dependent so the optimizer preserves their input sorting.

Add single-threaded regression tests with ascending and descending input. Test the stochastic functions separately so one function's metadata cannot mask the other's omission. A `sum` control verifies that sorting removal remains active for order-independent aggregates.

Both tests fail on unmodified master and pass with these changes.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Preserve input sorting for groupArrayInsertAt and stochastic regression.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119142&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119142](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119142+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1408` (included in `26.9` and later)
<!-- ch-version-info:end -->