### PR TITLE
Revert "Revert "Check access rights in the TimeSeries table functions""

### DIFF
--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -105,6 +105,10 @@ StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(A
 
     time_series_storage_id = context->resolveStorageID(time_series_storage_id);
 
+    /// The column types below are read from the TimeSeries table, so reaching them requires what
+    /// describing that table requires.
+    checkAccessToTimeSeriesTable(time_series_storage_id, context, AccessType::SHOW_COLUMNS);
+
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(time_series_storage_id, context));
     checkTimeSeriesVersionSupportedByPromQL(*time_series_storage);
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(context, false);
@@ -188,7 +192,16 @@ void StoragePrometheusQuery::readImpl(
     size_t /* max_block_size */,
     size_t /* num_streams */)
 {
+    /// Authorized here rather than where this storage is created, so that a persistent table built over this
+    /// table function is authorized on every read, with the reader's own grants. Before the table is
+    /// resolved, so that an unauthorized reader learns nothing about it.
+    checkAccessToTimeSeriesTable(config.evaluation_settings.time_series_storage_id, context, AccessType::SELECT);
+
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(config.evaluation_settings.time_series_storage_id, context));
+
+    /// The resolved storage names itself, and that is the table the rows below are read from.
+    checkAccessToTimeSeriesTable(time_series_storage->getStorageID(), context, AccessType::SELECT);
+
     checkTimeSeriesVersionSupportedByPromQL(*time_series_storage);
 
     LOG_INFO(log, "Building SQL to evaluate promql: {}", *config.promql_query);

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -1,5 +1,8 @@
 #include <Storages/StorageTimeSeries.h>
 
+#include <Access/Common/AccessFlags.h>
+#include <Access/Common/RowPolicyDefs.h>
+#include <Access/EnabledRowPolicies.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <Core/Settings.h>
@@ -21,6 +24,7 @@
 #include <Backups/IBackup.h>
 #include <Backups/RestorerFromBackup.h>
 #include <Storages/AlterCommands.h>
+#include <Storages/StorageAlias.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/TimeSeries/TimeSeriesSink.h>
 #include <Storages/TimeSeries/TimeSeriesSettings.h>
@@ -49,6 +53,7 @@ namespace TimeSeriesSetting
 
 namespace ErrorCodes
 {
+    extern const int ACCESS_DENIED;
     extern const int INCORRECT_QUERY;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
@@ -344,6 +349,20 @@ StorageID StorageTimeSeries::tryGetTargetTableID(ViewTarget::Kind target_kind, c
     if (auto target_table = tryGetTargetTable(target_kind, local_context))
         return target_table->getStorageID();
     return StorageID::createEmpty();
+}
+
+StorageID StorageTimeSeries::tryGetConfiguredExternalTargetTableID(ViewTarget::Kind target_kind, const ContextPtr & local_context) const
+{
+    const auto * target = tryGetTarget(target_kind);
+
+    /// An inner target carries a UUID or nothing at all, and the name of a non-Atomic one is derived from
+    /// this table's own identity, so in either case there is no separate name a grant could be written on.
+    if (!target || target->table_id.table_name.empty())
+        return StorageID::createEmpty();
+
+    /// The same resolution getTargetTableImpl() performs, so the two cannot disagree about which table the
+    /// configured name means.
+    return local_context->tryResolveStorageID(target->table_id);
 }
 
 bool StorageTimeSeries::isInnerTable(ViewTarget::Kind target_kind) const
@@ -782,6 +801,54 @@ std::shared_ptr<const StorageTimeSeries> storagePtrToTimeSeries(ConstStoragePtr 
         ErrorCodes::UNEXPECTED_TABLE_ENGINE,
         "This operation can be executed on a TimeSeries table only, the engine of table {} is not TimeSeries",
         storage->getStorageID().getNameForLogs());
+}
+
+
+void checkAccessToTimeSeriesTable(const StorageID & time_series_storage_id, const ContextPtr & context, AccessType access_type)
+{
+    context->checkAccess(access_type, time_series_storage_id);
+
+    if (access_type != AccessType::SELECT)
+        return;
+
+    auto row_policy_filter = context->getRowPolicyFilter(
+        time_series_storage_id.getDatabaseName(), time_series_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+    /// The rows are the target table's, and its columns are not the TimeSeries table's, so a filter written
+    /// against the latter has nothing here to evaluate against and cannot be translated.
+    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
+        throw Exception(
+            ErrorCodes::ACCESS_DENIED,
+            "A row policy is defined on table {}, and it cannot be enforced on the rows returned by this table "
+            "function because they belong to a target table with different columns",
+            time_series_storage_id.getNameForLogs());
+}
+
+
+void checkAccessToTimeSeriesTargetTable(
+    const StoragePtr & target_table, const ContextPtr & context, AccessType access_type, const String & column)
+{
+    if (column.empty())
+        context->checkAccess(access_type, target_table->getStorageID());
+    else
+        context->checkAccess(access_type, target_table->getStorageID(), column);
+
+    if (const auto * alias = target_table->as<StorageAlias>();
+        alias && !alias->isTargetTableGranted(context, access_type, column))
+        throw Exception(
+            ErrorCodes::ACCESS_DENIED,
+            "Not enough privileges to access the table that {} points to",
+            target_table->getStorageID().getNameForLogs());
+}
+
+
+void checkAccessToTimeSeriesTargetTableID(
+    const StorageID & target_table_id, const ContextPtr & context, AccessType access_type, const String & column)
+{
+    if (column.empty())
+        context->checkAccess(access_type, target_table_id);
+    else
+        context->checkAccess(access_type, target_table_id, column);
 }
 
 

--- a/src/Storages/StorageTimeSeries.h
+++ b/src/Storages/StorageTimeSeries.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Access/Common/AccessType.h>
 #include <Parsers/ASTViewTargets.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage_fwd.h>
@@ -51,6 +52,10 @@ public:
     StoragePtr tryGetTargetTable(ViewTarget::Kind target_kind, const ContextPtr & local_context) const;
     StorageID getTargetTableID(ViewTarget::Kind target_kind, const ContextPtr & local_context) const;
     StorageID tryGetTargetTableID(ViewTarget::Kind target_kind, const ContextPtr & local_context) const;
+
+    /// The identity a target is configured with, resolved to a database and a name but not looked up in the
+    /// catalog. Empty for an inner target, which has no name of its own, and for an absent optional target.
+    StorageID tryGetConfiguredExternalTargetTableID(ViewTarget::Kind target_kind, const ContextPtr & local_context) const;
 
     bool isInnerTable(ViewTarget::Kind target_kind) const;
     bool hasInnerTables() const { return has_inner_tables; }
@@ -150,5 +155,23 @@ private:
 
 std::shared_ptr<StorageTimeSeries> storagePtrToTimeSeries(StoragePtr storage);
 std::shared_ptr<const StorageTimeSeries> storagePtrToTimeSeries(ConstStoragePtr storage);
+
+/// Checks that the current user is allowed to reach a TimeSeries table through a table function.
+/// A row policy on a TimeSeries table is not enforceable on the rows such a function returns, so in the
+/// read direction this fails closed instead of silently returning rows the policy hides.
+void checkAccessToTimeSeriesTable(const StorageID & time_series_storage_id, const ContextPtr & context, AccessType access_type);
+
+/// Checks that the current user is allowed to reach a target table of a TimeSeries table through a table
+/// function. An `Alias` target exposes the data and metadata of another table, which a grant on the alias
+/// itself does not cover.
+/// An empty `column` checks the target as a whole, naming one checks that column alone.
+void checkAccessToTimeSeriesTargetTable(
+    const StoragePtr & target_table, const ContextPtr & context, AccessType access_type, const String & column = {});
+
+/// Checks a target's configured identity before the catalog is consulted, so that whether that target exists
+/// is itself covered by the grant on it. Grant-only: the `Alias` leg needs the resolved storage and stays in
+/// checkAccessToTimeSeriesTargetTable, which authorizes the identity the name resolved to.
+void checkAccessToTimeSeriesTargetTableID(
+    const StorageID & target_table_id, const ContextPtr & context, AccessType access_type, const String & column = {});
 
 }

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -132,12 +132,25 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
 
     time_series_storage_id = context->resolveStorageID(time_series_storage_id);
 
+    /// The types below are read from the TimeSeries table, so reaching them requires what describing that
+    /// table requires.
+    checkAccessToTimeSeriesTable(time_series_storage_id, context, AccessType::SHOW_COLUMNS);
+
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(time_series_storage_id, context));
     checkTimeSeriesVersionSupportedByPromQL(*time_series_storage);
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(context, false);
     auto [timestamp_data_type, scalar_data_type] = splitTimeSeriesType(
         time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type);
+    /// Only the id column of the tags target is read below, and the rows this function returns come from a
+    /// query it generates, which authorizes that target per column. Checked before the lookup, because
+    /// looking a name up reports whether that target exists, which is its metadata and not the parent's.
+    if (auto configured_tags_target_id = time_series_storage->tryGetConfiguredExternalTargetTableID(ViewTarget::Tags, context);
+        !configured_tags_target_id.empty())
+        checkAccessToTimeSeriesTargetTableID(
+            configured_tags_target_id, context, AccessType::SHOW_COLUMNS, TimeSeriesColumnNames::ID);
+
     auto tags_target = time_series_storage->getTargetTable(ViewTarget::Tags, context);
+    checkAccessToTimeSeriesTargetTable(tags_target, context, AccessType::SHOW_COLUMNS, TimeSeriesColumnNames::ID);
     auto tags_target_metadata = tags_target->getInMemoryMetadataPtr(context, false);
     DataTypePtr id_data_type = tags_target_metadata->columns.get(TimeSeriesColumnNames::ID).type;
 
@@ -823,7 +836,16 @@ void StorageTimeSeriesSelector::readImpl(
     size_t /* max_block_size */,
     size_t /* num_streams */)
 {
+    /// Authorized here rather than where this storage is created, so that a persistent table built over this
+    /// table function is authorized on every read, with the reader's own grants. Before the table is
+    /// resolved, so that an unauthorized reader learns nothing about it.
+    checkAccessToTimeSeriesTable(config.time_series_storage_id, context, AccessType::SELECT);
+
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(config.time_series_storage_id, context));
+
+    /// The resolved storage names itself, and that is the table the rows below are read from.
+    checkAccessToTimeSeriesTable(time_series_storage->getStorageID(), context, AccessType::SELECT);
+
     checkTimeSeriesVersionSupportedByPromQL(*time_series_storage);
     auto time_series_settings = time_series_storage->getStorageSettings();
 

--- a/src/TableFunctions/TableFunctionTimeSeries.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeries.cpp
@@ -69,15 +69,30 @@ void TableFunctionTimeSeriesTarget<target_kind>::parseArguments(const ASTPtr & a
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Couldn't get a table name from the arguments of the {} table function", name);
 
     time_series_storage_id = context->resolveStorageID(time_series_storage_id);
-    target_table_type_name = getTargetTable(context)->getName();
+
+    /// The engine of the TimeSeries table, the name of its target and that target's own engine are read
+    /// below, so reaching them requires what describing those two tables requires. The target's engine
+    /// also selects the source privilege this table function is checked against.
+    checkAccessToTimeSeriesTable(time_series_storage_id, context, AccessType::SHOW_COLUMNS);
+    auto target_table = getAuthorizedTargetTable(context, AccessType::SHOW_COLUMNS);
+    target_table_type_name = target_table->getName();
 }
 
 
 template <ViewTarget::Kind target_kind>
-StoragePtr TableFunctionTimeSeriesTarget<target_kind>::getTargetTable(const ContextPtr & context) const
+StoragePtr TableFunctionTimeSeriesTarget<target_kind>::getAuthorizedTargetTable(const ContextPtr & context, AccessType access_type) const
 {
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(time_series_storage_id, context));
-    return time_series_storage->getTargetTable(target_kind, context);
+
+    /// Before the lookup, because looking a name up reports whether it exists, and that is the target's
+    /// metadata rather than the TimeSeries table's.
+    if (auto configured_target_table_id = time_series_storage->tryGetConfiguredExternalTargetTableID(target_kind, context);
+        !configured_target_table_id.empty())
+        checkAccessToTimeSeriesTargetTableID(configured_target_table_id, context, access_type);
+
+    auto target_table = time_series_storage->getTargetTable(target_kind, context);
+    checkAccessToTimeSeriesTargetTable(target_table, context, access_type);
+    return target_table;
 }
 
 
@@ -87,15 +102,22 @@ StoragePtr TableFunctionTimeSeriesTarget<target_kind>::executeImpl(
         ContextPtr context,
         const String & /* table_name */,
         ColumnsDescription /* cached_columns */,
-        bool /* is_insert_query */) const
+        bool is_insert_query) const
 {
-    return getTargetTable(context);
+    /// Both tables, because the equivalent direct operation on the TimeSeries table authorizes both:
+    /// the TimeSeries table the user named, and the target table its rows actually come from.
+    const auto access_type = is_insert_query ? AccessType::INSERT : AccessType::SELECT;
+    checkAccessToTimeSeriesTable(time_series_storage_id, context, access_type);
+    return getAuthorizedTargetTable(context, access_type);
 }
 
 template <ViewTarget::Kind target_kind>
 ColumnsDescription TableFunctionTimeSeriesTarget<target_kind>::getActualTableStructure(ContextPtr context, bool /* is_insert_query */) const
 {
-    auto metadata_snapshot = getTargetTable(context)->getInMemoryMetadataPtr(context, false);
+    /// Resolving a table structure is a read operation whatever the direction of the enclosing query.
+    checkAccessToTimeSeriesTable(time_series_storage_id, context, AccessType::SHOW_COLUMNS);
+    auto target_table = getAuthorizedTargetTable(context, AccessType::SHOW_COLUMNS);
+    auto metadata_snapshot = target_table->getInMemoryMetadataPtr(context, false);
     return metadata_snapshot->columns;
 }
 

--- a/src/TableFunctions/TableFunctionTimeSeries.h
+++ b/src/TableFunctions/TableFunctionTimeSeries.h
@@ -33,7 +33,14 @@ private:
     ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
     const char * getStorageEngineName() const override;
 
-    StoragePtr getTargetTable(const ContextPtr & context) const;
+    /// This function hands back a pre-existing table that stores data on disk, which a persistent table
+    /// cannot proxy: the proxy renames that table in memory on its first read and then violates its own
+    /// assumption that a table function stores no data.
+    bool canBeUsedToCreateTable() const override { return false; }
+
+    /// Authorizes the target by the name the TimeSeries table configures and by the identity that name
+    /// resolves to, so neither a hidden target nor a rename escapes the check.
+    StoragePtr getAuthorizedTargetTable(const ContextPtr & context, AccessType access_type) const;
 
     StorageID time_series_storage_id = StorageID::createEmpty();
     String target_table_type_name;

--- a/tests/queries/0_stateless/05045_timeseries_table_function_access_check.reference
+++ b/tests/queries/0_stateless/05045_timeseries_table_function_access_check.reference
@@ -1,0 +1,21 @@
+describe with SHOW COLUMNS on both tables
+id	UInt64					
+timestamp	DateTime64(3)					
+value	Float64					
+File target: denial names the target
+File target: no source privilege named
+select with SELECT on both tables
+1	42
+selector, prometheusQuery and the persistent tables over them
+0
+3
+0
+3
+select under an always-true row policy
+1	42
+select again after the row policy is dropped
+1	42
+rows after the insert
+2
+the target table still exists under its own name
+1

--- a/tests/queries/0_stateless/05045_timeseries_table_function_access_check.sh
+++ b/tests/queries/0_stateless/05045_timeseries_table_function_access_check.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# no-fasttest: the timeSeriesSelector() and prometheusQuery() arms parse PromQL, which needs ANTLR4.
+# no-replicated-database: on a replicated database the DDL runs with no user, so an access check
+#                         asserted here is a no-op and the deny arms silently pass (issue #111561).
+
+# Reaching a TimeSeries table through a table function requires the privileges the equivalent direct
+# operation requires: on the TimeSeries table named in the call, and on the target table the rows or the
+# column definitions actually come from.
+
+# Statements are batched per client on purpose: this file's runtime is client startup, not query work,
+# and one file holding these arms and 05137's together runs past the 180-second limit under asan+ubsan.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user05045_${CLICKHOUSE_DATABASE}_$RANDOM"
+policy="policy05045_${CLICKHOUSE_DATABASE}"
+db=${CLICKHOUSE_DATABASE}
+
+CLIENT_TS="${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table 1"
+
+${CLIENT_TS} <<EOF
+CREATE TABLE $db.ts_samples (id UInt64, timestamp DateTime64(3), value Float64)
+    ENGINE = MergeTree ORDER BY (id, timestamp);
+CREATE TABLE $db.ts_tags (id UInt64, metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String), min_time DateTime64(3), max_time DateTime64(3))
+    ENGINE = MergeTree ORDER BY id;
+CREATE TABLE $db.ts_metrics (metric_family_name String, type String, unit String, help String)
+    ENGINE = ReplacingMergeTree ORDER BY metric_family_name;
+CREATE TABLE $db.ts ENGINE = TimeSeries DATA $db.ts_samples TAGS $db.ts_tags METRICS $db.ts_metrics;
+INSERT INTO $db.ts_samples VALUES (1, '2026-01-01 00:00:00.000', 42);
+
+CREATE TABLE $db.ts_samples_hidden (id UInt64, timestamp DateTime64(3), value Float64)
+    ENGINE = MergeTree ORDER BY (id, timestamp);
+CREATE TABLE $db.ts_samples_alias ENGINE = Alias('$db', 'ts_samples_hidden');
+CREATE TABLE $db.ts_via_alias ENGINE = TimeSeries
+    DATA $db.ts_samples_alias TAGS $db.ts_tags METRICS $db.ts_metrics;
+
+CREATE TABLE $db.f_samples (id UInt64, timestamp DateTime64(3), value Float64) ENGINE = File(TSV);
+CREATE TABLE $db.ts_file ENGINE = TimeSeries
+    DATA $db.f_samples TAGS $db.ts_tags METRICS $db.ts_metrics;
+
+-- Two TimeSeries tables whose external target is configured and then dropped: one on the data target,
+-- one on the tags target that timeSeriesSelector() reads its id type from.
+CREATE TABLE $db.samples_gone (id UInt64, timestamp DateTime64(3), value Float64)
+    ENGINE = MergeTree ORDER BY (id, timestamp);
+CREATE TABLE $db.ts_gone ENGINE = TimeSeries
+    DATA $db.samples_gone TAGS $db.ts_tags METRICS $db.ts_metrics;
+CREATE TABLE $db.tags_gone (id UInt64, metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String), min_time DateTime64(3), max_time DateTime64(3))
+    ENGINE = MergeTree ORDER BY id;
+CREATE TABLE $db.ts_tags_gone ENGINE = TimeSeries
+    DATA $db.ts_samples TAGS $db.tags_gone METRICS $db.ts_metrics;
+DROP TABLE $db.samples_gone;
+DROP TABLE $db.tags_gone;
+
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+EOF
+
+CLIENT_USER="${CLICKHOUSE_CLIENT} --user $user"
+
+${CLIENT_USER} <<EOF
+-- With no grants at all, a direct DESCRIBE is refused; so is every table function reaching the same table.
+DESCRIBE $db.ts FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesTags($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesMetrics($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE prometheusQuery($db.ts, 'up', 1000) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE prometheusQueryRange($db.ts, 'up', 1000, 2000, 60) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+INSERT INTO FUNCTION timeSeriesSamples($db.ts) SELECT toUInt64(2), toDateTime64('2026-01-01 00:00:02.000', 3), toFloat64(7); -- { serverError ACCESS_DENIED }
+
+-- Reading the engine of the named table and the name of its target is refused too, so the argument a
+-- caller may not describe cannot be told apart from one holding a different engine. Each function
+-- resolves its argument in its own code, so each is checked here.
+SELECT * FROM timeSeriesSamples($db.ts_samples) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesSelector($db.ts_samples, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE prometheusQuery($db.ts_samples, '1 + 2', 1000) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+${CLIENT_TS} <<EOF
+SELECT * FROM timeSeriesSamples($db.ts_samples) FORMAT Null; -- { serverError UNEXPECTED_TABLE_ENGINE }
+DESCRIBE timeSeriesSelector($db.ts_samples, 'up', 0, 9999999999) FORMAT Null; -- { serverError UNEXPECTED_TABLE_ENGINE }
+DESCRIBE prometheusQuery($db.ts_samples, '1 + 2', 1000) FORMAT Null; -- { serverError UNEXPECTED_TABLE_ENGINE }
+
+-- Granting the target tables is not enough: the TimeSeries table named in the call is checked as well.
+GRANT SELECT, INSERT, SHOW COLUMNS ON $db.ts_samples TO $user;
+EOF
+
+${CLIENT_USER} <<EOF
+DESCRIBE timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+INSERT INTO FUNCTION timeSeriesSamples($db.ts) SELECT toUInt64(2), toDateTime64('2026-01-01 00:00:02.000', 3), toFloat64(7); -- { serverError ACCESS_DENIED }
+EOF
+
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT, SHOW COLUMNS ON $db.ts_tags TO $user"
+
+${CLIENT_USER} <<EOF
+SELECT * FROM timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM prometheusQuery($db.ts, '1 + 2', 1000) FORMAT Null; -- { serverError ACCESS_DENIED }
+-- timeSeriesSelector() reads column types from the TimeSeries table as well as from its tags target,
+-- so holding the tags target alone does not describe it.
+DESCRIBE timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+# A persistent table built over timeSeriesSelector() is authorized on every read, not once at creation,
+# so holding only the privilege that creating it needed does not make it readable.
+${CLICKHOUSE_CLIENT} <<EOF
+GRANT CREATE TABLE ON $db.* TO $user;
+GRANT SELECT ON $db.sel_dst TO $user;
+GRANT SELECT ON $db.pq_dst TO $user;
+GRANT SHOW COLUMNS ON $db.ts TO $user;
+EOF
+
+${CLIENT_USER} <<EOF
+CREATE TABLE $db.sel_dst AS timeSeriesSelector($db.ts, 'up', 0, 9999999999);
+SELECT * FROM $db.sel_dst FORMAT Null; -- { serverError ACCESS_DENIED }
+-- prometheusQuery() is a separate storage, authorized in its own read path, so it needs its own case.
+CREATE TABLE $db.pq_dst AS prometheusQuery($db.ts, '1 + 2', 1000);
+SELECT * FROM $db.pq_dst FORMAT Null; -- { serverError ACCESS_DENIED }
+-- reading it directly is refused for the same reason: describing the TimeSeries table is not reading it.
+SELECT * FROM timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM prometheusQuery($db.ts, '1 + 2', 1000) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+# Symmetrically, granting only the TimeSeries table is not enough either.
+${CLICKHOUSE_CLIENT} <<EOF
+REVOKE SELECT, INSERT, SHOW COLUMNS ON $db.ts_samples FROM $user;
+REVOKE SELECT, SHOW COLUMNS ON $db.ts_tags FROM $user;
+GRANT SELECT, INSERT, SHOW COLUMNS ON $db.ts TO $user;
+EOF
+
+${CLIENT_USER} <<EOF
+DESCRIBE timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+INSERT INTO FUNCTION timeSeriesSamples($db.ts) SELECT toUInt64(2), toDateTime64('2026-01-01 00:00:02.000', 3), toFloat64(7); -- { serverError ACCESS_DENIED }
+-- and symmetrically for the tags target that timeSeriesSelector() reads its id type from.
+DESCRIBE timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+# SHOW COLUMNS on both tables describes, but does not read.
+${CLICKHOUSE_CLIENT} -q "GRANT SHOW COLUMNS ON $db.ts_samples TO $user"
+echo 'describe with SHOW COLUMNS on both tables'
+${CLIENT_USER} <<EOF
+DESCRIBE timeSeriesSamples($db.ts) FORMAT TSV;
+SELECT * FROM timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+-- describe_include_virtual_columns resolves the structure through the data path, which needs SELECT.
+DESCRIBE timeSeriesSamples($db.ts) SETTINGS describe_include_virtual_columns = 1 FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+# An Alias target exposes another table's metadata, so that table is checked too. Nothing grants this
+# user on ts_samples_hidden, which is what ts_samples_alias points at.
+${CLICKHOUSE_CLIENT} <<EOF
+GRANT SHOW COLUMNS ON $db.ts_via_alias TO $user;
+GRANT SHOW COLUMNS ON $db.ts_samples_alias TO $user;
+EOF
+${CLIENT_USER} -q "DESCRIBE timeSeriesSamples($db.ts_via_alias) FORMAT Null; -- { serverError ACCESS_DENIED }"
+
+# A target's engine selects the source privilege the call is checked against, so the target is checked
+# before that engine is read: nothing here ever grants on f_samples, and the denial names it rather than
+# the source privilege its File engine would ask for.
+${CLICKHOUSE_CLIENT} -q "GRANT SHOW COLUMNS ON $db.ts_file TO $user"
+file_denial=$(${CLIENT_USER} -q "DESCRIBE timeSeriesSamples($db.ts_file) FORMAT Null" 2>&1)
+echo "$file_denial" | grep -q "SHOW COLUMNS ON $db.f_samples" \
+    && echo 'File target: denial names the target' || echo "File target: UNEXPECTED [$file_denial]"
+echo "$file_denial" | grep -q 'READ ON FILE' \
+    && echo "File target: UNEXPECTED source privilege [$file_denial]" || echo 'File target: no source privilege named'
+
+# With both tables granted, every function works as before.
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT ON $db.ts_samples TO $user"
+echo 'select with SELECT on both tables'
+${CLIENT_USER} -q "SELECT id, value FROM timeSeriesSamples($db.ts) ORDER BY id FORMAT TSV"
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT, SHOW COLUMNS ON $db.ts_tags TO $user"
+echo 'selector, prometheusQuery and the persistent tables over them'
+${CLIENT_USER} <<EOF
+SELECT count() FROM timeSeriesSelector($db.ts, 'up', 0, 9999999999);
+SELECT value FROM prometheusQuery($db.ts, '1 + 2', 1000) FORMAT TSV;
+SELECT count() FROM $db.sel_dst;
+SELECT value FROM $db.pq_dst FORMAT TSV;
+DESCRIBE timeSeriesSamples($db.ts) SETTINGS describe_include_virtual_columns = 1 FORMAT Null;
+EOF
+
+# A row policy on the TimeSeries table cannot be enforced on the target table's rows, so the read fails
+# closed while such a policy hides rows, and works again once it is dropped. The two siblings hold that
+# contract in their own read paths, so each is refused on its own; both tables are read successfully above.
+# It is the effective filter that decides, not a policy existing: an always-true one hides nothing.
+${CLICKHOUSE_CLIENT} -q "CREATE ROW POLICY $policy ON $db.ts FOR SELECT USING 1 TO $user"
+echo 'select under an always-true row policy'
+${CLIENT_USER} -q "SELECT id, value FROM timeSeriesSamples($db.ts) ORDER BY id FORMAT TSV"
+${CLICKHOUSE_CLIENT} -q "ALTER ROW POLICY $policy ON $db.ts FOR SELECT USING 0"
+${CLIENT_USER} <<EOF
+SELECT * FROM timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM $db.sel_dst FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM $db.pq_dst FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+${CLICKHOUSE_CLIENT} -q "DROP ROW POLICY $policy ON $db.ts"
+echo 'select again after the row policy is dropped'
+${CLIENT_USER} <<EOF
+SELECT id, value FROM timeSeriesSamples($db.ts) ORDER BY id FORMAT TSV;
+-- The write direction needs INSERT on both tables. Holding SELECT on the target and INSERT on the
+-- TimeSeries table only is not enough, which is what separates the two directions.
+INSERT INTO FUNCTION timeSeriesSamples($db.ts) SELECT toUInt64(2), toDateTime64('2026-01-01 00:00:02.000', 3), toFloat64(7); -- { serverError ACCESS_DENIED }
+EOF
+${CLICKHOUSE_CLIENT} -q "GRANT INSERT ON $db.ts_samples TO $user"
+${CLIENT_USER} -q "INSERT INTO FUNCTION timeSeriesSamples($db.ts) SELECT toUInt64(2), toDateTime64('2026-01-01 00:00:02.000', 3), toFloat64(7)"
+echo 'rows after the insert'
+${CLICKHOUSE_CLIENT} <<EOF
+SELECT count() FROM $db.ts_samples;
+-- and symmetrically for the TimeSeries table: holding INSERT on the target alone does not write either.
+REVOKE INSERT ON $db.ts FROM $user;
+GRANT SELECT, INSERT, SHOW COLUMNS ON $db.ts_gone TO $user;
+GRANT SHOW COLUMNS ON $db.ts_tags_gone TO $user;
+EOF
+${CLIENT_USER} -q "INSERT INTO FUNCTION timeSeriesSamples($db.ts) SELECT toUInt64(3), toDateTime64('2026-01-01 00:00:03.000', 3), toFloat64(9); -- { serverError ACCESS_DENIED }"
+
+# Whether a target exists is that target's own metadata, so a caller holding the TimeSeries table but not
+# the target is refused before the catalog is consulted, and cannot tell a missing target from a hidden one.
+# Nothing here ever grants on samples_gone or tags_gone, which are the dropped targets.
+${CLIENT_USER} <<EOF
+DESCRIBE timeSeriesSamples($db.ts_gone) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM timeSeriesSamples($db.ts_gone) FORMAT Null; -- { serverError ACCESS_DENIED }
+INSERT INTO FUNCTION timeSeriesSamples($db.ts_gone) SELECT toUInt64(1), toDateTime64('2026-01-01 00:00:01.000', 3), toFloat64(1); -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesSelector($db.ts_tags_gone, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+# A caller entitled to the target still learns that it is missing: the check narrows what is disclosed
+# rather than hiding breakage from whoever may see it.
+${CLICKHOUSE_CLIENT} -q "GRANT SHOW COLUMNS ON $db.samples_gone TO $user"
+${CLIENT_USER} -q "DESCRIBE timeSeriesSamples($db.ts_gone) FORMAT Null; -- { serverError UNKNOWN_TABLE }"
+
+# These three functions hand back a pre-existing table that stores data on disk, which cannot back a
+# persistent table.
+${CLIENT_TS} -q "CREATE TABLE $db.dst AS timeSeriesSamples($db.ts); -- { serverError BAD_ARGUMENTS }"
+echo 'the target table still exists under its own name'
+${CLICKHOUSE_CLIENT} <<EOF
+EXISTS $db.ts_samples;
+DROP USER IF EXISTS $user;
+EOF

--- a/tests/queries/0_stateless/05137_timeseries_table_function_target_grants.reference
+++ b/tests/queries/0_stateless/05137_timeseries_table_function_target_grants.reference
@@ -1,0 +1,18 @@
+selector with a column-scoped grant on the tags target
+id	UInt64					
+timestamp	DateTime64(3)					
+value	Float64					
+0
+and again with one of those columns revoked
+id	UInt64					
+timestamp	DateTime64(3)					
+value	Float64					
+ids read directly with a column-scoped grant on the samples target
+1
+2
+ids read through an Alias target with a column-scoped grant on the table behind it
+5
+selector over an Alias tags target, granted the id column on the alias and on its target
+id,timestamp,value
+selector over an inner tags target, granted its id column
+id,timestamp,value

--- a/tests/queries/0_stateless/05137_timeseries_table_function_target_grants.sh
+++ b/tests/queries/0_stateless/05137_timeseries_table_function_target_grants.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# no-fasttest: the timeSeriesSelector() and prometheusQuery() arms parse PromQL, which needs ANTLR4.
+# no-replicated-database: on a replicated database the DDL runs with no user, so an access check
+#                         asserted here is a no-op and the deny arms silently pass (issue #111561).
+
+# The second half of 05045: a persistent table built over one of these functions, and the grants that
+# are checked on a target table rather than on the TimeSeries table itself.
+
+# Statements are batched per client on purpose: these files' runtime is client startup, not query work,
+# and holding both halves in one file runs past the 180-second limit under asan+ubsan.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user05137_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+CLIENT_TS="${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table 1"
+CLIENT_USER="${CLICKHOUSE_CLIENT} --user $user"
+
+# Only the tables the arms below read, and a user holding nothing on them: every grant an arm needs, it
+# makes itself, so that what each one proves is visible where it is written.
+${CLIENT_TS} <<EOF
+CREATE TABLE $db.ts_samples (id UInt64, timestamp DateTime64(3), value Float64)
+    ENGINE = MergeTree ORDER BY (id, timestamp);
+CREATE TABLE $db.ts_tags (id UInt64, metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String), min_time DateTime64(3), max_time DateTime64(3))
+    ENGINE = MergeTree ORDER BY id;
+CREATE TABLE $db.ts_metrics (metric_family_name String, type String, unit String, help String)
+    ENGINE = ReplacingMergeTree ORDER BY metric_family_name;
+CREATE TABLE $db.ts ENGINE = TimeSeries DATA $db.ts_samples TAGS $db.ts_tags METRICS $db.ts_metrics;
+INSERT INTO $db.ts_samples VALUES (1, '2026-01-01 00:00:00.000', 42), (2, '2026-01-01 00:00:02.000', 7);
+
+CREATE TABLE $db.ts_samples_hidden (id UInt64, timestamp DateTime64(3), value Float64)
+    ENGINE = MergeTree ORDER BY (id, timestamp);
+CREATE TABLE $db.ts_samples_alias ENGINE = Alias('$db', 'ts_samples_hidden');
+CREATE TABLE $db.ts_via_alias ENGINE = TimeSeries
+    DATA $db.ts_samples_alias TAGS $db.ts_tags METRICS $db.ts_metrics;
+
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+EOF
+
+# A persistent table over these functions authorizes its TimeSeries table on each read, and whether that
+# table is still the one the persistent table was built over is covered by the grant on it too: the reader
+# granted on the persistent table alone is refused the same way once the TimeSeries table is dropped, or
+# renamed so that only its stored id resolves. Both storages keep that order in their own read path.
+${CLIENT_TS} <<EOF
+CREATE TABLE $db.ts_src_gone ENGINE = TimeSeries
+    DATA $db.ts_samples TAGS $db.ts_tags METRICS $db.ts_metrics;
+CREATE TABLE $db.ts_src_ren ENGINE = TimeSeries
+    DATA $db.ts_samples TAGS $db.ts_tags METRICS $db.ts_metrics;
+CREATE TABLE $db.sel_src_gone AS timeSeriesSelector($db.ts_src_gone, 'up', 0, 9999999999);
+CREATE TABLE $db.pq_src_gone AS prometheusQuery($db.ts_src_gone, '1 + 2', 1000);
+CREATE TABLE $db.sel_src_ren AS timeSeriesSelector($db.ts_src_ren, 'up', 0, 9999999999);
+GRANT SELECT ON $db.sel_src_gone TO $user;
+GRANT SELECT ON $db.pq_src_gone TO $user;
+GRANT SELECT ON $db.sel_src_ren TO $user;
+EOF
+${CLIENT_USER} <<EOF
+SELECT * FROM $db.sel_src_gone FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM $db.pq_src_gone FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+${CLICKHOUSE_CLIENT} <<EOF
+DROP TABLE $db.ts_src_gone;
+RENAME TABLE $db.ts_src_ren TO $db.ts_src_ren_new;
+EOF
+${CLIENT_USER} <<EOF
+SELECT * FROM $db.sel_src_gone FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM $db.pq_src_gone FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+# Separately, so that a regression here is reported as its own failure rather than skipped behind one above.
+${CLIENT_USER} -q "SELECT * FROM $db.sel_src_ren FORMAT Null; -- { serverError ACCESS_DENIED }"
+# and a reader entitled to it is told what became of it instead.
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT ON $db.ts_src_gone TO $user"
+${CLIENT_USER} -q "SELECT * FROM $db.sel_src_gone FORMAT Null; -- { serverError UNKNOWN_TABLE }"
+${CLICKHOUSE_CLIENT} -q "REVOKE SELECT ON $db.ts_src_gone FROM $user"
+
+# timeSeriesSelector() reads one column of the tags target, its id, so a grant on that column is enough
+# for it: what the generated query reads is authorized by that query, per column, which the last arm here
+# pins by revoking a single column the query needs. No SHOW COLUMNS is granted on the tags target below;
+# SELECT on a column implies it for that column.
+user_tags_cols="user05045c_${CLICKHOUSE_DATABASE}_$RANDOM"
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user_tags_cols;
+CREATE USER $user_tags_cols;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user_tags_cols;
+GRANT SELECT, SHOW COLUMNS ON $db.ts TO $user_tags_cols;
+GRANT SELECT, SHOW COLUMNS ON $db.ts_samples TO $user_tags_cols;
+GRANT SELECT(id, metric_name, tags, min_time, max_time) ON $db.ts_tags TO $user_tags_cols;
+EOF
+
+echo 'selector with a column-scoped grant on the tags target'
+${CLICKHOUSE_CLIENT} --user "$user_tags_cols" <<EOF
+DESCRIBE timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT TSV;
+SELECT count() FROM timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT TSV;
+EOF
+
+${CLICKHOUSE_CLIENT} -q "REVOKE SELECT(min_time) ON $db.ts_tags FROM $user_tags_cols"
+echo 'and again with one of those columns revoked'
+${CLICKHOUSE_CLIENT} --user "$user_tags_cols" <<EOF
+SELECT count() FROM timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+-- Describing it reads no row of the tags target, so it still works.
+DESCRIBE timeSeriesSelector($db.ts, 'up', 0, 9999999999) FORMAT TSV;
+EOF
+${CLICKHOUSE_CLIENT} -q "DROP USER $user_tags_cols"
+
+# The functions that hand the target table back whole check it whole, so a column-scoped grant on it is
+# not enough for them, however many columns it names: it reads that column directly and gets no further.
+user_target_col="user05045t_${CLICKHOUSE_DATABASE}_$RANDOM"
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user_target_col;
+CREATE USER $user_target_col;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user_target_col;
+GRANT SELECT, SHOW COLUMNS ON $db.ts TO $user_target_col;
+GRANT SELECT(id, timestamp, value) ON $db.ts_samples TO $user_target_col;
+EOF
+echo 'ids read directly with a column-scoped grant on the samples target'
+${CLICKHOUSE_CLIENT} --user "$user_target_col" <<EOF
+SELECT id FROM $db.ts_samples ORDER BY id FORMAT TSV;
+DESCRIBE timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+SELECT * FROM timeSeriesSamples($db.ts) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+${CLICKHOUSE_CLIENT} -q "DROP USER $user_target_col"
+
+# The same holds behind an `Alias` target, where the alias leg carries the rule: this caller holds the
+# alias whole and the table behind it column by column, so it reads that column through the alias and
+# is still refused the target whole.
+user_alias_col="user05045a_${CLICKHOUSE_DATABASE}_$RANDOM"
+${CLICKHOUSE_CLIENT} <<EOF
+INSERT INTO $db.ts_samples_hidden VALUES (5, '2026-01-01 00:00:05.000', 11);
+DROP USER IF EXISTS $user_alias_col;
+CREATE USER $user_alias_col;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user_alias_col;
+GRANT SELECT, SHOW COLUMNS ON $db.ts_via_alias TO $user_alias_col;
+GRANT SELECT, SHOW COLUMNS ON $db.ts_samples_alias TO $user_alias_col;
+GRANT SHOW COLUMNS, SELECT(id) ON $db.ts_samples_hidden TO $user_alias_col;
+EOF
+echo 'ids read through an Alias target with a column-scoped grant on the table behind it'
+${CLICKHOUSE_CLIENT} --user "$user_alias_col" <<EOF
+SELECT id FROM $db.ts_samples_alias ORDER BY id FORMAT TSV;
+SELECT id FROM timeSeriesSamples($db.ts_via_alias) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+${CLICKHOUSE_CLIENT} -q "DROP USER $user_alias_col"
+
+# An `Alias` tags target carries that same column through to the table it points at. Nothing grants on
+# tags_hidden until the last arm here, while the alias itself is granted throughout.
+${CLIENT_TS} <<EOF
+CREATE TABLE $db.tags_hidden (id UInt64, metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String), min_time DateTime64(3), max_time DateTime64(3))
+    ENGINE = MergeTree ORDER BY id;
+CREATE TABLE $db.ts_tags_alias ENGINE = Alias('$db', 'tags_hidden');
+CREATE TABLE $db.ts_via_tags_alias ENGINE = TimeSeries
+    DATA $db.ts_samples TAGS $db.ts_tags_alias METRICS $db.ts_metrics;
+EOF
+${CLICKHOUSE_CLIENT} <<EOF
+GRANT SHOW COLUMNS ON $db.ts_via_tags_alias TO $user;
+GRANT SELECT(id) ON $db.ts_tags_alias TO $user;
+EOF
+${CLIENT_USER} -q "DESCRIBE timeSeriesSelector($db.ts_via_tags_alias, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT(id) ON $db.tags_hidden TO $user"
+echo 'selector over an Alias tags target, granted the id column on the alias and on its target'
+${CLIENT_USER} -q "DESCRIBE timeSeriesSelector($db.ts_via_tags_alias, 'up', 0, 9999999999) FORMAT TSV" | cut -f1 | paste -sd,
+
+# An inner target has no configured name of its own to authorize before the lookup, so there the identity
+# the lookup returns is what the check covers. Nothing grants on this table's inner targets until below.
+${CLIENT_TS} -q "CREATE TABLE $db.ts_inner ENGINE = TimeSeries"
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT, SHOW COLUMNS ON $db.ts_inner TO $user"
+${CLIENT_USER} <<EOF
+DESCRIBE timeSeriesSamples($db.ts_inner) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesTags($db.ts_inner) FORMAT Null; -- { serverError ACCESS_DENIED }
+DESCRIBE timeSeriesSelector($db.ts_inner, 'up', 0, 9999999999) FORMAT Null; -- { serverError ACCESS_DENIED }
+EOF
+
+# An inner table is named after the UUID of the TimeSeries table it belongs to. Granting the tags one the
+# single column the selector reads there describes it, as it does for an external target.
+inner_tags=$(${CLICKHOUSE_CLIENT} -q "SELECT concat('.inner_id.tags.', toString(uuid)) FROM system.tables WHERE database = '$db' AND name = 'ts_inner'")
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT(id) ON $db.\`$inner_tags\` TO $user"
+echo 'selector over an inner tags target, granted its id column'
+${CLIENT_USER} -q "DESCRIBE timeSeriesSelector($db.ts_inner, 'up', 0, 9999999999) FORMAT TSV" | cut -f1 | paste -sd,
+
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS $user"


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#119281

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119282&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119282](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119282+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
