### PR TITLE
Resolve the 26.3 cherry-pick of #109212: Verify array offsets read as absolute values, not only in the Native format

### DIFF
--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -421,11 +421,15 @@ bool SerializationArray::deserializeOffsetsBinaryBulk(
         else
             SerializationNumber<ColumnArray::Offset>().deserializeBinaryBulk(*offsets_column->assumeMutable(), *stream, 0, limit, 0);
 
-        /// Verify offsets if the data comes over the network
-        if (settings.native_format)
+        /// Verify offsets that were read as absolute values. The other branch accumulates sizes, so it
+        /// is monotonic by construction. Only the values appended by this call are new: everything below
+        /// `prev_size` was verified by the previous call, and starting one element earlier keeps the
+        /// comparison across the range boundary.
+        if (!settings.position_independent_encoding)
         {
             const auto & offsets = assert_cast<const ColumnArray::ColumnOffsets &>(*offsets_column).getData();
-            const auto * const it = std::adjacent_find(offsets.begin(), offsets.end(), std::greater<>());
+            const auto * const scan_begin = offsets.begin() + (prev_size ? prev_size - 1 : 0);
+            const auto * const it = std::adjacent_find(scan_begin, offsets.end(), std::greater<>());
             if (it != offsets.end())
             {
                 throw Exception(ErrorCodes::INCORRECT_DATA, "Arrays offsets are not monotonically increasing (starting at {}, value {})",
@@ -510,10 +514,20 @@ void SerializationArray::deserializeBinaryBulkWithMultipleStreams(
     settings.path.pop_back();
 
     /// Check consistency between offsets and elements subcolumns.
-    /// But if elements column is empty - it's ok for columns of Nested types that was added by ALTER.
-    if (!nested_column->empty() && nested_column->size() != last_offset)
-        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Cannot read all array values: read just {} of {}",
-            toString(nested_column->size()), toString(last_offset));
+    if (nested_column->size() != last_offset)
+    {
+        if (!nested_column->empty())
+            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Cannot read all array values: read just {} of {}",
+                toString(nested_column->size()), toString(last_offset));
+
+        /// An empty elements column is ok for the sizes encoding: it is how a column of a Nested type
+        /// that was added by ALTER reads the parts written before that ALTER. The absolute-offsets
+        /// encoding always writes the elements next to the offsets, so there an empty elements column
+        /// means the data is corrupted and the offsets would index past the end of the elements.
+        if (!settings.position_independent_encoding)
+            throw Exception(ErrorCodes::INCORRECT_DATA,
+                "Cannot read array values: elements column is empty while the last offset is {}", toString(last_offset));
+    }
 
     column = std::move(mutable_column);
 }

--- a/src/DataTypes/Serializations/tests/gtest_serialization_array_offsets.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_serialization_array_offsets.cpp
@@ -1,0 +1,175 @@
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/Serializations/SerializationArray.h>
+#include <DataTypes/Serializations/SerializationNumber.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <Common/Exception.h>
+
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int INCORRECT_DATA;
+}
+
+namespace
+{
+
+/// Absolute offsets, the encoding used by skip index granules (`position_independent_encoding = false`).
+String absoluteOffsets(const std::vector<UInt64> & offsets)
+{
+    WriteBufferFromOwnString out;
+    for (UInt64 offset : offsets)
+        writeBinaryLittleEndian(offset, out);
+    return out.str();
+}
+
+/// Read `limit` offsets into `offsets_column`, the way `MergeTreeIndexGranuleSet::deserializeBinary` does.
+/// `data` is a reference so that a temporary passed by the caller outlives the non-owning `in`.
+void readOffsets(ColumnPtr & offsets_column, const String & data, size_t limit, bool position_independent_encoding = false)
+{
+    ReadBufferFromString in(data);
+    ISerialization::DeserializeBinaryBulkSettings settings;
+    settings.getter = [&in](const ISerialization::SubstreamPath &) -> ReadBuffer * { return &in; };
+    settings.position_independent_encoding = position_independent_encoding;
+    SerializationArray::deserializeOffsetsBinaryBulk(offsets_column, limit, settings, nullptr);
+}
+
+ColumnPtr emptyOffsets()
+{
+    return ColumnArray::ColumnOffsets::create();
+}
+
+/// Read a whole `Array(UInt8)` column: offsets from `offsets_data`, elements from `elements_data`.
+/// Both buffers are references so that temporaries passed by the caller outlive the non-owning readers.
+ColumnPtr readArrayColumn(const String & offsets_data, const String & elements_data, size_t limit, bool position_independent_encoding)
+{
+    ReadBufferFromString offsets_in(offsets_data);
+    ReadBufferFromString elements_in(elements_data);
+
+    ISerialization::DeserializeBinaryBulkSettings settings;
+    settings.position_independent_encoding = position_independent_encoding;
+    settings.getter = [&](const ISerialization::SubstreamPath & path) -> ReadBuffer *
+    {
+        return path.back().type == ISerialization::Substream::ArraySizes ? &offsets_in : &elements_in;
+    };
+
+    auto serialization = std::make_shared<SerializationArray>(std::make_shared<SerializationNumber<UInt8>>());
+    ColumnPtr column = ColumnArray::create(ColumnUInt8::create());
+    ISerialization::DeserializeBinaryBulkStatePtr state;
+    serialization->deserializeBinaryBulkWithMultipleStreams(column, 0, limit, settings, state, nullptr);
+    return column;
+}
+
+const ColumnArray::Offsets & offsetValues(const ColumnPtr & column)
+{
+    return assert_cast<const ColumnArray::ColumnOffsets &>(*column).getData();
+}
+
+}
+
+/// Decreasing absolute offsets make `offsetAt` exceed the row's own offset, so consumers that read the
+/// nested column over that range index it out of bounds. Reject them where they are read.
+TEST(SerializationArrayOffsets, RejectsDecreasingAbsoluteOffsets)
+{
+    auto offsets_column = emptyOffsets();
+    try
+    {
+        readOffsets(offsets_column, absoluteOffsets({2, 1, 3}), 3);
+        FAIL() << "Expected INCORRECT_DATA for decreasing offsets";
+    }
+    catch (const Exception & e)
+    {
+        ASSERT_EQ(ErrorCodes::INCORRECT_DATA, e.code());
+    }
+}
+
+TEST(SerializationArrayOffsets, AcceptsNonDecreasingAbsoluteOffsets)
+{
+    auto offsets_column = emptyOffsets();
+    readOffsets(offsets_column, absoluteOffsets({0, 2, 2, 5}), 4);
+    ASSERT_EQ(offsetValues(offsets_column), (ColumnArray::Offsets{0, 2, 2, 5}));
+}
+
+/// Offsets accumulate across range reads, so each call only verifies what it appended. The scan still
+/// starts one element early, which is what catches a drop across the boundary between two reads.
+TEST(SerializationArrayOffsets, RejectsDecreaseAcrossRangeBoundary)
+{
+    auto offsets_column = emptyOffsets();
+    readOffsets(offsets_column, absoluteOffsets({1, 4}), 2);
+    ASSERT_EQ(offsetValues(offsets_column), (ColumnArray::Offsets{1, 4}));
+
+    try
+    {
+        readOffsets(offsets_column, absoluteOffsets({3, 7}), 2);
+        FAIL() << "Expected INCORRECT_DATA for an offset lower than the last one already read";
+    }
+    catch (const Exception & e)
+    {
+        ASSERT_EQ(ErrorCodes::INCORRECT_DATA, e.code());
+    }
+}
+
+TEST(SerializationArrayOffsets, AcceptsNonDecreasingAcrossRangeBoundary)
+{
+    auto offsets_column = emptyOffsets();
+    readOffsets(offsets_column, absoluteOffsets({1, 4}), 2);
+    readOffsets(offsets_column, absoluteOffsets({4, 6}), 2);
+    ASSERT_EQ(offsetValues(offsets_column), (ColumnArray::Offsets{1, 4, 4, 6}));
+}
+
+/// Sizes are accumulated with a non-negative step, so that encoding cannot produce decreasing offsets
+/// and reading the same bytes as sizes stays accepted.
+TEST(SerializationArrayOffsets, SizesEncodingIsMonotonicByConstruction)
+{
+    auto offsets_column = emptyOffsets();
+    readOffsets(offsets_column, absoluteOffsets({2, 1, 3}), 3, /*position_independent_encoding=*/true);
+    ASSERT_EQ(offsetValues(offsets_column), (ColumnArray::Offsets{2, 3, 6}));
+}
+
+/// A monotonic absolute-offsets stream whose elements stream is empty declares elements that were never
+/// read: the offsets pass the monotonicity check, the elements reader appends nothing without throwing,
+/// and consumers of the resulting column would index the empty elements column out of bounds.
+TEST(SerializationArrayOffsets, RejectsEmptyElementsWithNonZeroLastAbsoluteOffset)
+{
+    try
+    {
+        readArrayColumn(absoluteOffsets({1}), /*elements_data=*/"", 1, /*position_independent_encoding=*/false);
+        FAIL() << "Expected INCORRECT_DATA for an empty elements stream with a non-zero last offset";
+    }
+    catch (const Exception & e)
+    {
+        ASSERT_EQ(ErrorCodes::INCORRECT_DATA, e.code());
+    }
+}
+
+/// The sizes encoding keeps accepting an empty elements column: that is how a column of a Nested type
+/// that was added by ALTER reads the parts written before that ALTER.
+TEST(SerializationArrayOffsets, SizesEncodingAcceptsEmptyElements)
+{
+    auto column = readArrayColumn(absoluteOffsets({1}), /*elements_data=*/"", 1, /*position_independent_encoding=*/true);
+    const auto & column_array = assert_cast<const ColumnArray &>(*column);
+    ASSERT_EQ(column_array.getOffsets(), (ColumnArray::Offsets{1}));
+    ASSERT_TRUE(column_array.getData().empty());
+}
+
+/// Repeated reads into one accumulating column keep appending, so a column filled over many calls ends
+/// up with every offset that was read and stays accepted throughout.
+TEST(SerializationArrayOffsets, AccumulatesAcrossManyReads)
+{
+    auto offsets_column = emptyOffsets();
+    UInt64 offset = 0;
+    for (size_t round = 0; round < 64; ++round)
+    {
+        std::vector<UInt64> chunk;
+        for (size_t i = 0; i < 16; ++i)
+            chunk.push_back(++offset);
+        readOffsets(offsets_column, absoluteOffsets(chunk), chunk.size());
+    }
+    ASSERT_EQ(offsetValues(offsets_column).size(), 64u * 16u);
+    ASSERT_EQ(offsetValues(offsets_column).back(), 64u * 16u);
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109212
Related: https://github.com/ClickHouse/ClickHouse/pull/118921
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Rejects non-monotonic `Array` offsets on every read path that decodes them as absolute values, instead of only in the `Native` format. A corrupt `set` skip index granule previously passed unchecked and was then read out of bounds.

### Description

Related: #109212 (the merged master fix, `pr-must-backport`), #118921 (the robot 26.3 leg). 26.3 is the only branch of the wave still missing it: #118922 (26.6) and #118923 (26.7) merged green.

The robot leg cannot deliver it: its head `f5e115bf` carries the correct one-line adaptation alongside a whole-repository deletion, `+1 / -997,602` over 4033 files, so the branch is unmergeable and, `.github/` being deleted, no workflow can trigger on it. I have no push access to it (`push: false`, `maintainerCanModify: false`), so this PR carries the same content against `26.3`, as #116837 did.

The content is the robot's own two-file cherry-pick, one line adapted. 26.3 predates #96563, which added the static `SerializationArray::create` / `SerializationNumber<T>::create` factories, so the ported test's line 61 does not compile here. That reddens `Build (amd_debug)`, `(amd_asan)` and `(amd_tsan)` on #118921: three errors, all on that line. It becomes `std::make_shared<SerializationArray>(std::make_shared<SerializationNumber<UInt8>>())`, 26.3's own idiom, byte-identical to the adaptation already on the robot branch. `SerializationArray.cpp` is verbatim: both changed hunks are byte-identical to 26.6, differing elsewhere in those two functions only by its #96563 pool idiom. So 26.3 converges on what its siblings ship.

Validated with clang-21, which 26.3 pins: the translation unit reproduces the three CI errors without the adaptation and is clean with it; `unit_tests_dbms` builds and all 8 `SerializationArrayOffsets` cases pass, 400 of 400 over 50 shuffled repeats; with the source hunks reverted and the test kept, three of the eight fail, so the ported tests are not vacuous here.

A single push resetting `backport/26.3/109212` to `d11769ca6` plus this line would be cheaper; say so and I will close this. One cost: under a `groeneai/...` head the automated `Backported to` list on #109212 will not pick up 26.3, since `tests/ci/pr_version_info.py` scans that head ref; this PR still gets its own `Merged into` line.