### PR TITLE
Create the ReplicatedMergeTree restarting thread's task deactivated

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -165,6 +165,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(rmt_mutation_prune_pause_before_analysis) \
     PAUSEABLE_ONCE(rmt_mutation_prune_pause_before_block_allocation) \
     PAUSEABLE_ONCE(rmt_mutation_prune_pause_before_zk_partition_list) \
+    PAUSEABLE_ONCE(rmt_restarting_thread_pause_after_activation) \
     PAUSEABLE_ONCE(kafka2_remove_zk_before_get_children) \
     PAUSEABLE_ONCE(kafka2_remove_zk_before_final_multi) \
     PAUSEABLE_ONCE(nats_pause_before_building_insert_pipeline) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -41,6 +41,7 @@ namespace ErrorCodes
 namespace FailPoints
 {
     extern const char finish_clean_quorum_failed_parts[];
+    extern const char rmt_restarting_thread_pause_after_activation[];
 };
 
 /// Used to check whether it's us who set node `is_active`, or not.
@@ -59,6 +60,10 @@ ReplicatedMergeTreeRestartingThread::ReplicatedMergeTreeRestartingThread(Storage
     check_period_ms = (*storage_settings)[MergeTreeSetting::zookeeper_session_expiration_check_period].totalSeconds() * 1000;
 
     task = storage.getContext()->getSchedulePool()->createTask(storage.getStorageID(), log_name, [this]{ run(); });
+
+    /// Not schedulable until `start`: the attach path calls `run` inline, and a pool execution of
+    /// `run` must not overlap that call.
+    task->deactivate();
 }
 
 void ReplicatedMergeTreeRestartingThread::start(bool schedule)
@@ -183,6 +188,10 @@ bool ReplicatedMergeTreeRestartingThread::runImpl()
     storage.deduplication_hashes_cache.start();
 
     LOG_DEBUG(log, "Table started successfully");
+
+    /// Pauses where the replica is not readonly, first_time is still set, and queue_updating_task is armed.
+    FailPointInjection::pauseFailPoint(FailPoints::rmt_restarting_thread_pause_after_activation);
+
     return true;
 }
 

--- a/tests/integration/test_replicated_restarting_thread_race/test.py
+++ b/tests/integration/test_replicated_restarting_thread_race/test.py
@@ -1,0 +1,153 @@
+import concurrent.futures
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+# The default `background_schedule_pool_size` is required: with a single pool thread the second
+# executor of `ReplicatedMergeTreeRestartingThread::run` this test needs cannot exist at all.
+node = cluster.add_instance("node", with_zookeeper=True, stay_alive=True)
+
+FAILPOINT = "rmt_restarting_thread_pause_after_activation"
+SESSION_QUERY = "SELECT client_id FROM system.zookeeper_connection WHERE name = 'default'"
+RESTART_TASK_QUERY = (
+    "SELECT count() FROM system.background_schedule_pool "
+    "WHERE table = 't' AND log_name LIKE '%ReplicatedMergeTreeRestartingThread%'"
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def wait_failpoint_paused(instance, failpoint, timeout=60):
+    """Block until a thread parks at `failpoint`.
+
+    `SYSTEM WAIT FAILPOINT ... PAUSE` blocks, so it runs on a worker thread: a failpoint that is
+    never reached must fail the test rather than hang it. The executor is not joined on the failure
+    path, because its worker is still stuck inside the blocking query."""
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = pool.submit(instance.query, f"SYSTEM WAIT FAILPOINT {failpoint} PAUSE")
+    done, _ = concurrent.futures.wait([future], timeout=timeout)
+    if not done:
+        pool.shutdown(wait=False, cancel_futures=True)
+        raise AssertionError(f"failpoint {failpoint} was not reached within {timeout}s")
+    pool.shutdown(wait=False)
+    future.result()
+
+
+def test_session_expires_during_attach_path_activation(started_cluster):
+    node.query("DROP TABLE IF EXISTS t SYNC")
+    node.query(
+        "CREATE TABLE t (k UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/t', 'r1') ORDER BY k"
+    )
+    node.query("INSERT INTO t VALUES (1)")
+
+    # `DETACH` is the lever back onto the attach path: `ATTACH` creates an `attach_thread`, whose
+    # `startupImpl(from_attach_thread=true)` calls `restarting_thread.run` inline instead of
+    # letting the pool run it. The failpoint is enabled only now, because `CREATE TABLE` waits on
+    # `startup_event` and would block forever on a pause inside its own first activation.
+    node.query("DETACH TABLE t")
+    node.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
+
+    attach_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    attach_future = attach_pool.submit(node.query, "ATTACH TABLE t")
+    try:
+        # Reaching the pause proves `setNotReadonly` has run while `first_time` is still set.
+        wait_failpoint_paused(node, FAILPOINT)
+
+        old_session = node.query(SESSION_QUERY)
+        # Finalizing the shared session leaves the handle the storage latched in `setZooKeeper`
+        # expired, which is what makes the parked activation's state inconsistent. A lost
+        # connection here is already a symptom of the abort this test is about, so the verdict is
+        # left to the log checks below, which do not need a live server.
+        try:
+            node.query("SYSTEM RECONNECT ZOOKEEPER")
+        except Exception:
+            pass
+
+        # Finalization fires the watch `queue_updating_task` installed, so it re-runs, throws
+        # `ZSESSIONEXPIRED` and calls `restarting_thread.wakeup`. Waiting for that line is what
+        # makes the second executor's arming observed rather than assumed, and it is what stops
+        # this test from passing vacuously if the session was never actually replaced.
+        node.wait_for_log_line("queueUpdatingTask.*Session expired", timeout=60)
+
+        # The refused schedule is the whole mechanism, so observe it rather than infer it from the
+        # absence of an abort: a deactivated task is in none of the pool's collections, so it does
+        # not appear in `system.background_schedule_pool`, while one the `wakeup` managed to schedule
+        # does. Polling also hands the pool worker its window, since the line waited for above is
+        # logged before `wakeup` is even called.
+        deadline = time.monotonic() + 30
+        samples = 0
+        while time.monotonic() < deadline:
+            try:
+                queued = node.query(RESTART_TASK_QUERY).strip()
+            except Exception:
+                # A dead server here is the abort this test is about, and the log check below is the
+                # verdict for it. Anything else is transient, so it costs one sample rather than the
+                # rest of the window; a window that observed nothing is reported after that verdict.
+                time.sleep(0.5)
+                continue
+            samples += 1
+            assert queued == "0", (
+                "the restarting thread's task was scheduled while the inline activation was still "
+                f"parked (system.background_schedule_pool rows: {queued})"
+            )
+            time.sleep(0.5)
+    finally:
+        # Releases the parked thread and disarms the failpoint. The server is already dead when
+        # the assertion below is the one that fires, so this must not mask it.
+        try:
+            node.query(f"SYSTEM DISABLE FAILPOINT {FAILPOINT}")
+        except Exception:
+            pass
+        attach_pool.shutdown(wait=False, cancel_futures=True)
+
+    assert not node.contains_in_log("Logical error: 'storage.is_readonly'"), (
+        "the restarting thread aborted on chassert(storage.is_readonly): a pool execution of "
+        "run observed first_time while the replica was already not readonly"
+    )
+
+    assert samples >= 1, (
+        "the parked observation window produced no sample in 30s, so it cannot tell a refused schedule "
+        "from a query that never ran"
+    )
+
+    attach_future.result(timeout=60)
+    assert node.query(SESSION_QUERY) != old_session, (
+        f"the Keeper session was not replaced (still {old_session!r})"
+    )
+
+    # The refused `wakeup` must be coalesced, not lost: the table has to come back on its own.
+    node.query_with_retry(
+        "SELECT is_readonly FROM system.replicas WHERE table = 't'",
+        check_callback=lambda res: res.strip() == "0",
+        retry_count=120,
+        sleep_time=0.5,
+    )
+    node.query("INSERT INTO t VALUES (2)")
+    assert node.query("SELECT count() FROM t") == "2\n"
+
+    # Positive control for the poll above: the same query must be able to return a row, so that a
+    # zero while parked means "refused" and not "matches nothing". A recovered task is delay-scheduled
+    # with `zookeeper_session_expiration_check_period`, so it stays in the pool's collections.
+    # `query_with_retry` retries a transient sample but returns its last result once the retries run
+    # out, so the value it settles on is what decides the control.
+    queued_after_recovery = node.query_with_retry(
+        RESTART_TASK_QUERY,
+        check_callback=lambda res: res.strip() == "1",
+        retry_count=60,
+        sleep_time=0.5,
+    )
+    assert queued_after_recovery.strip() == "1", (
+        "the restarting thread's task never came back to system.background_schedule_pool, so the poll "
+        f"above cannot tell a refused schedule from a query that matches nothing (rows: {queued_after_recovery!r})"
+    )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117293


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a race during `ReplicatedMergeTree` startup on the attach path: a ZooKeeper session expiring during replica activation could run `ReplicatedMergeTreeRestartingThread::run` on a background pool thread concurrently with the inline activation. The observed effect is an assertion abort (`Logical error: 'storage.is_readonly'`) in debug and sanitizer builds; a release build instead re-runs `setZooKeeper` and `tryStartup` mid-activation.

### Description

`ReplicatedMergeTreeRestartingThread::run` has two independent executors and must not run on both at once: its own `BackgroundSchedulePool` task, serialized by `exec_mutex`, and the inline `restarting_thread.run` the attach path takes (`StorageReplicatedMergeTree.cpp:5979`), which bypasses both.

`BackgroundSchedulePoolTaskInfo::deactivated` defaults to `false`, so the task is schedulable from construction and the inline activation can be overtaken by its own side effects: `runImpl` arms `queue_updating_task`, the session expires, `queueUpdatingTask` catches `ZSESSIONEXPIRED` and calls `restarting_thread.wakeup`, and a pool thread enters `run` while the inline executor is still between `setNotReadonly` and `first_time = false`. It reads `first_time == true` with `is_readonly == false` and trips `chassert(storage.is_readonly)`.

Creating the task deactivated is the convention the storage constructor already states at `StorageReplicatedMergeTree.cpp:481`: the four tasks created there are all deactivated there, and `ReplicatedMergeTreePartCheckThread` does the same in its own constructor. It makes the `wakeup` in that window a no-op, and the attach path's following `start(/*schedule=*/true)` activates and schedules, so it is coalesced, not lost.

Requested by @ alexey-milovidov in https://github.com/ClickHouse/ClickHouse/pull/117293#issuecomment-5613722893.

A new integration test parks the inline activation at a failpoint and expires the session with `SYSTEM RECONNECT ZOOKEEPER`, forcing the interleaving. While parked it polls `system.background_schedule_pool`, where a deactivated task has no row, so the refused schedule is observed rather than inferred; the same query must return the row again after recovery. Without the one-line change it aborts the server in 5 of 5 runs with the stack from the CI report; with it, 20 of 20 pass, and in the 10 runs whose server log I counted the refused `wakeup` is coalesced into a normal session-replacement restart in all 10. `test_replicated_table_attach` still passes 6 of 6, so no wakeup is dropped.

<details>
<summary>Neighbouring races left untouched, and CIDB breadth for this signature</summary>

Three neighbouring races are untouched, none reachable for this assertion, none with a CIDB occurrence: `session_expired_callback_handler` outliving a failed attach attempt, `is_readonly_metric_set` written from both threads, and `shutdown` not waiting for an inline execution.

Exactly one occurrence in 90 days, and no open issue or pull request matches the signature, so this is not verifiable post-merge by a drop in failure frequency; the evidence is the reddening negative arm plus the call-site enumeration.

```sql
SELECT check_start_time, check_name, pull_request_number, commit_sha, head_ref
FROM default.checks
WHERE position(test_context_raw, 'storage.is_readonly') > 0
  AND check_start_time >= now() - INTERVAL 90 DAY
```

```
2026-09-04 01:08:01    Stress test (arm_debug)    117293    1209779bd81c5de44849dc0908019d0bda7b670a    fix-chain-to-in-fixed-string-padding
```

Report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117293&sha=1209779bd81c5de44849dc0908019d0bda7b670a&name_0=PR&name_1=Stress%20test%20%28arm_debug%29

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119264&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119264](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119264+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
