### PR TITLE
Take the pointer after the move, not before

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2065,9 +2065,8 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                             join_pos);
                         creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_pos), max_len);
 
-                        auto * step_raw_ptr = creating_set_step.get();
                         plan.addStep(std::move(creating_set_step));
-                        return step_raw_ptr;
+                        return static_cast<CreateSetAndFilterOnTheFlyStep *>(plan.getRootNode()->step.get());
                     };
 
                     if (expressions.join->pipelineType() == JoinPipelineType::YShaped && expressions.join->getTableJoin().kind() != JoinKind::Paste)

--- a/src/Parsers/Prometheus/PrometheusQueryTree.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryTree.cpp
@@ -162,7 +162,6 @@ namespace
     NodeType * cloneNodeImpl(const NodeType * node, std::vector<std::unique_ptr<Node>> & node_list)
     {
         auto new_node = std::make_unique<NodeType>(*node);
-        auto * ptr = new_node.get();
         for (const auto * & child : new_node->children)
         {
             auto * new_child = child->clone(node_list);
@@ -171,7 +170,7 @@ namespace
         }
         new_node->parent = nullptr;
         node_list.emplace_back(std::move(new_node));
-        return ptr;
+        return static_cast<NodeType *>(node_list.back().get());
     }
 }
 

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1188,9 +1188,8 @@ static void addSortingForMergeJoin(
             node->step->getOutputHeader(), key_names, join_settings.max_rows_in_set_to_optimize_join, crosswise_connection, join_table_side);
         creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_table_side), max_step_description_length);
 
-        auto * step_raw_ptr = creating_set_step.get();
         node = &nodes.emplace_back(QueryPlan::Node{std::move(creating_set_step), {node}});
-        return step_raw_ptr;
+        return static_cast<CreateSetAndFilterOnTheFlyStep *>(node->step.get());
     };
 
     const auto & join_clause = join_ptr->getTableJoin().getOnlyClause();

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -639,9 +639,7 @@ const ManifestFilesPruner * ManifestFileIterator::getOrCreatePruner(Int32 schema
 
     auto pruner = std::make_unique<ManifestFilesPruner>(
         *schema_processor_ptr, table_snapshot_schema_id, schema_id, filter_dag.get(), *this, context);
-    auto * raw_ptr = pruner.get();
-    pruners_by_schema_id.emplace(schema_id, std::move(pruner));
-    return raw_ptr;
+    return pruners_by_schema_id.emplace(schema_id, std::move(pruner)).first->second.get();
 }
 
 bool ManifestFileIterator::isInitialized() const

--- a/src/Storages/Statistics/StatisticsPartPruner.cpp
+++ b/src/Storages/Statistics/StatisticsPartPruner.cpp
@@ -182,8 +182,9 @@ KeyCondition * StatisticsPartPruner::getKeyConditionForEstimates(const NamesAndT
         return nullptr;
     }
 
-    auto * key_condition_ptr = new_key_condition.get();
-    key_condition_cache[column_names] = std::move(new_key_condition);
+    auto & cached_key_condition = key_condition_cache[column_names];
+    cached_key_condition = std::move(new_key_condition);
+    auto * key_condition_ptr = cached_key_condition.get();
 
     for (size_t col_idx : key_condition_ptr->getUsedColumns())
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the build with clang 23.


### Documentation entry for user-facing changes

Not applicable.


### Description

Building master with clang 23 fails. Five places take a raw pointer out of a `unique_ptr`, move the `unique_ptr` into a container, and then return the pointer they saved earlier, which the new `-Wlifetime-safety-return-stack-addr-moved` rejects under `-Werror`:

```
src/Parsers/Prometheus/PrometheusQueryTree.cpp:165:22: error: stack memory associated with
local variable 'new_node' may be returned later. This could be a false positive as the storage
may have been moved. Consider moving first and then aliasing later to resolve the issue
[-Werror,-Wlifetime-safety-return-stack-addr-moved]
```

The pointee is on the heap and outlives the move, so the diagnostic is a false positive in every one of these cases. `cmake/warnings.cmake` already silences three of its siblings (`-Wno-lifetime-safety-intra-tu-suggestions`, `-Wno-lifetime-safety-cross-tu-suggestions`, `-Wno-lifetime-safety-invalidation`), so adding a fourth would have been consistent. I went with the order the compiler suggests instead, because it is also the clearer one to read: hand ownership over first, then ask the container where the object now lives.

Sites:

* `src/Parsers/Prometheus/PrometheusQueryTree.cpp` — `cloneNodeImpl`
* `src/Interpreters/InterpreterSelectQuery.cpp` — `add_create_set`
* `src/Processors/QueryPlan/JoinStepLogical.cpp` — `add_create_set`
* `src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp` — pruner cache
* `src/Storages/Statistics/StatisticsPartPruner.cpp` — key condition cache

Each returns the same object as before. I found them by scanning `src/` for the shape rather than by fixing them one build failure at a time, so this should be all of them; the build gets past every one of these files afterwards.

Tested on aarch64 macOS with `clang 23.1.1`. `02382_join_and_filtering_set`, `02841_join_filter_set_sparse`, `02861_filter_pushdown_const_bug`, `02907_filter_pushdown_crash` and `04657_parallel_full_sorting_merge_join_set_on_the_fly` cover the two `add_create_set` sites and pass.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119211&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119211](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119211+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1528` (included in `26.9` and later)
<!-- ch-version-info:end -->