### PR TITLE
Revert "Revert "Resume a NATS JetStream subscription after a reconnect""

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -166,6 +166,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(rmt_mutation_prune_pause_before_zk_partition_list) \
     PAUSEABLE_ONCE(kafka2_remove_zk_before_get_children) \
     PAUSEABLE_ONCE(kafka2_remove_zk_before_final_multi) \
+    PAUSEABLE_ONCE(nats_pause_before_building_insert_pipeline) \
     PAUSEABLE_ONCE(keeper_map_delete_pause_before_multi) \
     PAUSEABLE_ONCE(paimon_incremental_read_pause_before_is_active_remove) \
     PAUSEABLE(dummy_pausable_failpoint) \

--- a/src/Storages/NATS/INATSConsumer.cpp
+++ b/src/Storages/NATS/INATSConsumer.cpp
@@ -55,6 +55,16 @@ bool INATSConsumer::hasClosedSubscription() const
         subscriptions, [](const auto & subscription) { return !natsSubscription_IsValid(subscription.get()); });
 }
 
+bool INATSConsumer::hasConnectionReconnected() const
+{
+    return connection->getReconnectCount() != connection_reconnect_count;
+}
+
+bool INATSConsumer::isConnectionConnected() const
+{
+    return connection->isConnected();
+}
+
 void INATSConsumer::subscribe()
 {
     if (isSubscribed())
@@ -63,14 +73,17 @@ void INATSConsumer::subscribe()
     if (loadReceived()->isFinished())
         storeReceived(std::make_shared<ConcurrentBoundedQueue<MessageData>>(queue_size));
 
+    /// Read before subscribing: a reconnect racing `subscribeImpl` can already have dropped what the
+    /// new subscription is waiting for, and the count from before still reports that reconnect.
+    const UInt64 reconnect_count_before_subscribe = connection->getReconnectCount();
+
     subscribeImpl();
+
+    connection_reconnect_count = reconnect_count_before_subscribe;
 }
 
-void INATSConsumer::unsubscribe(bool finish_queue)
+void INATSConsumer::unsubscribe()
 {
-    if (finish_queue)
-        loadReceived()->finish();
-
     for (auto & subscription : subscriptions)
     {
         /// The client closes a subscription itself when its fetch is terminated, so draining an
@@ -100,9 +113,61 @@ void INATSConsumer::unsubscribe(bool finish_queue)
     LOG_DEBUG(log, "Consumer {} unsubscribed", static_cast<void*>(this));
 }
 
+void INATSConsumer::finishAndReturnUnprocessed(SkippedMessages skipped_messages_action)
+{
+    /// Handing a message back needs the subscription it arrived on: `natsMsg_Nak` follows a plain
+    /// pointer from the message to that subscription, and on to the JetStream context and the
+    /// connection. An unsubscribed consumer holds only leftovers of a subscription that is already
+    /// gone - a direct `SELECT` that ended leaves them behind - so there is nothing to hand them
+    /// back through, and nothing more can arrive either.
+    if (!isSubscribed())
+    {
+        loadReceived()->finish();
+        dropBuffered();
+        return;
+    }
+
+    /// Handles of messages this consumer has read but not acknowledged: nothing inserted them, so
+    /// the broker has to deliver them again.
+    for (auto & msg : consumed_messages)
+        nackMessage(msg.get());
+    consumed_messages.clear();
+
+    /// Messages that yielded no rows are not waiting to be inserted: `nats_skip_broken_messages`
+    /// passed over them on purpose. Where that skip is already final, handing them back would undo
+    /// it and deliver the same malformed input again, so they are acknowledged instead. Where it is
+    /// not - an uncommitted direct `SELECT`, which must consume nothing - they go back to the
+    /// broker like every other message this consumer has not committed.
+    if (skipped_messages_action == SkippedMessages::Acknowledge)
+    {
+        ackMessages(skipped_messages);
+    }
+    else
+    {
+        for (auto & msg : skipped_messages)
+            nackMessage(msg.get());
+        skipped_messages.clear();
+    }
+
+    /// Finishing the queue before draining it is what makes this complete rather than a snapshot:
+    /// the queue serializes `push` with `finish`, so a message the NATS client thread is delivering
+    /// right now either lands in the queue before it is finished, and the loop below returns it, or
+    /// fails to push and `onMsg` returns it itself. Nothing can be appended afterwards.
+    auto queue = loadReceived();
+    queue->finish();
+
+    MessageData buffered;
+    while (queue->tryPop(buffered))
+    {
+        if (buffered.msg)
+            nackMessage(buffered.msg.get());
+    }
+}
+
 void INATSConsumer::dropBuffered()
 {
     consumed_messages.clear();
+    skipped_messages.clear();
     auto queue = loadReceived();
     MessageData dropped;
     while (queue->tryPop(dropped)) {}
@@ -124,22 +189,42 @@ ReadBufferPtr INATSConsumer::consume(std::optional<UInt64> timeout_ms)
     return std::make_shared<ReadBufferFromMemory>(current.message);
 }
 
-void INATSConsumer::ackConsumed()
+void INATSConsumer::ackMessages(std::vector<NatsMsgPtr> & messages)
 {
-    for (auto & msg : consumed_messages)
+    for (auto & msg : messages)
     {
         auto status = natsMsg_Ack(msg.get(), nullptr);
         if (status != NATS_OK)
             LOG_WARNING(log, "Failed to acknowledge a message in consumer {}: {} (server may redeliver it)",
                 static_cast<void *>(this), natsStatus_GetText(status));
     }
-    consumed_messages.clear();
+    messages.clear();
+}
+
+void INATSConsumer::ackConsumed()
+{
+    ackMessages(consumed_messages);
+    ackMessages(skipped_messages);
+}
+
+void INATSConsumer::markLastConsumedSkipped()
+{
+    /// Core NATS messages are destroyed as they arrive - there is nothing to acknowledge and
+    /// nothing was recorded - so a cycle that skips one has nothing to move here.
+    if (consumed_messages.empty())
+        return;
+
+    skipped_messages.push_back(std::move(consumed_messages.back()));
+    consumed_messages.pop_back();
 }
 
 void INATSConsumer::dropConsumed()
 {
-    /// Release without acking, for JetStream the server redelivers these messages.
+    /// Release without acking, for JetStream the server redelivers these messages. A skipped
+    /// message is released the same way: nothing committed the cycle that skipped it, and the
+    /// redelivered message is skipped again.
     consumed_messages.clear();
+    skipped_messages.clear();
 }
 
 void INATSConsumer::onMsg(natsConnection *, natsSubscription *, natsMsg * msg, void * consumer)

--- a/src/Storages/NATS/INATSConsumer.h
+++ b/src/Storages/NATS/INATSConsumer.h
@@ -47,14 +47,54 @@ public:
 
     /// True when the NATS client has closed a subscription we still hold: consuming has stopped
     /// and only a re-subscribe resumes it. Base implementation always returns false, because
-    /// recovery drops buffered messages and only JetStream redelivers them.
+    /// recovery parts with the buffered messages and only JetStream redelivers them.
     virtual bool needsResubscribe() const { return false; }
 
     void subscribe();
-    void unsubscribe(bool finish_queue);
+    void unsubscribe();
+
+    /// Stop buffering and hand back to the broker every message the client has delivered but
+    /// ClickHouse has not inserted yet, so JetStream redelivers it at once instead of after the
+    /// ACK deadline. Must run before the subscription those messages arrived on is destroyed: a
+    /// `natsMsg` keeps a plain pointer to it, and `natsMsg_Nak` follows that pointer to reach the
+    /// JetStream context and the connection.
+    /// A consumer that is not subscribed holds only leftovers of a subscription that is already
+    /// gone, which it can only destroy. That tells the two apart because nothing re-subscribes
+    /// without clearing the queue first, so a subscribed consumer never holds a message that
+    /// arrived on an older subscription.
+    ///
+    /// What happens to the messages `nats_skip_broken_messages` passed over is the caller's to
+    /// decide, because only the caller knows whether that skip is already final. `Acknowledge`
+    /// keeps it: a background streaming cycle never inserts such a message, so nothing is left to
+    /// commit for it. `ReturnToBroker` is what a direct `SELECT` needs, which consumes only what it
+    /// has committed - the redelivered message is skipped again by the query that gets it next, and
+    /// acknowledged with the rest of what that query reads once it commits.
+    enum class SkippedMessages
+    {
+        Acknowledge,
+        ReturnToBroker,
+    };
+
+    void finishAndReturnUnprocessed(SkippedMessages skipped_messages_action);
 
     void ackConsumed();
     void dropConsumed();
+
+    /// Move the message `consume` returned last out of the set of messages that still owe rows:
+    /// it was parsed into none, which `nats_skip_broken_messages` makes an ordinary outcome rather
+    /// than an error. Such a message is never going to produce a row, so it does not hold back a
+    /// resubscribe of the subscription it arrived on - see `finishAndReturnUnprocessed` for what
+    /// happens to it there.
+    void markLastConsumedSkipped();
+
+    /// True while this consumer holds messages it has handed out and which may still turn into rows
+    /// nothing has acknowledged yet. A message enters this set as soon as `consume` returns it,
+    /// before it is parsed, and leaves it again through `markLastConsumedSkipped` once it turns out
+    /// to have yielded no rows.
+    bool hasConsumedMessages() const { return !consumed_messages.empty(); }
+
+    /// Throw away leftovers of a subscription that is already gone, which is all that can be done
+    /// with them: acknowledging or returning a message needs the subscription it arrived on.
     void dropBuffered();
 
     size_t subjectsCount() { return subjects.size(); }
@@ -86,6 +126,14 @@ protected:
     /// nothing is subscribed, so there is nothing to recover.
     bool hasClosedSubscription() const;
 
+    /// True if the connection has been re-established since we subscribed. The subscriptions we hold
+    /// are still valid, but the broker kept nothing of what they were waiting for.
+    bool hasConnectionReconnected() const;
+
+    /// True while the client holds an open connection to the broker, as opposed to being in the
+    /// middle of re-establishing one.
+    bool isConnectionConnected() const;
+
     static void onMsg(natsConnection * nc, natsSubscription * sub, natsMsg * msg, void * consumer);
 
     virtual void subscribeImpl() = 0;
@@ -95,11 +143,17 @@ protected:
     virtual bool needsAck() const { return false; }
 
 private:
+    /// Acknowledge every message in `messages` and clear it.
+    void ackMessages(std::vector<NatsMsgPtr> & messages);
+
     std::shared_ptr<ConcurrentBoundedQueue<MessageData>> loadReceived() const;
     void storeReceived(std::shared_ptr<ConcurrentBoundedQueue<MessageData>> queue);
 
     NATSConnectionPtr connection;
     std::vector<NATSSubscriptionPtr> subscriptions;
+    /// Reconnect count of the connection as of the moment we subscribed. Only ever touched under the
+    /// storage's consumers mutex, together with `subscriptions`.
+    UInt64 connection_reconnect_count = 0;
     const std::vector<String> subjects;
     LoggerPtr log;
     const std::atomic<bool> & stopped;
@@ -111,6 +165,10 @@ private:
     std::shared_ptr<ConcurrentBoundedQueue<MessageData>> received;
     MessageData current;
     std::vector<NatsMsgPtr> consumed_messages;
+    /// Messages that were consumed and parsed into no rows. They are acknowledged together with
+    /// `consumed_messages` when the query that read them commits; a resubscribe in the middle of a
+    /// query resolves them the way `finishAndReturnUnprocessed` was told to.
+    std::vector<NatsMsgPtr> skipped_messages;
 };
 
 }

--- a/src/Storages/NATS/NATSConnection.cpp
+++ b/src/Storages/NATS/NATSConnection.cpp
@@ -56,8 +56,17 @@ NATSConnection::NATSConnection(const NATSConfiguration & configuration_, LoggerP
     : configuration(configuration_)
     , log(std::move(log_))
     , options(std::move(options_))
+    , statistics(nullptr, &natsStatistics_Destroy)
     , connection(nullptr, &natsConnection_Destroy)
 {
+    natsStatistics * new_statistics = nullptr;
+    auto status = natsStatistics_Create(&new_statistics);
+    if (status != NATS_OK)
+        throw Exception(
+            ErrorCodes::CANNOT_CONNECT_NATS,
+            "Can not create NATS statistics. Nats error: {}", natsStatus_GetText(status));
+    statistics.reset(new_statistics);
+
     if (!configuration.username.empty() && !configuration.password.empty())
         natsOptions_SetUserInfo(options.get(), configuration.username.c_str(), configuration.password.c_str());
     if (!configuration.token.empty())
@@ -139,6 +148,28 @@ bool NATSConnection::isClosed()
 {
     std::lock_guard lock(mutex);
     return isClosedImpl(lock);
+}
+
+UInt64 NATSConnection::getReconnectCount()
+{
+    std::lock_guard lock(mutex);
+    if (!connection)
+        return 0;
+
+    auto status = natsConnection_GetStats(connection.get(), statistics.get());
+    if (status != NATS_OK)
+        throw Exception(
+            ErrorCodes::CANNOT_CONNECT_NATS,
+            "Can not get statistics of connection to {}. Nats error: {}", connectionInfoForLog(), natsStatus_GetText(status));
+
+    uint64_t reconnects = 0;
+    status = natsStatistics_GetCounts(statistics.get(), nullptr, nullptr, nullptr, nullptr, &reconnects);
+    if (status != NATS_OK)
+        throw Exception(
+            ErrorCodes::CANNOT_CONNECT_NATS,
+            "Can not read statistics of connection to {}. Nats error: {}", connectionInfoForLog(), natsStatus_GetText(status));
+
+    return reconnects;
 }
 
 bool NATSConnection::connect()

--- a/src/Storages/NATS/NATSConnection.h
+++ b/src/Storages/NATS/NATSConnection.h
@@ -40,6 +40,7 @@ struct NATSConfiguration
 };
 
 using NATSOptionsPtr = std::unique_ptr<natsOptions, decltype(&natsOptions_Destroy)>;
+using NATSStatisticsPtr = std::unique_ptr<natsStatistics, decltype(&natsStatistics_Destroy)>;
 
 /// Loads the TLS material into `options`. Both calls parse the files immediately, so one which
 /// cannot be read or parsed is reported here instead of at connect time.
@@ -69,6 +70,11 @@ public:
     natsConnection * getConnection() { return connection.get(); }
     int getReconnectWait() const { return configuration.reconnect_wait; }
 
+    /// How many times the client has re-established this connection. The client restores a
+    /// subscription itself, but only its `SUB` line, so anything a subscription was waiting for on
+    /// the broker is gone: whoever needs it back has to notice this count changing.
+    UInt64 getReconnectCount();
+
     String connectionInfoForLog() const;
 
 private:
@@ -87,6 +93,7 @@ private:
     LoggerPtr log;
 
     NATSOptionsPtr options;
+    NATSStatisticsPtr statistics;
     std::unique_ptr<natsConnection, decltype(&natsConnection_Destroy)> connection;
 
     std::mutex mutex;

--- a/src/Storages/NATS/NATSJetStreamConsumer.h
+++ b/src/Storages/NATS/NATSJetStreamConsumer.h
@@ -25,11 +25,24 @@ public:
 
     bool needsAck() const override { return true; }
 
-    /// An asynchronous pull subscription is renewed only when a message is delivered, and a
-    /// reconnect resends the `SUB` line but not the outstanding pull request, so a subscription
-    /// whose fetch the client has terminated never consumes again. JetStream redelivers unacked
-    /// messages, so re-subscribing is safe here.
-    bool needsResubscribe() const override { return isSubscribed() && hasClosedSubscription(); }
+    /// An asynchronous pull subscription is renewed only when a message is delivered, so it consumes
+    /// nothing more once the pull request it is waiting for is gone. That happens two ways: the
+    /// client closes the subscription when the broker answers the request while shutting down, and a
+    /// reconnect resends the `SUB` line but not the request, leaving a subscription that still looks
+    /// healthy with nothing parked on the broker. JetStream redelivers unacked messages, so
+    /// re-subscribing is safe here.
+    /// Reported only while the client is connected. The client lets a subscription be created while
+    /// it is reconnecting: the consumer lookup times out and is tolerated for a bound pull consumer,
+    /// the `SUB` line and the pull request wait in the pending buffer, and the reconnect that then
+    /// completes sends them. Such a subscription is sound, but it was created against a reconnect
+    /// count that predates that reconnect, so it would read as stale once more and be replaced,
+    /// handing back whatever the broker had just delivered to it. Waiting for the connection costs
+    /// nothing: a stale subscription receives nothing in the meantime, and both conditions keep
+    /// reporting until they have been acted on.
+    bool needsResubscribe() const override
+    {
+        return isSubscribed() && isConnectionConnected() && (hasClosedSubscription() || hasConnectionReconnected());
+    }
 
 protected:
     void subscribeImpl() override;

--- a/src/Storages/NATS/NATSSource.cpp
+++ b/src/Storages/NATS/NATSSource.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/Context.h>
 #include <Processors/Executors/StreamingFormatExecutor.h>
 #include <Storages/NATS/INATSConsumer.h>
+#include <Common/logger_useful.h>
 
 namespace DB
 {
@@ -59,6 +60,7 @@ NATSSource::NATSSource(
     , storage(storage_)
     , storage_snapshot(storage_snapshot_)
     , context(context_)
+    , log(getLogger("NATSSource (" + storage_.getStorageID().getFullTableName() + ")"))
     , column_names(columns)
     , max_block_size(max_block_size_)
     , handle_error_mode(handle_error_mode_)
@@ -77,7 +79,7 @@ NATSSource::~NATSSource()
     consumer->dropConsumed();
 
     if (unsubscribe_on_destroy)
-        consumer->unsubscribe(/*finish_queue=*/false);
+        consumer->unsubscribe();
 
     storage.pushConsumer(consumer);
 }
@@ -168,6 +170,49 @@ Chunk NATSSource::generateImpl()
             return {};
         }
 
+        /// A JetStream pull subscription survives a reconnect client side, but the server has
+        /// discarded the pull request it was waiting for. Direct reads do not return the consumer
+        /// to `StorageNATS` until this source is destroyed, so recover it here instead of waiting
+        /// for the background streaming task to notice it.
+        /// Nothing the consumer holds locally can outlive its subscription: a `natsMsg` keeps a
+        /// plain pointer to the `natsSubscription` it arrived on, and `natsMsg_Ack` follows it to
+        /// reach the JetStream context and the connection, so acknowledging a message whose
+        /// subscription has been destroyed reads freed memory. So recovery prefers a cycle that
+        /// starts holding nothing: no rows in the current output block, whose ACK handles
+        /// `StorageNATS` needs until it has inserted them, and nothing left in the local queue,
+        /// which the cycles before this one insert and acknowledge.
+        /// Those checks are only a snapshot - `onMsg` runs on the NATS client thread and the
+        /// drain inside `unsubscribe` delivers whatever the subscription still has - so what the
+        /// consumer does turn out to hold is returned to the broker instead of being destroyed,
+        /// while the subscription it arrived on is still alive.
+        /// Emitting no rows is not the same as having consumed nothing: `consume` takes a message
+        /// before it is parsed, and `nats_skip_broken_messages` turns a message that yields no rows
+        /// into an ordinary outcome. Such a message is not waiting to be inserted, so the recovery
+        /// does not have to wait for it: `markLastConsumedSkipped` moves it aside as soon as it
+        /// turns out to have produced nothing. Only a background streaming cycle, which never
+        /// inserts such a message and whose skip is therefore already final when it happens,
+        /// acknowledges it here rather than handing it back, which keeps the skip instead of
+        /// showing the same malformed input to the next cycle. A direct `SELECT` consumes only what
+        /// it has committed, and this recovery runs long before the commit point in `generate` - a
+        /// query cancelled in between must leave the message for the next reader, whatever
+        /// `nats_commit_on_select` says - so there a skipped message goes back to the broker like
+        /// the rest of what the consumer holds. The redelivery is skipped again right away and is
+        /// acknowledged with everything else once the query does commit.
+        /// What the guard below waits for is a message that still owes rows to this query.
+        /// `unsubscribe_on_destroy` keeps its previous value: a background streaming consumer must
+        /// stay subscribed when this source is destroyed, so the next streaming cycle keeps
+        /// consuming where this one left off. Only a consumer this source subscribed from an
+        /// unsubscribed state (the direct `SELECT` case above) is unsubscribed on destroy.
+        if (total_rows == 0 && !consumer->hasConsumedMessages() && consumer->queueEmpty() && consumer->needsResubscribe())
+        {
+            LOG_INFO(log, "A subscription stopped consuming from the NATS server, resubscribing within a running query");
+            consumer->finishAndReturnUnprocessed(
+                background_streaming ? INATSConsumer::SkippedMessages::Acknowledge
+                                     : INATSConsumer::SkippedMessages::ReturnToBroker);
+            consumer->unsubscribe();
+            consumer->subscribe();
+        }
+
         if (consumer->isConsumerStopped() || !checkTimeLimit())
             break;
 
@@ -181,7 +226,15 @@ Chunk NATSSource::generateImpl()
             buf = consumer->consume();
 
         if (buf)
+        {
             new_rows = executor.execute(*buf);
+
+            /// A message that parsed into no rows is one `nats_skip_broken_messages` passed over
+            /// (with `handle_error_mode = 'stream'` a malformed message still yields its error row).
+            /// Nothing is waiting for it, so it must not hold back a reconnect recovery.
+            if (new_rows == 0)
+                consumer->markLastConsumedSkipped();
+        }
         else if (!wait_for_flush_interval)
             break;
 

--- a/src/Storages/NATS/NATSSource.h
+++ b/src/Storages/NATS/NATSSource.h
@@ -4,6 +4,7 @@
 #include <Processors/ISource.h>
 #include <Storages/NATS/INATSConsumer.h>
 #include <Storages/NATS/StorageNATS.h>
+#include <Common/Logger.h>
 
 #include <optional>
 
@@ -38,6 +39,12 @@ public:
 
     void setCommitOnSelect(bool value) { commit_on_select = value; }
 
+    /// A source that feeds the materialized views rather than a query result. It matters for the
+    /// messages `nats_skip_broken_messages` passed over: a streaming cycle never inserts them, so
+    /// their skip is final as soon as it happened, while a direct `SELECT` consumes nothing before
+    /// it commits, so a resubscribe inside the query hands them back to the broker instead.
+    void setBackgroundStreaming(bool value) { background_streaming = value; }
+
     bool wasConsumptionAborted() const { return consumption_aborted; }
 
 private:
@@ -47,6 +54,7 @@ private:
     StorageNATS & storage;
     StorageSnapshotPtr storage_snapshot;
     ContextPtr context;
+    LoggerPtr log;
     Names column_names;
     const size_t max_block_size;
     StreamingHandleErrorMode handle_error_mode;
@@ -65,6 +73,7 @@ private:
     Poco::Timespan max_execution_time = 0;
     bool wait_for_flush_interval = false;
     bool commit_on_select = false;
+    bool background_streaming = false;
     Stopwatch total_stopwatch {CLOCK_MONOTONIC_COARSE};
 
     NATSSource(

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -20,6 +20,7 @@
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/QueryPipeline.h>
 #include <Storages/MessageQueueSink.h>
 #include <Storages/NATS/NATSCoreConsumer.h>
 #include <Storages/NATS/NATSCoreProducer.h>
@@ -36,6 +37,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/Macros.h>
 #include <Common/ThreadPool.h>
 #include <Common/logger_useful.h>
@@ -98,6 +100,10 @@ extern const int CANNOT_CONNECT_NATS;
 extern const int QUERY_NOT_ALLOWED;
 }
 
+namespace FailPoints
+{
+extern const char nats_pause_before_building_insert_pipeline[];
+}
 
 StorageNATS::StorageNATS(
     const StorageID & table_id_,
@@ -377,6 +383,27 @@ bool StorageNATS::subscribeConsumers()
     {
         try
         {
+            /// A consumer can reach this point still subscribed, because `unsubscribeConsumers`
+            /// only reaches the consumers that are in the pool at that moment: a direct `SELECT`
+            /// holds one out of the pool and hands it back subscribed whenever it found it that
+            /// way. What such a consumer buffered belongs to the window when the table was not
+            /// streaming - messages published while the materialized view was detached - and must
+            /// not be inserted into the views by the cycles that follow. Clearing the queue alone
+            /// does not guarantee that: `onMsg` keeps appending from the NATS client thread, and
+            /// `subscribe` does nothing for a consumer that is subscribed already, so the live
+            /// subscription is replaced the way `unsubscribeConsumers` would have replaced it. The
+            /// queue is finished before the drain inside `unsubscribe` delivers what the
+            /// subscription still holds, so nothing from that window can land behind the cleanup,
+            /// and a JetStream message goes back to the broker while the subscription it arrived
+            /// on is still alive, so it is redelivered at once rather than after the ACK deadline.
+            if (consumer->isSubscribed())
+            {
+                consumer->finishAndReturnUnprocessed(INATSConsumer::SkippedMessages::Acknowledge);
+                consumer->unsubscribe();
+            }
+
+            /// What an unsubscribed consumer still holds are leftovers of a subscription that is
+            /// already gone, which can only be thrown away.
             consumer->dropBuffered();
             consumer->subscribe();
             ++num_initialized;
@@ -398,10 +425,51 @@ bool StorageNATS::subscribeConsumers()
     return are_consumers_initialized;
 }
 
-bool StorageNATS::consumersNeedResubscribe()
+void StorageNATS::resubscribeStaleConsumers()
 {
     std::lock_guard lock(consumers_mutex);
-    return std::ranges::any_of(consumers, [](const auto & consumer) { return consumer->needsResubscribe(); });
+    for (auto & consumer : consumers)
+    {
+        if (!consumer->needsResubscribe())
+            continue;
+
+        /// Nothing the consumer holds locally can outlive its subscription: a `natsMsg` keeps a
+        /// plain pointer to the `natsSubscription` it arrived on, and `natsMsg_Ack` follows it to
+        /// reach the JetStream context and the connection, so acknowledging a message whose
+        /// subscription has been destroyed reads freed memory. Recovery therefore prefers a
+        /// consumer that holds nothing: the streaming cycles insert and acknowledge what the
+        /// broker delivered before it went stale, and a stale subscription delivers nothing more,
+        /// so the queue does drain and the reconnect this keys on is still reported once it has.
+        if (!consumer->queueEmpty())
+        {
+            LOG_DEBUG(log, "A subscription stopped consuming from the NATS server, resubscribing once the buffered messages are drained");
+            continue;
+        }
+
+        LOG_INFO(log, "A subscription stopped consuming from the NATS server, resubscribing");
+
+        /// The check above is only a snapshot: `onMsg` runs on the NATS client thread and appends
+        /// to the queue without `consumers_mutex`, and the drain inside `unsubscribe` delivers
+        /// whatever the subscription still has. So the messages are returned to the broker rather
+        /// than destroyed, while the subscription they arrived on is still alive, and the queue is
+        /// finished first so that nothing can be appended behind that.
+        consumer->finishAndReturnUnprocessed(INATSConsumer::SkippedMessages::Acknowledge);
+        consumer->unsubscribe();
+
+        try
+        {
+            consumer->subscribe();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log);
+            /// A consumer left unsubscribed no longer reports that it needs to be recovered, so it
+            /// would stay silent. Hand it to `subscribeConsumers`, which only runs while the
+            /// consumers are not ready.
+            consumers_ready.store(false);
+            break;
+        }
+    }
 }
 
 void StorageNATS::unsubscribeConsumers()
@@ -409,8 +477,8 @@ void StorageNATS::unsubscribeConsumers()
     std::lock_guard lock(consumers_mutex);
     for (auto & consumer : consumers)
     {
-        consumer->unsubscribe(/*finish_queue=*/true);
-        consumer->dropBuffered();
+        consumer->finishAndReturnUnprocessed(INATSConsumer::SkippedMessages::Acknowledge);
+        consumer->unsubscribe();
     }
 
     consumers_ready.store(false);
@@ -723,13 +791,10 @@ void StorageNATS::threadFunc()
     if (consumers_ready && subscription_stale.exchange(false))
         unsubscribeConsumers();
 
-    /// A consumer whose subscription the NATS client has closed never receives another message,
-    /// so drop the subscriptions here and let the cycle below subscribe again.
-    if (consumers_ready && consumersNeedResubscribe())
-    {
-        LOG_INFO(log, "A subscription was closed by the NATS server, resubscribing");
-        unsubscribeConsumers();
-    }
+    /// A subscription the NATS client has closed, or one that outlived a reconnect, never receives
+    /// another message, so replace it here, keeping everything the consumer already holds locally.
+    if (consumers_ready)
+        resubscribeStaleConsumers();
 
     const size_t num_views = DatabaseCatalog::instance().getDependentViews(table_id).size();
     const bool is_connected = consumers_connection && consumers_connection->isConnected();
@@ -832,6 +897,8 @@ bool StorageNATS::streamToViews(UInt64 cycle_epoch)
     /// ensure no stale state is reused.
     new_context->makeQueryContext();
 
+    FailPointInjection::pauseFailPoint(FailPoints::nats_pause_before_building_insert_pipeline);
+
     // Only insert into dependent views and expect that input blocks contain virtual columns
     InterpreterInsertQuery interpreter(
         insert,
@@ -841,6 +908,24 @@ bool StorageNATS::streamToViews(UInt64 cycle_epoch)
         /* no_destination */ true,
         /* async_isnert */ false);
     auto block_io = interpreter.execute();
+
+    /// `threadFunc` streams only while the table has ready dependent views, but the interpreter looks
+    /// them up again, and a `DROP VIEW` or `DETACH TABLE` landing in between leaves it with nowhere
+    /// to insert into: the pipeline it builds then discards whatever the sources consume (see
+    /// `InsertDependenciesBuilder::createChainWithDependencies`), and the acknowledgement below
+    /// would confirm to the broker messages that were never inserted anywhere. Such a cycle must not
+    /// consume anything. What the consumers hold goes back to the broker when the next cycle finds
+    /// the last view gone and unsubscribes them, or stays with them until the view is attached again.
+    /// This repeats the readiness check of `threadFunc`, not a check of the dependency metadata or of
+    /// the shape of the pipeline: a plain `DETACH TABLE` keeps the dependency registered while the
+    /// view is gone, and a materialized view whose target is `Null` legitimately ends in the same
+    /// discarding sink while being a view the table streams to. The check can only err towards
+    /// skipping a cycle whose pipeline would have inserted somewhere, which consumes nothing.
+    if (!checkDependencies(table_id))
+    {
+        LOG_DEBUG(log, "The last materialized view was dropped or detached while the streaming cycle was being prepared, nothing to stream to");
+        return true;
+    }
 
     const auto metadata_snapshot = getInMemoryMetadataPtr(getContext(), false);
     auto storage_snapshot = getStorageSnapshot(metadata_snapshot, getContext());
@@ -876,6 +961,7 @@ bool StorageNATS::streamToViews(UInt64 cycle_epoch)
         /// Only hold blocks open for the whole flush interval when `nats_wait_for_flush_interval` is set.
         source->setWaitForFlushInterval(
             (*nats_settings)[NATSSetting::nats_wait_for_flush_interval] && max_execution_time.totalMicroseconds() > 0);
+        source->setBackgroundStreaming(true);
     }
 
     block_io.pipeline.complete(Pipe::unitePipes(std::move(pipes)));

--- a/src/Storages/NATS/StorageNATS.h
+++ b/src/Storages/NATS/StorageNATS.h
@@ -142,7 +142,10 @@ private:
     void createConsumers();
 
     bool subscribeConsumers();
-    bool consumersNeedResubscribe();
+    /// Replaces the subscription of every consumer that stopped consuming, without losing what it
+    /// has already buffered locally: a consumer that still holds messages is left to a later cycle,
+    /// and whatever it does turn out to hold is handed back to the broker rather than destroyed.
+    void resubscribeStaleConsumers();
     void unsubscribeConsumers();
 
     void stopEventLoop();

--- a/tests/integration/test_storage_nats/common.py
+++ b/tests/integration/test_storage_nats/common.py
@@ -58,6 +58,13 @@ def kill_nats(cluster):
     p.communicate()
     return p.returncode == 0
 
+def hard_kill_nats(cluster):
+    # `SIGKILL`, so the broker answers nothing on its way out: unlike `kill_nats`, which stops it
+    # gracefully, the client is left holding subscriptions it has no status for.
+    p = subprocess.Popen(("docker", "kill", cluster.nats_docker_id), stdout=subprocess.PIPE)
+    p.communicate()
+    return p.returncode == 0
+
 def revive_nats(cluster):
     p = subprocess.Popen(("docker", "start", cluster.nats_docker_id), stdout=subprocess.PIPE)
     p.communicate()
@@ -95,14 +102,33 @@ def wait_for_mv_attached_to_table(instance, table_name, sleep_timeout = 0.5, tim
 
 STREAMING_STARTED_LOG_LINE = "Started streaming to [0-9]+ attached views"
 
-def wait_for_streaming_started(instance, table_name, time_limit_sec = 60):
+def wait_for_streaming_started(instance, table_name, time_limit_sec = 60, anchor = None, sleep_timeout = 0.2):
     # The background task logs the line on every iteration, right after the consumer has
     # subscribed, so a fresh occurrence means the subscription is live now. Tests within a
-    # module reuse table names, hence the wait is anchored past the occurrences the previous
-    # tests left in the window `wait_for_log_line` looks at.
+    # module reuse table names, hence the wait has to tell a fresh occurrence from the ones the
+    # previous tests left behind.
+    #
+    # `anchor` - an absolute log offset from `log_line_count`, taken before whatever makes the
+    # table stream - draws that line exactly, and is the only reliable way to draw it for a table
+    # with a long flush interval. Without it the earlier occurrences are counted in a tail window
+    # that keeps sliding as the log grows, so a line written between that count and the wait is not
+    # new to the window the wait then looks at: it evicted an older match instead of adding to one.
+    # The wait then needs the streaming cycle after it, a whole flush interval away.
     log_line = "{}.*{}".format(table_name, STREAMING_STARTED_LOG_LINE)
-    seen = count_in_recent_log(instance, log_line)
-    instance.wait_for_log_line(log_line, timeout=time_limit_sec, repetitions=seen + 1)
+
+    if anchor is None:
+        seen = count_in_recent_log(instance, log_line)
+        instance.wait_for_log_line(log_line, timeout=time_limit_sec, repetitions=seen + 1)
+        return
+
+    deadline = time.monotonic() + time_limit_sec
+    while time.monotonic() < deadline:
+        if count_in_log_after(instance, log_line, anchor) > 0:
+            return
+        time.sleep(sleep_timeout)
+
+    raise AssertionError(
+        "{} did not start streaming within {} seconds".format(table_name, time_limit_sec))
 
 def count_in_recent_log(instance, pattern, look_behind_lines = 10000):
     result = instance.exec_in_container(

--- a/tests/integration/test_storage_nats/test_nats_jet_stream.py
+++ b/tests/integration/test_storage_nats/test_nats_jet_stream.py
@@ -111,7 +111,7 @@ async def delete_stream(cluster_inst, stream_name):
     await nc.close()
 
 
-async def add_durable_consumer(cluster_inst, stream_name, consumer_name):
+async def add_durable_consumer(cluster_inst, stream_name, consumer_name, ack_wait_sec = None):
     nc = await nats_helpers.nats_connect_ssl(cluster_inst)
     logging.debug("NATS connection status: " + str(nc.is_connected))
 
@@ -119,6 +119,8 @@ async def add_durable_consumer(cluster_inst, stream_name, consumer_name):
     js = nc.jetstream()
 
     consumer_config = api.ConsumerConfig(name=consumer_name, durable_name=consumer_name)
+    if ack_wait_sec is not None:
+        consumer_config.ack_wait = ack_wait_sec
 
     # Persist messages on 'foo's subject.
     consumer_info = await js.add_consumer(stream=stream_name, config=consumer_config)
@@ -144,6 +146,26 @@ async def delete_durable_consumer(cluster_inst, stream_name, consumer_name):
     await js.delete_consumer(stream_name, consumer_name)
 
     await nc.close()
+
+
+async def get_num_ack_pending(cluster_inst, stream_name, consumer_name):
+    nc = await nats_helpers.nats_connect_ssl(cluster_inst)
+    js = nc.jetstream()
+
+    consumer_info = await js.consumer_info(stream_name, consumer_name)
+
+    await nc.close()
+    return consumer_info.num_ack_pending
+
+
+async def get_delivered_consumer_seq(cluster_inst, stream_name, consumer_name):
+    nc = await nats_helpers.nats_connect_ssl(cluster_inst)
+    js = nc.jetstream()
+
+    consumer_info = await js.consumer_info(stream_name, consumer_name)
+
+    await nc.close()
+    return consumer_info.delivered.consumer_seq
 
 
 async def get_num_waiting(cluster_inst, stream_name, consumer_name):
@@ -1151,8 +1173,7 @@ def test_nats_restore_failed_connection_without_losses_on_write(nats_cluster):
     assert int(result) == messages_num, "ClickHouse lost some messages: {}".format(result)
 
 
-RESUBSCRIBE_LOG_LINE = "A subscription was closed by the NATS server, resubscribing"
-SUBSCRIBED_LOG_LINE = "Subscribed to subject test_subject"
+RESUBSCRIBE_LOG_LINE = "A subscription stopped consuming from the NATS server, resubscribing"
 
 
 def _setup_restart_table(subject, consumer_name):
@@ -1208,60 +1229,20 @@ def _wait_for_parked_pull_request(consumer_name = "test_consumer", time_limit_se
         "no pull request is parked for consumer {}: num_waiting is {}".format(consumer_name, num_waiting))
 
 
-def _restart_nats(nats_cluster, attempts = 4):
-    # Restarts the broker with a pull request parked, retrying until the restart lands outside the
-    # window this fix does not cover.
+def _restart_nats(nats_cluster, kill = nats_helpers.kill_nats):
+    # Restarts the broker with a pull request parked, which is the state that used to leave the table
+    # subscribed and permanently silent.
     #
-    # This fix recovers a subscription that the NATS client has closed, which happens when the server
-    # answers our outstanding pull request while shutting down. A restart landing in the milliseconds
-    # between a re-subscribe and its request being parked instead leaves the client holding a
-    # subscription it has no status for, so nothing reports it as closed and it never consumes again -
-    # the residual this fix deliberately does not cover, which a hard kill or a network partition
-    # reaches the same way.
-    #
-    # Such a restart cannot be excluded in advance. Delivering the backlog these tests drain to reach
-    # the idle state is itself followed by a re-subscribe at an unpredictable delay, and `num_waiting`
-    # cannot rule one out because it counts parked requests broker side without saying which
-    # subscription parked them: it reads one for the previous request while a fresh subscription has
-    # none parked yet.
-    #
-    # So it is detected afterwards instead. A re-subscribe logs before it can park a request, so a
-    # subscribe line written between the parked-request check and the restart marks a restart that
-    # never exercised the recovery, and that attempt is retried. Every measured failure has such a
-    # line within tens of milliseconds of the restart and no passing run has one. This decides which
-    # restarts count as a trial and cannot mask the bug it tests for: without the fix, the restart
-    # still lands with no subscribe line in between, so the attempt proceeds and the consumption
-    # assertion fails, which is what the pristine-master arm confirms.
-    for attempt in range(attempts):
-        # Anchored before the wait rather than after it: `num_waiting` can be satisfied by the
-        # previous request while a re-subscribe is already under way, and a window opened only after
-        # the wait returns would not contain that subscribe line at all.
-        anchor = nats_helpers.log_line_count(instance)
-        _wait_for_parked_pull_request()
+    # Recovery keys on two things, and a restart can land on either: a graceful shutdown answers the
+    # outstanding pull request, which closes the subscription client side, while a restart landing in
+    # the milliseconds between a re-subscribe and its request being parked leaves the client holding a
+    # subscription it has no status for. The reconnect itself is what reports the second one, so no
+    # restart needs to be excluded here, and which one a restart lands on need not be known.
+    _wait_for_parked_pull_request()
 
-        nats_helpers.kill_nats(nats_cluster)
-        time.sleep(4)
-        resubscribed = nats_helpers.count_in_log_after(instance, SUBSCRIBED_LOG_LINE, anchor)
-        nats_helpers.revive_nats(nats_cluster)
-        if not resubscribed:
-            return
-
-        logging.info(
-            "restart attempt %s raced a re-subscribe, retrying so the restart exercises the recovery",
-            attempt)
-
-        # The discarded attempt leaves the subscription it raced holding no request: the restart
-        # destroyed that request broker side while the client kept a handle it has no status for, so
-        # nothing reports it closed and the recovery this fix adds never fires for it. Retrying
-        # against it would poll `num_waiting` forever, so rebuild the subscription first and require
-        # a fresh streaming cycle before the next attempt reads the precondition again.
-        instance.query("SYSTEM STOP test.consume")
-        instance.query("SYSTEM START test.consume")
-        nats_helpers.wait_for_streaming_started(instance, "test.consume")
-
-    raise AssertionError(
-        "every one of {} restarts raced a re-subscribe, so the recovery was never exercised".format(
-            attempts))
+    kill(nats_cluster)
+    time.sleep(4)
+    nats_helpers.revive_nats(nats_cluster)
 
 
 def test_nats_jet_stream_resumes_consuming_after_broker_restart(nats_cluster):
@@ -1278,6 +1259,1002 @@ def test_nats_jet_stream_resumes_consuming_after_broker_restart(nats_cluster):
 
     total_expected += 10
     _publish_and_expect("test_subject", range(100, 110), total_expected)
+
+
+def test_nats_jet_stream_resumes_consuming_after_broker_hard_kill(nats_cluster):
+    # A hard kill answers nothing, so no subscription is ever reported as closed: the client keeps
+    # handles that still look healthy while the request they wait on died with the broker. Only the
+    # reconnect reports this, and it is the same state a restart reaches when it lands between a
+    # re-subscribe and its request being parked - the window that made a graceful restart flaky.
+    _setup_restart_table("test_subject", "test_consumer")
+
+    total_expected = 10
+    _publish_and_expect("test_subject", range(0, 10), total_expected)
+
+    _restart_nats(nats_cluster, kill = nats_helpers.hard_kill_nats)
+
+    total_expected += 10
+    _publish_and_expect("test_subject", range(100, 110), total_expected)
+
+
+IN_SOURCE_RESUBSCRIBE_LOG_LINE = (
+    "A subscription stopped consuming from the NATS server, resubscribing within a running query"
+)
+
+
+def test_nats_jet_stream_direct_select_resumes_after_broker_hard_kill(nats_cluster):
+    # Unlike the materialized-view path, a direct SELECT owns its consumer until the query ends.
+    # Keep that query waiting on a parked pull request, then hard-kill the broker: a reconnect
+    # restores the NATS `SUB`, but not the JetStream pull request. The source must therefore
+    # re-subscribe itself before the message published after the reconnect can arrive.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer"))
+
+    instance.query(
+        """
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n';
+        """
+    )
+
+    # The query has to still be waiting when the message is published, and the whole broker restart
+    # happens inside that wait, so the limit is generous rather than tight: it is a deadline for the
+    # restart, not a measurement. The source returns as soon as it has the single row it is asked
+    # for, so nothing here is spent waiting when the recovery works.
+    select = instance.get_query_request(
+        "SELECT key FROM test.consume SETTINGS stream_like_engine_allow_direct_select = 1, rabbitmq_max_wait_ms = 120000",
+        timeout=180,
+    )
+    _wait_for_parked_pull_request()
+    _restart_nats(nats_cluster, kill = nats_helpers.hard_kill_nats)
+
+    asyncio.run(publish_messages(nats_cluster, "test_stream", "test_subject", [json.dumps({"key": 42, "value": 42})]))
+    assert TSV(select.get_answer()) == TSV("42")
+
+
+def test_nats_jet_stream_direct_select_resumes_after_broker_graceful_restart(nats_cluster):
+    # The recovery inside a running query keys on two things, and a graceful restart is the one
+    # that reaches the other: the broker answers the parked pull request on its way down, and the
+    # client closes the subscription in response, so the query is holding a subscription that is
+    # invalid long before the connection comes back. The hard kill above never produces that
+    # state; it leaves handles that look healthy until the reconnect count says otherwise. So
+    # this is a separate contract on the direct-`SELECT` path, where the query performs the
+    # `unsubscribe` and `subscribe` itself rather than through the retry loop of the background
+    # task: a subscription that turns out to be closed while the broker is still unreachable must
+    # not fail the query, it must be replaced once the broker is back.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer"))
+
+    instance.query(
+        """
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n';
+        """
+    )
+
+    # Anchored before the query starts, so a recovery counts however early in the query it runs.
+    anchor = nats_helpers.log_line_count(instance)
+
+    select = instance.get_query_request(
+        "SELECT key FROM test.consume SETTINGS stream_like_engine_allow_direct_select = 1, rabbitmq_max_wait_ms = 120000",
+        timeout=180,
+    )
+    _wait_for_parked_pull_request()
+    _restart_nats(nats_cluster, kill = nats_helpers.kill_nats)
+
+    asyncio.run(publish_messages(nats_cluster, "test_stream", "test_subject", [json.dumps({"key": 42, "value": 42})]))
+    assert TSV(select.get_answer()) == TSV("42")
+
+    # The row alone would also be explained by a recovery the background task performed on a
+    # consumer the query had already handed back, so require the query to have done it itself.
+    assert nats_helpers.count_in_log_after(instance, IN_SOURCE_RESUBSCRIBE_LOG_LINE, anchor) > 0, (
+        "the query did not recover its subscription itself")
+
+
+def test_nats_jet_stream_streaming_drains_local_backlog_after_in_source_recovery(nats_cluster):
+    # When a reconnect lands while a streaming source is inside its flush interval, the source
+    # itself recovers the subscription. The consumer must then stay subscribed when that source is
+    # destroyed: rows beyond the first output block are already delivered to the local queue, and
+    # unsubscribing would make the next cycle drop them locally, stalling the view until the server
+    # redelivers them after the ACK deadline.
+    #
+    # The ACK deadline is set far beyond the waits below, so server redelivery cannot make up for a
+    # locally dropped backlog: the final assertion holds only if the recovered consumer stayed
+    # subscribed and the following streaming cycles drained the local queue.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    # Anchored before the table exists, so the first streaming cycle counts however quickly it
+    # starts. A cycle here spans a whole 60 second flush interval, longer than the wait itself, so
+    # a first cycle the wait fails to recognize has no successor to fall back on.
+    created = nats_helpers.log_line_count(instance)
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_max_block_size = 5,
+                     nats_flush_interval_ms = 60000,
+                     nats_wait_for_flush_interval = 1;
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+    nats_helpers.wait_for_streaming_started(instance, "test.consume", anchor = created)
+
+    # A streaming cycle spans the whole 60 second flush interval, so a reconnect all but always
+    # lands mid-cycle, where the source performs the recovery itself. Only that in-source recovery
+    # exercises the code path under test, so wait for its log line; in the rare case the reconnect
+    # hits the gap between cycles and the background task recovers the subscription instead, the
+    # broker is healthy again and the restart can simply be retried.
+    anchor = nats_helpers.log_line_count(instance)
+    for _ in range(3):
+        _restart_nats(nats_cluster, kill = nats_helpers.hard_kill_nats)
+
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if nats_helpers.count_in_log_after(instance, IN_SOURCE_RESUBSCRIBE_LOG_LINE, anchor) > 0:
+                break
+            time.sleep(0.2)
+        else:
+            continue
+        break
+    else:
+        raise AssertionError("no streaming source performed an in-source recovery")
+
+    # More rows than one output block: the first block ends the recovering source's cycle, and the
+    # rest waits in the local queue for the cycles after it.
+    _publish_and_expect("test_subject", range(0, 25), 25)
+
+
+def _wait_for_ack_pending(expected, consumer_name = "test_consumer", time_limit_sec = 60):
+    # Waits until the broker counts exactly `expected` messages as delivered and awaiting an
+    # acknowledgement, which is how a message the streaming cycle is holding reads from outside.
+    deadline = time.monotonic() + time_limit_sec
+    num_ack_pending = 0
+    while time.monotonic() < deadline:
+        num_ack_pending = asyncio.run(get_num_ack_pending(cluster, "test_stream", consumer_name))
+        if num_ack_pending == expected:
+            return
+        time.sleep(0.2)
+
+    raise AssertionError(
+        "consumer {} holds {} unacknowledged messages, expected {}".format(
+            consumer_name, num_ack_pending, expected))
+
+
+# The recovery keys on two things, and the two restarts below reach one each: a hard kill answers
+# nothing, so only the reconnect count reports it, while a graceful shutdown answers the parked pull
+# request and the client closes the subscription in response. What the recovery does with the
+# messages the consumer holds - and with the ones `nats_skip_broken_messages` passed over - has to
+# be the same on both, and the closed-subscription case is the one where it acknowledges or hands
+# back messages through a subscription the client has already marked closed.
+BROKER_RESTARTS = [
+    pytest.param(nats_helpers.hard_kill_nats, id = "hard_kill"),
+    pytest.param(nats_helpers.kill_nats, id = "graceful_restart"),
+]
+
+
+@pytest.mark.parametrize("kill", BROKER_RESTARTS)
+def test_nats_jet_stream_skipped_broken_message_is_not_redelivered_after_reconnect(nats_cluster, kill):
+    # A cycle that has emitted no rows is not a cycle that has consumed nothing:
+    # `nats_skip_broken_messages` makes a message that yields no rows an ordinary outcome, and
+    # `consume` takes the message before it is parsed. Reconnect recovery hands back to the broker
+    # everything the consumer has consumed but not acknowledged, so recovering on a zero-row cycle
+    # would undo the skip - the malformed message is delivered again and parsed again, and a
+    # reconnect in front of the first good row can keep the table reprocessing the same bad input.
+    #
+    # The broker's own delivery counter is the oracle, and it is read while the malformed message is
+    # the only one published, so the count is a statement about that message alone: one delivery
+    # means the skip survived the reconnect, two mean it was handed back. Losing the recovery's
+    # publish can only keep the count at one, so this is asked on both arms; only the
+    # acknowledgement itself is asked where the guard below says. The ACK deadline is far beyond
+    # every wait here, so a redelivery cannot come from anywhere else, and the run holds the flush
+    # interval open so the reconnect lands inside a cycle.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    # Anchored before the table exists, so the first streaming cycle counts however quickly it
+    # starts - the cycles here are longer than the wait itself.
+    created = nats_helpers.log_line_count(instance)
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_skip_broken_messages = 1000,
+                     nats_flush_interval_ms = 30000,
+                     nats_wait_for_flush_interval = 1;
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+    nats_helpers.wait_for_streaming_started(instance, "test.consume", anchor = created)
+
+    # Values the format cannot parse into the column types. The cycle skips the message and keeps
+    # waiting for the rest of the flush interval, which is the state under test: an unacknowledged
+    # message held by a source that has emitted nothing.
+    asyncio.run(publish_messages(
+        cluster, "test_stream", "test_subject", [json.dumps({"key": "not a number", "value": "neither"})]))
+    _wait_for_ack_pending(1)
+
+    # Anchored immediately before the restart, so the recovery the wait below looks for is the one
+    # this restart provokes rather than an earlier one.
+    recovery_anchor = nats_helpers.log_line_count(instance)
+
+    _restart_nats(nats_cluster, kill = kill)
+
+    # The restart lands inside the same cycle, while the skipped message is still held: the wait
+    # above read that state off the broker, and the flush interval is far longer than the restart
+    # takes.
+    #
+    # Only a recovery the source performs inside its own cycle holds a skipped message across the
+    # reconnect. The background task reaches a consumer between cycles instead, where the cycle it
+    # follows has already acknowledged what it held, so accepting that line would let the assertions
+    # below pass on a run that never reached the state under test. Retrying is not available for the
+    # same reason: a second restart would land after that acknowledgement.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if nats_helpers.count_in_log_after(instance, IN_SOURCE_RESUBSCRIBE_LOG_LINE, recovery_anchor) > 0:
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("no streaming source performed an in-source recovery")
+
+    # The replacement subscription has its own request parked, so the recovery has finished rather
+    # than still being in flight when the counter is read.
+    _wait_for_parked_pull_request()
+
+    # Only the hard kill can be asked for the acknowledgement itself. It answers nothing on its way
+    # out, so the recovery runs after the client has reconnected and its acknowledgement reaches a
+    # live broker. A graceful shutdown answers the parked pull request as it exits, so the recovery
+    # publishes into a connection whose JetStream side is already down, and neither `natsMsg_Ack` nor
+    # `natsMsg_Nak` waits for the server, so the publish can be lost and the floor stay at zero.
+    if kill is nats_helpers.hard_kill_nats:
+        # The recovery acknowledged the skipped message and the broker has it, so the skip is
+        # committed rather than merely not redelivered yet.
+        _wait_for_ack_floor(1)
+
+    # A hand-back is a NAK, which the broker redelivers at once, so one delivery for the single
+    # message published so far means the skip survived the reconnect. This holds on both arms: the
+    # cycle consumed the message before the restart, so one delivery is the floor, and losing the
+    # recovery's publish can only keep the count there.
+    consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
+    assert consumer_seq == 1, (
+        "the skipped message was handed back to the broker and delivered again: "
+        "{} deliveries for one message".format(consumer_seq))
+
+    # A stale subscription consumes nothing, so the view holding this row also means the recovery
+    # did happen - deferred to a cycle that holds nothing rather than skipped altogether. It waits
+    # out the rest of the current cycle and then a whole cycle of its own.
+    messages = [json.dumps({"key": 42, "value": 42})]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+    result = instance.query_with_retry(
+        "SELECT count() FROM test.view",
+        retry_count = 120,
+        sleep_time = 1,
+        check_callback = lambda num_rows: int(num_rows) == 1)
+    assert int(result) == 1, "consumption did not resume, view holds {} rows".format(result)
+
+
+@pytest.mark.parametrize("kill", BROKER_RESTARTS)
+def test_nats_jet_stream_direct_select_resumes_after_skipped_broken_message(nats_cluster, kill):
+    # A direct `SELECT` owns its consumer for the whole query, so the query itself has to notice a
+    # reconnect and replace the stale pull subscription. A message it passed over because of
+    # `nats_skip_broken_messages` must not stand in the way of that: nothing is waiting for it to
+    # become a row, so the recovery hands it back to the broker instead of holding the resubscribe
+    # up, and the rows published after the reconnect reach this query rather than leaving it to sit
+    # on a stale subscription until `rabbitmq_max_wait_ms` runs out. With `nats_commit_on_select`
+    # the redelivery is skipped again and acknowledged where the query commits what it read, so
+    # after a hard kill the skip costs one extra delivery and nothing is left outstanding. A
+    # graceful shutdown can lose the hand-back on its way out, and then the broker never redelivers:
+    # the count stays at two and the skipped message stays outstanding until the ACK deadline.
+    #
+    # The ACK deadline is far beyond every wait below, so a redelivery can only come from the
+    # recovery handing the message back, which makes the broker's own counters the oracle.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_skip_broken_messages = 1000,
+                     nats_commit_on_select = 1;
+        """
+    )
+
+    # Values the format cannot parse into the column types. The query consumes this message, emits
+    # nothing for it and keeps waiting, which is the state under test: an unacknowledged message
+    # held by a query that has produced no rows.
+    asyncio.run(publish_messages(
+        cluster, "test_stream", "test_subject", [json.dumps({"key": "not a number", "value": "neither"})]))
+
+    # The whole broker restart happens inside this wait, so the limit is a deadline for the restart
+    # rather than a measurement; a query that recovers its subscription returns as soon as it has
+    # the row published below.
+    select = instance.get_query_request(
+        "SELECT key FROM test.consume SETTINGS stream_like_engine_allow_direct_select = 1, rabbitmq_max_wait_ms = 120000",
+        timeout = 180,
+    )
+    _wait_for_ack_pending(1)
+
+    _restart_nats(nats_cluster, kill = kill)
+
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", [json.dumps({"key": 42, "value": 42})]))
+    assert TSV(select.get_answer()) == TSV("42")
+
+    # The query returned a row, so it committed what it read, and the message it passed over is not
+    # part of that: the recovery had to hand it back to the broker rather than commit it on behalf of
+    # a query that had returned nothing yet, which is what a cancelled query must not leave behind.
+    # A graceful shutdown answers the parked pull request as it exits, so there the recovery publishes
+    # into a connection whose JetStream side is already going down and the hand-back can be dropped;
+    # a hard kill answers nothing, so its recovery reaches a live broker.
+    _wait_for_the_skipped_message_not_to_be_committed(
+        hand_back_may_be_lost = kill is not nats_helpers.hard_kill_nats)
+
+    # The query did commit, so the row it returned is consumed by the time it returns, and so is the
+    # skipped message where its redelivery reached the query before that row did. It does not have
+    # to: a direct `SELECT` returns as soon as it has a row, and a graceful shutdown can lose the
+    # redelivery on the wire (the broker counts it as delivered, the client never sees it), leaving
+    # it outstanding until the ACK deadline with nothing left to pull it. What must hold is that the
+    # only thing the broker may still count as outstanding is that skipped message, never the row.
+    _wait_for_nothing_but_the_first_message_outstanding()
+
+
+def _wait_for_the_skipped_message_not_to_be_committed(
+        hand_back_may_be_lost, consumer_name = "test_consumer", time_limit_sec = 60):
+    # A hand-back is a NAK, which the broker redelivers at once, so a third delivery for two messages
+    # is the skipped message going back and being skipped again. Where that NAK can be dropped there
+    # is no third delivery, and then what the broker holds is what says the message was not
+    # committed: a NAK it never saw leaves the message delivered and unacknowledged, so it is the one
+    # message outstanding with the acknowledgement floor still below it, while a commit moves that
+    # floor past it and so reaches neither state.
+    deadline = time.monotonic() + time_limit_sec
+    info = None
+    while time.monotonic() < deadline:
+        info = asyncio.run(get_consumer_info(cluster, "test_stream", consumer_name))
+        if info.delivered.consumer_seq >= 3:
+            return
+        if hand_back_may_be_lost and info.num_ack_pending == 1 and info.ack_floor.stream_seq == 0:
+            logging.debug("the hand-back did not reach the broker: {} deliveries, {} outstanding".format(
+                info.delivered.consumer_seq, info.num_ack_pending))
+            return
+        time.sleep(0.2)
+
+    raise AssertionError(
+        "the recovery acknowledged the skipped message before the query committed anything: "
+        "{} deliveries for two messages, {} outstanding, acknowledgement floor {}".format(
+            info.delivered.consumer_seq, info.num_ack_pending, info.ack_floor.stream_seq))
+
+
+def _wait_for_nothing_but_the_first_message_outstanding(consumer_name = "test_consumer", time_limit_sec = 60):
+    # With two messages in the stream, an acknowledgement floor of zero together with a single
+    # outstanding message means the first one is outstanding and the second acknowledged.
+    deadline = time.monotonic() + time_limit_sec
+    info = None
+    while time.monotonic() < deadline:
+        info = asyncio.run(get_consumer_info(cluster, "test_stream", consumer_name))
+        if info.num_ack_pending == 0:
+            return
+        if info.num_ack_pending == 1 and info.ack_floor.stream_seq == 0:
+            return
+        time.sleep(0.2)
+
+    raise AssertionError(
+        "consumer {} holds {} unacknowledged messages with acknowledgement floor {}".format(
+            consumer_name, info.num_ack_pending, info.ack_floor.stream_seq))
+
+
+def test_nats_jet_stream_direct_select_does_not_commit_a_skipped_message_when_cancelled(nats_cluster):
+    # `nats_commit_on_select` commits only what the read returns, and reconnect recovery runs long
+    # before that commit point. A query that skipped a malformed message, replaced its subscription
+    # after a reconnect and was then cancelled without returning a single row must leave that
+    # message to the next reader, exactly like the messages it had read but not returned.
+    #
+    # The ACK deadline is far beyond every wait below, so a redelivery can only come from the
+    # recovery handing the message back, and nothing but this query can acknowledge one.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_skip_broken_messages = 1000,
+                     nats_commit_on_select = 1;
+        """
+    )
+
+    asyncio.run(publish_messages(
+        cluster, "test_stream", "test_subject", [json.dumps({"key": "not a number", "value": "neither"})]))
+
+    # Nothing is published for this query to return, so it waits out the limit unless it is
+    # cancelled first, which is what happens below.
+    select = instance.get_query_request(
+        "SELECT key FROM test.consume SETTINGS stream_like_engine_allow_direct_select = 1, rabbitmq_max_wait_ms = 120000",
+        timeout = 180,
+    )
+    _wait_for_ack_pending(1)
+
+    _restart_nats(nats_cluster, kill = nats_helpers.hard_kill_nats)
+
+    # A pull request parked after the restart can only come from this query: it holds the consumer
+    # for as long as it runs, so the recovery has happened by the time the broker counts one, and
+    # whatever the recovery did with the skipped message it has done by then.
+    _wait_for_parked_pull_request()
+
+    instance.query("SYSTEM CANCEL test.consume")
+    assert TSV(select.get_answer()) == TSV("")
+
+    # The cancelled read returned nothing, so it committed nothing: the malformed message went back
+    # to the broker at the resubscribe, was delivered a second time and is waiting to be read again.
+    # Acknowledging it in the recovery would leave one delivery and nothing pending, putting a
+    # message out of reach of every later query without a single row having been returned for it.
+    deadline = time.monotonic() + 60
+    consumer_seq = 0
+    while time.monotonic() < deadline:
+        consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
+        if consumer_seq >= 2:
+            break
+        time.sleep(0.2)
+
+    assert consumer_seq >= 2, (
+        "the cancelled query consumed the message it skipped: "
+        "{} deliveries for one message".format(consumer_seq))
+
+    _wait_for_ack_pending(1)
+
+
+def test_nats_jet_stream_direct_select_does_not_consume_skipped_broken_message(nats_cluster):
+    # The same reconnect recovery with `nats_commit_on_select` left at its default `0`, where a
+    # direct read must consume nothing at all: the query never commits, so the message it passed
+    # over because of `nats_skip_broken_messages` has to go back to the broker with everything else
+    # the recovery hands back, and the next query gets to see it again. Acknowledging it there would
+    # consume a message on behalf of an uncommitted read and put it out of reach for good.
+    #
+    # The ACK deadline is far beyond every wait below, so a redelivery can only come from the
+    # recovery handing the message back, which makes the broker's delivery counter the oracle.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_skip_broken_messages = 1000;
+        """
+    )
+
+    asyncio.run(publish_messages(
+        cluster, "test_stream", "test_subject", [json.dumps({"key": "not a number", "value": "neither"})]))
+
+    select = instance.get_query_request(
+        "SELECT key FROM test.consume SETTINGS stream_like_engine_allow_direct_select = 1, rabbitmq_max_wait_ms = 120000",
+        timeout = 180,
+    )
+    _wait_for_ack_pending(1)
+
+    _restart_nats(nats_cluster, kill = nats_helpers.hard_kill_nats)
+
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", [json.dumps({"key": 42, "value": 42})]))
+    assert TSV(select.get_answer()) == TSV("42")
+
+    # Three deliveries for two messages: the skipped one was handed back and delivered again. Two
+    # would mean the uncommitted query acknowledged it.
+    deadline = time.monotonic() + 60
+    consumer_seq = 0
+    while time.monotonic() < deadline:
+        consumer_seq = asyncio.run(get_delivered_consumer_seq(cluster, "test_stream", "test_consumer"))
+        if consumer_seq >= 3:
+            break
+        time.sleep(0.2)
+
+    assert consumer_seq >= 3, (
+        "an uncommitted direct SELECT acknowledged the message it skipped: "
+        "{} deliveries for two messages".format(consumer_seq))
+
+
+def test_nats_jet_stream_keeps_buffered_backlog_across_broker_restart(nats_cluster):
+    # Reconnect recovery re-subscribes the consumer, and the local queue of messages the broker had
+    # already delivered used to go with the stale subscription. Those rows are in this server's
+    # hands: dropping them leaves the view short until JetStream redelivers them, a whole ACK
+    # deadline later. The deadline here is far beyond every wait below, so redelivery cannot cover
+    # for a dropped backlog - the final count holds only if the buffered messages survived the
+    # recovery.
+    total_expected = 3000
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    # Published before the table exists, so the whole backlog is waiting when it subscribes: the
+    # client pulls it into the local queue far faster than the streaming cycles insert it, which is
+    # what leaves a large buffered backlog for the restart below to land on.
+    messages = [json.dumps({"key": key, "value": key}) for key in range(total_expected)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_max_block_size = 5;
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+
+    # Blocks of five rows make every streaming cycle insert a handful at a time, so the view
+    # crossing this mark means consuming is well under way while most of the backlog is still
+    # buffered locally.
+    consumed = instance.query_with_retry(
+        "SELECT count() FROM test.view",
+        retry_count = 600,
+        sleep_time = 0.1,
+        check_callback = lambda num_rows: int(num_rows) >= 50)
+    assert int(consumed) >= 50, "streaming did not start, the view holds {} rows".format(consumed)
+    assert int(consumed) < total_expected, "the whole backlog was consumed before the restart"
+
+    nats_helpers.hard_kill_nats(nats_cluster)
+    time.sleep(4)
+    nats_helpers.revive_nats(nats_cluster)
+
+    result = instance.query_with_retry(
+        "SELECT count(DISTINCT key) FROM test.view",
+        retry_count = 120,
+        sleep_time = 1,
+        check_callback = lambda num_rows: int(num_rows) == total_expected)
+    assert int(result) == total_expected, "the buffered backlog was dropped, view holds {} of {} keys".format(
+        result, total_expected)
+
+
+UNSUBSCRIBED_LOG_LINE = "Consumer .* unsubscribed"
+
+
+def test_nats_jet_stream_returns_buffered_backlog_to_the_broker_when_unsubscribing(nats_cluster):
+    # A table that keeps consuming can have its subscription replaced under it - by reconnect
+    # recovery, by a `SYSTEM STOP`, or by the last materialized view going away - and has to part
+    # with the messages the broker had already delivered into the local queue, because a `natsMsg`
+    # cannot outlive the subscription it arrived on. Those are not lost rows from the broker's
+    # point of view: it counts them as delivered and awaiting an acknowledgement, so destroying
+    # them locally makes them unreachable until the ACK deadline. Handing them back with
+    # `natsMsg_Nak` while the subscription is still alive is what keeps them reachable, and it is
+    # what closes the window where a message arrives in the moment between a recovery deciding the
+    # queue is empty and that queue being finished.
+    #
+    # Dropping the last view reaches that state deterministically: nothing pops the local queue
+    # from the moment the view is gone, so it is certainly holding a large backlog when the
+    # consumer is unsubscribed. The ACK deadline is far beyond every wait below, so server-side
+    # redelivery cannot make up for a backlog that was destroyed instead of returned.
+    total_expected = 3000
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    # Published before the table exists, so the whole backlog is waiting when it subscribes: the
+    # client pulls it into the local queue far faster than the streaming cycles insert it.
+    messages = [json.dumps({"key": key, "value": key}) for key in range(total_expected)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_max_block_size = 5;
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+
+    # Blocks of five rows make every streaming cycle insert a handful at a time, so the view
+    # crossing this mark means consuming is well under way while most of the backlog is still
+    # buffered locally.
+    consumed = instance.query_with_retry(
+        "SELECT count() FROM test.view",
+        retry_count = 600,
+        sleep_time = 0.1,
+        check_callback = lambda num_rows: int(num_rows) >= 50)
+    assert int(consumed) >= 50, "streaming did not start, the view holds {} rows".format(consumed)
+    assert int(consumed) < total_expected, "the whole backlog was consumed before the view was dropped"
+
+    anchor = nats_helpers.log_line_count(instance)
+    assert anchor > 0, "log offset anchor is not a line number: {}".format(anchor)
+
+    instance.query("DROP VIEW test.consumer")
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if nats_helpers.count_in_log_after(instance, UNSUBSCRIBED_LOG_LINE, anchor) > 0:
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("the consumer stayed subscribed after the last view was dropped")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+
+    result = instance.query_with_retry(
+        "SELECT count(DISTINCT key) FROM test.view",
+        retry_count = 120,
+        sleep_time = 1,
+        check_callback = lambda num_rows: int(num_rows) == total_expected)
+    assert int(result) == total_expected, (
+        "the buffered backlog was destroyed instead of returned to the broker, view holds {} of {} keys".format(
+            result, total_expected))
+
+
+def test_nats_jet_stream_does_not_acknowledge_messages_discarded_by_a_view_dropped_mid_cycle(nats_cluster):
+    # A streaming cycle checks that views are attached and then has its insert pipeline built, which
+    # looks them up again. A `DROP VIEW` landing between the two leaves the pipeline with nowhere to
+    # insert into: it discards what the sources consume, and the cycle used to acknowledge those
+    # messages all the same, so the broker counted as consumed a block of rows that reached no
+    # table. The gap is a millisecond wide, so a failpoint holds a cycle open exactly there.
+    #
+    # The ACK deadline is far beyond every wait below, so the rows can only reach the view attached
+    # afterwards if the cycle handed them back rather than acknowledging them.
+    total_expected = 10
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n';
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+    nats_helpers.wait_for_streaming_started(instance, "test.consume")
+
+    # Streaming is under way, so the next cycle stops right before it builds the insert pipeline,
+    # having already found the view attached.
+    instance.query("SYSTEM ENABLE FAILPOINT nats_pause_before_building_insert_pipeline")
+    instance.query("SYSTEM WAIT FAILPOINT nats_pause_before_building_insert_pipeline PAUSE")
+
+    # Delivered into the consumer's local queue while the cycle is held, so the cycle has something
+    # to consume once it goes on. The broker counts them as delivered and awaiting acknowledgement.
+    messages = [json.dumps({"key": key, "value": key}) for key in range(total_expected)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+    _wait_for_ack_pending(total_expected)
+
+    anchor = nats_helpers.log_line_count(instance)
+    assert anchor > 0, "log offset anchor is not a line number: {}".format(anchor)
+
+    instance.query("DROP VIEW test.consumer")
+    instance.query("SYSTEM DISABLE FAILPOINT nats_pause_before_building_insert_pipeline")
+
+    # The released cycle finds no view to stream to, and the task unsubscribes its consumers once it
+    # notices the last view is gone, handing back whatever they hold. Waiting for that makes the
+    # count below a statement about what the released cycle did with the messages, not about a
+    # view recreated before it ran.
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if nats_helpers.count_in_log_after(instance, UNSUBSCRIBED_LOG_LINE, anchor) > 0:
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("the consumer stayed subscribed after the last view was dropped")
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+
+    result = instance.query_with_retry(
+        "SELECT count(DISTINCT key) FROM test.view",
+        retry_count = 60,
+        sleep_time = 1,
+        check_callback = lambda num_rows: int(num_rows) == total_expected)
+    assert int(result) == total_expected, (
+        "the cycle that had no view to stream to acknowledged the messages it discarded, "
+        "view holds {} of {} keys".format(result, total_expected))
+
+
+NOTHING_TO_STREAM_TO_LOG_LINE = "nothing to stream to"
+
+
+def test_nats_jet_stream_does_not_acknowledge_messages_discarded_by_a_view_detached_mid_cycle(nats_cluster):
+    # The detach twin of the test above. Unlike `DROP VIEW`, a plain `DETACH TABLE` keeps the view
+    # registered as a dependency of the `NATS` table, so a cycle that decides whether it has anywhere
+    # to stream to by the dependency metadata alone would go on to consume into the discarding
+    # pipeline and acknowledge. The view stays a dependency, so the consumer stays subscribed and
+    # keeps the held messages locally: they can only reach the re-attached view if the held cycle
+    # left them alone.
+    total_expected = 10
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n';
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    )
+    nats_helpers.wait_for_streaming_started(instance, "test.consume")
+
+    instance.query("SYSTEM ENABLE FAILPOINT nats_pause_before_building_insert_pipeline")
+    instance.query("SYSTEM WAIT FAILPOINT nats_pause_before_building_insert_pipeline PAUSE")
+
+    messages = [json.dumps({"key": key, "value": key}) for key in range(total_expected)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+    _wait_for_ack_pending(total_expected)
+
+    anchor = nats_helpers.log_line_count(instance)
+    assert anchor > 0, "log offset anchor is not a line number: {}".format(anchor)
+
+    instance.query("DETACH TABLE test.consumer")
+    instance.query("SYSTEM DISABLE FAILPOINT nats_pause_before_building_insert_pipeline")
+
+    # The released cycle must notice that the view is gone. Waiting for that makes the count below
+    # a statement about what the released cycle did with the messages, not about a view attached
+    # again before it ran.
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if nats_helpers.count_in_log_after(instance, NOTHING_TO_STREAM_TO_LOG_LINE, anchor) > 0:
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("the released cycle did not report that the view was gone")
+
+    instance.query("ATTACH TABLE test.consumer")
+
+    result = instance.query_with_retry(
+        "SELECT count(DISTINCT key) FROM test.view",
+        retry_count = 60,
+        sleep_time = 1,
+        check_callback = lambda num_rows: int(num_rows) == total_expected)
+    assert int(result) == total_expected, (
+        "the cycle that had no view to stream to acknowledged the messages it discarded, "
+        "view holds {} of {} keys".format(result, total_expected))
+
+
+def _wait_for_ack_floor(expected, consumer_name = "test_consumer", time_limit_sec = 60):
+    # Waits until the broker has every message up to stream sequence `expected` acknowledged, which
+    # is how a stream consumed and committed in full reads from outside.
+    deadline = time.monotonic() + time_limit_sec
+    ack_floor = 0
+    while time.monotonic() < deadline:
+        info = asyncio.run(get_consumer_info(cluster, "test_stream", consumer_name))
+        ack_floor = info.ack_floor.stream_seq
+        if ack_floor == expected:
+            return
+        time.sleep(0.2)
+
+    raise AssertionError(
+        "consumer {} has acknowledged messages up to stream sequence {}, expected {}".format(
+            consumer_name, ack_floor, expected))
+
+
+def test_nats_jet_stream_streams_to_a_materialized_view_with_a_null_target(nats_cluster):
+    # A materialized view whose target is `Null` is a legitimate way to consume a stream for its
+    # side effects (or to drop it on the floor on purpose): the insert pipeline it produces ends in
+    # the same discarding sink as the pipeline of a table whose last view was dropped mid-cycle. The
+    # cycle must tell the two apart by the dependency metadata and keep streaming - and, with
+    # JetStream, acknowledging - rather than treating the view as absent and never consuming.
+    total_expected = 10
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n';
+        CREATE MATERIALIZED VIEW test.consumer ENGINE = Null AS
+            SELECT * FROM test.consume;
+        """
+    )
+    nats_helpers.wait_for_streaming_started(instance, "test.consume")
+
+    messages = [json.dumps({"key": key, "value": key}) for key in range(total_expected)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+
+    # Consumed and committed: the broker has every message acknowledged. A table that mistook the
+    # `Null` target for a dropped view would never build a source, and the floor would stay at zero.
+    _wait_for_ack_floor(total_expected)
+
+
+def test_nats_jet_stream_streams_to_a_fan_out_with_a_null_target(nats_cluster):
+    # The same with a view that has somewhere to insert into next to the `Null` one: every row
+    # reaches the real target, and the discarding sink of the other branch does not stop the cycle.
+    total_expected = 10
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n';
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        CREATE MATERIALIZED VIEW test.discarding_consumer ENGINE = Null AS
+            SELECT * FROM test.consume;
+        """
+    )
+    nats_helpers.wait_for_streaming_started(instance, "test.consume")
+
+    messages = [json.dumps({"key": key, "value": key}) for key in range(total_expected)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+
+    result = instance.query_with_retry(
+        "SELECT count(DISTINCT key) FROM test.view",
+        retry_count = 60,
+        sleep_time = 1,
+        check_callback = lambda num_rows: int(num_rows) == total_expected)
+    assert int(result) == total_expected, "view holds {} of {} keys".format(result, total_expected)
+
+    _wait_for_ack_floor(total_expected)
+
+
+def test_nats_jet_stream_hands_back_the_backlog_of_a_consumer_a_direct_select_left_subscribed(nats_cluster):
+    # Once the last materialized view is gone the streaming task unsubscribes the consumers, but it
+    # only reaches the ones in the pool at that moment. A direct `SELECT` issued right after the
+    # `DROP VIEW` takes the consumer out of the pool still subscribed and hands it back that way,
+    # and nothing unsubscribes it afterwards: everything published while no view is attached lands
+    # in its local queue. Attaching a view again must part with that backlog the way dropping a
+    # view does - by handing it back to the broker while the subscription it arrived on is still
+    # alive - rather than by clearing the queue under a live subscription, which the client can
+    # keep appending to and which the broker counts as delivered until the ACK deadline. The
+    # deadline here is far beyond every wait below, so the final count holds only if the backlog
+    # was returned.
+    asyncio.run(add_durable_consumer(cluster, "test_stream", "test_consumer", ack_wait_sec = 600))
+
+    # A short flush interval keeps the streaming cycles short, so the `SELECT` below gets the
+    # consumer as soon as the cycle that is holding it ends.
+    instance.query(
+        """
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE TABLE test.consume (key UInt64, value UInt64)
+            ENGINE = NATS
+            SETTINGS nats_url = 'nats1:4444',
+                     nats_stream = 'test_stream',
+                     nats_consumer_name = 'test_consumer',
+                     nats_subjects = 'test_subject',
+                     nats_format = 'JSONEachRow',
+                     nats_row_delimiter = '\\n',
+                     nats_flush_interval_ms = 1000;
+        """
+    )
+    nats_helpers.wait_for_table_is_ready(instance, "test.consume")
+
+    create_view = """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.consume;
+        """
+    instance.query(create_view)
+    nats_helpers.wait_for_mv_attached_to_table(instance, "test.consume")
+    _publish_and_expect("test_subject", range(20), 20)
+
+    # The streaming task notices the dropped view on its next run, up to half a second after the
+    # `DROP VIEW`, and unsubscribes whatever consumer is in the pool at that moment. The `SELECT`
+    # has to take the consumer out of the pool before that run: both statements go over a single
+    # client connection, so the query is planned a few milliseconds after the drop completes, not
+    # after a second round trip into the container, which is slower than the task on a sanitizer
+    # build. The query then holds the consumer well past that run, and the task, which is not
+    # rescheduled once it finds no view, never reaches it again. Whether the query really found
+    # the consumer subscribed shows in the log: a consumer the query had to subscribe itself is
+    # unsubscribed again when the query ends, and one it found subscribed is not.
+    for _ in range(5):
+        anchor = nats_helpers.log_line_count(instance)
+        instance.query(
+            """
+            DROP VIEW test.consumer;
+            SELECT * FROM test.consume SETTINGS rabbitmq_max_wait_ms = 5000;
+            """
+        )
+        time.sleep(1)
+        if nats_helpers.count_in_log_after(instance, UNSUBSCRIBED_LOG_LINE, anchor) == 0:
+            break
+        instance.query(create_view)
+        nats_helpers.wait_for_mv_attached_to_table(instance, "test.consume")
+    else:
+        raise AssertionError("no direct SELECT got hold of a consumer that was still subscribed")
+
+    # The subscription the query left behind keeps a pull request parked, so what is published now
+    # is delivered into the local queue of a table that is not streaming. The broker counting all
+    # of it as awaiting an acknowledgement is what proves it got there.
+    _wait_for_parked_pull_request()
+    detached = 100
+    messages = [json.dumps({"key": key, "value": key}) for key in range(100, 100 + detached)]
+    asyncio.run(publish_messages(cluster, "test_stream", "test_subject", messages))
+    _wait_for_ack_pending(detached)
+
+    instance.query(create_view)
+    nats_helpers.wait_for_mv_attached_to_table(instance, "test.consume")
+
+    # Both what was buffered while detached and what arrives afterwards have to reach the view: a
+    # backlog cleared locally instead of returned stays unreachable for the whole ACK deadline.
+    _publish_and_expect("test_subject", range(20, 40), 20 + detached + 20)
 
 
 def test_nats_jet_stream_resumes_consuming_after_two_broker_restarts(nats_cluster):


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#119270

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119301&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119301](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119301+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
