### PR TITLE
Show progress percentage for reads from files

### DIFF
--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1378,6 +1378,7 @@ StorageFile::StorageFile(FileSource file_source_, CommonArguments args)
     is_path_with_globs = file_source_.with_globs;
     path_for_partitioned_write = std::move(file_source_.path_for_partitioned_write);
     archive_info = std::move(file_source_.archive_info);
+    total_bytes_to_read = file_source_.total_bytes_to_read;
 
     is_db_table = false;
 

--- a/tests/queries/0_stateless/05175_file_table_function_progress_total_bytes.reference
+++ b/tests/queries/0_stateless/05175_file_table_function_progress_total_bytes.reference
@@ -1,0 +1,1 @@
+percentage shown

--- a/tests/queries/0_stateless/05175_file_table_function_progress_total_bytes.sh
+++ b/tests/queries/0_stateless/05175_file_table_function_progress_total_bytes.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DATA_FILE="${CLICKHOUSE_DATABASE}_progress.tsv"
+seq 1 3000000 > "${USER_FILES_PATH}/${DATA_FILE}"
+
+# Reading from a file knows the total size upfront, so the progress bar must show the completion percentage.
+${CLICKHOUSE_CLIENT} --progress=err --max_threads 1 --query \
+    "SELECT sum(x) FROM file('${DATA_FILE}', 'TSV', 'x UInt32') FORMAT Null" 2>&1 \
+    | tr '\r' '\n' | grep -c -o -m1 -E '[0-9]+%' | (grep -q -v '^0$' && echo "percentage shown" || echo "no percentage")
+
+rm "${USER_FILES_PATH}/${DATA_FILE}"


### PR DESCRIPTION
Queries reading from the `file` table function (and `INFILE`) showed no completion percentage in the progress bar, only rows and bytes read. The `StorageFile` constructor taking a `FileSource` copied every field except `total_bytes_to_read`, so the progress callback reported a total of 0 bytes and the client had no denominator for the percentage.

Closes: https://github.com/ClickHouse/ClickHouse/issues/102637
Related: https://github.com/ClickHouse/ClickHouse/pull/88947

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Show the progress percentage again for queries reading from the `file` table function and `INFILE`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119213&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119213](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119213+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1208` (included in `26.9` and later)
<!-- ch-version-info:end -->