### PR TITLE
Fix flaky test 04611_iceberg_parquet_schema_evolution_prewhere_rename on release branches

### DIFF
--- a/tests/queries/0_stateless/04611_iceberg_parquet_schema_evolution_prewhere_rename.sh
+++ b/tests/queries/0_stateless/04611_iceberg_parquet_schema_evolution_prewhere_rename.sh
@@ -47,6 +47,9 @@ rm -rf "${ICEBERG_PATH}"
 # (c0 Int64, c1 String, c2 Int32). One data file, 100 rows.
 ${CLICKHOUSE_CLIENT} --query "
     SET allow_experimental_insert_into_iceberg = 1;
+    -- StorageObjectStorage caches supportsPrewhere() at CREATE time from this
+    -- session setting; pinning it only on the SELECTs below is too late.
+    SET input_format_parquet_use_native_reader_v3 = 1;
 
     CREATE TABLE ${TEST_TABLE} (c0 Int64, c1 String, c2 Int32)
         ENGINE = IcebergLocal('${ICEBERG_PATH}', 'Parquet');


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110941
Related: https://github.com/ClickHouse/ClickHouse/pull/118991
Related: https://github.com/ClickHouse/ClickHouse/pull/107970
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Pin `input_format_parquet_use_native_reader_v3 = 1` at `CREATE TABLE` in
`04611_iceberg_parquet_schema_evolution_prewhere_rename`.

### Description

On 26.3 this test fails about 1 run in 6 with `Code: 182 ... Storage IcebergLocal (...) does not
support PREWHERE. (ILLEGAL_PREWHERE)`.

**Root cause.** On 26.3 the Parquet PREWHERE-support checker returns the session setting
`input_format_parquet_use_native_reader_v3` (`ParquetBlockInputFormat.cpp:1495`); from 26.6 on it
returns `true` and the setting is `MAKE_OBSOLETE`. `StorageObjectStorage` computes `supports_prewhere`
once in its constructor, from the creating session's format settings
(`StorageObjectStorage.cpp:299,322`), so `CREATE TABLE` fixes PREWHERE support for the table's
lifetime and a later per-query `SETTINGS` cannot revive it. 26.3's runner randomizes it to
`0` with probability 1/6 (`tests/clickhouse-test:1335`). This test never pinned it, and became
exposed only when #118991 backported #110941 to 26.3.

**Change.** Three lines pinning the setting in the test's `CREATE TABLE` invocation: the same fix at
the same site as #107970 for the sibling `04146_iceberg_orc_row_policy_prewhere`. `04147` carries it
too on 26.3.

**Validation.** On the official `26.3.33.24` binary with the setting forced to `0` via
`clickhouse-test --client-option`, the unpatched test reproduces the CI error; the patched test does
not. A control with the pin moved after `CREATE TABLE` still fails, so per-query `SETTINGS` are
inert. On master the obsolete `SET` is accepted and the test passes 50/50 under randomization,
`.reference` unchanged. In CIDB, on `26.3` over 30 days, this test is 14 OK / 1 FAIL; the three
siblings that pin the setting are 548 OK / 0 FAIL.

**Branch scope.** No-op on master and 26.6+, where the setting is obsolete; 26.4 and 26.5 do not
carry this test.
26.3 is the only branch this changes, so it needs a backport label to take effect there, which I
leave to a maintainer as on #107970.

The `no-parallel-replicas` header comment is left as is: its `StorageObjectStorageCluster` rationale
does not apply to this test's table-engine path, but the wording is shared with the sibling family.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119294&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119294](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119294+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
