### PR TITLE
Do not run 05076_error_trace_file_offsets on Darwin

### DIFF
--- a/tests/queries/0_stateless/05076_error_trace_file_offsets.sh
+++ b/tests/queries/0_stateless/05076_error_trace_file_offsets.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Tags: no-darwin
+# no-darwin: on Darwin StackTrace::resolveAddress keeps runtime addresses (AddressKind::Unsupported) and
+# system.symbols reports absolute addresses of every loaded image, so no frame is stored as a file offset
+# and max(address_end) is above all of them: neither column below can measure anything there.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/119136
Related: https://github.com/ClickHouse/ClickHouse/pull/117449

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`05076_error_trace_file_offsets` no longer runs on Darwin, where the storage form it asserts is not implemented.

### Description

`05076_error_trace_file_offsets` has not passed once on `Fast test (arm_darwin)` since #117449 merged it: CIDB has 24 FAIL and 0 OK across 24 distinct PRs, almost all bystanders, and it prints `1 0` instead of `1 1`. Report for `ac5f2596d6e8d3391a1c8f973713ac706b68d2ae`: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=111423&sha=ac5f2596d6e8d3391a1c8f973713ac706b68d2ae&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29

The test asserts a storage form that Darwin documents itself as not implementing. `StackTrace::resolveAddress` is compiled `#if defined(__ELF__) && !defined(OS_FREEBSD)`; elsewhere it returns `AddressKind::Unsupported` with the address unchanged, which `StackTrace.h` describes as "the platform keeps runtime addresses". So no frame reaches `last_error_trace` as a file offset there. `collectSymbolsFromMachOImage` meanwhile stores absolute addresses (`n_value + slide`) and extends each image's last symbol to that image's `max_addr`, for every loaded dyld image, so `max(address_end) FROM system.symbols` is a ceiling above every captured frame: the second column can never hold, and the first stops measuring the offset form. Neither ThinLTO nor dyld layout is involved, which is why #119136 (the ELF half of this, `SHN_ABS` symbols inflating the same bound on `amd_release`) does not repair this arm.

Tagging is therefore the fix, and the assertion is untouched on the 20+ arms where the contract holds (`Fast test` is 84 OK / 0 FAIL over 53 PRs). Since there is no macOS host to iterate on, this PR's own `Fast test (arm_darwin)` run is the verification, and it lands before merge; locally the runner's `should_skip_test` was exercised over both platform arms and both versions of the file, and the test passes 50/50 on Linux.

Two residuals I am not changing: `03172_error_log_table_not_empty` shares the bound but only in the in-range shape, so a high ceiling satisfies it weakly rather than falsely; and on macOS a stored trace is not portable across restarts as it is on ELF. Whether Darwin should implement file offsets is an owner-level design question, not attempted here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119145&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119145](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119145+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1117` (included in `26.9` and later)
<!-- ch-version-info:end -->