### PR TITLE
Do not push a view read down to `Distributed` when a subcolumn is read

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -2234,6 +2234,25 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(TableExpressionNodePtr table_
                                         column_checks_passed = false;
                                         break;
                                     }
+
+                                    /// Any other name the view does not declare is either one of its
+                                    /// virtual columns, materialized the same way on both paths, or a
+                                    /// subcolumn of a view column: `arr.size0`, a `Tuple` element, `m.keys`,
+                                    /// `n.null`, a `JSON` path, a `Dynamic` typed subcolumn. Subcolumns are
+                                    /// read straight from a table, so the outer query holds a plain column
+                                    /// node named after the subcolumn; the inlined body projects the view's
+                                    /// columns and not their subcolumns, so after the rewrite that node would
+                                    /// name a column the subquery does not produce and planning would fail
+                                    /// with `NOT_FOUND_COLUMN_IN_BLOCK`. `readImpl` instead wraps the body as
+                                    /// `SELECT <subcolumn> FROM (<body>)`, where the analyzer rewrites the
+                                    /// read into `getSubcolumn(<column>, '<subcolumn>')` over the body's
+                                    /// output, so fall back to it.
+                                    if (!storage_snapshot->metadata->virtuals.has(name))
+                                    {
+                                        column_checks_passed = false;
+                                        break;
+                                    }
+
                                     continue;
                                 }
                                 auto it = inner_types.find(name);

--- a/tests/queries/0_stateless/05196_view_over_distributed_subcolumns.reference
+++ b/tests/queries/0_stateless/05196_view_over_distributed_subcolumns.reference
@@ -1,0 +1,11 @@
+a plain column	45
+Array size0	20
+a Tuple element	45
+Map keys	10
+Map values	45
+Nullable null	4
+a JSON path	70
+a Dynamic typed subcolumn	45
+a subcolumn next to a plain column	45	20
+a subcolumn in WHERE	4
+directly	20	45	4	70	45

--- a/tests/queries/0_stateless/05196_view_over_distributed_subcolumns.sql
+++ b/tests/queries/0_stateless/05196_view_over_distributed_subcolumns.sql
@@ -1,0 +1,46 @@
+-- Reading a subcolumn through a `VIEW` over a `Distributed` table. The trivial view pushdown
+-- (`optimize_trivial_view_pushdown_to_distributed`) replaces the view's table expression with the
+-- inlined view body, whose projection columns are the view's columns and not their subcolumns, so
+-- every subcolumn kind used to fail with `NOT_FOUND_COLUMN_IN_BLOCK`. Such a read now falls back to
+-- the regular `StorageView` path, which wraps the body in `SELECT <subcolumn> FROM (<body>)`.
+
+DROP TABLE IF EXISTS t_05196;
+DROP TABLE IF EXISTS t_05196_dist;
+DROP VIEW IF EXISTS v_05196;
+
+CREATE TABLE t_05196
+(
+    id UInt64,
+    arr Array(UInt32),
+    tup Tuple(a UInt32, b String),
+    m Map(String, UInt32),
+    n Nullable(UInt32),
+    j JSON(a UInt32),
+    d Dynamic
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_05196
+SELECT number, [1, 2], (number, 'x'), map('k', number), if(number % 3 = 0, NULL, number), '{"a": 7}', number
+FROM numbers(10);
+
+CREATE TABLE t_05196_dist AS t_05196 ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_05196);
+CREATE VIEW v_05196 AS SELECT * FROM t_05196_dist;
+
+SELECT 'a plain column', sum(id) FROM v_05196;
+SELECT 'Array size0', sum(arr.size0) FROM v_05196;
+SELECT 'a Tuple element', sum(tup.a) FROM v_05196;
+SELECT 'Map keys', sum(length(m.keys)) FROM v_05196;
+SELECT 'Map values', sum(arraySum(m.values)) FROM v_05196;
+SELECT 'Nullable null', sum(n.null) FROM v_05196;
+SELECT 'a JSON path', sum(j.a) FROM v_05196;
+SELECT 'a Dynamic typed subcolumn', sum(d.UInt64) FROM v_05196;
+SELECT 'a subcolumn next to a plain column', sum(id), sum(arr.size0) FROM v_05196;
+SELECT 'a subcolumn in WHERE', count() FROM v_05196 WHERE tup.a > 5;
+
+-- The same answers as reading the `Distributed` table directly.
+SELECT 'directly', sum(arr.size0), sum(tup.a), sum(n.null), sum(j.a), sum(d.UInt64) FROM t_05196_dist;
+
+DROP VIEW v_05196;
+DROP TABLE t_05196_dist;
+DROP TABLE t_05196;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `NOT_FOUND_COLUMN_IN_BLOCK` when reading a subcolumn (`Array` `.size0`, a `Tuple` element, `Map` `.keys`/`.values`, `Nullable` `.null`, a `JSON` path, a `Dynamic` typed subcolumn) through a `VIEW` over a `Distributed` table.

### Documentation entry for user-facing changes

...

`SELECT sum(arr.size0) FROM v`, where `v` is a view over a `Distributed` table, threw `NOT_FOUND_COLUMN_IN_BLOCK` (``Not found column __table1.`arr.size0` in block``), while the same read of the `Distributed` table itself, or through a plain subquery, returned the rows. Every subcolumn kind was affected.

The cause is the trivial view pushdown (`optimize_trivial_view_pushdown_to_distributed`), which replaces the view's table expression with the inlined view body so that the shards receive the body against their local table. A subcolumn is read straight from a table, so the outer query holds a plain column node named after the subcolumn; the inlined body projects the view's columns and not their subcolumns, so after the rewrite that node named a column the subquery does not produce. The per-column loop that already suppresses the pushdown for a declared type mismatch and for `_table`/`_database` skipped every other name the view does not declare, which is exactly where a subcolumn lands.

Suppress the pushdown for a read of any name that is neither a declared column nor a virtual column of the view. `StorageView::readImpl` then wraps the body as `SELECT <subcolumn> FROM (<body>)`, where the analyzer rewrites the read into `getSubcolumn(<column>, '<subcolumn>')` over the body's output, which is the path a plain subquery already takes.

The old analyzer fails on this query too (`UNKNOWN_IDENTIFIER`), independently of the pushdown; that is not addressed here.

New test: `05196_view_over_distributed_subcolumns`. Verified in both directions, and a differential run of the `view`/`subcolumn`/`distributed`/`pushdown` stateless tests shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115270

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119293&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119293](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119293+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
