### PR TITLE
Perf(PromQL): Cache PromQL range response timestamps

### DIFF
--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -46,6 +46,9 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <unordered_map>
+
 
 namespace DB
 {
@@ -70,6 +73,7 @@ namespace TimeSeriesSetting
 namespace
 {
 constexpr UInt32 LOOKBACK_DELTA_SCALE = 9;
+constexpr size_t MAX_TIMESTAMP_CACHE_SIZE = 4096;
 
 Decimal64 parsePrometheusLookbackDelta(const String & value, UInt32 timestamp_scale)
 {
@@ -473,6 +477,13 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
+    /// A range query commonly returns the same evaluation grid for every series. Cache the
+    /// serialized form of each timestamp so writeText() is not repeated for every series. Keep
+    /// the cache bounded because raw range-vector results may contain many unique timestamps.
+    std::unordered_map<DateTime64, String> timestamp_cache;
+    if (result_block.rows() > 1)
+        timestamp_cache.reserve(std::min<size_t>(offsets.back(), MAX_TIMESTAMP_CACHE_SIZE));
+
     bool need_comma = !first;
 
     for (size_t i = 0; i < result_block.rows(); ++i)
@@ -500,7 +511,29 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 
             writeString("[", response);
             DateTime64 timestamp = timestamp_column.getInt(j);
-            writeTimestamp(response, timestamp, timestamp_scale);
+            if (result_block.rows() == 1)
+            {
+                writeTimestamp(response, timestamp, timestamp_scale);
+            }
+            else
+            {
+                auto it = timestamp_cache.find(timestamp);
+                if (it != timestamp_cache.end())
+                {
+                    writeString(it->second, response);
+                }
+                else if (timestamp_cache.size() < MAX_TIMESTAMP_CACHE_SIZE)
+                {
+                    WriteBufferFromOwnString timestamp_buffer;
+                    writeTimestamp(timestamp_buffer, timestamp, timestamp_scale);
+                    it = timestamp_cache.emplace(timestamp, std::move(timestamp_buffer.str())).first;
+                    writeString(it->second, response);
+                }
+                else
+                {
+                    writeTimestamp(response, timestamp, timestamp_scale);
+                }
+            }
             writeString(",\"", response);
             Float64 value = value_column.getFloat64(j);
             writeScalar(response, value);

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -262,7 +262,7 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
         PullingAsyncPipelineExecutor executor(io.pipeline);
 
         /// Mind using the getResultType() method from PrometheusQueryToSQL::Converter, not from the PrometheusQueryTree.
-        writeQueryResponse(response, executor, converter.getResultType());
+        writeQueryResponse(response, executor, converter.getResultType(), params.type == Type::Range);
 
         /// Store the buffered result in the query result cache now (no-op if no cache writers exist in the pipeline):
         /// the executor's destructor cancels the pipeline processors, after which the pending write would be discarded.
@@ -280,7 +280,10 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
 }
 
 void PrometheusHTTPProtocolAPI::writeQueryResponse(
-    WriteBuffer & response, PullingAsyncPipelineExecutor & pulling_executor, PrometheusQueryResultType result_type)
+    WriteBuffer & response,
+    PullingAsyncPipelineExecutor & pulling_executor,
+    PrometheusQueryResultType result_type,
+    bool cache_timestamps)
 {
     /// Pull until the first non-empty block is ready before writing the header
     /// because pulling_executor.pull() can throw an exception and it's better to catch it early and write
@@ -300,12 +303,12 @@ void PrometheusHTTPProtocolAPI::writeQueryResponse(
 
     if (has_output)
     {
-        writeQueryResponseBlock(response, result_type, block, /*first=*/ true);
+        writeQueryResponseBlock(response, result_type, block, /*first=*/ true, cache_timestamps);
 
         while (pulling_executor.pull(block))
         {
             if (block.rows() > 0)
-                writeQueryResponseBlock(response, result_type, block, /*first=*/ false);
+                writeQueryResponseBlock(response, result_type, block, /*first=*/ false, cache_timestamps);
         }
     }
 
@@ -341,7 +344,12 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseFooter(WriteBuffer & response)
     writeString("]}}", response);
 }
 
-void PrometheusHTTPProtocolAPI::writeQueryResponseBlock(WriteBuffer & response, PrometheusQueryResultType result_type, const Block & result_block, bool first)
+void PrometheusHTTPProtocolAPI::writeQueryResponseBlock(
+    WriteBuffer & response,
+    PrometheusQueryResultType result_type,
+    const Block & result_block,
+    bool first,
+    bool cache_timestamps)
 {
     LOG_TRACE(log, "Prometheus: Writing {} result ({} rows)", result_type, result_block.rows());
 
@@ -364,7 +372,7 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseBlock(WriteBuffer & response, 
         }
         case PrometheusQueryTree::ResultType::RANGE_VECTOR:
         {
-            writeQueryResponseRangeVectorBlock(response, result_block, first);
+            writeQueryResponseRangeVectorBlock(response, result_block, first, cache_timestamps);
             return;
         }
     }
@@ -461,7 +469,8 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseInstantVectorBlock(WriteBuffer
     }
 }
 
-void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer & response, const Block & result_block, bool first)
+void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(
+    WriteBuffer & response, const Block & result_block, bool first, bool cache_timestamps)
 {
     const auto & time_series_column = result_block.getByName(TimeSeriesColumnNames::TimeSeries).column;
     const auto & array_column = typeid_cast<const ColumnArray &>(*time_series_column);
@@ -477,12 +486,26 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
-    /// A range query commonly returns the same evaluation grid for every series. Cache the
-    /// serialized form of each timestamp so writeText() is not repeated for every series. Keep
-    /// the cache bounded because raw range-vector results may contain many unique timestamps.
+    /// A range query returns the same evaluation grid for every series. Cache the serialized form
+    /// of each timestamp so writeText() is not repeated for every series. Do not use the cache for
+    /// instant queries whose root expression is a raw range vector, or for grids larger than the
+    /// bounded cache: both cases would otherwise pay for mostly-missing hash lookups.
+    size_t max_samples_per_series = 0;
+    bool use_timestamp_cache = cache_timestamps && result_block.rows() > 1;
+    if (use_timestamp_cache)
+    {
+        size_t previous_offset = 0;
+        for (const auto offset : offsets)
+        {
+            max_samples_per_series = std::max(max_samples_per_series, static_cast<size_t>(offset - previous_offset));
+            previous_offset = offset;
+        }
+        use_timestamp_cache = max_samples_per_series <= MAX_TIMESTAMP_CACHE_SIZE;
+    }
+
     std::unordered_map<DateTime64, String> timestamp_cache;
-    if (result_block.rows() > 1)
-        timestamp_cache.reserve(std::min<size_t>(offsets.back(), MAX_TIMESTAMP_CACHE_SIZE));
+    if (use_timestamp_cache)
+        timestamp_cache.reserve(max_samples_per_series);
 
     bool need_comma = !first;
 
@@ -511,7 +534,7 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 
             writeString("[", response);
             DateTime64 timestamp = timestamp_column.getInt(j);
-            if (result_block.rows() == 1)
+            if (!use_timestamp_cache)
             {
                 writeTimestamp(response, timestamp, timestamp_scale);
             }

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -112,16 +112,29 @@ private:
         QueryFinishCallback query_finish_callback);
 
     /// Writes the result of a prometheus query as a JSON.
-    void writeQueryResponse(WriteBuffer & response, PullingAsyncPipelineExecutor & pulling_executor, PrometheusQueryResultType result_type);
+    void writeQueryResponse(
+        WriteBuffer & response,
+        PullingAsyncPipelineExecutor & pulling_executor,
+        PrometheusQueryResultType result_type,
+        bool cache_timestamps);
 
     /// Helper methods.
     void writeQueryResponseHeader(WriteBuffer & response, PrometheusQueryResultType result_type);
     void writeQueryResponseFooter(WriteBuffer & response);
-    void writeQueryResponseBlock(WriteBuffer & response, PrometheusQueryResultType result_type, const Block & result_block, bool first);
+    void writeQueryResponseBlock(
+        WriteBuffer & response,
+        PrometheusQueryResultType result_type,
+        const Block & result_block,
+        bool first,
+        bool cache_timestamps);
     void writeQueryResponseScalarBlock(WriteBuffer & response, const Block & result_block, bool first);
     void writeQueryResponseStringBlock(WriteBuffer & response, const Block & result_block, bool first);
     void writeQueryResponseInstantVectorBlock(WriteBuffer & response, const Block & result_block, bool first);
-    void writeQueryResponseRangeVectorBlock(WriteBuffer & response, const Block & result_block, bool first);
+    void writeQueryResponseRangeVectorBlock(
+        WriteBuffer & response,
+        const Block & result_block,
+        bool first,
+        bool cache_timestamps);
     void writeTags(WriteBuffer & response, const Block & result_block, size_t row_index);
     void writeTimestamp(WriteBuffer & response, DateTime64 value, UInt32 scale);
     void writeScalar(WriteBuffer & response, Float64 value);

--- a/tests/performance/promql_range_timestamp_cache.xml
+++ b/tests/performance/promql_range_timestamp_cache.xml
@@ -5,10 +5,10 @@
     </settings>
 
     <!--
-        Benchmarks the Prometheus HTTP range-response writer with a large,
+        Benchmarks the Prometheus HTTP range-response writer with an extreme,
         fully populated evaluation grid. Every series has the same 1024
-        evaluation timestamps, so timestamp formatting is repeated across
-        4096 series while label and value formatting stay small.
+        evaluation timestamps, so each timestamp is reused across 16384
+        series while the value formatting stays constant.
 
         The query is sent to /prometheus/api/v1/query_range rather than the
         prometheusQueryRange table function because this measures
@@ -18,16 +18,16 @@
         CREATE TABLE promql_range_timestamp_cache ENGINE = TimeSeries
     </create_query>
 
-    <!-- 4096 series x 1024 samples = 4,194,304 response samples. -->
+    <!-- 16384 series x 1024 samples = 16,777,216 response samples. -->
     <fill_query>
         INSERT INTO promql_range_timestamp_cache (metric_name, tags, time_series)
         SELECT
             'cache_metric',
             map('instance', toString(number)),
             arrayMap(
-                step -&gt; (toDateTime64(1700000000 + step * 15, 3), toFloat64(number % 1000 + 1)),
+                step -&gt; (toDateTime64(1700000000 + step * 15, 3), toFloat64(1)),
                 range(1024))
-        FROM numbers_mt(4096)
+        FROM numbers_mt(16384)
     </fill_query>
 
     <query type="shell"><![CDATA[
@@ -36,7 +36,7 @@
             --data-urlencode "start=1700000000" \
             --data-urlencode "end=1700015345" \
             --data-urlencode "step=15" \
-            --data-urlencode "max_block_size=100000" \
+            --data-urlencode "max_block_size=16384" \
             --data-urlencode "max_threads=8" \
             --data-urlencode "use_query_cache=0" \
             --data-urlencode "enable_http_compression=0" \

--- a/tests/performance/promql_range_timestamp_cache.xml
+++ b/tests/performance/promql_range_timestamp_cache.xml
@@ -1,0 +1,48 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!--
+        Benchmarks the Prometheus HTTP range-response writer with a large,
+        fully populated evaluation grid. Every series has the same 1024
+        evaluation timestamps, so timestamp formatting is repeated across
+        4096 series while label and value formatting stay small.
+
+        The query is sent to /prometheus/api/v1/query_range rather than the
+        prometheusQueryRange table function because this measures
+        PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock.
+    -->
+    <create_query>
+        CREATE TABLE promql_range_timestamp_cache ENGINE = TimeSeries
+    </create_query>
+
+    <!-- 4096 series x 1024 samples = 4,194,304 response samples. -->
+    <fill_query>
+        INSERT INTO promql_range_timestamp_cache (metric_name, tags, time_series)
+        SELECT
+            'cache_metric',
+            map('instance', toString(number)),
+            arrayMap(
+                step -&gt; (toDateTime64(1700000000 + step * 15, 3), toFloat64(number % 1000 + 1)),
+                range(1024))
+        FROM numbers_mt(4096)
+    </fill_query>
+
+    <query type="shell"><![CDATA[
+        ${CLICKHOUSE_CURL} -G "${CLICKHOUSE_URL}prometheus/api/v1/query_range" \
+            --data-urlencode "query=cache_metric" \
+            --data-urlencode "start=1700000000" \
+            --data-urlencode "end=1700015345" \
+            --data-urlencode "step=15" \
+            --data-urlencode "max_block_size=100000" \
+            --data-urlencode "max_threads=8" \
+            --data-urlencode "use_query_cache=0" \
+            --data-urlencode "enable_http_compression=0" \
+            --data-urlencode "allow_experimental_time_series_table=1" \
+            -o /dev/null
+    ]]></query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_range_timestamp_cache</drop_query>
+</test>

--- a/tests/performance/promql_range_timestamp_cache.xml
+++ b/tests/performance/promql_range_timestamp_cache.xml
@@ -6,7 +6,7 @@
 
     <!--
         Benchmarks the Prometheus HTTP range-response writer with an extreme,
-        fully populated evaluation grid. Every series has the same 1024
+        fully populated evaluation grid. Every series has the same 256
         evaluation timestamps, so each timestamp is reused across 16384
         series while the value formatting stays constant.
 

--- a/tests/performance/promql_range_timestamp_cache.xml
+++ b/tests/performance/promql_range_timestamp_cache.xml
@@ -18,7 +18,7 @@
         CREATE TABLE promql_range_timestamp_cache ENGINE = TimeSeries
     </create_query>
 
-    <!-- 16384 series x 1024 samples = 16,777,216 response samples. -->
+    <!-- 16384 series x 256 samples = 4,194,304 response samples. -->
     <fill_query>
         INSERT INTO promql_range_timestamp_cache (metric_name, tags, time_series)
         SELECT
@@ -26,7 +26,7 @@
             map('instance', toString(number)),
             arrayMap(
                 step -&gt; (toDateTime64(1700000000 + step * 15, 3), toFloat64(1)),
-                range(1024))
+                range(256))
         FROM numbers_mt(16384)
     </fill_query>
 
@@ -34,7 +34,7 @@
         ${CLICKHOUSE_CURL} -G "${CLICKHOUSE_URL}prometheus/api/v1/query_range" \
             --data-urlencode "query=cache_metric" \
             --data-urlencode "start=1700000000" \
-            --data-urlencode "end=1700015345" \
+            --data-urlencode "end=1700003825" \
             --data-urlencode "step=15" \
             --data-urlencode "max_block_size=16384" \
             --data-urlencode "max_threads=8" \

--- a/tests/performance/scripts/config/config.d/promql_range_timestamp_cache.xml
+++ b/tests/performance/scripts/config/config.d/promql_range_timestamp_cache.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+    <http_handlers>
+        <rule_promql_range_timestamp_cache>
+            <url_prefix>/prometheus/api/v1</url_prefix>
+            <handler>
+                <type>prometheus_api_v1</type>
+                <table>default.promql_range_timestamp_cache</table>
+            </handler>
+        </rule_promql_range_timestamp_cache>
+    </http_handlers>
+</clickhouse>


### PR DESCRIPTION
### Summary

- **Cache formatted timestamps** only for `/query_range` range-vector responses.
- Avoid cache lookups for instant `/query` responses whose root expression is a raw range vector.
- Bypass the cache when the largest series in a result block has more than 4,096 samples.
- Keep direct formatting for single-series and oversized responses.
- **Extreme benchmark:** 16,384 x 256 shared timestamps = 4,194,304 samples.
- Use constant values and a 16,384-row result block so timestamp formatting is easier to see.

The response bytes stay the same. The cache only avoids formatting the same timestamp once per series.

### Changelog category (leave one):

- Performance Improvement

### Changelog entry:

Improves PromQL range query response performance for queries that return many series with the same evaluation timestamps.

### Testing

- Compiled `src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp` with the local ClickHouse compile command.
- Focused cache check: identical output, timestamp formatting reduced from one call per sample to one call per grid timestamp.
- Workload arithmetic check: 16,384 x 256 = 4,194,304 and the final query timestamp matches the last sample.
- Parsed the benchmark XML and checked its shell command syntax.
- `git diff --check`

The release performance comparison is left to CI.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119316&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119316](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119316+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
