### PR TITLE
Do not log kafka secrets

### DIFF
--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -549,6 +549,23 @@ void updateConfigurationFromConfig(
 
 }
 
+namespace
+{
+
+/// Log all properties of a Kafka client configuration. The values of properties that can contain
+/// secrets, e.g. `sasl.password` or `sasl.oauthbearer.client.secret`, are replaced with `[HIDDEN]`.
+/// These log records can reach not only the server log, but also clients that set `send_logs_level`.
+void logConfigProperties(const cppkafka::Configuration & conf, const LoggerPtr & log, std::string_view client_type)
+{
+    for (const auto & property : conf.get_all())
+    {
+        const bool is_secret = property.first.contains("password") || property.first.contains("secret");
+        LOG_TRACE(log, "{} set property {}:{}", client_type, property.first, is_secret ? "[HIDDEN]" : property.second);
+    }
+}
+
+}
+
 template <typename TKafkaStorage>
 cppkafka::Configuration KafkaConfigLoader::getConsumerConfiguration(TKafkaStorage & storage, const ConsumerConfigParams & params, IKafkaExceptionInfoSinkPtr exception_info_sink_ptr)
 {
@@ -579,12 +596,7 @@ cppkafka::Configuration KafkaConfigLoader::getConsumerConfiguration(TKafkaStorag
     conf.set("enable.auto.offset.store", "false"); // Update offset automatically - to commit them all at once.
     conf.set("enable.partition.eof", "false"); // Ignore EOF messages
 
-    for (auto & property : conf.get_all())
-    {
-        if (property.first.contains("password"))
-            continue;
-        LOG_TRACE(params.log, "Consumer set property {}:{}", property.first, property.second);
-    }
+    logConfigProperties(conf, params.log, "Consumer");
 
     return conf;
 }
@@ -605,8 +617,7 @@ cppkafka::Configuration KafkaConfigLoader::getProducerConfiguration(TKafkaStorag
 
     updateConfigurationFromConfig(loadProducerConfig, conf, storage, params);
 
-    for (auto & property : conf.get_all())
-        LOG_TRACE(params.log, "Producer set property {}:{}", property.first, property.second);
+    logConfigProperties(conf, params.log, "Producer");
 
     /// compression.codec is a global and topic level property, however compression.level is only a topic level property.
     /// cppkafka::Configuration::get_all returns the global properties only, so we need to check compression.level separately.

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -1932,6 +1932,50 @@ def test_kafka_producer_consumer_separate_settings(
 
 
 @pytest.mark.parametrize(
+    "create_query_generator",
+    [
+        k.generate_old_create_table_query,
+        k.generate_new_create_table_query,
+    ],
+)
+def test_kafka_password_not_logged(kafka_cluster, create_query_generator):
+    suffix = k.random_string(6)
+    kafka_table = f"kafka_{suffix}"
+    password = f"secret_kafka_password_{suffix}"
+
+    instance.rotate_logs()
+    instance.query(
+        create_query_generator(
+            kafka_table,
+            "key UInt64",
+            topic_list="password_not_logged",
+            consumer_group="test",
+            settings={"kafka_sasl_password": password},
+        )
+    )
+
+    # Create an mv to initialize the librdkafka consumers
+    instance.query(f"CREATE MATERIALIZED VIEW test.{kafka_table}_view ENGINE=MergeTree ORDER BY tuple() AS SELECT * FROM test.{kafka_table}")
+    instance.wait_for_log_line(f"{kafka_table}.*Created #0 consumer")
+    instance.query(f"DROP TABLE test.{kafka_table}_view")
+    instance.query(f"INSERT INTO test.{kafka_table} VALUES (1)")
+
+    assert instance.contains_in_log(f"{kafka_table}.*Kafka producer created")
+
+    # The property-logging loops ran for both the consumer and the producer,
+    # but they hid the password value
+    assert instance.contains_in_log(
+        f"{kafka_table}.*Consumer set property sasl.password:\\[HIDDEN\\]"
+    )
+    assert instance.contains_in_log(
+        f"{kafka_table}.*Producer set property sasl.password:\\[HIDDEN\\]"
+    )
+    assert not instance.contains_in_log(password)
+
+    instance.query(f"DROP TABLE test.{kafka_table}")
+
+
+@pytest.mark.parametrize(
     "create_query_generator, log_line",
     [
         (k.generate_new_create_table_query, "Saved offset 5"),


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Kafka producer and consumer trace logs now show the value of secret librdkafka properties, such as sasl.password, as [HIDDEN] instead of the cleartext value.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119244&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119244](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119244+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
