### PR TITLE
praktika: add GH.api and strict/argv support to the gh retry helpers

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -530,7 +530,7 @@ class GH:
         return res
 
     @classmethod
-    def get_output_with_retries(cls, command, verbose=False, strict=False):
+    def get_output_with_retries(cls, command, verbose=False, strict=False, retries=None):
         """Run a read-style ``gh`` command and return its stdout.
 
         Mirrors :meth:`do_command_with_retries` but returns the captured
@@ -551,12 +551,13 @@ class GH:
         """
         if not isinstance(command, str):
             command = shlex.join(command)
+        limit = Settings.MAX_RETRIES_GH if retries is None else retries
         retry_count = 0
         # Counted where the subprocess is invoked, so a non-retryable class that breaks out
         # of the loop still reports the attempt it made. retry_count counts retries taken.
         attempts = 0
         out, err, ret_code = "", "", -1
-        while retry_count < Settings.MAX_RETRIES_GH:
+        while retry_count < limit:
             attempts += 1
             ret_code, out, err = Shell.get_res_stdout_stderr(command, verbose=verbose)
             if ret_code == 0:
@@ -618,6 +619,7 @@ class GH:
         jq=None,
         paginate=False,
         strict=False,
+        retries=None,
         verbose=False,
     ):
         """Run a REST ``gh api`` call with retries and return its stdout.
@@ -627,6 +629,8 @@ class GH:
         ``fields`` are sent as ``-f`` string params (no typed or ``@file`` forms).
         Returns trimmed stdout ("" for a no-body response such as DELETE);
         ``strict=True`` raises on persistent failure instead of returning "".
+        ``retries=1`` disables retrying, e.g. for a best-effort call whose
+        expected failure (a 404) is not transient.
         """
         argv = ["gh", "api", "-X", method, endpoint]
         for key, value in (fields or {}).items():
@@ -635,7 +639,9 @@ class GH:
             argv += ["--jq", jq]
         if paginate:
             argv.append("--paginate")
-        return cls.get_output_with_retries(argv, verbose=verbose, strict=strict)
+        return cls.get_output_with_retries(
+            argv, verbose=verbose, strict=strict, retries=retries
+        )
 
     @classmethod
     def _gh_graphql_json(cls, query, variables, verbose=False):

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -622,14 +622,13 @@ class GH:
     ):
         """Run a REST ``gh api`` call with retries and return its stdout.
 
-        ``fields`` become ``-f key=value`` params and ``method`` maps to ``-X``.
-        Returns the trimmed stdout ("" for a no-body response such as DELETE);
-        with ``strict=True`` a persistent failure raises instead of returning "".
+        ``method`` is always passed as ``-X`` so ``fields`` stay query params on a
+        ``GET`` (``gh api`` switches to ``POST`` as soon as a field is present).
+        ``fields`` are sent as ``-f`` string params (no typed or ``@file`` forms).
+        Returns trimmed stdout ("" for a no-body response such as DELETE);
+        ``strict=True`` raises on persistent failure instead of returning "".
         """
-        argv = ["gh", "api"]
-        if method != "GET":
-            argv += ["-X", method]
-        argv.append(endpoint)
+        argv = ["gh", "api", "-X", method, endpoint]
         for key, value in (fields or {}).items():
             argv += ["-f", f"{key}={value}"]
         if jq:

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -495,7 +495,7 @@ class GH:
             shutil.rmtree(temp_root, ignore_errors=True)
 
     @classmethod
-    def do_command_with_retries(cls, command, verbose=False):
+    def do_command_with_retries(cls, command, verbose=False, strict=False):
         res = False
         retry_count = 0
         out, err = "", ""
@@ -518,9 +518,15 @@ class GH:
                 time.sleep(delay)
 
         if not res:
-            print(
-                f"ERROR: Failed to execute gh command [{command}] out:[{out}] err:[{err}] after [{retry_count}] attempts"
+            # Field order matters: this message can reach a public report page, so the
+            # fields naming the cause come before the API-controlled output.
+            message = (
+                f"Failed to execute gh command [{command}] "
+                f"after [{retry_count}] attempts err:[{_elide(err)}] out:[{_elide(out)}]"
             )
+            print(f"ERROR: {message}")
+            if strict:
+                raise RuntimeError(message)
         return res
 
     @classmethod
@@ -539,7 +545,12 @@ class GH:
         ``strict=True`` raises instead, so a caller can report why the
         read failed rather than be handed an empty string that is
         indistinguishable from an empty result.
+
+        ``command`` may be a string or an argv list; a list is joined with
+        ``shlex.join`` (the command runs through the shell).
         """
+        if not isinstance(command, str):
+            command = shlex.join(command)
         retry_count = 0
         # Counted where the subprocess is invoked, so a non-retryable class that breaks out
         # of the loop still reports the attempt it made. retry_count counts retries taken.
@@ -597,6 +608,35 @@ class GH:
             else:
                 result.append(page)
         return result
+
+    @classmethod
+    def api(
+        cls,
+        endpoint,
+        method="GET",
+        fields=None,
+        jq=None,
+        paginate=False,
+        strict=False,
+        verbose=False,
+    ):
+        """Run a REST ``gh api`` call with retries and return its stdout.
+
+        ``fields`` become ``-f key=value`` params and ``method`` maps to ``-X``.
+        Returns the trimmed stdout ("" for a no-body response such as DELETE);
+        with ``strict=True`` a persistent failure raises instead of returning "".
+        """
+        argv = ["gh", "api"]
+        if method != "GET":
+            argv += ["-X", method]
+        argv.append(endpoint)
+        for key, value in (fields or {}).items():
+            argv += ["-f", f"{key}={value}"]
+        if jq:
+            argv += ["--jq", jq]
+        if paginate:
+            argv.append("--paginate")
+        return cls.get_output_with_retries(argv, verbose=verbose, strict=strict)
 
     @classmethod
     def _gh_graphql_json(cls, query, variables, verbose=False):


### PR DESCRIPTION
Add a `GH.api(endpoint, method=, fields=, jq=, paginate=, strict=)` REST wrapper in `ci/praktika/gh.py` that builds the `gh api` command as an argv list and runs it through `get_output_with_retries`, so REST callers stop hand-assembling the command string and inherit the retry/`strict` behaviour. Also:

- add a `strict=` flag to `do_command_with_retries` (mirroring `get_output_with_retries`) so a caller can raise with the command's stderr instead of wrapping the boolean in an `assert`;
- let `get_output_with_retries` accept an argv list (joined with `shlex.join`).

Framework-only change; mirrors the `ci/praktika/gh.py` helper change made in the private repo's `AWSDeployApply` work so the two praktika copies do not diverge.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119166&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119166](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119166+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
