### PR TITLE
illumos: fix tcp shutdown.

### DIFF
--- a/src/Server/TCPServer.h
+++ b/src/Server/TCPServer.h
@@ -44,8 +44,9 @@ public:
         if (!is_open)
             return;
 
-        // FIXME: On darwin calling shutdown(SHUT_RD) on the socket blocked in accept() leads to ENOTCONN
-#ifndef OS_DARWIN
+        // FIXME: On Darwin and illumos, shutdown(SHUT_RD) on a listening socket
+        // returns ENOTCONN, so accept() is not explicitly awakened.
+#if !defined(OS_DARWIN) && !defined(OS_SUNOS)
         // Shutdown the listen socket before stopping tcp server to avoid 2.5second delay
         socket.shutdownReceive();
 #endif


### PR DESCRIPTION
As on darwin, calling shutdown(SHUT_RD) on a listening socket returns ENOTCONN on illumos. To prevent exceptions on SIGTERM on illumos, extend the darwin workaround to skip shutdownReceive() on illumos as well.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119314&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119314](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119314+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1257` (included in `26.9` and later)
<!-- ch-version-info:end -->