### PR TITLE
Perf: benchmark PromQL range timestamp formatting

### DIFF
--- a/tests/performance/promql_range_timestamp_cache.xml
+++ b/tests/performance/promql_range_timestamp_cache.xml
@@ -1,0 +1,48 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!--
+        Benchmarks the Prometheus HTTP range-response writer with a large,
+        fully populated evaluation grid. Every series has the same 1024
+        evaluation timestamps, so timestamp formatting is repeated across
+        4096 series while label and value formatting stay small.
+
+        The query is sent to /prometheus/api/v1/query_range rather than the
+        prometheusQueryRange table function because this measures
+        PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock.
+    -->
+    <create_query>
+        CREATE TABLE promql_range_timestamp_cache ENGINE = TimeSeries
+    </create_query>
+
+    <!-- 4096 series x 1024 samples = 4,194,304 response samples. -->
+    <fill_query>
+        INSERT INTO promql_range_timestamp_cache (metric_name, tags, time_series)
+        SELECT
+            'cache_metric',
+            map('instance', toString(number)),
+            arrayMap(
+                step -&gt; (toDateTime64(1700000000 + step * 15, 3), toFloat64(number % 1000 + 1)),
+                range(1024))
+        FROM numbers_mt(4096)
+    </fill_query>
+
+    <query type="shell"><![CDATA[
+        ${CLICKHOUSE_CURL} -G "${CLICKHOUSE_URL}prometheus/api/v1/query_range" \
+            --data-urlencode "query=cache_metric" \
+            --data-urlencode "start=1700000000" \
+            --data-urlencode "end=1700015345" \
+            --data-urlencode "step=15" \
+            --data-urlencode "max_block_size=100000" \
+            --data-urlencode "max_threads=8" \
+            --data-urlencode "use_query_cache=0" \
+            --data-urlencode "enable_http_compression=0" \
+            --data-urlencode "allow_experimental_time_series_table=1" \
+            -o /dev/null
+    ]]></query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_range_timestamp_cache</drop_query>
+</test>

--- a/tests/performance/scripts/config/config.d/promql_range_timestamp_cache.xml
+++ b/tests/performance/scripts/config/config.d/promql_range_timestamp_cache.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+    <http_handlers>
+        <rule_promql_range_timestamp_cache>
+            <url_prefix>/prometheus/api/v1</url_prefix>
+            <handler>
+                <type>prometheus_api_v1</type>
+                <table>default.promql_range_timestamp_cache</table>
+            </handler>
+        </rule_promql_range_timestamp_cache>
+    </http_handlers>
+</clickhouse>


### PR DESCRIPTION
## Summary

- add a performance test for PromQL HTTP range responses
- use 4,096 series sharing a 1,024-point evaluation grid
- add the HTTP handler config needed by the test

## Why

This keeps timestamp formatting cost visible in the performance suite. The request goes through `/prometheus/api/v1/query_range`, so it measures the HTTP response writer.

## Checks

- XML parsing
- shell syntax check
- `git diff --cached --check`

The CI performance job will run the live comparison.