### PR TITLE
Tag the subcolumn name collision test as Memory-engine only

### DIFF
--- a/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.sql
+++ b/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.sql
@@ -1,3 +1,5 @@
+-- Tags: memory-engine
+
 -- A rewrite to a subcolumn must land on the subcolumn it means. Subcolumn names are flat, so a
 -- Tuple element or a JSON path can claim the name of an automatic subcolumn with the same type,
 -- and an enclosing Nullable can wrap the automatic subcolumn. Every query below must give the same


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115632

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

**What breaks.** `04935_optimize_functions_to_subcolumns_name_collision` (#115777) declares `ENGINE = Memory` deliberately and says why: "Memory, because the Map cases collide on file names in MergeTree". It carries no tag, so a stress run that enables `--replace-log-memory-with-mergetree` (`ci/jobs/scripts/stress/stress.py:487`, probability 0.3) rewrites those engines to `MergeTree` and creates tables the test never intended.

For ``c Tuple(`a.keys` Array(String), `a` Map(String, UInt64))`` two substreams of the one column render to the same stream file name, so the Compact writer emits a mark per substream occurrence for the data granules while the final mark row and `columns_substreams.txt` carry the deduplicated count. Read back with that stride, the loader parses a zero granularity early and throws `Logical error: Cannot append mark after final` (`MergeTreeIndexGranularityAdaptive.cpp:63` via `MergeTreeDataPartCompact.cpp:194`) inside `loadDataPartsFromDisk` at startup, so the server aborts on every start: 11/11 in CI. Master went red on three shas on 2026-09-10 (`amd_tsan`, `azure amd_tsan`, `amd_debug`); report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=e80499dc9fb2dc7adde9a14bbaa1e428c4504e1c&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_tsan%29 . PR #117248's `arm_tsan` run reached the same throw through the Wide loader; its run log names this test and the unreadable `c%2Et%2Ea.cmrk2` of `t_shadowed_tuple_element`.

**Change.** `-- Tags: memory-engine`, the existing opt-out for that substitution (49 stateless tests use it). Runs that enable the substitution skip the whole file, including its four `MergeTree` arms; every other run is unchanged.

**Not in scope.** The engine defect is #115632, which refuses such a schema at `CREATE`. The tag is needed either way: once that merges the substituted `CREATE` raises `BAD_ARGUMENTS`, and 04935's statement has no `{ serverError }` annotation, so untagged it would fail the stress lane instead of aborting the server.

**Validation.** With the tag: 5/5 skipped under the flag, 20/20 OK randomized and 20/20 without. Without it: not skipped, fails on the first run, and the part it leaves aborts the server 3/3 with the CI stack line-for-line.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119188&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119188](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119188+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1162` (included in `26.9` and later)
<!-- ch-version-info:end -->