### PR TITLE
Detect an unreadable view in the SQLancer++ check instead of aborting the run

### DIFF
--- a/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
+++ b/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
@@ -38,22 +38,20 @@
    false-positive failure. Let the `IgnoreMeException` propagate instead; genuine
    unexpected errors (a re-thrown `SQLException`, or an `AssertionError` with a
    message) are unaffected and still reported.
-5. Read the view with an aggregate in `GeneralProvider.checkViewsAreValid`'s
-   per-view validity probe, instead of `SELECT * FROM <view>`. That probe goes
-   through `SQLQueryAdapter.execute`, which closes the statement without draining
-   the result set, so an error ClickHouse reports mid-stream - a generated view
-   body dividing by zero on the generated data, say - arrives only as a truncated
-   chunked body that the driver logs and swallows: `execute` returns `true` and
-   neither `dropView` branch fires. `COUNT(*)` cannot emit its row before it has
-   consumed all input, so the server finishes the view before answering and the
-   failure arrives as a normal error response. `WHERE NOT ignore(*)` stops the
-   view's projection being pruned away (`ignore` takes every view column as an
-   argument, is never constant-folded and returns 0, so the filter keeps every
-   row); a plain `COUNT(*)` returns `1` for a view whose only defect sits in its
-   SELECT list. The existing `if (!execute()) -> dropView` /
-   `catch (Throwable) -> dropView` branches then drop exactly the unreadable
-   view, so it no longer reaches the cross-join size probe below - which is
-   called outside the per-oracle `catch (AssertionError)` and so killed the run.
+5. Read the view with `SELECT sum(ignore(*)) FROM <view>` in
+   `GeneralProvider.checkViewsAreValid`'s per-view validity probe, instead of
+   `SELECT * FROM <view>`. That probe goes through `SQLQueryAdapter.execute`,
+   which closes the statement without draining the result set, so an error
+   ClickHouse reports mid-stream is invisible: `execute` returns `true` and
+   neither `dropView` branch fires. An aggregate cannot emit its row before it
+   has consumed all input, and `ignore(*)` takes every view column as an
+   argument and is never constant-folded, so the projection cannot be pruned.
+   An outer predicate (`... WHERE NOT ignore(*)`) is not equivalent: it is
+   pushed into the view and can filter rows before the failing projection runs.
+   The existing `if (!execute()) -> dropView` / `catch (Throwable) -> dropView`
+   branches then drop exactly the unreadable view, so it no longer reaches the
+   cross-join size probe, which is called outside the per-oracle
+   `catch (AssertionError)` and so killed the run.
 """
 
 import argparse
@@ -176,20 +174,18 @@ def patch_view_validity_probe(repo: pathlib.Path) -> None:
     # `SELECT * FROM <view>` cannot tell this probe that the view is unreadable:
     # `execute` never drains the result set, so ClickHouse's mid-stream error is
     # invisible and the view survives into the cross-join size probe, where the
-    # same error is fatal. An aggregate makes the server finish the view before it
-    # answers; `ignore(*)` keeps the view's projection from being pruned, so a
-    # defect in the SELECT list is caught as well as one in the view's WHERE.
+    # same error is fatal. An aggregate over `ignore(*)` reads the view the way
+    # that size probe does: every column is a required input, and no predicate
+    # sits above the view where it could drop rows before the projection runs.
     anchor = (
         '            SQLQueryAdapter q = new SQLQueryAdapter("SELECT * FROM " + view.getName(),'
         " new ExpectedErrors(), false,\n"
         "                    globalState.getOptions().canonicalizeSqlString());\n"
     )
     replacement = (
-        "            // ClickHouse patch: an aggregate makes the server finish the view before it answers,\n"
-        "            // and ignore(*) keeps its projection from being pruned. A mid-stream error never\n"
-        "            // reaches execute(), which does not drain the result set.\n"
-        "            SQLQueryAdapter q = new SQLQueryAdapter(\n"
-        '                    "SELECT COUNT(*) FROM " + view.getName() + " WHERE NOT ignore(*)",\n'
+        "            // ClickHouse patch: an aggregate makes the server finish the view before it answers, and\n"
+        "            // ignore(*) requires every column, so the view's projection cannot be pruned away.\n"
+        '            SQLQueryAdapter q = new SQLQueryAdapter("SELECT sum(ignore(*)) FROM " + view.getName(),\n'
         "                    new ExpectedErrors(), false, globalState.getOptions().canonicalizeSqlString());\n"
     )
     if anchor not in text:

--- a/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
+++ b/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
@@ -38,6 +38,22 @@
    false-positive failure. Let the `IgnoreMeException` propagate instead; genuine
    unexpected errors (a re-thrown `SQLException`, or an `AssertionError` with a
    message) are unaffected and still reported.
+5. Read the view with an aggregate in `GeneralProvider.checkViewsAreValid`'s
+   per-view validity probe, instead of `SELECT * FROM <view>`. That probe goes
+   through `SQLQueryAdapter.execute`, which closes the statement without draining
+   the result set, so an error ClickHouse reports mid-stream - a generated view
+   body dividing by zero on the generated data, say - arrives only as a truncated
+   chunked body that the driver logs and swallows: `execute` returns `true` and
+   neither `dropView` branch fires. `COUNT(*)` cannot emit its row before it has
+   consumed all input, so the server finishes the view before answering and the
+   failure arrives as a normal error response. `WHERE NOT ignore(*)` stops the
+   view's projection being pruned away (`ignore` takes every view column as an
+   argument, is never constant-folded and returns 0, so the filter keeps every
+   row); a plain `COUNT(*)` returns `1` for a view whose only defect sits in its
+   SELECT list. The existing `if (!execute()) -> dropView` /
+   `catch (Throwable) -> dropView` branches then drop exactly the unreadable
+   view, so it no longer reaches the cross-join size probe below - which is
+   called outside the per-oracle `catch (AssertionError)` and so killed the run.
 """
 
 import argparse
@@ -154,6 +170,35 @@ def patch_where_oracle(repo: pathlib.Path) -> None:
     src.write_text(text.replace(anchor, replacement))
 
 
+def patch_view_validity_probe(repo: pathlib.Path) -> None:
+    src = repo / "src" / "sqlancer" / "general" / "GeneralProvider.java"
+    text = src.read_text()
+    # `SELECT * FROM <view>` cannot tell this probe that the view is unreadable:
+    # `execute` never drains the result set, so ClickHouse's mid-stream error is
+    # invisible and the view survives into the cross-join size probe, where the
+    # same error is fatal. An aggregate makes the server finish the view before it
+    # answers; `ignore(*)` keeps the view's projection from being pruned, so a
+    # defect in the SELECT list is caught as well as one in the view's WHERE.
+    anchor = (
+        '            SQLQueryAdapter q = new SQLQueryAdapter("SELECT * FROM " + view.getName(),'
+        " new ExpectedErrors(), false,\n"
+        "                    globalState.getOptions().canonicalizeSqlString());\n"
+    )
+    replacement = (
+        "            // ClickHouse patch: an aggregate makes the server finish the view before it answers,\n"
+        "            // and ignore(*) keeps its projection from being pruned. A mid-stream error never\n"
+        "            // reaches execute(), which does not drain the result set.\n"
+        "            SQLQueryAdapter q = new SQLQueryAdapter(\n"
+        '                    "SELECT COUNT(*) FROM " + view.getName() + " WHERE NOT ignore(*)",\n'
+        "                    new ExpectedErrors(), false, globalState.getOptions().canonicalizeSqlString());\n"
+    )
+    if anchor not in text:
+        sys.exit(f"failed to locate the view-validity probe in {src}")
+    if text.count(anchor) != 1:
+        sys.exit(f"expected exactly one view-validity probe in {src}")
+    src.write_text(text.replace(anchor, replacement))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("repo", help="Path to the SQLancer++ checkout")
@@ -172,6 +217,7 @@ def main() -> None:
     patch_jdbc_properties(repo)
     patch_norec_oracle(repo)
     patch_where_oracle(repo)
+    patch_view_validity_probe(repo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109466
Related: https://github.com/ClickHouse/ClickHouse/pull/118541


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The SQLancer++ check now reads each generated view with an aggregate, so a view it cannot evaluate is dropped instead of aborting the whole oracle run.


### Description

`SQLancerPP (arm_release)` returned 2 FAIL / 2 OK on master `59991a41` ([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=59991a415be6bb7aa306ebceb124369b04a612c0&name_0=NightlySQLancer&name_1=SQLancerPP%20%28arm_release%29)); `FUZZING` and `NoREC` died at the baseline `SELECT COUNT(*)`.

The server is right: a generated view's body raises on the generated data (`Code: 153` from `c0 DIV c0`), and in one reproduced database the division is in the view's `WHERE`, which a row count must evaluate. The failure is in SQLancer++'s invalid-view check. `checkViewsAreValid` probes each view with `SELECT * FROM <view>` through `SQLQueryAdapter.execute`, which closes the statement without draining the result set, so the mid-stream error arrives as a truncated chunked body the driver swallows: `execute` returns `true`, neither `dropView` branch fires, and that nightly recorded 38 `CREATE VIEW`, 0 `DROP VIEW`.

The view then reaches the size probe `SELECT COUNT(*) FROM <all tables>`, which must evaluate it fully. That probe has an empty `ExpectedErrors` and runs at `ProviderAdapter:59`, outside the per-oracle `catch (AssertionError)`, so the assertion kills the run at `exit=255`.

One query string changes: `SELECT sum(ignore(*)) FROM <view>`. Detection per view, harness execute path, 17 fixtures:

| probe | unreadable missed, of 8 |
|---|---|
| `SELECT * FROM v` (today) | 1-2, varies per run |
| `SELECT COUNT(*) FROM v` | 4, projection pruned |
| `COUNT(*) FROM v WHERE NOT ignore(*)` | 1, filter pushed into the view |
| `sum(ignore(*)) FROM v` | 0 |

Paired base-vs-patched runs, same parameters: escalations FUZZING 26 -> 0 and 9 -> 0, NoREC 9 -> 0, WHERE 3 -> 0, QUERY_PARTITIONING 0 -> 0; no new assertion class. Views still survive validation (718 of 1003 probes accepted, base 717 of 951; no healthy fixture rejected) and no size probe over a survivor failed, against 3 on base.

`NightlySQLancer` is schedule-only, so this PR's CI only builds the image; first confirmation is the 2026-09-13 nightly.

<details><summary>CIDB: how often this signature has fired</summary>

```sql
SELECT check_start_time::Date AS day, head_ref, test_name
FROM default.checks
WHERE check_name LIKE 'SQLancerPP%'
  AND test_status IN ('FAIL','ERROR')
  AND check_start_time > now() - INTERVAL 120 DAY
  AND test_context_raw LIKE '%AssertionError%SELECT COUNT(*)%'
ORDER BY day
```

| day | head_ref | test_name |
|---|---|---|
| 2026-07-22 | master | WHERE |
| 2026-08-14 | fm4v/nightly-sqlancer-validate | QUERY_PARTITIONING |
| 2026-09-10 | master | NoREC |
| 2026-09-10 | master | FUZZING |

Four rows over three commits in 120 days, and a lower bound: CIDB truncates `test_context_raw` at ~500 chars and the assertion's message is the query text, so the signature is only visible when a `checkViewsAreValid` line happens to come first in the job's grep output.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119303&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119303](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119303+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
