### PR TITLE
Planner: honor use_query_cache contributed via a nested SETTINGS profile

### DIFF
--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -297,10 +297,16 @@ void SettingsConstraints::checkOrClamp(const Settings & current_settings, Settin
 {
     /// If we filter out settings that match the current default here, `compatibility` will silently override them.
     /// So when `compatibility` is present, we keep unchanged settings so they are applied after `compatibility`.
+    /// The same applies to `profile`: a profile applied earlier in the same batch can set a setting to some
+    /// value, and a literal change later in the same clause must still be applied after the profile even if
+    /// it happens to match the value the setting had before the batch started - dropping it as a no-op against
+    /// the pre-batch value would let the profile's value win instead of the explicit override (#119019).
     bool has_compatibility_setting = changes.tryGet("compatibility") != nullptr;
+    bool has_profile_setting = changes.tryGet("profile") != nullptr;
+    bool ignore_unchanged_settings = has_compatibility_setting || has_profile_setting;
     std::erase_if(changes, [&](SettingChange & change)
     {
-        return !checkImpl(current_settings, change, reaction, source, /*ignore_unchanged_settings=*/has_compatibility_setting);
+        return !checkImpl(current_settings, change, reaction, source, /*ignore_unchanged_settings=*/ignore_unchanged_settings);
     });
 }
 

--- a/src/Analyzer/QueryNode.cpp
+++ b/src/Analyzer/QueryNode.cpp
@@ -367,7 +367,8 @@ bool QueryNode::isEqualImpl(const IQueryTreeNode & rhs, CompareOptions options) 
         is_order_by_all == rhs_typed.is_order_by_all &&
         is_limit_by_all == rhs_typed.is_limit_by_all &&
         projection_columns == rhs_typed.projection_columns &&
-        settings_changes == rhs_typed.settings_changes;
+        settings_changes == rhs_typed.settings_changes &&
+        settings_contributed_names == rhs_typed.settings_contributed_names;
 }
 
 void QueryNode::updateTreeHashImpl(HashState & state, CompareOptions options) const
@@ -426,6 +427,13 @@ void QueryNode::updateTreeHashImpl(HashState & state, CompareOptions options) co
         state.update(setting_change_value_dump.size());
         state.update(setting_change_value_dump);
     }
+
+    state.update(settings_contributed_names.size());
+    for (const auto & contributed_name : settings_contributed_names)
+    {
+        state.update(contributed_name.size());
+        state.update(contributed_name);
+    }
 }
 
 QueryTreeNodePtr QueryNode::cloneImpl() const
@@ -448,6 +456,7 @@ QueryTreeNodePtr QueryNode::cloneImpl() const
     result_query_node->cte_name = cte_name;
     result_query_node->projection_columns = projection_columns;
     result_query_node->settings_changes = settings_changes;
+    result_query_node->settings_contributed_names = settings_contributed_names;
     result_query_node->projection_aliases_to_override = projection_aliases_to_override;
 
     return result_query_node;

--- a/src/Analyzer/QueryNode.h
+++ b/src/Analyzer/QueryNode.h
@@ -102,9 +102,30 @@ public:
         return settings_changes;
     }
 
+    /// Get names of settings this query node's SETTINGS clause contributes to its context,
+    /// including via an applied profile. Sorted, for binary_search in contributesSetting().
+    const Names & getSettingsContributedNames() const
+    {
+        return settings_contributed_names;
+    }
+
+    /// Set query node settings contributed names. Caller must pass a sorted, deduplicated list.
+    void setSettingsContributedNames(Names settings_contributed_names_value)
+    {
+        settings_contributed_names = std::move(settings_contributed_names_value);
+    }
+
+    /// Returns true if this query node's own SETTINGS clause contributes `name` to its context,
+    /// either directly or through an applied profile.
+    bool contributesSetting(const std::string & name) const
+    {
+        return std::binary_search(settings_contributed_names.begin(), settings_contributed_names.end(), name);
+    }
+
     void clearSettingsChanges()
     {
         settings_changes.clear();
+        settings_contributed_names.clear();
     }
 
     /// Returns true if query node is subquery, false otherwise
@@ -732,6 +753,7 @@ private:
     Names projection_aliases_to_override;
     ContextMutablePtr context;
     SettingsChanges settings_changes;
+    Names settings_contributed_names;
 
     static constexpr size_t with_child_index = 0;
     static constexpr size_t projection_child_index = 1;

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -7,6 +7,8 @@
 #include <Common/SettingSource.h>
 #include <Common/quoteString.h>
 
+#include <Access/SettingsProfilesInfo.h>
+
 #include <DataTypes/FieldToDataType.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
@@ -278,6 +280,7 @@ QueryTreeNodePtr QueryTreeBuilder::buildSelectExpression(
     auto updated_context = Context::createCopy(context);
     auto select_settings = select_query_typed.settings();
     SettingsChanges settings_changes;
+    Names contributed_names;
 
     if (select_settings)
     {
@@ -315,14 +318,29 @@ QueryTreeNodePtr QueryTreeBuilder::buildSelectExpression(
         {
             auto checked_changes = set_query.changes;
             updated_context->clampToSettingsConstraints(checked_changes, SettingSource::QUERY);
-            updated_context->applySettingsChanges(checked_changes);
+
+            /// Collect exactly which settings this clause contributes to the node's context,
+            /// including through an applied profile, so the Planner can later tell a genuine
+            /// opt-in (e.g. `use_query_cache`) from a value merely inherited from an outer scope (#119019).
+            std::vector<std::shared_ptr<const SettingsProfilesInfo>> applied_profiles;
+            updated_context->applySettingsChanges(checked_changes, &applied_profiles);
             settings_changes = set_query.changes;
+
+            for (const auto & change : set_query.changes)
+                contributed_names.push_back(change.name);
+            for (const auto & profile_info : applied_profiles)
+                for (const auto & setting_change : profile_info->settings)
+                    contributed_names.push_back(setting_change.name);
+
+            ::sort(contributed_names.begin(), contributed_names.end());
+            contributed_names.erase(std::unique(contributed_names.begin(), contributed_names.end()), contributed_names.end());
         }
     }
 
     const auto enable_order_by_all = updated_context->getSettingsRef()[Setting::enable_order_by_all];
 
     auto current_query_tree = std::make_shared<QueryNode>(std::move(updated_context), std::move(settings_changes));
+    current_query_tree->setSettingsContributedNames(std::move(contributed_names));
 
     current_query_tree->setIsSubquery(is_subquery);
     current_query_tree->setIsCTE(!cte_data.cte_name.empty());

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2523,12 +2523,13 @@ std::vector<QuotaUsage> Context::getQuotaUsages() const
     return getAccess()->getQuotaUsages();
 }
 
-void Context::setCurrentProfileWithLock(const String & profile_name, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock)
+void Context::setCurrentProfileWithLock(const String & profile_name, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     try
     {
         UUID profile_id = getAccessControl().getID<SettingsProfile>(profile_name);
-        setCurrentProfileWithLock(profile_id, check_constraints, lock);
+        setCurrentProfileWithLock(profile_id, check_constraints, lock, applied_profiles);
     }
     catch (Exception & e)
     {
@@ -2537,17 +2538,23 @@ void Context::setCurrentProfileWithLock(const String & profile_name, bool check_
     }
 }
 
-void Context::setCurrentProfileWithLock(const UUID & profile_id, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock)
+void Context::setCurrentProfileWithLock(const UUID & profile_id, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     auto profile_info = getAccessControl().getSettingsProfileInfo(profile_id);
-    setCurrentProfilesWithLock(*profile_info, check_constraints, lock);
+    /// Record the resolved snapshot right where it's applied, so a subquery's SETTINGS clause
+    /// can later be checked for exactly which settings it contributed (see #119019).
+    if (applied_profiles)
+        applied_profiles->push_back(profile_info);
+    setCurrentProfilesWithLock(*profile_info, check_constraints, lock, applied_profiles);
 }
 
-void Context::setCurrentProfilesWithLock(const SettingsProfilesInfo & profiles_info, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock)
+void Context::setCurrentProfilesWithLock(const SettingsProfilesInfo & profiles_info, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     if (check_constraints)
         checkSettingsConstraintsWithLock(profiles_info.settings, SettingSource::PROFILE);
-    applySettingsChangesWithLock(profiles_info.settings, lock);
+    applySettingsChangesWithLock(profiles_info.settings, lock, applied_profiles);
     settings_constraints_and_current_profiles = profiles_info.getConstraintsAndProfileIDs(settings_constraints_and_current_profiles);
     contextSanityClampSettingsWithLock(*this, *settings, lock);
 }
@@ -3500,11 +3507,12 @@ void Context::setSettings(const Settings & settings_)
     contextSanityClampSettings(*this, *settings);
 }
 
-void Context::setSettingWithLock(std::string_view name, const String & value, const std::lock_guard<ContextSharedMutex> & lock)
+void Context::setSettingWithLock(std::string_view name, const String & value, const std::lock_guard<ContextSharedMutex> & lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     if (name == "profile")
     {
-        setCurrentProfileWithLock(value, true /*check_constraints*/, lock);
+        setCurrentProfileWithLock(value, true /*check_constraints*/, lock, applied_profiles);
         return;
     }
     settings->set(name, value);
@@ -3513,11 +3521,12 @@ void Context::setSettingWithLock(std::string_view name, const String & value, co
     contextSanityClampSettingsWithLock(*this, *settings, lock);
 }
 
-void Context::setSettingWithLock(std::string_view name, const Field & value, const std::lock_guard<ContextSharedMutex> & lock)
+void Context::setSettingWithLock(std::string_view name, const Field & value, const std::lock_guard<ContextSharedMutex> & lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     if (name == "profile")
     {
-        setCurrentProfileWithLock(value.safeGet<String>(), true /*check_constraints*/, lock);
+        setCurrentProfileWithLock(value.safeGet<String>(), true /*check_constraints*/, lock, applied_profiles);
         return;
     }
     settings->set(name, value);
@@ -3525,7 +3534,8 @@ void Context::setSettingWithLock(std::string_view name, const Field & value, con
         need_recalculate_access = true;
 }
 
-void Context::applySettingChangeWithLock(const SettingChange & change, const std::lock_guard<ContextSharedMutex> & lock)
+void Context::applySettingChangeWithLock(const SettingChange & change, const std::lock_guard<ContextSharedMutex> & lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     try
     {
@@ -3533,7 +3543,7 @@ void Context::applySettingChangeWithLock(const SettingChange & change, const std
         /// it does not know the settings schema. `setSettingWithLock` takes a name and a value, so
         /// the check has to happen here, where the change is still whole.
         settings->checkShorthandChange(change);
-        setSettingWithLock(change.name, change.value, lock);
+        setSettingWithLock(change.name, change.value, lock, applied_profiles);
         contextSanityClampSettingsWithLock(*this, *settings, lock);
     }
     catch (Exception & e)
@@ -3545,10 +3555,11 @@ void Context::applySettingChangeWithLock(const SettingChange & change, const std
     }
 }
 
-void Context::applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex>& lock)
+void Context::applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex>& lock,
+    std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     for (const SettingChange & change : changes)
-        applySettingChangeWithLock(change, lock);
+        applySettingChangeWithLock(change, lock, applied_profiles);
     applySettingsQuirks(*settings);
     adjustSettingsForMakeDistributedPlan(*settings);
 }
@@ -3589,10 +3600,10 @@ void Context::applySettingChange(const SettingChange & change)
 }
 
 
-void Context::applySettingsChanges(const SettingsChanges & changes)
+void Context::applySettingsChanges(const SettingsChanges & changes, std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles)
 {
     std::lock_guard lock(mutex);
-    applySettingsChangesWithLock(changes, lock);
+    applySettingsChangesWithLock(changes, lock, applied_profiles);
 }
 
 void Context::checkSettingsConstraintsWithLock(const AlterSettingsProfileElements & profile_elements, SettingSource source)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1258,7 +1258,7 @@ public:
     void setSetting(std::string_view name, const Field & value);
     void setServerSetting(std::string_view name, const Field & value);
     void applySettingChange(const SettingChange & change);
-    void applySettingsChanges(const SettingsChanges & changes);
+    void applySettingsChanges(const SettingsChanges & changes, std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
     /// Checks the constraints.
     void checkSettingsConstraints(const AlterSettingsProfileElements & profile_elements, SettingSource source);
@@ -2076,11 +2076,14 @@ public:
 private:
     std::shared_ptr<const SettingsConstraintsAndProfileIDs> getSettingsConstraintsAndCurrentProfilesWithLock() const;
 
-    void setCurrentProfileWithLock(const String & profile_name, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock);
+    void setCurrentProfileWithLock(const String & profile_name, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
-    void setCurrentProfileWithLock(const UUID & profile_id, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock);
+    void setCurrentProfileWithLock(const UUID & profile_id, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
-    void setCurrentProfilesWithLock(const SettingsProfilesInfo & profiles_info, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock);
+    void setCurrentProfilesWithLock(const SettingsProfilesInfo & profiles_info, bool check_constraints, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
     void setCurrentRolesWithLock(const std::vector<UUID> & new_current_roles, const std::lock_guard<ContextSharedMutex> & lock);
 
@@ -2090,13 +2093,17 @@ private:
 
     void setAuthenticationValidUntilWithLock(time_t authentication_valid_until_, const std::lock_guard<ContextSharedMutex> & lock);
 
-    void setSettingWithLock(std::string_view name, const String & value, const std::lock_guard<ContextSharedMutex> & lock);
+    void setSettingWithLock(std::string_view name, const String & value, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
-    void setSettingWithLock(std::string_view name, const Field & value, const std::lock_guard<ContextSharedMutex> & lock);
+    void setSettingWithLock(std::string_view name, const Field & value, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
-    void applySettingChangeWithLock(const SettingChange & change, const std::lock_guard<ContextSharedMutex> & lock);
+    void applySettingChangeWithLock(const SettingChange & change, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
-    void applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex> & lock);
+    void applySettingsChangesWithLock(const SettingsChanges & changes, const std::lock_guard<ContextSharedMutex> & lock,
+        std::vector<std::shared_ptr<const SettingsProfilesInfo>> * applied_profiles = nullptr);
 
     void setUserIDWithLock(const UUID & user_id_, const std::lock_guard<ContextSharedMutex> & lock);
 

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -121,6 +121,7 @@ namespace Setting
     extern const SettingsBool enable_memory_bound_merging_of_aggregation_results;
     extern const SettingsBool enable_reads_from_query_cache;
     extern const SettingsBool query_cache_for_subqueries;
+    extern const SettingsBool use_query_cache;
     extern const SettingsBool enable_writes_to_query_cache;
     extern const SettingsBool empty_result_for_aggregation_by_constant_keys_on_empty_set;
     extern const SettingsBool empty_result_for_aggregation_by_empty_set;
@@ -2465,16 +2466,13 @@ static bool shouldUseQueryCacheForSubquery(
         || query_context->getClientInfo().query_kind != ClientInfo::QueryKind::INITIAL_QUERY)
         return false;
 
-    /// Only check explicit per-node `use_query_cache` for actual subqueries.
+    /// Only check `use_query_cache` for actual subqueries, and only when the subquery's own
+    /// SETTINGS clause contributed it (directly or through a profile) — reading the node's
+    /// context value here, rather than re-scanning the clause's literal names, means a profile
+    /// that sets `use_query_cache` is honored the same way a literal `use_query_cache = 1` is (#119019).
     /// For the top-level query, this setting is handled by `executeQuery` (with `is_subquery = false` key).
-    if (is_subquery && query_node.hasSettingsChanges())
-    {
-        for (const auto & change : query_node.getSettingsChanges())
-        {
-            if (change.name == "use_query_cache")
-                return change.value.safeGet<bool>();
-        }
-    }
+    if (is_subquery && query_node.contributesSetting("use_query_cache"))
+        return query_node.getContext()->getSettingsRef()[Setting::use_query_cache];
 
     /// `query_cache_for_subqueries` enables the Planner-level (`is_subquery = true`) cache
     /// only for actual subqueries. The top-level query is cached separately by `executeQuery`

--- a/tests/queries/0_stateless/05055_subquery_profile_query_cache.reference
+++ b/tests/queries/0_stateless/05055_subquery_profile_query_cache.reference
@@ -1,0 +1,35 @@
+-- a nested profile enabling use_query_cache creates a subquery cache entry
+3
+1
+-- a nested profile followed by an explicit use_query_cache = 0 does not create an entry
+3
+0
+-- an explicit use_query_cache = 1 followed by a profile that sets it to 0 does not create an entry
+3
+0
+-- a neutral profile (no use_query_cache mention), no outer use_query_cache anywhere, does not create an entry
+3
+0
+-- normalization: profile before make_distributed_plan still ends with the same adjustment as today
+3
+-- normalization: reverse order still gives today\'s result, proving no normalization point moved
+3
+-- a CTE referenced twice (cloned query tree) still produces subquery cache entries
+1
+-- EXPLAIN QUERY TREE output is unchanged by a profile-opted-in subquery
+QUERY id: 0
+  PROJECTION COLUMNS
+    count() UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: count, function_type: aggregate, result_type: UInt64
+  JOIN TREE
+    QUERY id: 3, alias: __table1, is_subquery: 1
+      PROJECTION COLUMNS
+        id UInt64
+      PROJECTION
+        LIST id: 4, nodes: 1
+          COLUMN id: 5, column_name: id, result_type: UInt64, source_id: 6
+      JOIN TREE
+        TABLE id: 6, alias: __table2, table_name: default.t_05055
+      SETTINGS profile=qc_on_05055

--- a/tests/queries/0_stateless/05055_subquery_profile_query_cache.sql
+++ b/tests/queries/0_stateless/05055_subquery_profile_query_cache.sql
@@ -1,0 +1,85 @@
+-- Tags: no-parallel
+-- no-parallel: a settings profile is server-global rather than per-database, and its name cannot be
+-- made unique per run: query parameters are not accepted in access-entity DDL. So this test is not
+-- safe against a concurrent copy of itself - which is how the flaky check runs it.
+
+-- A nested `SETTINGS profile = ...` clause that enables `use_query_cache` through the profile must
+-- opt the subquery into the query result cache the same way a literal `SETTINGS use_query_cache = 1`
+-- does. A profile that does not mention `use_query_cache` must not let the outer query's
+-- `use_query_cache` propagate into the subquery - the no-propagation rule still holds. See #119019.
+
+SET enable_analyzer = 1;
+
+DROP SETTINGS PROFILE IF EXISTS qc_on_05055;
+DROP SETTINGS PROFILE IF EXISTS qc_off_05055;
+DROP SETTINGS PROFILE IF EXISTS mdp_off_05055;
+DROP TABLE IF EXISTS t_05055;
+
+CREATE TABLE t_05055 (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05055 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+CREATE SETTINGS PROFILE qc_on_05055 SETTINGS use_query_cache = 1;
+CREATE SETTINGS PROFILE qc_off_05055 SETTINGS use_query_cache = 0;
+CREATE SETTINGS PROFILE mdp_off_05055 SETTINGS make_distributed_plan = 0;
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- a nested profile enabling use_query_cache creates a subquery cache entry';
+SELECT count() FROM (SELECT id FROM t_05055 WHERE s != 'x1' SETTINGS profile = 'qc_on_05055');
+SELECT count(*) FROM system.query_cache;
+-- Expected: 1
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- a nested profile followed by an explicit use_query_cache = 0 does not create an entry';
+SELECT count() FROM (SELECT id FROM t_05055 WHERE s != 'x2' SETTINGS profile = 'qc_on_05055', use_query_cache = 0);
+SELECT count(*) FROM system.query_cache;
+-- Expected: 0
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- an explicit use_query_cache = 1 followed by a profile that sets it to 0 does not create an entry';
+SELECT count() FROM (SELECT id FROM t_05055 WHERE s != 'x3' SETTINGS use_query_cache = 1, profile = 'qc_off_05055');
+SELECT count(*) FROM system.query_cache;
+-- Expected: 0
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- a neutral profile (no use_query_cache mention), no outer use_query_cache anywhere, does not create an entry';
+SELECT count() FROM (SELECT id FROM t_05055 WHERE s != 'x4' SETTINGS profile = 'mdp_off_05055');
+SELECT count(*) FROM system.query_cache;
+-- Expected: 0
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- normalization: profile before make_distributed_plan still ends with the same adjustment as today';
+SELECT count() FROM (
+    SELECT id, getSetting('compile_expressions') AS ce FROM t_05055
+    WHERE s != 'x5' SETTINGS profile = 'mdp_off_05055', make_distributed_plan = 1, compile_expressions = 1
+) WHERE ce = 0;
+-- Expected: 3 (compile_expressions was forced false by adjustSettingsForMakeDistributedPlan)
+
+SELECT '-- normalization: reverse order still gives today''s result, proving no normalization point moved';
+SELECT count() FROM (
+    SELECT id, getSetting('compile_expressions') AS ce, getSetting('make_distributed_plan') AS mdp FROM t_05055
+    WHERE s != 'x6' SETTINGS make_distributed_plan = 1, compile_expressions = 1, profile = 'mdp_off_05055'
+) WHERE ce = 1 AND mdp = 0;
+-- Expected: 3
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- a CTE referenced twice (cloned query tree) still produces subquery cache entries';
+WITH cte AS (SELECT id FROM t_05055 WHERE s != 'x7' SETTINGS profile = 'qc_on_05055')
+SELECT a.id, b.id FROM cte AS a, cte AS b WHERE a.id = b.id ORDER BY a.id FORMAT Null;
+SELECT count(*) FROM system.query_cache;
+-- Expected: 1
+
+SYSTEM DROP QUERY CACHE;
+
+SELECT '-- EXPLAIN QUERY TREE output is unchanged by a profile-opted-in subquery';
+EXPLAIN QUERY TREE SELECT count() FROM (SELECT id FROM t_05055 SETTINGS profile = 'qc_on_05055') FORMAT Null;
+
+DROP TABLE t_05055;
+DROP SETTINGS PROFILE qc_on_05055;
+DROP SETTINGS PROFILE qc_off_05055;
+DROP SETTINGS PROFILE mdp_off_05055;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/119019

### Changelog category
Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry
A nested `SETTINGS profile = ...` clause on a subquery that enables `use_query_cache` through the profile now correctly opts the subquery into the query result cache, matching the existing behavior of an explicit `SETTINGS use_query_cache = 1`. Previously the Planner only recognized a literal `use_query_cache` change in the clause and silently ignored one contributed via a profile.

### Details

`QueryNode` gains a sorted `settings_contributed_names` list recording which settings the node's own `SETTINGS` clause contributes to its context, including via an applied profile. This is collected inside `Context::applySettingsChanges` by threading an optional collector of the applied `SettingsProfilesInfo` snapshots through the existing batch-application path
(`applySettingsChangesWithLock -> applySettingChangeWithLock -> setSettingWithLock -> setCurrentProfileWithLock`). The Planner's `shouldUseQueryCacheForSubquery` now checks `contributesSetting("use_query_cache")` and reads the resulting context value directly, rather than re-scanning the clause's literal setting names. This correctly handles clause ordering (an explicit `use_query_cache` before or after `profile = 'p'` behaves as expected) and preserves the existing no-propagation rule: a profile that does not mention `use_query_cache` contributes nothing, so the outer query's `use_query_cache` still does not leak into the subquery.

While testing, I found and fixed a related bug in `SettingsConstraints::checkOrClamp`: any `SETTINGS` clause containing `profile` could silently drop a later setting in that same clause as an unchanged no-op, whenever the new value happened to match the value the setting had *before* the clause was applied - even though a profile applied earlier in the same clause may have changed what "unchanged" should mean. This let a profile's value win over an explicit override elsewhere in the clause. It mirrors the existing `compatibility` carve-out in the same function and is fixed the same way: a clause containing `profile` is now treated like one containing `compatibility`, and unchanged-looking settings in it are no longer dropped before being checked/applied.

### Known gap

This PR does not include a Distributed-cluster test verifying that the query forwarded to a shard still carries the literal `profile = 'p'` text (rather than an expanded `use_query_cache = ...`), and that a shard-local constraint on one of the profile's settings still wins locally. The `toASTImpl` behavior this would exercise is unchanged by this PR by design (`settings_contributed_names` is not part of `toAST`), but I wasn't able to verify it end-to-end without a genuine multi-shard fixture, which is beyond `tests/queries/0_stateless` scope. Happy to add an integration test if pointed to the right fixture, or to open a follow-up issue if preferred.