### PR TITLE
Set promql_evaluation_time to auto no matter the compatibility value

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -740,7 +740,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"allow_experimental_correlated_subqueries", false, true, "Mark correlated subqueries support as Beta."},
             {"promql_database", "", "", "New experimental setting"},
             {"promql_table", "", "", "New experimental setting"},
-            {"evaluation_time", 0, Field{"auto"}, "New experimental setting"},
+            {"evaluation_time", Field{"auto"}, Field{"auto"}, "New experimental setting"},
             {"output_format_parquet_date_as_uint16", false, false, "Added a compatibility setting for a minor compatibility-breaking change introduced back in 24.12."},
             {"enable_lightweight_update", false, true, "Lightweight updates were moved to Beta. Added an alias for setting 'allow_experimental_lightweight_update'."},
             {"allow_experimental_lightweight_update", false, true, "Lightweight updates were moved to Beta."},

--- a/tests/queries/0_stateless/04652_system_documentation_settings_history.sql
+++ b/tests/queries/0_stateless/04652_system_documentation_settings_history.sql
@@ -210,8 +210,9 @@ SELECT description FROM system.documentation WHERE type = 'Setting' AND name = '
 SELECT description FROM system.documentation WHERE type = 'Setting' AND name = 'text_index_density_threshold';
 
 -- The record that renames a setting does not claim to introduce the old name when that name is older than it:
--- `evaluation_time` changed its default in 25.8 and became an alias of `promql_evaluation_time` in 25.9.
-SELECT position(description, '**Introduced in:**') = 0,
+-- `evaluation_time` appeared in 25.8 and became an alias of `promql_evaluation_time` in 25.9, so the version it
+-- was introduced in is the one it appeared in and not the one of the rename.
+SELECT position(description, '**Introduced in:** v25.8') > 0,
        position(description, '\n- **25.9** — the default value remained `auto`. The setting was renamed.') > 0
 FROM system.documentation WHERE type = 'Setting' AND name = 'evaluation_time';
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Set promql_evaluation_time to auto no matter the compatibility value

Using auto in all cases is better, even for old compatibility values (where the setting was experimental)

Closes https://github.com/ClickHouse/ClickHouse/issues/102572

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119202&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119202](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119202+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1175` (included in `26.9` and later)
<!-- ch-version-info:end -->