### PR TITLE
Fix a table with a non-deterministic sorting or partition key failing to load after an upgrade

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -805,7 +805,7 @@ MergeTreeData::MergeTreeData(
     {
         try
         {
-            checkPartitionKeyAndInitMinMax(metadata_.partition_key);
+            checkPartitionKeyAndInitMinMax(metadata_.partition_key, !sanity_checks);
             setProperties(metadata_, metadata_, !sanity_checks);
             if (minmax_idx_date_column_pos == -1)
                 throw Exception(ErrorCodes::BAD_TYPE_OF_FIELD, "Could not find Date column");
@@ -820,7 +820,7 @@ MergeTreeData::MergeTreeData(
     else
     {
         is_custom_partitioned = true;
-        checkPartitionKeyAndInitMinMax(metadata_.partition_key);
+        checkPartitionKeyAndInitMinMax(metadata_.partition_key, !sanity_checks);
     }
     setProperties(metadata_, metadata_, !sanity_checks);
 
@@ -977,19 +977,25 @@ bool MergeTreeData::supportsFinal() const
         || merging_params.mode == MergingParams::VersionedCollapsing;
 }
 
-static void checkKeyExpression(const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key)
+static void checkKeyExpression(
+    const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key, bool attach)
 {
     if (expr.hasArrayJoin())
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "{} key cannot contain array joins", key_name);
 
-    try
+    /// A function can be marked non-deterministic in a later version, so this must not fire on attach:
+    /// otherwise a table stored by an earlier version stops loading and its data becomes unreachable.
+    if (!attach)
     {
-        expr.assertDeterministic();
-    }
-    catch (Exception & e)
-    {
-        e.addMessage(fmt::format("for {} key", key_name));
-        throw;
+        try
+        {
+            expr.assertDeterministic();
+        }
+        catch (Exception & e)
+        {
+            e.addMessage(fmt::format("for {} key", key_name));
+            throw;
+        }
     }
 
     for (const ColumnWithTypeAndName & element : sample_block)
@@ -1418,7 +1424,7 @@ void MergeTreeData::checkProperties(
         MergeTreeStatisticsFactory::instance().validate(col.statistics, col.type, allow_deprecated_minmax);
     }
 
-    checkKeyExpression(*new_sorting_key.expression, new_sorting_key.sample_block, "Sorting", allow_nullable_key_);
+    checkKeyExpression(*new_sorting_key.expression, new_sorting_key.sample_block, "Sorting", allow_nullable_key_, attach);
 }
 
 void MergeTreeData::checkMetadataProperties(
@@ -1557,12 +1563,12 @@ MergeTreeData::getSortingKeyAndSkipIndicesExpression(const StorageMetadataPtr & 
     return getCombinedIndicesExpression(metadata_snapshot->getSortingKey(), indices, metadata_snapshot->columns, metadata_snapshot->virtuals, getContext());
 }
 
-void MergeTreeData::checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key)
+void MergeTreeData::checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key, bool attach)
 {
     if (new_partition_key.expression_list_ast->children.empty())
         return;
 
-    checkKeyExpression(*new_partition_key.expression, new_partition_key.sample_block, "Partition", allow_nullable_key);
+    checkKeyExpression(*new_partition_key.expression, new_partition_key.sample_block, "Partition", allow_nullable_key, attach);
 
     /// Add all columns used in the partition key to the min-max index.
     const auto minmax_columns = getMinMaxColumns(new_partition_key, getSettings());

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1912,7 +1912,7 @@ protected:
 
     void checkMinMaxIndexForJSON(const IndexDescription & index) const;
 
-    void checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key);
+    void checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key, bool attach);
 
     void checkTTLExpressions(const StorageInMemoryMetadata & new_metadata, const StorageInMemoryMetadata & old_metadata) const;
 

--- a/tests/queries/0_stateless/01943_non_deterministic_key_attach.reference
+++ b/tests/queries/0_stateless/01943_non_deterministic_key_attach.reference
@@ -1,0 +1,10 @@
+-- CREATE stays refused
+(BAD_ARGUMENTS)
+(BAD_ARGUMENTS)
+(BAD_ARGUMENTS)
+-- rows survive a reload from the stored definition
+100	t_sort
+100	t_part
+100	t_conc
+-- a constant key is still refused on attach
+(ILLEGAL_COLUMN)

--- a/tests/queries/0_stateless/01943_non_deterministic_key_attach.sh
+++ b/tests/queries/0_stateless/01943_non_deterministic_key_attach.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tags: no-ordinary-database, no-replicated-database
+# The full-definition ATTACH rows need an explicit per-copy UUID: a .sql file cannot interpolate one,
+# an Ordinary database rejects the form, and a Replicated database assigns the UUID itself.
+
+# The CREATE side of this rule is covered by 01943_non_deterministic_order_key.sql.
+#
+# A non-deterministic function in the sorting or partition key is refused for a new table, but a table
+# already stored with such a key must keep loading and keep its rows readable: a function can start
+# reporting itself as non-deterministic in a later version, and that must not put existing data out of
+# reach. Only the determinism rule is relaxed on load - a key that is constant stays refused either way.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+CLIENT="${CLICKHOUSE_CLIENT} --server_logs_file=/dev/null --allow_introspection_functions=1"
+
+# Report the error name once, whether or not the client repeats the message.
+error_name() { grep -oE '\([A-Z_]+\)' | tail -1; }
+
+echo '-- CREATE stays refused'
+${CLIENT} -q "CREATE TABLE t_sort (d Date, addr UInt64) ENGINE = MergeTree ORDER BY (d, addressToSymbol(addr))" 2>&1 | error_name
+${CLIENT} -q "CREATE TABLE t_part (d Date, addr UInt64) ENGINE = MergeTree PARTITION BY addressToSymbol(addr) ORDER BY d" 2>&1 | error_name
+${CLIENT} -q "CREATE TABLE t_conc (s DateTime, f DateTime) ENGINE = MergeTree ORDER BY (s, runningConcurrency(s, f))" 2>&1 | error_name
+
+echo '-- rows survive a reload from the stored definition'
+attach_insert_reload() {
+    local name="$1" definition="$2" rows="$3"
+    local uuid err
+    uuid=$(${CLIENT} -q "SELECT generateUUIDv4()")
+    err=$(${CLIENT} -q "ATTACH TABLE ${name} UUID '${uuid}' ${definition}" 2>&1)
+    # A refused attach is reported here, so it does not resurface as a missing table below.
+    if [ -n "${err}" ]; then
+        echo "${err}" | error_name
+        return
+    fi
+    ${CLIENT} -q "INSERT INTO ${name} ${rows}"
+    # The short ATTACH re-reads the stored definition - the same path a server restart takes.
+    ${CLIENT} -q "DETACH TABLE ${name}"
+    err=$(${CLIENT} -q "ATTACH TABLE ${name}" 2>&1)
+    if [ -n "${err}" ]; then
+        echo "${err}" | error_name
+        return
+    fi
+    ${CLIENT} -q "SELECT count(), '${name}' FROM ${name}"
+    ${CLIENT} -q "DROP TABLE ${name}"
+}
+
+attach_insert_reload t_sort \
+    "(d Date, addr UInt64) ENGINE = MergeTree ORDER BY (d, addressToSymbol(addr))" \
+    "SELECT toDate('2026-01-01') + number % 10, number * 64 FROM numbers(100)"
+attach_insert_reload t_part \
+    "(d Date, addr UInt64) ENGINE = MergeTree PARTITION BY addressToSymbol(addr) ORDER BY d" \
+    "SELECT toDate('2026-01-01') + number % 10, number * 64 FROM numbers(100)"
+attach_insert_reload t_conc \
+    "(s DateTime, f DateTime) ENGINE = MergeTree ORDER BY (s, runningConcurrency(s, f))" \
+    "SELECT toDateTime('2026-01-01 00:00:00') + number, toDateTime('2026-01-01 01:00:00') + number FROM numbers(100)"
+
+echo '-- a constant key is still refused on attach'
+UUID_CONST=$(${CLIENT} -q "SELECT generateUUIDv4()")
+${CLIENT} -q "ATTACH TABLE t_const UUID '${UUID_CONST}' (n UInt64) ENGINE = MergeTree ORDER BY (n, now())" 2>&1 | error_name


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/118502
Related: https://github.com/ClickHouse/ClickHouse/pull/112938
Related: https://github.com/ClickHouse/ClickHouse/pull/114403

## Problem

A `MergeTree` table whose sorting or partition key contains a non-deterministic function stops loading
after an upgrade, and its data becomes unreachable. Every released version accepts such a key, so the
table exists in the wild:

```sql
SET allow_introspection_functions = 1;
CREATE TABLE t (d Date, addr UInt64) ENGINE = MergeTree ORDER BY (d, addressToSymbol(addr));  -- accepted on 26.8
```

After upgrading to a build that carries #112938 (`addressToSymbol`, `addressToLine`,
`addressToLineWithInlines`) or #114403 (`runningConcurrency`), loading that table fails permanently:

```
Load job 'load table default.intro' failed: Code: 36. DB::Exception: Expression must be deterministic
but it contains non-deterministic part `addressToSymbol(addr)`: for Sorting key: Cannot attach table
```

Concrete consequences:

- The data is intact on disk but completely unreachable.
- There is no SQL-level recovery: `SELECT`, `DETACH TABLE` and `DROP TABLE` on the table all fail with
  the same error wrapped in `ASYNC_LOAD_WAIT_FAILED`.
- `SHOW TABLES` and `system.tables` queries against the containing database fail too, because they wait
  on the failed async load job — so one broken table hides every other table in that database.
- The only workaround is hand-editing the stored metadata `.sql` file with the server down.

Both the sorting key and the partition key are affected.

## Root cause

`checkKeyExpression` in `src/Storages/MergeTree/MergeTreeData.cpp` calls `assertDeterministic` on every
path, including metadata load. The check itself is old (`ff5c433f105`, 2021); what changed is that the
functions above only recently began reporting themselves as non-deterministic.

Neither call site consults the `attach` flag: the sorting key is checked at the tail of
`checkProperties`, which already receives `attach` and simply did not pass it on, and the partition key
is checked in `checkPartitionKeyAndInitMinMax`, which had no such parameter at all. That is unlike the
many other validations in `checkProperties` — suspicious indices, deprecated `minmax` statistics, JSON
`minmax`, unique-key TTL — which are already attach-gated precisely so that a table stored by an
earlier version stays loadable.

## Fix

Gate **only** the determinism probe on `!attach`. `checkKeyExpression` takes an `attach` parameter; the
sorting-key call site passes the flag `checkProperties` already has, and
`checkPartitionKeyAndInitMinMax` gains the parameter, fed `!sanity_checks` from both constructor call
sites (`sanity_checks = mode <= LoadingStrictnessLevel::CREATE`, which the constructor already inverts
as `attach` when calling `setProperties`).

The array-join, constant and nullable checks are deliberately left alone: they are not part of this
regression, and a constant key stays refused on load as well. `CREATE` and `ALTER` are unaffected —
`checkAlterEligibility` and `checkMetadataProperties` both pass `attach=false` — so the tightening that
#112938 and #114403 intended still applies to every new definition.

Regression test `01943_non_deterministic_key_attach.sh`, placed next to the existing
`01943_non_deterministic_order_key.sql` which covers the `CREATE` side of the same rule. For each of
the three shapes it attaches the stored definition, inserts 100 rows, detaches and re-attaches by name
so the stored metadata is re-read (the path a restart takes), and asserts the rows are still readable.
It also pins the scope: `CREATE` stays refused for all three shapes, and a constant key
(`ORDER BY (n, now())`) is still refused on attach.

Verified against the issue on a local build: the four reported shapes fail on `master` with the exact
`Code: 36` above and pass with this change; removing the guard turns the test red, and passing
`attach=false` at the partition call site alone turns only the partition arm red.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed tables with a non-deterministic function such as `addressToSymbol` or `runningConcurrency` in the sorting or partition key failing to load after an upgrade, leaving their data unreachable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119153&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119153](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119153+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
