### PR TITLE
Don't use backoffs on concurrent inserts conflicts

### DIFF
--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -70,7 +70,8 @@ bool isRetriableHTTPError(const Poco::Net::HTTPResponse::HTTPStatus http_status)
         Poco::Net::HTTPResponse::HTTPStatus::HTTP_NOT_FOUND,
         Poco::Net::HTTPResponse::HTTPStatus::HTTP_FORBIDDEN,
         Poco::Net::HTTPResponse::HTTPStatus::HTTP_NOT_IMPLEMENTED,
-        Poco::Net::HTTPResponse::HTTPStatus::HTTP_METHOD_NOT_ALLOWED};
+        Poco::Net::HTTPResponse::HTTPStatus::HTTP_METHOD_NOT_ALLOWED,
+        Poco::Net::HTTPResponse::HTTPStatus::HTTP_CONFLICT};
 
     return std::all_of(
         non_retriable_errors.begin(), non_retriable_errors.end(), [&](const auto status) { return http_status != status; });

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -70,7 +70,6 @@ DEFAULT_PARTITION_SPEC = PartitionSpec(
 
 DEFAULT_SORT_ORDER = SortOrder(SortField(source_id=2, transform=IdentityTransform()))
 
-
 def list_namespaces(started_cluster):
     base_url_local = f"http://localhost:{started_cluster.iceberg_rest_catalog_port}/v1"
     response = requests.get(f"{base_url_local}/namespaces")

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -2251,3 +2251,60 @@ def test_catalog_listing_error_surfaces_in_system_tables(started_cluster):
     assert "table_x" in result
 
     node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
+
+
+def test_catalog_commit_conflict_reaches_caller_at_once(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_catalog_commit_conflict_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+    table_ref = f"{CATALOG_NAME}.`{root_namespace}.{table_name}`"
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    create_clickhouse_iceberg_table(
+        started_cluster, node, root_namespace, table_name, "(x UInt64)"
+    )
+
+    # Every sink reads the branch tip in its constructor, and all `max_insert_threads` sinks are
+    # constructed before the pipeline starts, so all but one of them commit against a stale parent
+    # and are refused with `409`. That makes the conflict a property of the plan rather than a race.
+    num_writers = 4
+    query_id = uuid.uuid4().hex
+    node.query(
+        f"INSERT INTO {table_ref} SELECT number FROM numbers_mt(4000000)",
+        query_id=query_id,
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "write_full_path_in_iceberg_metadata": 1,
+            "max_insert_threads": num_writers,
+            "max_threads": num_writers,
+        },
+    )
+
+    node.query("SYSTEM FLUSH LOGS system.text_log")
+
+    conflicts, http_requests = map(
+        int,
+        node.query(
+            f"""
+            SELECT
+                countIf(logger_name LIKE 'RestCatalog%' AND message LIKE '%updateMetadata conflict%'),
+                countIf(logger_name = 'ReadWriteBufferFromHTTP')
+            FROM system.text_log
+            WHERE query_id = '{query_id}' AND message LIKE '%409%'
+            """
+        ).split(),
+    )
+
+    assert conflicts, (
+        "no writer was refused, so nothing about conflict handling was exercised"
+    )
+    assert http_requests == conflicts, (
+        f"{conflicts} refused commit(s) cost {http_requests} catalog requests, so a conflict is "
+        f"resent with backoff instead of being handed back to the sink at once"
+    )
+
+    assert int(node.query(f"SELECT count() FROM {table_ref}")) == 4000000
+
+    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")

--- a/tests/queries/0_stateless/05055_http_conflict_is_not_retried.reference
+++ b/tests/queries/0_stateless/05055_http_conflict_is_not_retried.reference
@@ -1,0 +1,2 @@
+HTTP status code: 409
+requests: 1

--- a/tests/queries/0_stateless/05055_http_conflict_is_not_retried.sh
+++ b/tests/queries/0_stateless/05055_http_conflict_is_not_retried.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# `409 Conflict` reports a state mismatch on the server, so resending the same bytes cannot succeed.
+# Retrying it only postpones the error the caller has to act on: an Iceberg REST catalog commit
+# refused with `409` was resent `http_max_tries` times with backoff, adding ~32 seconds per conflict.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+HTTP_PORT=$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+")
+
+python3 -c "
+import threading
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+
+requests = 0
+lock = threading.Lock()
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        global requests
+        if self.path == '/requests':
+            with lock:
+                body = str(requests).encode()
+            self.send_response(200)
+        else:
+            with lock:
+                requests += 1
+            body = b'{\"error\": \"conflict\"}'
+            self.send_response(409)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+ThreadingHTTPServer(('127.0.0.1', $HTTP_PORT), Handler).serve_forever()
+" &
+HTTP_PID=$!
+
+trap 'kill $HTTP_PID 2>/dev/null' EXIT
+
+for _ in {1..100}; do
+    if [ "$(${CLICKHOUSE_CURL} -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${HTTP_PORT}/requests")" = "200" ]; then
+        break
+    fi
+    sleep 0.1
+done
+
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM url('http://127.0.0.1:${HTTP_PORT}/data', JSONEachRow, 'x Int32')" 2>&1 | grep -o "HTTP status code: 409" | head -n 1
+
+echo "requests: $(${CLICKHOUSE_CURL} -s "http://127.0.0.1:${HTTP_PORT}/requests")"


### PR DESCRIPTION
In case when we have catalog + iceberg concurrent inserts we can get a lot of errors like this:

```
Row 1:
──────
t:       2026-09-10
level:   Trace
message: Failed to make request to '...)","type":"CommitFailedException","code":409}}'. Failed at try 2/10. Will retry with current backoff wait is 100/10000 ms.
```

In fact, there is no need of backoffs here, so let's just cancel them

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Don't use backoffs on concurrent inserts conflicts (when we use Iceberg + catalog, for example)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119238&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119238](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119238+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.4.5`, `26.7.8.6`, `26.6.6.9`
<!-- ch-version-info:end -->