### PR TITLE
Fix an exception on Iceberg partition pruning of pre-1970 partition values

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestListPruning.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestListPruning.cpp
@@ -8,10 +8,83 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergFieldParseHelpers.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h>
 
+#include <Common/FieldAccurateComparison.h>
+#include <Common/logger_useful.h>
+#include <DataTypes/DataTypeNullable.h>
+
 using namespace DB;
 
 namespace DB::Iceberg
 {
+
+namespace
+{
+
+std::optional<Int64> decodeSignedInteger(const String & bytes)
+{
+    if (bytes.empty() || bytes.size() > sizeof(Int64))
+        return {};
+
+    UInt64 value = (bytes.back() & 0x80) ? ~UInt64(0) : UInt64(0);
+    for (size_t i = bytes.size(); i > 0; --i)
+        value = (value << 8) | static_cast<UInt8>(bytes[i - 1]);
+
+    return static_cast<Int64>(value);
+}
+
+std::optional<Field> deserializeUnsignedBound(const String & bytes, const IDataType & type)
+{
+    const auto value = decodeSignedInteger(bytes);
+    if (!value.has_value() || *value < 0)
+        return {};
+
+    const size_t type_bits = 8 * type.getSizeOfValueInMemory();
+    if (type_bits < 8 * sizeof(UInt64) && (static_cast<UInt64>(*value) >> type_bits) != 0)
+        return {};
+
+    return Field(static_cast<UInt64>(*value));
+}
+
+std::optional<std::pair<Field, Field>> boundsOfPartitionFieldSummary(
+    const PartitionFieldSummary & summary, const DataTypePtr & type, Int32 partition_spec_id, size_t field_index)
+{
+    if (summary.contains_null || summary.contains_nan || !summary.lower_bound.has_value() || summary.lower_bound->empty()
+        || !summary.upper_bound.has_value() || summary.upper_bound->empty())
+        return {};
+
+    const auto non_nullable_type = removeNullable(type);
+
+    std::optional<Field> lower;
+    std::optional<Field> upper;
+    if (WhichDataType(non_nullable_type).isUInt())
+    {
+        lower = deserializeUnsignedBound(*summary.lower_bound, *non_nullable_type);
+        upper = deserializeUnsignedBound(*summary.upper_bound, *non_nullable_type);
+    }
+    else
+    {
+        lower = deserializeFieldFromBinaryRepr(*summary.lower_bound, type, true);
+        upper = deserializeFieldFromBinaryRepr(*summary.upper_bound, type, false);
+    }
+
+    if (!lower.has_value() || !upper.has_value())
+        return {};
+
+    if (accurateLess(*upper, *lower))
+    {
+        LOG_WARNING(
+            getLogger("ManifestListPruner"),
+            "Manifest list declares a lower bound above the upper bound for field {} of partition spec {}; skipping "
+            "partition pruning for this field",
+            field_index,
+            partition_spec_id);
+        return {};
+    }
+
+    return std::pair{std::move(*lower), std::move(*upper)};
+}
+
+}
 
 ManifestListPruner::ManifestListPruner(
     const IcebergSchemaProcessor & schema_processor_,
@@ -68,20 +141,11 @@ bool ManifestListPruner::canBePruned(Int32 partition_spec_id, const PartitionFie
     std::vector<FieldRef> right_keys(partition_summaries.size());
     for (size_t i = 0; i < partition_summaries.size(); ++i)
     {
-        const auto & summary = partition_summaries[i];
-        const auto & type = partition_key.data_types.at(i);
+        auto bounds
+            = boundsOfPartitionFieldSummary(partition_summaries[i], partition_key.data_types.at(i), partition_spec_id, i);
 
-        std::optional<Field> lower;
-        std::optional<Field> upper;
-        if (!summary.contains_nan && summary.lower_bound.has_value() && !summary.lower_bound->empty()
-            && summary.upper_bound.has_value() && !summary.upper_bound->empty())
-        {
-            lower = deserializeFieldFromBinaryRepr(*summary.lower_bound, type, true);
-            upper = deserializeFieldFromBinaryRepr(*summary.upper_bound, type, false);
-        }
-
-        left_keys[i] = (lower.has_value() && !summary.contains_null) ? FieldRef(*lower) : FieldRef(NEGATIVE_INFINITY);
-        right_keys[i] = (upper.has_value() && !summary.contains_null) ? FieldRef(*upper) : FieldRef(POSITIVE_INFINITY);
+        left_keys[i] = bounds.has_value() ? FieldRef(bounds->first) : FieldRef(NEGATIVE_INFINITY);
+        right_keys[i] = bounds.has_value() ? FieldRef(bounds->second) : FieldRef(POSITIVE_INFINITY);
     }
 
     return !condition_it->second.condition.mayBeTrueInRange(

--- a/tests/integration/test_storage_iceberg_with_spark/test_partition_pruning_with_functions.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_partition_pruning_with_functions.py
@@ -139,3 +139,59 @@ def test_partition_pruning_with_functions_before_epoch(started_cluster_iceberg_w
     assert check_validity_and_get_prunned_files(select("toDate32(ts) < toDate32('1970-01-01')")) == 2
     assert check_validity_and_get_prunned_files(select("toYear(d) = 1969")) == 3
     assert check_validity_and_get_prunned_files(select("toYear(d) >= 1971")) == 2
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_partition_pruning_with_functions_before_epoch_separate_commits(started_cluster_iceberg_with_spark, storage_type):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_partition_pruning_before_epoch_separate_commits_" + storage_type + "_" + get_uuid_str()
+
+    def execute_spark_query(query: str):
+        return execute_spark_query_general(
+            spark, started_cluster_iceberg_with_spark, storage_type, TABLE_NAME, query
+        )
+
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (ts TIMESTAMP, d DATE, tag INT)
+            USING iceberg
+            PARTITIONED BY (days(ts), years(d))
+            OPTIONS('format-version'='2')
+        """
+    )
+
+    # One manifest file per commit, so the partition summaries of the first manifest are negative on
+    # both of their sides, while the ones of the second manifest are positive on both.
+    execute_spark_query(
+        f"""
+        INSERT INTO {TABLE_NAME} VALUES
+        (TIMESTAMP '1969-11-15 07:00:00', DATE '1969-11-15', 1),
+        (TIMESTAMP '1969-12-31 23:00:00', DATE '1969-06-01', 2);
+    """
+    )
+
+    execute_spark_query(
+        f"""
+        INSERT INTO {TABLE_NAME} VALUES
+        (TIMESTAMP '2024-01-20 10:00:00', DATE '2024-01-20', 3);
+    """
+    )
+
+    creation_expression = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_with_spark, table_function=True
+    )
+
+    def check_validity_and_get_prunned_files(select_expression):
+        settings1 = {"use_iceberg_partition_pruning": 0, "session_timezone": "UTC"}
+        settings2 = {"use_iceberg_partition_pruning": 1, "session_timezone": "UTC"}
+        return check_validity_and_get_prunned_files_general(
+            instance, TABLE_NAME, settings1, settings2, "IcebergPartitionPrunedFiles", select_expression
+        )
+
+    def select(where):
+        return f"SELECT * FROM {creation_expression} WHERE {where} ORDER BY ALL"
+
+    assert check_validity_and_get_prunned_files(select("toDate32(ts) = toDate32('1969-11-15')")) == 2
+    assert check_validity_and_get_prunned_files(select("toDate32(ts) >= toDate32('1970-01-01')")) == 2
+    assert check_validity_and_get_prunned_files(select("toYear(d) = 1969")) == 1


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118606
Related: https://github.com/ClickHouse/ClickHouse/issues/116499
Related: https://github.com/ClickHouse/ClickHouse/pull/116604

An Iceberg partition field summary keeps its bounds in the single-value serialization of the partition field's own type, and for the `day`, `month`, `year` and `hour` transforms that type is a signed `int` counting units from 1970. ClickHouse models those transforms in the partition key with `toRelativeDayNum`, `toMonthNumSinceEpoch`, `toYearNumSinceEpoch` and `toRelativeHourNum`, whose result types are unsigned, so `ManifestListPruner::canBePruned` read a bound from before 1970 as a huge unsigned number. For a manifest that spans 1969 and 2024 the lower bound then came out above the upper bound, and `KeyCondition::checkInRange` hit `chassert(key_order.compareTuples(left_keys, right_keys, used_key_size) <= 0)`, which aborts a build with assertions.

That is what broke `test_storage_iceberg_with_spark/test_partition_pruning_with_functions.py::test_partition_pruning_with_functions_before_epoch` on master in `Integration tests (amd_tsan, 3/6)` and `Integration tests (amd_msan, 8/8)`: https://github.com/ClickHouse/ClickHouse/pull/118606 gave `toDate32` its monotonicity on a `Nullable` column, which let the filter of that test reach the pruner. No open issue tracks this failure. The release builds pass because `chassert` compiles out there and the unusable range keeps the manifest instead of pruning it.

A bound of an unsigned key column is now read as the signed number Iceberg wrote, and a negative one leaves the whole field unknown: the ClickHouse functions standing for those transforms cannot return a negative number - they map every point before 1970 to zero - so nothing about the key's value space follows from such a bound and no range of it may be pruned on. A pair of bounds that still comes out inverted drops the field with a warning instead of being pruned on, which is what `ManifestFileIterator` already does for the min/max bounds of a data file. One decodable bound of a pair no longer stands on its own either: the other side of the field is unknown then, and `KeyCondition` takes the whole universe of the column for it anyway.

`test_partition_pruning_with_functions_before_epoch` covers the abort. The new `test_partition_pruning_with_functions_before_epoch_separate_commits` commits the pre-1970 rows separately, so the summaries of that manifest are negative on both sides, and pins that such a manifest is not pruned away.

Tested locally with `python3 -m ci.praktika run "integration" --test "test_storage_iceberg_with_spark/test_partition_pruning_with_functions.py"`: 6 passed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119292&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119292](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119292+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
