### PR TITLE
Do not symbolize trace_log in-flush on coverage builds either

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6944,7 +6944,7 @@ ORDER BY (test_name, callee_offset)
                 Too much memory has been allocated without checking for memory limits: {unchecked_memory/1024/1024/1024} GiB.
                 Take a look at:
 
-                SELECT arrayStringConcat(symbols, '\\n'), sum(size)
+                SELECT arrayStringConcat(arrayMap(a -> demangle(addressToSymbol(a)), trace), '\\n'), sum(size)
                 FROM system.trace_log
                 WHERE trace_type = 'MemoryAllocatedWithoutCheck'
                     AND event_date >= toDate(fromUnixTimestamp({int(tests_start_time)}))
@@ -6952,6 +6952,7 @@ ORDER BY (test_name, callee_offset)
                 GROUP BY 1
                 ORDER BY 2
                 LIMIT -10
+                SETTINGS allow_introspection_functions = 1
                 FORMAT Vertical
 
                 See also at

--- a/tests/config/config.d/trace_log_no_symbolize.xml
+++ b/tests/config/config.d/trace_log_no_symbolize.xml
@@ -1,5 +1,5 @@
 <clickhouse>
-    <!-- Under sanitizer builds, in-flush symbolization (SymbolIndex::findSymbol +
+    <!-- Under sanitizer and coverage builds, in-flush symbolization (SymbolIndex::findSymbol +
          tryDemangle + AddressToLineCache) is too slow to keep up with the sample rate
          from the global + per-query profilers. The trace_log flush thread falls
          behind, backlog grows, and tests that issue SYSTEM FLUSH LOGS can wait

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -107,19 +107,38 @@ function build_option_flag()
     echo "$value"
 }
 
+# Print 1 or 0 for whether a named system.build_options row is enabled, or fail. Flags that cmake
+# applies per-directory never reach CXX_FLAGS, so build_option_flag cannot probe them. A missing
+# row aborts the install instead of reading as false, so a renamed option cannot go unnoticed.
+function build_option_enabled()
+{
+    local description=$1 name=$2 value rc=0
+    value=$(clickhouse local --query \
+        "SELECT multiIf(count() = 0, 'missing', countIf(upper(value) IN ('ON', '1')) > 0, '1', '0') \
+         FROM system.build_options WHERE name = '$name'") || rc=$?
+    if [ "$rc" != "0" ] || { [ "$value" != "0" ] && [ "$value" != "1" ]; }; then
+        echo "install.sh: cannot determine whether this is a $description (exit $rc, output '$value')" >&2
+        return 1
+    fi
+    echo "$value"
+}
+
 # Install the configs whose presence depends on the build flavour of the binary installed right
 # now. Idempotent in both directions, so a tree installed for one build type can be re-decided
 # for another (see --build-type-configs-only).
 function install_build_type_configs()
 {
-    local is_memory_sanitizer is_sanitizer
-    # Resolve both probes before touching either file, so a failing probe cannot leave a
+    local is_memory_sanitizer is_sanitizer is_coverage
+    # Resolve every probe before touching any file, so a failing probe cannot leave a
     # half-adjusted tree.
     is_memory_sanitizer=$(build_option_flag "MemorySanitizer build" '%-fsanitize=memory%')
     # A runtime sanitizer build is marked with -DSANITIZER (cmake/sanitize.cmake). Do not test
     # for -fsanitize=, which also matches CFI (cfi-vcall, cfi-derived-cast): its checks trap on
     # a bad vcall or cast without a sanitizer runtime, so symbolization runs at full speed.
     is_sanitizer=$(build_option_flag "sanitizer build" '%-DSANITIZER%')
+    # Coverage instrumentation slows in-flush symbolization as much as a sanitizer runtime does,
+    # and carries no -DSANITIZER, so the flavour is read from its own build_options row.
+    is_coverage=$(build_option_enabled "coverage build" 'WITH_COVERAGE')
 
     # A non-zero global_profiler_* period is rejected by an msan server while it parses its own
     # settings, so the config must be absent rather than merely unused there.
@@ -129,7 +148,7 @@ function install_build_type_configs()
         ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
     fi
 
-    if [ "$is_sanitizer" = "1" ]; then
+    if [ "$is_sanitizer" = "1" ] || [ "$is_coverage" = "1" ]; then
         ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/
     else
         rm -f $DEST_SERVER_PATH/config.d/trace_log_no_symbolize.xml

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -137,8 +137,13 @@ function install_build_type_configs()
     # a bad vcall or cast without a sanitizer runtime, so symbolization runs at full speed.
     is_sanitizer=$(build_option_flag "sanitizer build" '%-DSANITIZER%')
     # Coverage instrumentation slows in-flush symbolization as much as a sanitizer runtime does,
-    # and carries no -DSANITIZER, so the flavour is read from its own build_options row.
-    is_coverage=$(build_option_enabled "coverage build" 'WITH_COVERAGE')
+    # and carries no -DSANITIZER, so the flavour is read from its own build_options row. That row
+    # exists from 26.2 on; the upgrade check installs these configs for an older released server.
+    if check_clickhouse_version 26.2; then
+        is_coverage=$(build_option_enabled "coverage build" 'WITH_COVERAGE')
+    else
+        is_coverage=0
+    fi
 
     # A non-zero global_profiler_* period is rejected by an msan server while it parses its own
     # settings, so the config must be absent rather than merely unused there.

--- a/tests/queries/0_stateless/00974_query_profiler.sql
+++ b/tests/queries/0_stateless/00974_query_profiler.sql
@@ -140,7 +140,7 @@ ORDER BY event_time DESC LIMIT 1;
 -- all of them. The `query_id` filter sits inside the `LIMIT` subquery, so other queries' samples are
 -- never symbolized either, and the `trace_type` filter keeps the oracle specific to this sub-test.
 -- Resolve the symbols here rather than reading the `symbols` column of `system.trace_log`: the
--- stateless harness turns in-flush symbolization off on sanitizer builds
+-- stateless harness turns in-flush symbolization off on sanitizer and coverage builds
 -- (`trace_log_no_symbolize.xml`), so that column is empty there. Only `addressToSymbol` is used -
 -- `addressToLine` walks DWARF and costs about a millisecond per row in CI.
 SELECT countIf(arrayExists(addr -> demangle(addressToSymbol(addr)) LIKE '%Source%', trace)) > 0


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/100242
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Stateless jobs on `amd_llvm_coverage` keep losing whole runs to
`Timeout exceeded (180 s) while flushing system log 'DB::SystemLogQueue<DB::TraceLogElement>'`. Six
different tests died on this signature in
[one coverage job run](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110015&sha=309e680385f67b3272471172b3e242305283be48&name_0=PR)
on 2026-09-05, so it is a job-wide `trace_log` drain stall, not a property of any test.

**Root cause.** `trace_log.symbolize` defaults to `true`, and in-flush symbolization
(`SymbolIndex::findSymbol` + `tryDemangle` + `AddressToLineCache::get`, per frame, in
`TraceLogElement::appendToBlock`) is what the flusher spends its 180 s on. #100242 already fixed
this with `tests/config/config.d/trace_log_no_symbolize.xml`, but its gate probes
`CXX_FLAGS LIKE '%-DSANITIZER%'` and the `else` arm *removes* the file. A coverage build is
configured `-DSANITIZE= ... -DWITH_COVERAGE=ON`, so it carries no `-DSANITIZER`: coverage was the
one stateless flavour where the mitigation got deleted again.

**Change.** Probe `WITH_COVERAGE`'s dedicated `system.build_options` row and install the config for
coverage as well as sanitizer builds. `-DWITH_COVERAGE` never reaches `CXX_FLAGS` (added only under
`WITH_COVERAGE_DEPTH`), so the existing `CXX_FLAGS` helper cannot answer this. The new helper is
fail-closed: a renamed or missing row aborts the install rather than reading as "not coverage", and is
version-gated on 26.2, where that row landed, because the upgrade check configures a previous-release
server.

The `MemoryAllocatedWithoutCheck` advisory in `tests/clickhouse-test` grouped by the `symbols`
column, which this config leaves empty; it now resolves symbols on read.

**Validation.** Debug build, fresh server per arm, identical workload, first flush timed: 0.35 s with
`symbolize=false` (0 of 13,226 rows symbolized) vs 3.12 s with `symbolize=true` (13,388 of 13,388) -
8.9x, so symbolization is ~89% of flush cost. No test is weakened and the 180 s constant is untouched
(#105484).

Residual in the same job, not addressed here: praktika wrote no results TSV after
`clickhouse-test` exited 1, so CIDB holds a job-level error with zero test rows for that head.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119187&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119187](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119187+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1260` (included in `26.9` and later)
<!-- ch-version-info:end -->