### PR TITLE
Keep an `ARRAY JOIN` filter out of a `Merge` child query

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1479,6 +1479,24 @@ QueryTreeNodePtr replaceTableExpressionAndRemoveJoin(
 
     auto * modified_query_node = modified_query->as<QueryNode>();
 
+    /// An `ARRAY JOIN` result column is produced above the table, so a filter over it is not a filter
+    /// over the table's own columns, and the child must not be asked to read it: `StorageMerge` reads
+    /// its children with `FetchColumns` and performs the array join on the initiator, where the filter
+    /// is applied. Replacing the join tree below rewires every column sourced from the `ARRAY JOIN`
+    /// node onto the child table expression, which makes such a filter indistinguishable from a filter
+    /// over the child's own columns, so drop those filters here, while the columns still point at the
+    /// `ARRAY JOIN` node. Filters over the table's columns are unaffected: they were rewired onto the
+    /// child table expression by the replacement above and are kept.
+    if (join_tree_type == QueryTreeNodeType::ARRAY_JOIN)
+    {
+        if (modified_query_node->hasPrewhere())
+            removeExpressionsThatDoNotDependOnTableIdentifiers(
+                modified_query_node->getPrewhere(), replacement_table_expression, context);
+        if (modified_query_node->hasWhere())
+            removeExpressionsThatDoNotDependOnTableIdentifiers(
+                modified_query_node->getWhere(), replacement_table_expression, context);
+    }
+
     // Remove the JOIN statement. As a result query will have a form like: SELECT * FROM <table> ...
     modified_query = modified_query->cloneAndReplace(modified_query_node->getJoinTreeNodeTyped(), replacement_table_expression);
     modified_query_node = modified_query->as<QueryNode>();

--- a/tests/queries/0_stateless/05197_merge_over_distributed_array_join_filter.reference
+++ b/tests/queries/0_stateless/05197_merge_over_distributed_array_join_filter.reference
@@ -1,0 +1,14 @@
+the local table	100
+the Distributed table	100
+Merge over the local table	100
+Merge over Distributed, no filter	300
+Merge over Distributed	100
+an equality filter	100
+an aliased array join	100
+LEFT ARRAY JOIN	100
+a filter on a table column	150
+both kinds of filter	50
+both kinds, reversed	50
+the values	0	ccc
+the values	2	ccc
+the values	4	ccc

--- a/tests/queries/0_stateless/05197_merge_over_distributed_array_join_filter.sql
+++ b/tests/queries/0_stateless/05197_merge_over_distributed_array_join_filter.sql
@@ -1,0 +1,41 @@
+-- `ARRAY JOIN` with a filter on the joined column over a `Merge` table whose child is a `Distributed`
+-- table. `StorageMerge` builds the child query by replacing its join tree with the child table, which
+-- rewires the columns of the removed `ARRAY JOIN` onto that table, so a filter over the array-joined
+-- column used to look like a filter over the child's own columns and the child was asked to read
+-- `__array_join_exp_1`. Only a `Distributed` child noticed, because it re-analyzes the child query.
+-- The array join and the filter are performed on the initiator either way.
+
+DROP TABLE IF EXISTS t_05197;
+DROP TABLE IF EXISTS t_05197_dist;
+DROP TABLE IF EXISTS t_05197_merge;
+DROP TABLE IF EXISTS t_05197_merge_local;
+
+CREATE TABLE t_05197 (id UInt16, data Array(String)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05197 SELECT number, if(number % 2, ['aaa'], ['bbb', 'ccc']) FROM numbers(200);
+
+CREATE TABLE t_05197_dist AS t_05197 ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_05197);
+CREATE TABLE t_05197_merge AS t_05197 ENGINE = Merge(currentDatabase(), '^t_05197_dist$');
+CREATE TABLE t_05197_merge_local AS t_05197 ENGINE = Merge(currentDatabase(), '^t_05197$');
+
+SELECT 'the local table', count() FROM t_05197 ARRAY JOIN data WHERE data IN ('aaa');
+SELECT 'the Distributed table', count() FROM t_05197_dist ARRAY JOIN data WHERE data IN ('aaa');
+SELECT 'Merge over the local table', count() FROM t_05197_merge_local ARRAY JOIN data WHERE data IN ('aaa');
+
+SELECT 'Merge over Distributed, no filter', count() FROM t_05197_merge ARRAY JOIN data;
+SELECT 'Merge over Distributed', count() FROM t_05197_merge ARRAY JOIN data WHERE data IN ('aaa');
+SELECT 'an equality filter', count() FROM t_05197_merge ARRAY JOIN data WHERE data = 'ccc';
+SELECT 'an aliased array join', count() FROM t_05197_merge ARRAY JOIN data AS d WHERE d = 'aaa';
+SELECT 'LEFT ARRAY JOIN', count() FROM t_05197_merge LEFT ARRAY JOIN data WHERE data = 'aaa';
+
+-- A filter on the table's own column is still a filter on the child table, and the two kinds combine.
+SELECT 'a filter on a table column', count() FROM t_05197_merge ARRAY JOIN data WHERE id < 100;
+SELECT 'both kinds of filter', count() FROM t_05197_merge ARRAY JOIN data WHERE id < 100 AND data = 'aaa';
+SELECT 'both kinds, reversed', count() FROM t_05197_merge ARRAY JOIN data WHERE data = 'aaa' AND id < 100;
+
+-- The array-joined values themselves, to show the filter selects the right rows.
+SELECT 'the values', id, data FROM t_05197_merge ARRAY JOIN data WHERE data = 'ccc' AND id < 5 ORDER BY id;
+
+DROP TABLE t_05197_merge_local;
+DROP TABLE t_05197_merge;
+DROP TABLE t_05197_dist;
+DROP TABLE t_05197;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix ``Column `__array_join_exp_1` not found in table`` for `ARRAY JOIN` with a filter on the array-joined column over a `Merge` table whose child is a `Distributed` table.

### Documentation entry for user-facing changes

...

`SELECT count() FROM mrg ARRAY JOIN data WHERE data IN ('aaa')`, where `mrg` is a `Merge` table over a `Distributed` table, threw ``Column `__array_join_exp_1` not found in table ...``. The same query over the local table, over the `Distributed` table, or over a `Merge` table whose child is a plain `MergeTree` returned the rows.

`replaceTableExpressionAndRemoveJoin` builds the child query by replacing the outer query's join tree with the child table expression, and `cloneAndReplace` rewires every column sourced from the replaced node onto the replacement. With `ARRAY JOIN` as the join tree, that node is the `ARRAY JOIN` itself, so its result column ended up claiming to come from the child table: the filter over it then looked like a filter over the child's own columns and survived the cleanup that follows, and the child was asked to read `__array_join_exp_1`. Only a `Distributed` child noticed, because it is the one that re-analyzes the child query.

Drop such a filter before the join tree is replaced, while its columns still point at the `ARRAY JOIN` node, so that `hasUnknownColumn` recognizes them. `StorageMerge` reads its children with `FetchColumns` when the query has an `ARRAY JOIN`, so the array join and this filter are performed on the initiator either way. A filter over the table's own columns is unaffected — the replacement above has already rewired it onto the child table expression — and a conjunction of both kinds keeps the part that belongs to the child.

New test: `05197_merge_over_distributed_array_join_filter`. Verified in both directions, and a differential run of the `merge_table`/`array_join`/`storage_merge`/`distributed`/`view` stateless tests shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115274

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119307&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119307](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119307+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
