### PR TITLE
Fix wrong results and a rejected query from index analysis of an `indexHint` argument

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1206,6 +1206,15 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
                 res = &cloneDAGWithInversionPushDown(*node.children.front(), inverted_dag, inputs_mapping, context, !need_inversion, boolean_context);
                 handled_inversion = true;
             }
+            else if (name == "indexHint" && need_inversion)
+            {
+                /// `indexHint` returns 1 for every row, so an inverted hint is 0 for every row. Index
+                /// analysis re-reads a hint's arguments from the `FunctionIndexHint` object, not from the
+                /// cloned children, so an inverted hint node would contribute its condition un-inverted.
+                auto uint8_type = std::make_shared<DataTypeUInt8>();
+                res = &inverted_dag.addColumn(uint8_type->createColumnConst(0, 0), uint8_type, "false");
+                handled_inversion = true;
+            }
             else if (name == "indexHint")
             {
                 ActionsDAG::NodeRawConstPtrs children;
@@ -1217,7 +1226,8 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
                         children = index_hint_dag.getOutputs();
 
                         for (auto & arg : children)
-                            arg = &cloneDAGWithInversionPushDown(*arg, inverted_dag, inputs_mapping, context, need_inversion, boolean_context);
+                            arg = &cloneDAGWithInversionPushDown(
+                                *arg, inverted_dag, inputs_mapping, context, /* need_inversion */ false, boolean_context);
                     }
                 }
 

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -4640,8 +4640,11 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             /// optimization (`SELECT count() ... WHERE nullable_key`) would count such NULL-only granules
             /// without reading them and return a wrong result. Leaving the atom unset (`FUNCTION_UNKNOWN`)
             /// reverts to reading and filtering those rows, which is correct.
+            /// Require a boolean reading, not merely a numeric type: `WHERE w` is rejected for a
+            /// wide integer or a `BFloat16`, so reading such a key as `key != 0` would prune
+            /// granules that no row-level filter can account for.
             if (!key_type_not_low_cardinality->isNullable()
-                && (isInteger(key_type_not_low_cardinality) || isFloat(key_type_not_low_cardinality)))
+                && key_type_not_low_cardinality->canBeUsedInBooleanContext())
             {
                 out.function = RPNElement::FUNCTION_NOT_IN_RANGE;
                 out.range = Range(Field(UInt64(0)));

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -593,7 +593,8 @@ const ActionsDAG::Node & MergeTreeIndexConditionSet::traverseDAG(const ActionsDA
             /// through the regular filter path.
             /// A type with no boolean reading takes the same way out. A wide integer is an integer,
             /// so `__bitWrapperFunc` would read `indexHint(toUInt256(v))` as `v != 0` and prune the
-            /// granules holding `v = 0`, while nothing else in the query reads that hint at all.
+            /// granules holding `v = 0`, while `WHERE toUInt256(v)` is rejected, so no row-level
+            /// filter corresponds to what was skipped.
             const auto & atom_result_type = atom_node_ptr->result_type;
             const bool is_integer_atom = WhichDataType(atom_result_type).isLowCardinality()
                 ? WhichDataType(removeLowCardinality(atom_result_type)).isInteger()

--- a/tests/queries/0_stateless/03703_primary_key_condition_boolean_column.reference
+++ b/tests/queries/0_stateless/03703_primary_key_condition_boolean_column.reference
@@ -18,3 +18,10 @@ yes
 --- Test 8: indexHint with bare column
 16
 16
+--- Test 9: a bare key column whose type has no boolean reading
+24
+24
+24
+8
+--- Test 10: partition pruning by a bare key column with no boolean reading
+16

--- a/tests/queries/0_stateless/03703_primary_key_condition_boolean_column.sql
+++ b/tests/queries/0_stateless/03703_primary_key_condition_boolean_column.sql
@@ -127,3 +127,51 @@ SELECT count() FROM test_indexhint WHERE indexHint(id) SETTINGS optimize_use_pro
 SELECT count() FROM test_indexhint WHERE indexHint(id != 0) SETTINGS optimize_use_projections = 0;
 
 DROP TABLE test_indexhint;
+
+SELECT '--- Test 9: a bare key column whose type has no boolean reading';
+
+DROP TABLE IF EXISTS test_indexhint_no_bool;
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- Same layout as Test 8. A wide integer, a `BFloat16` and their `LowCardinality` forms are
+-- rejected as a filter (`02473_prewhere_with_bigint`), so no row-level predicate corresponds to
+-- a granule skipped for one of them: the hint must state nothing and every row must be read.
+-- `n` is the control: it has a boolean reading, so its granule is still pruned.
+CREATE TABLE test_indexhint_no_bool
+(
+    w UInt256,
+    b BFloat16,
+    lw LowCardinality(UInt256),
+    n UInt64,
+    INDEX b_minmax  b  TYPE minmax GRANULARITY 1,
+    INDEX lw_minmax lw TYPE minmax GRANULARITY 1,
+    INDEX n_minmax  n  TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY w
+SETTINGS index_granularity = 8;
+
+INSERT INTO test_indexhint_no_bool
+SELECT if(number < 16, 0, number), if(number < 16, 0, number),
+       if(number < 16, 0, number), if(number < 16, 0, number) FROM numbers(24);
+
+SELECT count() FROM test_indexhint_no_bool WHERE indexHint(w)  SETTINGS optimize_use_projections = 0;
+SELECT count() FROM test_indexhint_no_bool WHERE indexHint(b)  SETTINGS optimize_use_projections = 0;
+SELECT count() FROM test_indexhint_no_bool WHERE indexHint(lw) SETTINGS optimize_use_projections = 0;
+SELECT count() FROM test_indexhint_no_bool WHERE indexHint(n)  SETTINGS optimize_use_projections = 0;
+
+DROP TABLE test_indexhint_no_bool;
+
+SELECT '--- Test 10: partition pruning by a bare key column with no boolean reading';
+
+DROP TABLE IF EXISTS test_indexhint_no_bool_part;
+
+CREATE TABLE test_indexhint_no_bool_part (w UInt256, id UInt32)
+ENGINE = MergeTree PARTITION BY w ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO test_indexhint_no_bool_part SELECT intDiv(number, 8) % 2, number FROM numbers(16);
+
+SELECT count() FROM test_indexhint_no_bool_part WHERE indexHint(w) SETTINGS optimize_use_projections = 0;
+
+DROP TABLE test_indexhint_no_bool_part;

--- a/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.reference
+++ b/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.reference
@@ -62,6 +62,9 @@ negated hint	0
 negated hint	3
 negated hint	501
 negated hint forces pk	3
+negated hint numbers	0
+negated hint numbers	3
+negated hint numbers limit	3
 negated hint twice	1000
 indexed no boolean	3
 indexed no boolean	3

--- a/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.reference
+++ b/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.reference
@@ -61,6 +61,7 @@ negated hint	3
 negated hint	0
 negated hint	3
 negated hint	501
+negated hint forces pk	3
 negated hint twice	1000
 indexed no boolean	3
 indexed no boolean	3

--- a/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.reference
+++ b/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.reference
@@ -57,6 +57,11 @@ and branch	3
 and branch	3
 and branch	3
 and branch falsy	0
+negated hint	3
+negated hint	0
+negated hint	3
+negated hint	501
+negated hint twice	1000
 indexed no boolean	3
 indexed no boolean	3
 indexed no boolean	3

--- a/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.sql
+++ b/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.sql
@@ -131,6 +131,12 @@ SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
 -- The inversion also reaches the hint through De Morgan, with no `NOT indexHint` in the text.
 SELECT 'negated hint', count() FROM t_index_hint WHERE NOT (indexHint(id) AND id > 500)
 SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
+-- An inverted hint has to contribute a constant false, not merely be dropped: `or(false, <key atom>)`
+-- still prunes on the real conjunct, while a dropped hint leaves the whole condition unknown, which
+-- `force_primary_key` rejects.
+SELECT 'negated hint forces pk', count() FROM t_index_hint
+WHERE NOT indexHint(id) OR (id >= 1 AND id <= 3)
+SETTINGS force_primary_key = 1;
 -- Two inversions cancel before any leaf, so this hint keeps its condition and every row matches.
 SELECT 'negated hint twice', count() FROM t_index_hint WHERE NOT NOT indexHint('x') OR (id >= 1 AND id <= 3);
 

--- a/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.sql
+++ b/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.sql
@@ -120,6 +120,20 @@ SELECT 'and branch', count() FROM t_index_hint WHERE (id >= 1 AND id <= 3) AND t
 SELECT 'and branch', count() FROM t_index_hint WHERE (id >= 1 AND id <= 3) AND 0.5;
 SELECT 'and branch falsy', count() FROM t_index_hint WHERE (id >= 1 AND id <= 3) AND 0;
 
+-- `indexHint` is row-level TRUE, so `NOT indexHint(...)` is row-level FALSE and only the other
+-- disjunct can match. Index analysis has to claim no more than that: the hint's own condition, left
+-- un-inverted, made granules it matches look like definite matches, and the exact-count
+-- optimization then counted their rows without reading them.
+SELECT 'negated hint', count() FROM t_index_hint WHERE NOT indexHint('x') OR (id >= 1 AND id <= 3);
+SELECT 'negated hint', count() FROM t_index_hint WHERE (NOT indexHint('x')) = 1;
+SELECT 'negated hint', count() FROM t_index_hint WHERE NOT indexHint(id) OR (id >= 1 AND id <= 3)
+SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
+-- The inversion also reaches the hint through De Morgan, with no `NOT indexHint` in the text.
+SELECT 'negated hint', count() FROM t_index_hint WHERE NOT (indexHint(id) AND id > 500)
+SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
+-- Two inversions cancel before any leaf, so this hint keeps its condition and every row matches.
+SELECT 'negated hint twice', count() FROM t_index_hint WHERE NOT NOT indexHint('x') OR (id >= 1 AND id <= 3);
+
 -- Every analyzer has to read an argument the same way, otherwise adding an index to a table
 -- changes the answer. The primary key, a `minmax` index and a `bloom_filter` index go through
 -- `KeyCondition`; a `set` index has its own evaluator, which used to read a wide integer as false

--- a/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.sql
+++ b/tests/queries/0_stateless/04838_index_hint_non_uint8_constant.sql
@@ -137,6 +137,17 @@ SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
 SELECT 'negated hint forces pk', count() FROM t_index_hint
 WHERE NOT indexHint(id) OR (id >= 1 AND id <= 3)
 SETTINGS force_primary_key = 1;
+-- The same inversion push-down serves readers with no granules: `numbers()` builds a key condition
+-- over `number`, and a blank range set there means no rows at all, with no row-level filter left to
+-- correct it.
+SELECT 'negated hint numbers', count() FROM numbers(10) WHERE NOT indexHint('x');
+SELECT 'negated hint numbers', count() FROM numbers(10) WHERE NOT indexHint('x') OR number < 3;
+-- Ranges extracted there are also taken as exact, which is what lets `LIMIT` stop an endless source.
+-- The row limit is the assertion: three rows are read when the range set is exact, a whole block
+-- otherwise.
+SELECT 'negated hint numbers limit', count() FROM (
+    SELECT number FROM system.numbers WHERE NOT indexHint('x') OR number < 3 LIMIT 5)
+SETTINGS max_rows_to_read = 100;
 -- Two inversions cancel before any leaf, so this hint keeps its condition and every row matches.
 SELECT 'negated hint twice', count() FROM t_index_hint WHERE NOT NOT indexHint('x') OR (id >= 1 AND id <= 3);
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/119129
Closes: https://github.com/ClickHouse/ClickHouse/issues/119128

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed three defects in index analysis of an `indexHint` argument. A bare key column whose type has no boolean reading (`UInt256`, `Int128`, `BFloat16`, or their `LowCardinality` forms) was read as `column != 0`, so primary-key, partition and `minmax` analysis silently skipped the granules holding zero, although `WHERE` rejects such a column. `NOT indexHint(x)` failed with `ILLEGAL_TYPE_OF_ARGUMENT` for an argument type that does not accept `not`. A negated `indexHint` in a disjunction kept its condition un-inverted, so `count()` could report rows that no row of the table matches.

### Description

`indexHint` never filters rows: it returns 1 for every row and only hands its argument to index analysis. Two gaps in `KeyCondition.cpp` broke that contract.

**A bare key column with no boolean reading was read as `column != 0`.** The gate tested `isInteger() || isFloat()`, wider than the language's own `canBeUsedInBooleanContext()` by exactly the wide integers, `BFloat16` and their `LowCardinality` forms; it now uses that predicate. `WHERE w` over such a column is rejected (`ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER`), so nothing at row level accounted for the skipped granules.

**An inverted hint kept its condition.** `cloneDAGWithInversionPushDown` claimed the inversion was handled, then re-emitted the hint unchanged, pushing it into cloned children nothing reads: consumers re-read a hint's arguments from `FunctionIndexHint`. So `NOT indexHint('x')` failed outright, and a negated hint in a disjunction left its condition un-inverted, definitely true for the granules it matches, whose rows the exact-count path counted unread: `NOT indexHint(id) OR (id >= 1 AND id <= 3)` answered 939 on a 1000-row table whose matching rows are `[1, 2, 3]`. `NOT indexHint(X)` equals the constant 0 at row level, so that constant is emitted instead and reduces to `ALWAYS_FALSE`.

A hint's index analysis may only narrow the read, never claim a match the row-level expression does not make.

The push-down is shared beyond MergeTree (`numbers()`, `system.primes`, the Parquet/ORC and Hive filters), and a reader with no granules drops an always-false condition to an empty source with no row-level filter behind it.

Coverage extends `03703_primary_key_condition_boolean_column` and `04838_index_hint_non_uint8_constant` (a `negated hint` group with `numbers()` arms); every new assertion fails on the parent commit, with `UInt64` and `NOT NOT indexHint(...)` controls. `Float32`/`Float64` and the caller-less `cloneASTWithInversionPushDown` twin are left alone on purpose.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119209&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119209](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119209+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
