### PR TITLE
Fix Docker cache-test paths and CI invalidation

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1758,6 +1758,7 @@ class JobConfigs:
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/docker_server.py",
+                "./ci/jobs/scripts/docker_server",
                 "./docker/server",
                 "./docker/keeper",
             ],
@@ -1774,6 +1775,7 @@ class JobConfigs:
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/docker_server.py",
+                "./ci/jobs/scripts/docker_server",
                 "./docker/server",
                 "./docker/keeper",
             ],

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/cache.xml
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/cache.xml
@@ -1,4 +1,5 @@
 <clickhouse>
+    <path from_env="CLICKHOUSE_TEST_DATA_PATH"/>
     <filesystem_caches>
         <docker_relative_cache>
             <max_size>10000000</max_size>

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-filesystem-cache-relative/run.sh
@@ -10,30 +10,38 @@ source "$dir/../lib.sh"
 
 image="$1"
 
-cid="$(
-  docker run -d \
-    -v "$dir/cache.xml":/etc/clickhouse-server/config.d/cache.xml:ro \
-    --name "$(cname)" \
-    "$image"
-)"
-trap 'docker rm -vf $cid > /dev/null' EXIT
+# Exercise both spellings independently of how the image was installed.
+for data_path in /var/lib/clickhouse /var/lib/clickhouse/; do
+(
+  # Override the `data-paths.xml` fragment created by `clickhouse install`.
+  cid="$(
+    docker run -d \
+      -e CLICKHOUSE_TEST_DATA_PATH="$data_path" \
+      -v "$dir/cache.xml":/etc/clickhouse-server/config.d/zz-cache.xml:ro \
+      --name "$(cname)" \
+      "$image"
+  )"
+  trap 'docker rm -vf "$cid" > /dev/null' EXIT
 
-chCli() {
-  docker exec "$cid" clickhouse-client --query "$*"
-}
+  chCli() {
+    docker exec "$cid" clickhouse-client --query "$*"
+  }
 
-# shellcheck source=../../../../../tmp/docker-library/official-images/test/retry.sh
-. "$TESTS_LIB_DIR/retry.sh" \
-  --cid "$cid" \
-  --image "$image" \
-  --tries "$CLICKHOUSE_TEST_TRIES" \
-  --sleep "$CLICKHOUSE_TEST_SLEEP" \
-  chCli SELECT 1
+  # shellcheck source=../../../../../tmp/docker-library/official-images/test/retry.sh
+  . "$TESTS_LIB_DIR/retry.sh" \
+    --cid "$cid" \
+    --image "$image" \
+    --tries "$CLICKHOUSE_TEST_TRIES" \
+    --sleep "$CLICKHOUSE_TEST_SLEEP" \
+    chCli SELECT 1
 
-data_dir="$(chCli "SELECT value FROM system.server_settings WHERE name = 'path'")"
-[ "$(chCli "SELECT path FROM system.filesystem_cache_settings WHERE cache_name = 'docker_relative_cache'")" = "${data_dir}caches/docker_relative_cache" ]
+  data_dir="$(chCli "SELECT value FROM system.server_settings WHERE name = 'path'")"
+  [ "$data_dir" = "$data_path" ]
+  [ "$(chCli "SELECT path FROM system.filesystem_cache_settings WHERE cache_name = 'docker_relative_cache'")" = "${data_dir%/}/caches/docker_relative_cache" ]
 
-# The entrypoint runs `cd "$DATA_DIR"` before `manage_clickhouse_directories`, regardless of
-# the image's `WORKDIR`. Without `grep '^/'`, it creates the raw relative path here,
-# beside `caches`, so this assertion must fail when that filter is removed.
-docker exec "$cid" test ! -e "${data_dir}docker_relative_cache"
+  # The entrypoint runs `cd "$DATA_DIR"` before `manage_clickhouse_directories`, regardless of
+  # the image's `WORKDIR`. Without `grep '^/'`, it creates the raw relative path here,
+  # beside `caches`, so this assertion must fail when that filter is removed.
+  docker exec "$cid" test ! -e "${data_dir%/}/docker_relative_cache"
+)
+done


### PR DESCRIPTION
The relative filesystem-cache Docker test concatenated the server's data path with a relative suffix, assuming that the configured path ended in `/`. The packaged configuration has that slash, but `clickhouse install` writes a path without it. Normalize both joins and explicitly run the regression with both path spellings, checking the effective server setting in each case. Load the test configuration after the installer's `data-paths.xml` so it can override the chosen path. Keep the assertion that the entrypoint must not create the raw relative cache directory beside `caches`.

The public Docker server and Keeper job cache digests also omitted `ci/jobs/scripts/docker_server`, where the shared runner, configuration, and tests now live. Include that directory in both digests so changes to these inputs invalidate cached results and select the affected jobs.

Validated locally with native ARM64 Ubuntu and Alpine server images using a cached ClickHouse `26.7.5.10` executable: both complete docker-library suites passed all 9 tests, with both path spellings exercised. Removing the path normalization or removing the entrypoint's relative-path filter makes the focused test fail at the corresponding assertion on both images. Bash syntax, ShellCheck, and diff checks passed. Throwaway checks using the real CI digest and affected-job logic reproduced all 10 missing-dependency cases on public master and verified that all 10 invalidate after this change. No new C++ build was needed.

A public Ubuntu fixture containing the installer's `data-paths.xml` reproduced the test-override ordering problem: the requested trailing-slash case read back without the slash. With the later-loaded test configuration, both path spellings and cache assertions pass.

Related: https://github.com/ClickHouse/ClickHouse/pull/118842

### Changelog category (leave one):

- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119271&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119271](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119271+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1178` (included in `26.9` and later)
<!-- ch-version-info:end -->