### PR TITLE
Parallel replicas for object storage writes

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -949,7 +949,9 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
             context_,
             /// Use is_table_function = true,
             /// because this table is actually stateless like a table function.
-            /* is_table_function */true);
+            /* is_table_function */true,
+            getFormatSettings(context_copy),
+            getCatalog());
 
         if (context_->hasQueryContext() && context_->getSettingsRef()[Setting::log_queries])
             context_->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Storage, storage_cluster->getName());

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -777,6 +777,18 @@ SinkToStoragePtr StorageObjectStorage::write(
         configuration->update(object_storage, local_context);
     }
 
+    return createSink(configuration, object_storage, storage_id, format_settings, catalog, metadata_snapshot, local_context);
+}
+
+SinkToStoragePtr StorageObjectStorage::createSink(
+    const StorageObjectStorageConfigurationPtr & configuration,
+    const ObjectStoragePtr & object_storage,
+    const StorageID & storage_id,
+    const std::optional<FormatSettings> & format_settings,
+    const std::shared_ptr<DataLake::ICatalog> & catalog,
+    const StorageMetadataPtr & metadata_snapshot,
+    const ContextPtr & local_context)
+{
     const auto sample_block = std::make_shared<const Block>(metadata_snapshot->getSampleBlock());
     const auto & settings = configuration->getQuerySettings(local_context);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -83,6 +83,15 @@ public:
         ContextPtr context,
         bool async_insert) override;
 
+    static SinkToStoragePtr createSink(
+        const StorageObjectStorageConfigurationPtr & configuration,
+        const ObjectStoragePtr & object_storage,
+        const StorageID & storage_id,
+        const std::optional<FormatSettings> & format_settings,
+        const std::shared_ptr<DataLake::ICatalog> & catalog,
+        const StorageMetadataPtr & metadata_snapshot,
+        const ContextPtr & context);
+
     void truncate(
         const ASTPtr & query,
         const StorageMetadataPtr & metadata_snapshot,

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -5,7 +5,13 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Databases/DatabasesCommon.h>
+#include <Databases/DataLake/Common.h>
+#include <Databases/DataLake/ICatalog.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Storages/AlterCommands.h>
+#include <Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h>
 #include <TableFunctions/TableFunctionFactory.h>
 
 #include <Core/Settings.h>
@@ -21,12 +27,14 @@
 #include <Storages/extractTableFunctionFromSelectQuery.h>
 #include <Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.h>
 
+#include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
 #include <base/sleep.h>
 namespace DB
 {
 namespace Setting
 {
+    extern const SettingsBool iceberg_delete_data_on_drop;
     extern const SettingsBool use_hive_partitioning;
     extern const SettingsBool cluster_function_process_archive_on_multiple_nodes;
     extern const SettingsObjectStorageGranularityLevel cluster_table_function_split_granularity;
@@ -35,6 +43,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int NOT_IMPLEMENTED;
 }
 
 namespace FailPoints
@@ -76,11 +85,15 @@ StorageObjectStorageCluster::StorageObjectStorageCluster(
     const ConstraintsDescription & constraints_,
     const ASTPtr & partition_by,
     ContextPtr context_,
-    bool is_table_function)
+    bool is_table_function,
+    std::optional<FormatSettings> format_settings_,
+    std::shared_ptr<DataLake::ICatalog> catalog_)
     : IStorageCluster(
         cluster_name_, table_id_, getLogger(fmt::format("{}({})", configuration_->getEngineName(), table_id_.table_name)))
     , configuration{configuration_}
     , object_storage(object_storage_)
+    , format_settings(std::move(format_settings_))
+    , catalog(std::move(catalog_))
 {
     configuration->initPartitionStrategy(partition_by, columns_in_table_or_function_definition, context_);
     /// We allow exceptions to be thrown on update(),
@@ -140,6 +153,108 @@ StorageObjectStorageCluster::StorageObjectStorageCluster(
 std::string StorageObjectStorageCluster::getName() const
 {
     return configuration->getEngineName();
+}
+
+SinkToStoragePtr StorageObjectStorageCluster::write(
+    const ASTPtr &,
+    const StorageMetadataPtr & metadata_snapshot,
+    ContextPtr local_context,
+    bool /* async_insert */)
+{
+    if (!configuration->isDataLakeConfiguration())
+        configuration->update(object_storage, local_context);
+
+    return StorageObjectStorage::createSink(
+        configuration, object_storage, getStorageID(), format_settings, catalog, metadata_snapshot, local_context);
+}
+
+bool StorageObjectStorageCluster::supportsParallelInsert() const
+{
+    if (configuration->isDataLakeConfiguration())
+        configuration->lazyInitializeIfNeeded(object_storage, CurrentThread::tryGetQueryContext());
+    return configuration->supportsParallelInsert();
+}
+
+bool StorageObjectStorageCluster::supportsDelete() const
+{
+    if (configuration->isDataLakeConfiguration())
+        configuration->lazyInitializeIfNeeded(object_storage, CurrentThread::tryGetQueryContext());
+    return configuration->supportsDelete();
+}
+
+bool StorageObjectStorageCluster::optimize(
+    const ASTPtr & /*query*/,
+    const StorageMetadataPtr & metadata_snapshot,
+    const ASTPtr & /*partition*/,
+    bool /*final*/,
+    bool /*deduplicate*/,
+    const Names & /*deduplicate_by_columns*/,
+    bool /*cleanup*/,
+    ContextPtr context)
+{
+    return configuration->optimize(object_storage, metadata_snapshot, context, format_settings);
+}
+
+void StorageObjectStorageCluster::mutate(const MutationCommands & commands, ContextPtr context)
+{
+    updateExternalDynamicMetadataIfExists(context);
+    auto metadata_snapshot = getInMemoryMetadataPtr(context, false);
+    configuration->mutate(commands, context, shared_from_this(), getStorageID(), metadata_snapshot, catalog, format_settings);
+}
+
+void StorageObjectStorageCluster::checkMutationIsPossible(const MutationCommands & commands, const Settings & /*settings*/) const
+{
+    configuration->checkMutationIsPossible(object_storage, CurrentThread::tryGetQueryContext(), commands);
+}
+
+void StorageObjectStorageCluster::alter(const AlterCommands & params, ContextPtr context, AlterLockHolder & /*alter_lock_holder*/)
+{
+    auto metadata_snapshot = getInMemoryMetadataPtr(context, false);
+    StorageInMemoryMetadata new_metadata = *metadata_snapshot;
+    params.apply(new_metadata, context);
+
+    checkMetadataDoesNotExceedMaxQuerySize(getStorageID(), new_metadata, context);
+
+    configuration->alter(object_storage, params, context, getStorageID(), catalog);
+
+    if (catalog)
+        return;
+
+    const auto storage_id = getStorageID();
+    DatabaseCatalog::instance()
+        .getDatabase(storage_id.database_name)
+        ->alterTable(context, storage_id, new_metadata, /*validate_new_create_query=*/true);
+    setInMemoryMetadata(new_metadata);
+}
+
+void StorageObjectStorageCluster::checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const
+{
+    configuration->checkAlterIsPossible(object_storage, context, commands);
+}
+
+Pipe StorageObjectStorageCluster::executeCommand(const String & command_name, const ASTPtr & args, ContextPtr context)
+{
+    if (!configuration->isDataLakeConfiguration())
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "EXECUTE command '{}' is not supported by this storage", command_name);
+
+    configuration->update(object_storage, context);
+    auto metadata = configuration->getExternalMetadata();
+    if (!metadata)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "EXECUTE command '{}' is not supported by this storage", command_name);
+
+    return metadata->executeCommand(command_name, args, object_storage, configuration, catalog, context, getStorageID());
+}
+
+void StorageObjectStorageCluster::drop()
+{
+    /// We cannot use query context here, because drop is executed in the background.
+    auto drop_context = Context::getGlobalContextInstance();
+    if (catalog)
+    {
+        const auto [namespace_name, table_name] = DataLake::parseTableName(getStorageID().getTableName());
+        catalog->dropTable(namespace_name, table_name, drop_context->getSettingsRef()[Setting::iceberg_delete_data_on_drop]);
+    }
+    configuration->drop(drop_context);
 }
 
 std::optional<UInt64> StorageObjectStorageCluster::totalRows(ContextPtr query_context) const

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
@@ -19,9 +19,45 @@ public:
         const ConstraintsDescription & constraints_,
         const ASTPtr & partition_by,
         ContextPtr context_,
-        bool is_table_function_ = false);
+        bool is_table_function_ = false,
+        std::optional<FormatSettings> format_settings_ = std::nullopt,
+        std::shared_ptr<DataLake::ICatalog> catalog_ = nullptr);
 
     std::string getName() const override;
+
+    SinkToStoragePtr write(
+        const ASTPtr & query,
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        bool async_insert) override;
+
+    bool isDataLake() const override { return configuration->isDataLakeConfiguration(); }
+
+    bool isObjectStorage() const override { return true; }
+
+    bool supportsParallelInsert() const override;
+
+    bool supportsDelete() const override;
+
+    bool optimize(
+        const ASTPtr & query,
+        const StorageMetadataPtr & metadata_snapshot,
+        const ASTPtr & partition,
+        bool final,
+        bool deduplicate,
+        const Names & deduplicate_by_columns,
+        bool cleanup,
+        ContextPtr context) override;
+
+    void mutate(const MutationCommands & commands, ContextPtr context) override;
+    void checkMutationIsPossible(const MutationCommands & commands, const Settings & settings) const override;
+
+    void alter(const AlterCommands & params, ContextPtr context, AlterLockHolder & alter_lock_holder) override;
+    void checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const override;
+
+    Pipe executeCommand(const String & command_name, const ASTPtr & args, ContextPtr context) override;
+
+    void drop() override;
 
     RemoteQueryExecutor::Extension getTaskIteratorExtension(
         const ActionsDAG::Node * predicate,
@@ -46,6 +82,8 @@ private:
     const String engine_name;
     const StorageObjectStorageConfigurationPtr configuration;
     const ObjectStoragePtr object_storage;
+    const std::optional<FormatSettings> format_settings;
+    const std::shared_ptr<DataLake::ICatalog> catalog;
     NamesAndTypesList hive_partition_columns_to_read_from_file_path;
 };
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1289,6 +1289,57 @@ def test_cluster_select(started_cluster):
     assert node2.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`", settings={"parallel_replicas_for_cluster_engines": 1, "enable_parallel_replicas": 2, "cluster_for_parallel_replicas": "cluster_simple"}) == 'pablo\n'
 
 
+def test_cluster_insert(started_cluster):
+    node1 = started_cluster.instances["node1"]
+    node2 = started_cluster.instances["node2"]
+
+    test_ref = f"test_cluster_insert_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    load_catalog_impl(started_cluster)
+    create_clickhouse_iceberg_database(started_cluster, node1, CATALOG_NAME)
+    create_clickhouse_iceberg_database(started_cluster, node2, CATALOG_NAME)
+    create_clickhouse_iceberg_table(
+        started_cluster, node1, root_namespace, table_name, "(x String)"
+    )
+
+    parallel_replicas_settings = {
+        "parallel_replicas_for_cluster_engines": 1,
+        "enable_parallel_replicas": 2,
+        "cluster_for_parallel_replicas": "cluster_simple",
+    }
+    insert_settings = {
+        "allow_insert_into_iceberg": 1,
+        "write_full_path_in_iceberg_metadata": 1,
+        **parallel_replicas_settings,
+    }
+
+    node1.query(
+        f"INSERT INTO {CATALOG_NAME}.`{root_namespace}.{table_name}` VALUES ('pablo');",
+        settings=insert_settings,
+    )
+    node2.query(
+        f"INSERT INTO {CATALOG_NAME}.`{root_namespace}.{table_name}` VALUES ('juan');",
+        settings=insert_settings,
+    )
+
+    for replica in [node1, node2]:
+        assert (
+            replica.query(
+                f"SELECT x FROM {CATALOG_NAME}.`{root_namespace}.{table_name}` ORDER BY x",
+                settings=parallel_replicas_settings,
+            )
+            == "juan\npablo\n"
+        )
+
+    node1.query(
+        f"DROP TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`",
+        settings=parallel_replicas_settings,
+    )
+    assert table_name not in node1.query(f"SHOW TABLES FROM {CATALOG_NAME}")
+
+
 def test_used_storages_in_query_log(started_cluster):
     node1 = started_cluster.instances["node1"]
     node2 = started_cluster.instances["node2"]

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_parallel_replicas_no_catalog.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_parallel_replicas_no_catalog.py
@@ -1,0 +1,70 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    create_iceberg_table,
+    get_creation_expression,
+    get_uuid_str,
+)
+
+
+PARALLEL_REPLICAS_SETTINGS = {
+    "parallel_replicas_for_cluster_engines": 1,
+    "enable_parallel_replicas": 2,
+    "cluster_for_parallel_replicas": "cluster_simple",
+}
+
+
+# Writes to an Iceberg table that is not managed by a catalog, with parallel
+# replicas enabled. `icebergS3Cluster` resolves to `StorageObjectStorageCluster`,
+# which used to implement only the read side, so `INSERT` failed with
+# `Method write is not supported by storage IcebergS3`.
+@pytest.mark.parametrize("storage_type", ["s3"])
+def test_writes_parallel_replicas_no_catalog(started_cluster_iceberg_no_spark, storage_type):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = (
+        "test_writes_parallel_replicas_no_catalog_" + storage_type + "_" + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int32)",
+    )
+
+    tf_single = get_creation_expression(
+        storage_type, table_name, started_cluster_iceberg_no_spark, table_function=True
+    )
+    tf_cluster = get_creation_expression(
+        storage_type,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        table_function=True,
+        run_on_cluster=True,
+    )
+
+    # Engine table: stays a plain `StorageObjectStorage`.
+    instance.query(
+        f"INSERT INTO {table_name} VALUES (1)", settings=PARALLEL_REPLICAS_SETTINGS
+    )
+    # Plain table function: not auto-converted to the cluster variant for `INSERT`.
+    instance.query(
+        f"INSERT INTO FUNCTION {tf_single} VALUES (2)",
+        settings=PARALLEL_REPLICAS_SETTINGS,
+    )
+    # Explicit cluster table function: the write is performed by the initiator.
+    instance.query(
+        f"INSERT INTO FUNCTION {tf_cluster} VALUES (3)",
+        settings=PARALLEL_REPLICAS_SETTINGS,
+    )
+
+    expected = "1\n2\n3\n"
+    for source in [table_name, f"{tf_single}", f"{tf_cluster}"]:
+        assert (
+            instance.query(
+                f"SELECT x FROM {source} ORDER BY ALL",
+                settings=PARALLEL_REPLICAS_SETTINGS,
+            )
+            == expected
+        )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support parallel replicas for object storage writes

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119214&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119214](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119214+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.87`, `26.7.8.7`, `26.6.6.12`
<!-- ch-version-info:end -->