### PR TITLE
Pin that a bare-column join filter is not pushed onto both external scans

### DIFF
--- a/tests/queries/0_stateless/05193_external_database_join_bare_column_filter.reference
+++ b/tests/queries/0_stateless/05193_external_database_join_bare_column_filter.reference
@@ -1,0 +1,7 @@
+bare column	2
+the same as a function	2
+the rows themselves	1	0	1
+the rows themselves	2	1	2
+the other side	1
+both sides	1
+locally	2

--- a/tests/queries/0_stateless/05193_external_database_join_bare_column_filter.sh
+++ b/tests/queries/0_stateless/05193_external_database_join_bare_column_filter.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs the `sqlite3` binary to build the external database.
+
+# A `WHERE` predicate that is a bare column reference, such as `WHERE b.flag`, used to survive in the
+# query built for the *other* side of a join: `removeExpressionsThatDoNotDependOnTableIdentifiers`
+# returned early for a top-level expression that is not a `FunctionNode`. For external databases the
+# leftover predicate was then written into that side's SQL without its qualifier, so `a`'s scan was
+# filtered by `a.flag`, and rows that should have joined disappeared. Spelled as a function,
+# `b.flag = 1`, the same condition was dropped correctly, which is why both spellings are compared.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DB="${CLICKHOUSE_TMP}/05193.sqlite3"
+rm -f "$DB"
+
+sqlite3 "$DB" 'CREATE TABLE t(id INTEGER, id2 INTEGER, flag INTEGER)'
+sqlite3 "$DB" 'INSERT INTO t VALUES (1, 10, 0), (50, 1, 1), (2, 20, 1), (60, 2, 1)'
+
+# Both spellings of the filter keep the same two joined rows: `a.id = 1` pairs with the row where
+# `id2 = 1` and `a.id = 2` with the row where `id2 = 2`, and both partners have `flag = 1`. The first
+# pair has `a.flag = 0`, which is what the leaked predicate used to filter out.
+${CLICKHOUSE_LOCAL} --multiquery "
+SELECT 'bare column', count() FROM sqlite('${DB}', 't') AS a
+JOIN sqlite('${DB}', 't') AS b ON a.id = b.id2 WHERE b.flag;
+
+SELECT 'the same as a function', count() FROM sqlite('${DB}', 't') AS a
+JOIN sqlite('${DB}', 't') AS b ON a.id = b.id2 WHERE b.flag = 1;
+
+SELECT 'the rows themselves', a.id, a.flag, b.id2 FROM sqlite('${DB}', 't') AS a
+JOIN sqlite('${DB}', 't') AS b ON a.id = b.id2 WHERE b.flag ORDER BY a.id;
+
+-- A filter on the other side of the join, and one on each side.
+SELECT 'the other side', count() FROM sqlite('${DB}', 't') AS a
+JOIN sqlite('${DB}', 't') AS b ON a.id = b.id2 WHERE a.flag;
+
+SELECT 'both sides', count() FROM sqlite('${DB}', 't') AS a
+JOIN sqlite('${DB}', 't') AS b ON a.id = b.id2 WHERE a.flag AND b.flag;
+
+-- The same data locally, as the answer to compare against.
+CREATE TABLE t (id Int64, id2 Int64, flag Int64) ENGINE = Memory;
+INSERT INTO t VALUES (1, 10, 0), (50, 1, 1), (2, 20, 1), (60, 2, 1);
+SELECT 'locally', count() FROM t AS a JOIN t AS b ON a.id = b.id2 WHERE b.flag;
+"
+
+rm -f "$DB"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

### Documentation entry for user-facing changes

...

Joining two external-database tables and filtering on a bare column of one side, as in

```sql
SELECT count() FROM sqlite(db, 't') AS a JOIN sqlite(db, 't') AS b ON a.id = b.id2 WHERE b.flag
```

silently lost rows: the predicate also reached `a`'s remote scan, where it was written without its qualifier and therefore filtered `a` by `a.flag`. Written as a function, `b.flag = 1`, the same condition was scoped correctly.

The cause was in `removeExpressionsThatDoNotDependOnTableIdentifiers`, which returned early for a top-level expression that is not a `FunctionNode`, so a bare-column predicate over the other side of the join stayed in the query built for this side. It was fixed in https://github.com/ClickHouse/ClickHouse/pull/111327 (`357a95cba2b`, merged into `master` on 2026-09-06) while fixing a related logical error for `Merge` over `Distributed`. This pull request adds the external-database spelling of the same defect, which that pull request's test does not cover, so it cannot come back unnoticed.

Verified in both directions with `clickhouse-local`: the new test fails on a build from 2026-09-03 (`bare column 1` instead of `2`) and passes on current `master`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/118430
Related: https://github.com/ClickHouse/ClickHouse/pull/111327

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119233&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119233](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119233+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
