### PR TITLE
Add integration tests for wide-row parquet memory over s3()

### DIFF
--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1444,6 +1444,69 @@ def test_seekable_formats(started_cluster, format_name, expected_bytes_read):
     assert int(result) > 140
 
 
+def _write_wide_parquet(instance, started_cluster, shape):
+    # 20 rows carrying ~12 MB each, so ~240 MB of payload in one object, laid
+    # out either as a single row group or as one row group per row.
+    rows_per_row_group = 1000000 if shape == "one_row_group" else 1
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/wide_{shape}.parquet"
+    table_function = f"s3('{url}', 'minio', '{minio_secret_key}', 'Parquet')"
+    exec_query_with_retry(
+        instance,
+        f"INSERT INTO TABLE FUNCTION {table_function} "
+        "SELECT toString(number) AS id, "
+        "arrayStringConcat(arrayMap(i -> repeat('a', 1000000), range(12))) AS payload "
+        "FROM numbers(20) SETTINGS s3_truncate_on_insert=1, "
+        f"output_format_parquet_row_group_size={rows_per_row_group}, "
+        "output_format_parquet_row_group_size_bytes=8000000000",
+        timeout=300,
+    )
+    return table_function
+
+
+# Limits sit between the two readers' measured peaks on 26.2.19.43, taken from
+# system.query_log. Reads: 715 MiB arrow / 1.25 GiB v3 from one row group,
+# 608 MiB arrow / 257-337 MiB v3 from many. Inserts: 717 MiB / 1.25 GiB from one row
+# group, 609 MiB / 871 MiB from many.
+READ_MEMORY_LIMIT = {"one_row_group": "1Gi", "many_row_groups": "512Mi"}
+INSERT_MEMORY_LIMIT = {"one_row_group": "1Gi", "many_row_groups": "720Mi"}
+
+WIDE_ROWS_READER_SETTINGS = "input_format_parquet_use_native_reader_v3={v3}"
+
+
+@pytest.mark.parametrize("shape", ["one_row_group", "many_row_groups"])
+@pytest.mark.parametrize("use_native_reader_v3", [0, 1])
+def test_parquet_wide_rows_read_memory(started_cluster, shape, use_native_reader_v3):
+    instance = started_cluster.instances["dummy"]
+    source = _write_wide_parquet(instance, started_cluster, shape)
+    assert (
+        int(
+            instance.query(
+                f"SELECT max(length(payload)) FROM {source} "
+                f"SETTINGS max_memory_usage='{READ_MEMORY_LIMIT[shape]}', "
+                + WIDE_ROWS_READER_SETTINGS.format(v3=use_native_reader_v3)
+            )
+        )
+        == 12000000
+    )
+
+
+@pytest.mark.parametrize("shape", ["one_row_group", "many_row_groups"])
+@pytest.mark.parametrize("use_native_reader_v3", [0, 1])
+def test_parquet_wide_rows_insert_memory(started_cluster, shape, use_native_reader_v3):
+    instance = started_cluster.instances["dummy"]
+    source = _write_wide_parquet(instance, started_cluster, shape)
+    dest_url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{started_cluster.minio_bucket}/wide_out_{shape}_{use_native_reader_v3}.parquet"
+    dest = f"s3('{dest_url}', 'minio', '{minio_secret_key}', 'Parquet')"
+    instance.query(
+        f"INSERT INTO TABLE FUNCTION {dest} SELECT * FROM {source} "
+        f"SETTINGS max_memory_usage='{INSERT_MEMORY_LIMIT[shape]}', s3_truncate_on_insert=1, "
+        + WIDE_ROWS_READER_SETTINGS.format(v3=use_native_reader_v3)
+        + ", output_format_parquet_row_group_size=1, "
+        "output_format_parquet_row_group_size_bytes=33554432"
+    )
+    assert int(instance.query(f"SELECT count() FROM {dest}")) == 20
+
+
 @pytest.mark.parametrize("format_name", ["Parquet", "ORC"])
 def test_seekable_formats_url(started_cluster, format_name):
     bucket = started_cluster.minio_bucket

--- a/tests/integration/test_storage_s3/wide_rows_memory_matrix.sh
+++ b/tests/integration/test_storage_s3/wide_rows_memory_matrix.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Runs the wide-row parquet memory tests from test_storage_s3 against several
+# released ClickHouse versions and prints one row per test.
+#
+# Each version is checked out at its own tag, because an older server binary
+# rejects a newer programs/server/config.xml and never starts. The two test
+# functions are taken from this checkout and appended to the tag's copy of
+# test_storage_s3/test.py.
+#
+# Usage: tests/integration/test_storage_s3/wide_rows_memory_matrix.sh [version:tag ...]
+set -euo pipefail
+
+VERSIONS=("${@:-}")
+if [ -z "${VERSIONS[0]}" ]; then
+    VERSIONS=("26.2:v26.2.19.43-stable" "26.8:v26.8.2.7-lts")
+fi
+
+SELF=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SOURCE_TEST="$SELF/test.py"
+WORK=${WIDE_ROWS_WORK_DIR:-/tmp/ch-wide-rows}
+TESTS=(
+    "test_storage_s3/test.py::test_parquet_wide_rows_read_memory"
+    "test_storage_s3/test.py::test_parquet_wide_rows_insert_memory"
+)
+
+extract_block() {
+    python3 - "$SOURCE_TEST" <<'PY'
+import sys
+s = open(sys.argv[1]).read()
+start = s.index("def _write_wide_parquet(")
+end = s.index('@pytest.mark.parametrize("format_name", ["Parquet", "ORC"])')
+sys.stdout.write(s[start:end])
+PY
+}
+
+report() {
+    python3 - "$1" "$2" <<'PY'
+import glob, json, os, sys
+label, root = sys.argv[1], sys.argv[2]
+files = sorted(glob.glob(os.path.join(root, "ci/tmp/result_integration_tests_*.json")), key=os.path.getmtime)
+if not files:
+    print(f"{label}\t(no result file)\t-")
+    raise SystemExit
+for r in json.load(open(files[-1])).get("results") or []:
+    name = (r.get("name") or "").replace("test_storage_s3/test.py::", "")
+    print(f"{label}\t{name}\t{r.get('status')}")
+PY
+}
+
+mkdir -p "$WORK"
+BLOCK=$(extract_block)
+RESULTS="$WORK/results.tsv"
+: > "$RESULTS"
+
+for entry in "${VERSIONS[@]}"; do
+    version=${entry%%:*}
+    tag=${entry#*:}
+    root="$WORK/$tag"
+    echo "=== $version ($tag)"
+
+    if [ ! -d "$root/.git" ]; then
+        git clone --depth 1 --filter=blob:none --sparse -b "$tag" \
+            https://github.com/ClickHouse/ClickHouse.git "$root"
+        git -C "$root" sparse-checkout set tests/integration ci programs/server docker/test
+    fi
+
+    target="$root/tests/integration/test_storage_s3/test.py"
+    if ! grep -q "_write_wide_parquet" "$target"; then
+        printf '\n\n%s' "$BLOCK" >> "$target"
+    fi
+
+    mkdir -p "$root/ci/tmp"
+    if [ ! -s "$root/ci/tmp/clickhouse" ]; then
+        cid=$(docker create "clickhouse/clickhouse-server:$version")
+        docker cp "$cid:/usr/bin/clickhouse" "$root/ci/tmp/clickhouse"
+        docker rm -f "$cid" > /dev/null
+    fi
+
+    docker ps -aq --filter name=praktika | xargs -r docker rm -f > /dev/null 2>&1 || true
+    ( cd "$root" && python3 -u -m ci.praktika run integration --test "${TESTS[@]}" ) \
+        > "$WORK/$version.log" 2>&1 || true
+
+    if grep -q "failed to start" "$WORK/$version.log"; then
+        echo -e "$version\t(server did not start)\t-" >> "$RESULTS"
+    else
+        report "$version" "$root" >> "$RESULTS"
+    fi
+done
+
+echo
+printf '%-8s %-58s %s\n' VERSION TEST STATUS
+while IFS=$'\t' read -r v t s; do printf '%-8s %-58s %s\n' "$v" "$t" "$s"; done < "$RESULTS"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/120027
Related: https://github.com/ClickHouse/ClickHouse/pull/120028
Related: https://github.com/ClickHouse/ClickHouse/pull/120029

<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/78934
Related: https://github.com/ClickHouse/ClickHouse/pull/100949
-->

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.


### Documentation entry for user-facing changes
Not applicable.


## What this PR does

Adds integration tests that read and copy a wide-row parquet object over `s3()` under a memory limit, and measures what removing the Arrow-based reader in #100949 costs those queries. Three cases pass on 26.2 and fail on 26.8, so the tests are red and this is a draft.

The fixture is 20 rows with one `String` column of about 12 MB each, so about 240 MB in one object, written both as a single row group and as one row group per row. `reader` is the value of `input_format_parquet_use_native_reader_v3`, obsolete on 26.8. Each `max_memory_usage` sits between the two readers' peaks on 26.2. Peaks in brackets come from `system.query_log` under an 8 GiB limit, as a range where repeated runs differ.

| operation | source | reader | `max_memory_usage` | 26.2.19.43 | 26.8.2.7 |
| --- | --- | --- | --- | --- | --- |
| read | 240 MB, 1 row group | arrow | 1 GiB | OK (715 MiB) | FAIL (1.25 GiB) |
| read | 240 MB, 1 row group | v3 | 1 GiB | FAIL (1.25 GiB) | FAIL (1.25 GiB) |
| read | 240 MB, 20 row groups | arrow | 512 MiB | FAIL (608 MiB) | OK (258-321 MiB) |
| read | 240 MB, 20 row groups | v3 | 512 MiB | OK (257-321 MiB) | OK (225-337 MiB) |
| insert | 240 MB, 1 row group | arrow | 1 GiB | OK (717 MiB) | FAIL (1.34 GiB) |
| insert | 240 MB, 1 row group | v3 | 1 GiB | FAIL (1.28 GiB) | FAIL (1.41 GiB) |
| insert | 240 MB, 20 row groups | arrow | 720 MiB | OK (609 MiB) | FAIL (872 MiB) |
| insert | 240 MB, 20 row groups | v3 | 720 MiB | FAIL (871 MiB) | FAIL (872 MiB) |

## Running it

```bash
tests/integration/test_storage_s3/wide_rows_memory_matrix.sh 26.2:v26.2.19.43-stable 26.8:v26.8.2.7-lts
```

## What this PR does not do

It does not fix anything, and does not say where the memory is held.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119300&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119300](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119300+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
