### PR TITLE
Name a pass-built constant on a shard as the initiator names it

### DIFF
--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -202,6 +202,20 @@ public:
                         else
                             result = calculateActionNodeName(constant_node.getSourceExpression());
                     }
+                    else if (!constant_node.hasSourceExpression())
+                    {
+                        /** The constant did not come from the query text: a query tree pass built it the
+                          * same way on this server as on the initiator (for example the index mask that
+                          * `GroupingFunctionsResolvePass` adds as a trailing argument of
+                          * `__groupingOrdinary`). There is no initiator naming to simulate, so name it
+                          * exactly as the initiator does, or a header the initiator expects from this shard
+                          * would not match. A constant that does come from the query text is unaffected:
+                          * the initiator writes the ones that need a cast as `_CAST(...)`, which arrive here
+                          * with a source expression, and the rest need no cast, so their name is the same
+                          * either way.
+                          */
+                        result = calculateActionNodeNameWithCastIfNeeded(constant_node, planner_context.getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
+                    }
                     else
                         result = calculateConstantActionNodeName(constant_node, planner_context.getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
                 }
@@ -1009,6 +1023,21 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
                 return calculateActionNodeNameWithCastIfNeeded(constant_node, planner_context->getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
             return action_node_name_helper.calculateActionNodeName(constant_node.getSourceExpression());
         }
+
+        if (!constant_node.hasSourceExpression())
+        {
+            /** The constant did not come from the query text: a query tree pass built it the same way
+              * on this server as on the initiator (for example the index mask that
+              * `GroupingFunctionsResolvePass` adds as a trailing argument of `__groupingOrdinary`).
+              * There is no initiator naming to simulate, so name it exactly as the initiator does,
+              * or a header the initiator expects from this shard would not match. A constant that
+              * does come from the query text is unaffected: the initiator writes the ones that need
+              * a cast as `_CAST(...)`, which arrive here with a source expression, and the rest
+              * need no cast, so their name is the same either way.
+              */
+            return calculateActionNodeNameWithCastIfNeeded(constant_node, planner_context->getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
+        }
+
         return calculateConstantActionNodeName(constant_node, planner_context->getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
     }();
 

--- a/tests/queries/0_stateless/05195_grouping_distributed_skip_unused_shards.reference
+++ b/tests/queries/0_stateless/05195_grouping_distributed_skip_unused_shards.reference
@@ -1,0 +1,13 @@
+the sharding key
+0	0
+0	0
+0	1
+0	5
+0	30
+another column
+0
+the ROLLUP and GROUPING SETS forms
+0	0
+0	1
+the cluster table function
+0

--- a/tests/queries/0_stateless/05195_grouping_distributed_skip_unused_shards.sql
+++ b/tests/queries/0_stateless/05195_grouping_distributed_skip_unused_shards.sql
@@ -10,6 +10,13 @@ CREATE TABLE t_05195 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
 INSERT INTO t_05195 SELECT number, 'v' FROM numbers(100);
 CREATE TABLE t_05195_dist (id UInt64, value String) ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), t_05195, id);
 
+-- The shards have to finalize the aggregation for the grouping column to be computed there, which is
+-- what `optimize_distributed_group_by_sharding_key` does for a `GROUP BY` on the sharding key, and the
+-- query has to actually go over the network. Both are pinned here so that randomized settings cannot
+-- silently turn this into a different case: with the sharding-key aggregation off, the initiator merges
+-- the groups of both shards and the `count()` below is 2 instead of 1.
+SET optimize_distributed_group_by_sharding_key = 1, prefer_localhost_replica = 0;
+
 SELECT 'the sharding key';
 SELECT grouping(id), id FROM t_05195_dist GROUP BY id ORDER BY id LIMIT 1;
 SELECT grouping(id), id FROM t_05195_dist GROUP BY id ORDER BY id LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;

--- a/tests/queries/0_stateless/05195_grouping_distributed_skip_unused_shards.sql
+++ b/tests/queries/0_stateless/05195_grouping_distributed_skip_unused_shards.sql
@@ -1,0 +1,30 @@
+-- `grouping()` over a `Distributed` table with `optimize_skip_unused_shards`: the query is sent to the
+-- shards up to `WithMergeableStateAfterAggregation`, so a shard computes the grouping column itself.
+-- The constant index mask that `GroupingFunctionsResolvePass` adds as an argument of
+-- `__groupingOrdinary` has to be named on the shard exactly as the initiator names it, or the
+-- initiator does not find the column in the block it receives.
+
+DROP TABLE IF EXISTS t_05195;
+DROP TABLE IF EXISTS t_05195_dist;
+CREATE TABLE t_05195 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05195 SELECT number, 'v' FROM numbers(100);
+CREATE TABLE t_05195_dist (id UInt64, value String) ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), t_05195, id);
+
+SELECT 'the sharding key';
+SELECT grouping(id), id FROM t_05195_dist GROUP BY id ORDER BY id LIMIT 1;
+SELECT grouping(id), id FROM t_05195_dist GROUP BY id ORDER BY id LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;
+SELECT grouping(id), count() FROM t_05195_dist GROUP BY id ORDER BY id LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;
+SELECT grouping(id), id FROM t_05195_dist WHERE id IN (5, 30) GROUP BY id ORDER BY id SETTINGS optimize_skip_unused_shards = 1;
+
+SELECT 'another column';
+SELECT grouping(value) FROM t_05195_dist GROUP BY value ORDER BY 1 LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;
+
+SELECT 'the ROLLUP and GROUPING SETS forms';
+SELECT grouping(id), grouping(value) FROM t_05195_dist GROUP BY ROLLUP(id, value) ORDER BY 1, 2 LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;
+SELECT grouping(id), grouping(value) FROM t_05195_dist GROUP BY GROUPING SETS ((id), (value)) ORDER BY 1, 2 LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;
+
+SELECT 'the cluster table function';
+SELECT grouping(id) FROM cluster(test_cluster_two_shards, currentDatabase(), t_05195) GROUP BY id ORDER BY 1 LIMIT 1 SETTINGS optimize_skip_unused_shards = 1;
+
+DROP TABLE t_05195_dist;
+DROP TABLE t_05195;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `NOT_FOUND_COLUMN_IN_BLOCK` for `grouping()` over a `Distributed` table with `optimize_skip_unused_shards = 1`: a constant that a query tree pass builds is now named on a shard exactly as the initiator names it.

### Documentation entry for user-facing changes

...

`SELECT grouping(id), id FROM dist GROUP BY id ORDER BY id SETTINGS optimize_skip_unused_shards = 1` threw `NOT_FOUND_COLUMN_IN_BLOCK`: the initiator looked for `__groupingOrdinary(__table1.id, _CAST([0]_Array(UInt64), 'Array(UInt64)'_String), 1_UInt8)` while the shards returned `__groupingOrdinary(__table1.id, [0]_Array(UInt64), 1_UInt8)`. The setting matters because `GROUP BY` on the sharding key sends the query up to `WithMergeableStateAfterAggregation(AndLimit)`, so a shard computes the grouping column itself instead of returning aggregate states for the initiator to finalize.

An action node name for a constant is built one of two ways. The initiator wraps the constant in `_CAST` whenever converting it to AST would (that is how it will be written into the query text sent to the shards). A shard, where AST level optimization is off, simulates that naming for a constant folded from a `_CAST` it received, and otherwise names the constant plainly — which is wrong for a constant that never came from the query text at all, because a query tree pass built it on the shard the same way as on the initiator. The index mask that `GroupingFunctionsResolvePass` adds as an argument of `__groupingOrdinary` is such a constant, and being an array it always needs the cast, so the two names never matched. Name a constant without a source expression exactly as the initiator does. A literal that does come from the query text is unaffected: the ones that need a cast arrive as `_CAST(...)` and therefore have a source expression, and the rest need no cast, so their name is the same either way.

Only the shard side changes, so a shard with this fix agrees with an initiator of either version.

The `grouping` specializations started carrying these constants as trailing arguments in https://github.com/ClickHouse/ClickHouse/pull/114950, which is what exposed the naming asymmetry.

New test: `05195_grouping_distributed_skip_unused_shards`. Verified in both directions, and a differential run of the `grouping`/`rollup`/`cube`/`distributed`/`shard`/`explain`/`constant` stateless tests (886 tests) shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119156
Related: https://github.com/ClickHouse/ClickHouse/pull/114950

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119273&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119273](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119273+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
