### PR TITLE
Revive latest_logs_cache_entry_count_threshold setting

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -1169,7 +1169,7 @@ void validateReadAheadSettings(const ReadAheadSettings & settings)
 }
 
 LogEntryStorage::LogEntryStorage(const LogFileSettings & log_settings, ReadAheadSettings readahead_settings_, KeeperContextPtr keeper_context_)
-    : latest_logs_cache(log_settings.latest_logs_cache_size_threshold)
+    : latest_logs_cache(log_settings.latest_logs_cache_size_threshold, log_settings.latest_logs_cache_entry_count_threshold)
     , keeper_context(std::move(keeper_context_))
     , log(getLogger("Changelog"))
     , readahead_settings(std::move(readahead_settings_))
@@ -1181,8 +1181,9 @@ LogEntryStorage::~LogEntryStorage()
     shutdown();
 }
 
-LogEntryStorage::InMemoryCache::InMemoryCache(size_t size_threshold_)
+LogEntryStorage::InMemoryCache::InMemoryCache(size_t size_threshold_, size_t count_threshold_)
     : size_threshold(size_threshold_)
+    , count_threshold(count_threshold_)
 {}
 
 void LogEntryStorage::InMemoryCache::updateStatsWithNewEntry(uint64_t index, size_t size)
@@ -1296,7 +1297,7 @@ void LogEntryStorage::InMemoryCache::clear()
 
 bool LogEntryStorage::InMemoryCache::hasUnlimitedSpace() const
 {
-    return size_threshold == 0;
+    return size_threshold == 0 && count_threshold == 0;
 }
 
 bool LogEntryStorage::InMemoryCache::empty() const
@@ -1314,7 +1315,13 @@ bool LogEntryStorage::InMemoryCache::hasSpaceAvailable(size_t log_entry_size) co
     if (hasUnlimitedSpace() || empty())
         return true;
 
-    return cache_size + log_entry_size <= size_threshold;
+    if (size_threshold != 0 && cache_size + log_entry_size > size_threshold)
+        return false;
+
+    if (count_threshold != 0 && numberOfEntries() + 1 > count_threshold)
+        return false;
+
+    return true;
 }
 
 void LogEntryStorage::addEntry(uint64_t index, const LogEntryPtr & log_entry)
@@ -1705,11 +1712,15 @@ void LogEntryStorage::refreshCache()
 
     const auto latest_log_cache_over_size_threshold = [&]
     {
-        return latest_logs_cache.cache_size > latest_logs_cache.size_threshold;
+        return latest_logs_cache.size_threshold != 0 && latest_logs_cache.cache_size > latest_logs_cache.size_threshold;
     };
 
+    const auto latest_log_cache_over_count_threshold = [&]
+    {
+        return latest_logs_cache.count_threshold != 0 && latest_logs_cache.numberOfEntries() > latest_logs_cache.count_threshold;
+    };
     while (latest_logs_cache.numberOfEntries() > 1 && latest_logs_cache.min_index_in_cache <= max_index_with_location
-           && latest_log_cache_over_size_threshold())
+           && (latest_log_cache_over_size_threshold() || latest_log_cache_over_count_threshold()))
         latest_logs_cache.popOldestEntry();
 }
 

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -198,6 +198,7 @@ struct LogFileSettings
     uint64_t max_size = 0;
     uint64_t overallocate_size = 0;
     uint64_t latest_logs_cache_size_threshold = 0;
+    uint64_t latest_logs_cache_entry_count_threshold = 0;
     /// 0 = automatically use the number of CPU cores (resolved by Changelog's constructor).
     uint64_t startup_read_max_streams = 0;
     uint64_t startup_read_buffer_size = 8 * 1024 * 1024;
@@ -286,8 +287,8 @@ struct ReadAheadReader;
   * an LRU/SLRU-style cache would not help.
   *
   * The latest logs cache holds the most recent logs in memory (unflushed tail plus a flushed
-  * suffix), bounded by latest_logs_cache_size_threshold; once persisted, its location is recorded
-  * (logs_location) and the entry may be evicted.
+  * suffix), bounded by latest_logs_cache_size_threshold and latest_logs_cache_entry_count_threshold;
+  * once persisted, its location is recorded (logs_location) and the entry may be evicted.
   *
   * Replication is served by per-peer read-ahead readers (peer_readers): each follower gets a
   * dedicated reader decoding entries ahead of the requested range.
@@ -384,7 +385,7 @@ struct LogEntryStorage
     /// Test-only: whether the commit reader currently exists.
     bool hasCommitReaderForTests() const;
 
-    /// True when latest_logs_cache has no size threshold (retains the whole live log, never evicts).
+    /// True when latest_logs_cache has no size or entry-count threshold (retains the whole live log, never evicts).
     bool isUnlimitedCacheMode() const { return latest_logs_cache.hasUnlimitedSpace(); }
 
     void addLocation(uint64_t index, uint64_t term, int32_t value_type, const LogEntryPtr & log_entry, LogLocation log_location);
@@ -400,7 +401,7 @@ private:
 
     struct InMemoryCache
     {
-        explicit InMemoryCache(size_t size_threshold_);
+        explicit InMemoryCache(size_t size_threshold_, size_t count_threshold_);
 
         void addEntry(uint64_t index, size_t size, LogEntryPtr log_entry);
 
@@ -429,6 +430,7 @@ private:
         size_t max_index_in_cache = 0;
 
         const size_t size_threshold;
+        const size_t count_threshold;
     };
 
     InMemoryCache latest_logs_cache;

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -97,7 +97,7 @@ namespace ErrorCodes
     DECLARE(UInt64, write_throttling_max_delay_us, 1000000, "LSMT: the maximum delay added to a write by write throttling, in microseconds.", HOT_RELOAD) \
     DECLARE(Float, write_throttling_factor, 32.0f, "LSMT: write throttling delay is multiplied by this factor if soft limit is exceeded by 2x. Should be greater than 1. Delay = write_throttling_min_delay_us * pow(write_throttling_factor, value / soft_limit - 1).", HOT_RELOAD) \
     DECLARE(UInt64, latest_logs_cache_size_threshold, 1_GiB, "Maximum total size of in-memory cache of latest log entries.", 0) \
-    DECLARE(UInt64, latest_logs_cache_entry_count_threshold, 200'000, "Deprecated, has no effect. The latest logs cache is bounded by latest_logs_cache_size_threshold alone.", SettingsTierType::OBSOLETE) \
+    DECLARE(UInt64, latest_logs_cache_entry_count_threshold, 200'000, "Maximum number of entries in in-memory cache of latest log entries.", 0) \
     DECLARE(UInt64, commit_logs_cache_size_threshold, 500_MiB, "Deprecated. Used as the value of log_readahead_commit_window_bytes if that setting is not itself set.", SettingsTierType::OBSOLETE) \
     DECLARE(UInt64, commit_logs_cache_entry_count_threshold, 100'000, "Deprecated, has no effect. Use log_readahead_commit_window_bytes instead.", SettingsTierType::OBSOLETE) \
     DECLARE(UInt64, disk_move_retries_wait_ms, 1000, "How long to wait between retries after a failure which happened while a file was being moved between disks.", 0) \

--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -23,6 +23,7 @@ namespace CoordinationSetting
     extern const CoordinationSettingsBool compress_logs;
     extern const CoordinationSettingsBool force_sync;
     extern const CoordinationSettingsUInt64 latest_logs_cache_size_threshold;
+    extern const CoordinationSettingsUInt64 latest_logs_cache_entry_count_threshold;
     extern const CoordinationSettingsUInt64 log_file_overallocate_size;
     extern const CoordinationSettingsUInt64 max_flush_batch_size;
     extern const CoordinationSettingsUInt64 max_log_file_size;
@@ -339,6 +340,7 @@ KeeperStateManager::KeeperStateManager(
               .max_size = keeper_context_->getCoordinationSettings()[CoordinationSetting::max_log_file_size],
               .overallocate_size = keeper_context_->getCoordinationSettings()[CoordinationSetting::log_file_overallocate_size],
               .latest_logs_cache_size_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::latest_logs_cache_size_threshold],
+              .latest_logs_cache_entry_count_threshold = keeper_context_->getCoordinationSettings()[CoordinationSetting::latest_logs_cache_entry_count_threshold],
               .startup_read_max_streams = keeper_context_->getCoordinationSettings()[CoordinationSetting::log_startup_read_max_streams],
               .startup_read_buffer_size = keeper_context_->getCoordinationSettings()[CoordinationSetting::log_startup_read_buffer_size],
           },


### PR DESCRIPTION
Restore the entry-count limit for Keeper's latest-log cache while preserving the newer changelog read-ahead implementation. A zero byte threshold can now be combined with a nonzero entry-count threshold.

Related: https://github.com/ClickHouse/ClickHouse/pull/84877
Related: https://github.com/ClickHouse/ClickHouse/pull/108473

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `latest_logs_cache_entry_count_threshold` setting is effective again and limits Keeper's in-memory latest-log cache by entry count independently of `latest_logs_cache_size_threshold`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119151&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119151](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119151+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1125` (included in `26.9` and later)
- Backported to: `26.8.3.83`
<!-- ch-version-info:end -->