### PR TITLE
Give the array_join String benchmark a sink so it measures replication, not its result transfer

### DIFF
--- a/tests/performance/array_join.xml
+++ b/tests/performance/array_join.xml
@@ -9,5 +9,7 @@
     <query>SELECT count() FROM (SELECT [number] a, [number * 2, number] b FROM numbers(10000000)) AS t ARRAY JOIN a, b WHERE NOT ignore(a + b) SETTINGS enable_unaligned_array_join = 1</query>
     <query>SELECT count() FROM (SELECT [number] a, [number * 2, number] b FROM numbers(10000000)) AS t LEFT ARRAY JOIN a, b WHERE NOT ignore(a + b) SETTINGS enable_unaligned_array_join = 1</query>
 
-    <query>with 'clickhouse' as str select arrayJoin(range(number % 10)),  materialize(str) from numbers(10000000)</query>
+    <!-- The arrayJoin function form expands in ExpressionActions, which by default wraps a String passenger in
+         a lazy ColumnReplicated; enable_lazy_columns_replication = 0 is what replicates it eagerly, and format Null keeps the result off the wire. -->
+    <query>with 'clickhouse' as str select arrayJoin(range(number % 10)),  materialize(str) from numbers(10000000) settings enable_lazy_columns_replication = 0 format Null</query>
 </test>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Performance test `array_join` query 6 no longer returns its 45M-row result to the client, so it measures the String replication it was written for instead of the transfer.

### Description

`Performance Comparison (amd_release, master_head, 6/6)` went red because `array_join` query 6 hit
perf.py's 15 s per-run cap (`Code: 159`, elapsed 15047 ms) and the raise ended the whole test file, so
the other six queries went unmeasured too. Failing report:
https://s3.amazonaws.com/clickhouse-test-reports/PRs/117841/cd367912710f933989029b2e7e808bdff049209c/pr/performance_comparison_amd_release_master_head_6_6/report.html

That query has no sink, alone in the file, so it ships all 45,000,000 result rows to the client: 540 MB
on the wire, and 95.9% of the failing run in `NetworkSendElapsedMicroseconds`. Its amd p50 is 7090 ms
against 47-275 ms for queries 0-5, past `report.py`'s 2 s flag on every run, and
`scripts/README.md:64-66` names the class ("a forgotten `format Null`").

I appended two settings to that one query and changed nothing else. Measured on the master
`amd_release` binary at the perf job's configuration (`max_threads=8`, 8 pinned cores), on a rig within
11% of the shard's CIDB p50:

- `format Null` removes the transfer: 540 MB on the wire becomes 81 bytes, 6.479 s becomes 0.092 s.
- `enable_lazy_columns_replication = 0` keeps the benchmark on its subject. This is the `arrayJoin`
  function form and `query_plan_lower_array_join_function` is off by default, so the expansion runs in
  `ExpressionActions`, which wraps the String passenger in a lazy `ColumnReplicated`: the pin moves
  `ColumnString::replicate` from 12.5% to 63% of sampled frames. Precedent:
  `array_join_filter_fusion.xml:26`.

Through `perf.py` the file's run stage drops from 53.5 s to 8.4 s, all seven queries measured. The
default lazy path keeps its coverage in `lazy_columns_replication`,
`array_join_lazy_replication_serialized_plan`, `lambda_captures_lazy_replication`,
`lazy_replicated_array_functions` and `array_join_filter_fusion`. Query 6's measurement changes
meaning, so its per-query history is incomparable across this commit.

If both paths should stay covered here, I will parameterize the setting over `0`/`1` as
`lambda_captures_lazy_replication.xml` does rather than pin one arm.

Not fixed here: the harness itself still lets one over-budget query end its test file.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119215&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119215](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119215+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1259` (included in `26.9` and later)
<!-- ch-version-info:end -->