### PR TITLE
Do not match a `JSON` subcolumn inside a typed path to a skip index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -309,8 +309,15 @@ std::optional<MapIndexInfo> tryResolveMapInfoFromNode(const RPNBuilderTreeNode &
 }
 
 MergeTreeIndexConditionBloomFilter::MergeTreeIndexConditionBloomFilter(
-    const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_)
-    : WithContext(context_), header(header_), hash_functions(hash_functions_)
+    const ActionsDAG::Node * predicate,
+    ContextPtr context_,
+    const Block & header_,
+    size_t hash_functions_,
+    JSONIndexArgumentTypes json_argument_types_)
+    : WithContext(context_)
+    , header(header_)
+    , hash_functions(hash_functions_)
+    , json_argument_types(std::move(json_argument_types_))
 {
     if (!predicate)
     {
@@ -490,7 +497,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseFunction(const RPNBuilderTreeNo
     if (function_name == "isNotNull" && arguments_size == 1)
     {
         auto arg = function.getArgumentAt(0);
-        if (auto json_info = tryMatchNodeToJSONIndex(arg, header, "JSONAllPaths"))
+        if (auto json_info = tryMatchNodeToJSONIndex(arg, header, "JSONAllPaths", json_argument_types))
         {
             auto arg_type = arg.getDAGNode()->result_type;
             /// It doesn't make sense to use bloom filter for isNotNull on non-Nullable type, as isNotNull will be always true.
@@ -626,7 +633,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
     /// tryMatchNodeToJSONIndex handles both plain subcolumns and CAST-wrapped expressions.
     /// NOT IN is not supported because after BoolMask inversion it never skips any granules.
     /// nullIn/globalNullIn are deliberately not wired here: JSON paths need per-path NULL checks.
-    if (auto json_info = tryMatchNodeToJSONIndex(key_node, header, "JSONAllPaths"))
+    if (auto json_info = tryMatchNodeToJSONIndex(key_node, header, "JSONAllPaths", json_argument_types))
     {
         if (function_name != "in" && function_name != "globalIn")
             return false;
@@ -1091,7 +1098,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
     /// Try to match the column name to a JSONAllPaths index for JSON subcolumn filtering.
     /// tryMatchNodeToJSONIndex handles both plain subcolumns and CAST-wrapped expressions
     /// like `json.some.path = value`, `json.some.path.:Type = value`, or `json.path::Type = value`.
-    if (auto json_info = tryMatchNodeToJSONIndex(key_node, header, "JSONAllPaths"))
+    if (auto json_info = tryMatchNodeToJSONIndex(key_node, header, "JSONAllPaths", json_argument_types))
     {
         if (function_name != "equals")
             return false;
@@ -1304,7 +1311,8 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilter::createIndexAggregator() c
 
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilter::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionBloomFilter>(predicate, context, index.sample_block, hash_functions);
+    return std::make_shared<MergeTreeIndexConditionBloomFilter>(
+        predicate, context, index.sample_block, hash_functions, collectJSONIndexArgumentTypes(*index.expression));
 }
 
 static void assertIndexColumnsType(const Block & header)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -4,6 +4,7 @@
 #include <Common/HashTable/HashSet.h>
 #include <Interpreters/BloomFilter.h>
 #include <Storages/MergeTree/KeyCondition.h>
+#include <Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 
 namespace DB
@@ -72,7 +73,12 @@ public:
         std::vector<std::pair<size_t, ColumnPtr>> predicate;
     };
 
-    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_);
+    MergeTreeIndexConditionBloomFilter(
+        const ActionsDAG::Node * predicate,
+        ContextPtr context_,
+        const Block & header_,
+        size_t hash_functions_,
+        JSONIndexArgumentTypes json_argument_types_);
 
     bool alwaysUnknownOrTrue() const override;
 
@@ -89,6 +95,8 @@ public:
 private:
     const Block & header;
     const size_t hash_functions;
+    /// Argument types of the JSON index functions of this index, by position in `header`.
+    const JSONIndexArgumentTypes json_argument_types;
     std::vector<RPNElement> rpn;
 
     bool mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -156,8 +156,10 @@ MergeTreeConditionBloomFilterText::MergeTreeConditionBloomFilterText(
     ContextPtr context,
     const Block & index_sample_block,
     const BloomFilterParameters & params_,
-    TokenizerPtr token_extactor_)
+    TokenizerPtr token_extactor_,
+    JSONIndexArgumentTypes json_argument_types_)
     : index_columns(index_sample_block.getNames())
+    , json_argument_types(std::move(json_argument_types_))
     , index_data_types(index_sample_block.getNamesAndTypesList().getTypes())
     , params(params_)
     , owned_tokenizer(token_extactor_ && token_extactor_->isStateful() ? token_extactor_->clone() : nullptr)
@@ -364,7 +366,7 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
         if (function_name == "isNotNull" && arguments_size == 1)
         {
             auto arg = function_node.getArgumentAt(0);
-            if (auto json_info = tryMatchNodeToJSONIndex(arg, index_columns, "JSONAllPaths"))
+            if (auto json_info = tryMatchNodeToJSONIndex(arg, index_columns, "JSONAllPaths", json_argument_types))
             {
                 auto arg_type = arg.getDAGNode()->result_type;
                 /// It doesn't make sense to use bloom filter for isNotNull on non-Nullable type, as isNotNull will be always true.
@@ -532,7 +534,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
     /// but we tokenize the *path* string against the JSONAllPaths index, not the value.
     if (function_name == "equals")
     {
-        if (auto json_info = tryMatchNodeToJSONIndex(key_node, index_columns, "JSONAllPaths"))
+        if (auto json_info = tryMatchNodeToJSONIndex(key_node, index_columns, "JSONAllPaths", json_argument_types))
         {
             auto key_type = key_node.getDAGNode()->result_type;
             if (!isJSONPathFilterSafe(key_type, value_field))
@@ -973,7 +975,8 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilterText::createIndexAggregator
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilterText::createIndexCondition(
         const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeConditionBloomFilterText>(predicate, context, index.sample_block, params, tokenizer.get());
+    return std::make_shared<MergeTreeConditionBloomFilterText>(
+        predicate, context, index.sample_block, params, tokenizer.get(), collectJSONIndexArgumentTypes(*index.expression));
 }
 
 MergeTreeIndexPtr bloomFilterIndexTextCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & /*settings*/)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Interpreters/BloomFilter.h>
@@ -70,7 +71,8 @@ public:
             ContextPtr context,
             const Block & index_sample_block,
             const BloomFilterParameters & params_,
-            TokenizerPtr token_extactor_);
+            TokenizerPtr token_extactor_,
+            JSONIndexArgumentTypes json_argument_types_);
 
     ~MergeTreeConditionBloomFilterText() override = default;
 
@@ -147,6 +149,8 @@ private:
         RPNElement & out, const Field & value, const BloomFilterParameters & params, TokenizerPtr tokenizer);
 
     Names index_columns;
+    /// Argument types of the JSON index functions of this index, by position in `index_columns`.
+    JSONIndexArgumentTypes json_argument_types;
     DataTypes index_data_types;
     BloomFilterParameters params;
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -140,9 +140,11 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     TokenizerPtr tokenizer_,
     MergeTreeIndexTextPreprocessorPtr preprocessor_,
     MergeTreeIndexTextPostprocessorPtr postprocessor_,
-    bool has_positions_)
+    bool has_positions_,
+    JSONIndexArgumentTypes json_argument_types_)
     : WithContext(context_)
     , header(index_sample_block)
+    , json_argument_types(std::move(json_argument_types_))
     , normalized_index_column_name(normalized_index_column_name_)
     , owned_tokenizer(tokenizer_ && tokenizer_->isStateful() ? std::shared_ptr<const ITokenizer>(tokenizer_->clone()) : nullptr)
     , tokenizer(owned_tokenizer ? owned_tokenizer.get() : tokenizer_)
@@ -1061,7 +1063,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         direct_read_mode = getHintOrNoneMode();
         candidate_for_exact_mode = false;
     }
-    else if (tryMatchNodeToJSONIndex(index_column_node, header, "JSONAllValues"))
+    else if (tryMatchNodeToJSONIndex(index_column_node, header, "JSONAllValues", json_argument_types))
     {
         has_index_column = true;
         direct_read_mode = getHintOrNoneMode();
@@ -1831,7 +1833,7 @@ bool MergeTreeIndexConditionText::traverseJSONSubcolumnKeyNode(
     auto output_column_name = outputs.front()->result_name;
 
     /// Try to match the required column to a JSON subcolumn with JSONAllPaths index.
-    auto json_info = tryMatchJSONSubcolumnToIndex(required_column.name, header, "JSONAllPaths");
+    auto json_info = tryMatchJSONSubcolumnToIndex(required_column.name, header, "JSONAllPaths", json_argument_types);
     if (!json_info)
         return false;
 
@@ -1886,7 +1888,7 @@ bool MergeTreeIndexConditionText::tryPrepareSetForTextSearch(
     {
         return hasIndexForColumn(node.getColumnName())
             || hasIndexForMapElementValue(node)
-            || tryMatchNodeToJSONIndex(node, header, "JSONAllValues");
+            || tryMatchNodeToJSONIndex(node, header, "JSONAllValues", json_argument_types);
     };
 
     if (lhs.isFunction() && lhs.toFunctionNode().getFunctionName() == "tuple")

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Common/OptimizedRegularExpression.h>
@@ -97,7 +98,8 @@ public:
         TokenizerPtr tokenizer_,
         MergeTreeIndexTextPreprocessorPtr preprocessor_,
         MergeTreeIndexTextPostprocessorPtr postprocessor_,
-        bool has_positions_);
+        bool has_positions_,
+        JSONIndexArgumentTypes json_argument_types_);
 
     ~MergeTreeIndexConditionText() override = default;
     static bool isSupportedFunction(const String & function_name);
@@ -204,6 +206,8 @@ private:
     static bool requiresReadingAllTokens(const RPNElement & element);
 
     Block header;
+    /// Argument types of the JSON index functions of this index, by position in `header`.
+    JSONIndexArgumentTypes json_argument_types;
     std::optional<String> normalized_index_column_name;
     /// A private clone of the index tokenizer when it is stateful, so concurrent conditions do not
     /// share mutable parsing state; null otherwise.

--- a/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.cpp
@@ -3,10 +3,52 @@
 
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeObject.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/ExpressionActions.h>
 #include <Interpreters/convertFieldToType.h>
 
 namespace DB
 {
+
+JSONIndexArgumentTypes collectJSONIndexArgumentTypes(const ExpressionActions & index_expression)
+{
+    JSONIndexArgumentTypes result;
+
+    const auto & outputs = index_expression.getActionsDAG().getOutputs();
+    for (size_t position = 0; position < outputs.size(); ++position)
+    {
+        const auto * node = outputs[position];
+        if (!node || node->type != ActionsDAG::ActionType::FUNCTION || node->children.empty())
+            continue;
+
+        const auto & argument_type = node->children.front()->result_type;
+        if (argument_type && typeid_cast<const DataTypeObject *>(argument_type.get()))
+            result.emplace(position, argument_type);
+    }
+
+    return result;
+}
+
+/// A typed path of a `JSON` type is reported by `JSONAllPaths` and `JSONAllValues` verbatim, and
+/// their contents are never recursed into: a `JSON(a JSON)` column holding `{"a":{"b":42}}` yields
+/// the granule path set `['a']`, and a `JSON(a Tuple(b Int64))` column yields the same. A subcolumn
+/// that reaches inside a typed path (`json.a.b`, whose path is `a.b`) is therefore absent from every
+/// granule, while reading it returns the value that lives inside the typed path's own column - so
+/// matching such a subcolumn to the index would prune every granule and silently lose rows.
+static bool pathIsInsideTypedPath(const DataTypePtr & json_type, const String & path)
+{
+    const auto * object_type = typeid_cast<const DataTypeObject *>(json_type.get());
+    if (!object_type)
+        return false;
+
+    for (const auto & [typed_path, _] : object_type->getTypedPaths())
+    {
+        if (path.size() > typed_path.size() && path.starts_with(typed_path) && path[typed_path.size()] == '.')
+            return true;
+    }
+
+    return false;
+}
 
 /// Extract the JSON path from a subcolumn name, stripping any `.:\`Type\`` suffix.
 /// For example:
@@ -34,15 +76,17 @@ static bool isPrefixedSubcolumn(std::string_view subcolumn_name, char prefix)
 std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
     const String & column_name,
     const Block & header,
-    const String & json_function_name)
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types)
 {
-    return tryMatchJSONSubcolumnToIndex(column_name, header.getNames(), json_function_name);
+    return tryMatchJSONSubcolumnToIndex(column_name, header.getNames(), json_function_name, json_argument_types);
 }
 
 std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
     const String & column_name,
     const Names & index_columns,
-    const String & json_function_name)
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types)
 {
     /// Scan the index columns, not the dot positions of the name: the name can embed a folded
     /// constant, so its length is unbounded while `index_columns` is not.
@@ -93,6 +137,10 @@ std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
     if (path.empty())
         return std::nullopt;
 
+    /// The index knows nothing about what is stored inside a declared typed path.
+    if (auto it = json_argument_types.find(matched_position); it != json_argument_types.end() && pathIsInsideTypedPath(it->second, path))
+        return std::nullopt;
+
     return JSONSubcolumnIndexInfo{
         .json_column_name = String(matched_json_column),
         .path = std::move(path),
@@ -103,17 +151,19 @@ std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
 std::optional<JSONSubcolumnIndexInfo> tryMatchNodeToJSONIndex(
     const RPNBuilderTreeNode & node,
     const Block & header,
-    const String & json_function_name)
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types)
 {
-    return tryMatchNodeToJSONIndex(node, header.getNames(), json_function_name);
+    return tryMatchNodeToJSONIndex(node, header.getNames(), json_function_name, json_argument_types);
 }
 
 std::optional<JSONSubcolumnIndexInfo> tryMatchNodeToJSONIndex(
     const RPNBuilderTreeNode & node,
     const Names & index_columns,
-    const String & json_function_name)
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types)
 {
-    auto json_info = tryMatchJSONSubcolumnToIndex(node.getColumnName(), index_columns, json_function_name);
+    auto json_info = tryMatchJSONSubcolumnToIndex(node.getColumnName(), index_columns, json_function_name, json_argument_types);
 
     /// Try CAST unwrapping: CAST(json.path, 'Type') or _CAST(json.path, 'Type')
     if (!json_info && node.isFunction())
@@ -122,7 +172,7 @@ std::optional<JSONSubcolumnIndexInfo> tryMatchNodeToJSONIndex(
         auto fname = func.getFunctionName();
         if ((fname == "CAST" || fname == "_CAST") && func.getArgumentsSize() == 2)
             json_info = tryMatchJSONSubcolumnToIndex(
-                func.getArgumentAt(0).getColumnName(), index_columns, json_function_name);
+                func.getArgumentAt(0).getColumnName(), index_columns, json_function_name, json_argument_types);
     }
 
     return json_info;

--- a/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h
+++ b/src/Storages/MergeTree/MergeTreeIndexJSONSubcolumnHelper.h
@@ -9,6 +9,16 @@
 namespace DB
 {
 
+class ExpressionActions;
+
+/// The type of the argument of every JSON index function of an index expression, by position in the
+/// index sample block. Only positions whose index column is a function over a `JSON` column are
+/// present, which is what the matchers below can match a subcolumn against.
+using JSONIndexArgumentTypes = std::unordered_map<size_t, DataTypePtr>;
+
+/// Collect the argument types of the JSON index functions of an index expression.
+JSONIndexArgumentTypes collectJSONIndexArgumentTypes(const ExpressionActions & index_expression);
+
 /// Information extracted from a column name that references a JSON subcolumn
 /// matched against a JSONAllPaths(...) index column.
 struct JSONSubcolumnIndexInfo
@@ -29,16 +39,19 @@ struct JSONSubcolumnIndexInfo
 /// Returns nullopt if:
 ///   - No matching index column is found in the header
 ///   - The subcolumn is a sub-object access (^ prefix) or a combined literal+sub-object access (@ prefix)
+///   - The subcolumn reaches inside a declared typed path of the `JSON` type (see the implementation)
 std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
     const String & column_name,
     const Block & header,
-    const String & json_function_name);
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types);
 
 /// Overload that works with a list of index column names instead of a Block.
 std::optional<JSONSubcolumnIndexInfo> tryMatchJSONSubcolumnToIndex(
     const String & column_name,
     const Names & index_columns,
-    const String & json_function_name);
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types);
 
 class RPNBuilderTreeNode; /// forward declaration to avoid heavy include
 
@@ -48,13 +61,15 @@ class RPNBuilderTreeNode; /// forward declaration to avoid heavy include
 std::optional<JSONSubcolumnIndexInfo> tryMatchNodeToJSONIndex(
     const RPNBuilderTreeNode & node,
     const Block & header,
-    const String & json_function_name);
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types);
 
 /// Overload that works with a list of index column names instead of a Block.
 std::optional<JSONSubcolumnIndexInfo> tryMatchNodeToJSONIndex(
     const RPNBuilderTreeNode & node,
     const Names & index_columns,
-    const String & json_function_name);
+    const String & json_function_name,
+    const JSONIndexArgumentTypes & json_argument_types);
 
 /// Check if a JSON path filter is safe to use for index skipping.
 /// When a JSON path is absent in a granule, the expression evaluates to:

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -2053,7 +2053,16 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexText::createIndexAggregator() const
 
 MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, normalized_index_column_name, tokenizer.get(), preprocessor, postprocessor, params.positions);
+    return std::make_shared<MergeTreeIndexConditionText>(
+        predicate,
+        context,
+        index.sample_block,
+        normalized_index_column_name,
+        tokenizer.get(),
+        preprocessor,
+        postprocessor,
+        params.positions,
+        collectJSONIndexArgumentTypes(*index.expression));
 }
 
 DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)

--- a/tests/queries/0_stateless/05198_json_skip_index_typed_path_subcolumn.reference
+++ b/tests/queries/0_stateless/05198_json_skip_index_typed_path_subcolumn.reference
@@ -1,0 +1,14 @@
+the granule paths	['a']
+a nested JSON typed path	4
+the same without the index	4
+isNotNull	4
+IN	4
+a cast	4
+a Tuple typed path	4
+the same without the index	4
+a token bloom filter	4
+the same without the index	4
+a scalar typed path	4
+the dynamic granule paths	['a.b']
+a nested dynamic path	4
+an absent path is still pruned	0

--- a/tests/queries/0_stateless/05198_json_skip_index_typed_path_subcolumn.sql
+++ b/tests/queries/0_stateless/05198_json_skip_index_typed_path_subcolumn.sql
@@ -1,0 +1,61 @@
+-- A `JSONAllPaths` skip index reports a declared typed path of a `JSON` type verbatim and never
+-- recurses into it: a `JSON(a JSON)` column holding `{"a":{"b":42}}` has the granule path set `['a']`.
+-- A filter on a subcolumn that reaches inside such a typed path (`json.a.b`, whose path is `a.b`) was
+-- matched against that path set, found no granule containing `a.b` and pruned all of them, silently
+-- returning no rows. The index is not consulted for such a subcolumn any more, which
+-- `force_data_skipping_indices` shows below.
+
+SET use_skip_indexes = 1;
+
+DROP TABLE IF EXISTS t_05198_nested;
+CREATE TABLE t_05198_nested (json JSON(a JSON), INDEX idx JSONAllPaths(json) TYPE bloom_filter GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 2;
+INSERT INTO t_05198_nested SELECT '{"a":{"b":42}}' FROM numbers(4);
+
+SELECT 'the granule paths', arraySort(groupUniqArrayArray(JSONAllPaths(json))) FROM t_05198_nested;
+SELECT 'a nested JSON typed path', count() FROM t_05198_nested WHERE json.a.b = 42;
+SELECT 'the same without the index', count() FROM t_05198_nested WHERE json.a.b = 42 SETTINGS use_skip_indexes = 0;
+SELECT 'isNotNull', count() FROM t_05198_nested WHERE isNotNull(json.a.b);
+SELECT 'IN', count() FROM t_05198_nested WHERE json.a.b::Int64 IN (42, 43);
+SELECT 'a cast', count() FROM t_05198_nested WHERE json.a.b::Int64 = 42;
+SELECT count() FROM t_05198_nested WHERE json.a.b = 42 SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+DROP TABLE IF EXISTS t_05198_tuple;
+CREATE TABLE t_05198_tuple (json JSON(a Tuple(b Int64)), INDEX idx JSONAllPaths(json) TYPE bloom_filter GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 2;
+INSERT INTO t_05198_tuple SELECT '{"a":{"b":42}}' FROM numbers(4);
+
+SELECT 'a Tuple typed path', count() FROM t_05198_tuple WHERE json.a.b = 42;
+SELECT 'the same without the index', count() FROM t_05198_tuple WHERE json.a.b = 42 SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_05198_tokenbf;
+CREATE TABLE t_05198_tokenbf (json JSON(a JSON), INDEX idx JSONAllPaths(json) TYPE tokenbf_v1(256, 2, 0) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 2;
+INSERT INTO t_05198_tokenbf SELECT '{"a":{"b":42}}' FROM numbers(4);
+
+SELECT 'a token bloom filter', count() FROM t_05198_tokenbf WHERE json.a.b = 42;
+SELECT 'the same without the index', count() FROM t_05198_tokenbf WHERE json.a.b = 42 SETTINGS use_skip_indexes = 0;
+
+-- The shapes the index is designed for keep using it: a scalar typed path is reported by its own
+-- name, and a dynamic path is reported with all of its components.
+DROP TABLE IF EXISTS t_05198_scalar;
+CREATE TABLE t_05198_scalar (json JSON(x Int64), INDEX idx JSONAllPaths(json) TYPE bloom_filter GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 2;
+INSERT INTO t_05198_scalar SELECT '{"x":42}' FROM numbers(4);
+
+SELECT 'a scalar typed path', count() FROM t_05198_scalar WHERE json.x = 42 SETTINGS force_data_skipping_indices = 'idx';
+
+DROP TABLE IF EXISTS t_05198_dynamic;
+CREATE TABLE t_05198_dynamic (json JSON, INDEX idx JSONAllPaths(json) TYPE bloom_filter GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 2;
+INSERT INTO t_05198_dynamic SELECT '{"a":{"b":42}}' FROM numbers(4);
+
+SELECT 'the dynamic granule paths', arraySort(groupUniqArrayArray(JSONAllPaths(json))) FROM t_05198_dynamic;
+SELECT 'a nested dynamic path', count() FROM t_05198_dynamic WHERE json.a.b = 42 SETTINGS force_data_skipping_indices = 'idx';
+SELECT 'an absent path is still pruned', count() FROM t_05198_dynamic WHERE json.absent = 42 SETTINGS force_data_skipping_indices = 'idx';
+
+DROP TABLE t_05198_dynamic;
+DROP TABLE t_05198_scalar;
+DROP TABLE t_05198_tokenbf;
+DROP TABLE t_05198_tuple;
+DROP TABLE t_05198_nested;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a `JSONAllPaths` skip index silently pruning every granule for a filter on a subcolumn inside a declared typed path of a `JSON` column (for example `json.a.b` for `JSON(a JSON)` or `JSON(a Tuple(b Int64))`). Such a filter no longer uses the index.

### Documentation entry for user-facing changes

...

A `JSONAllPaths` skip index silently returned no rows for a filter on a subcolumn that reaches inside a typed path of a `JSON` column:

```sql
CREATE TABLE t (json JSON(a JSON), INDEX idx JSONAllPaths(json) TYPE bloom_filter GRANULARITY 1)
ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 2;
INSERT INTO t SELECT '{"a":{"b":42}}' FROM numbers(4);
SELECT count() FROM t WHERE json.a.b = 42;                               -- 0
SELECT count() FROM t WHERE json.a.b = 42 SETTINGS use_skip_indexes = 0; -- 4
```

`JSONAllPaths` reports a declared typed path verbatim and never recurses into its contents, so the granule path set here is `['a']`, both for a nested `JSON` typed path and for a structured one such as `JSON(a Tuple(b Int64))`. The query side derives the path `a.b` from the subcolumn `json.a.b` and asks whether any granule contains it; none does, so every granule was pruned, even though the value lives inside the typed path's own column and reading the subcolumn returns it. The assumption behind the match — a path absent from `JSONAllPaths` means the subcolumn is `NULL` — holds for a dynamic path but not for the substructure of a typed path.

Refuse the match when the derived path has a strict prefix that is a declared typed path of the `JSON` type, so such a filter simply does not use the index. The type is taken from the argument of the JSON index function in the index expression, collected per index sample block position and passed to the condition, so it is available regardless of how the column is named inside the index function. This covers every index type sharing the matcher (`bloom_filter`, `tokenbf_v1`, `ngrambf_v1`, `text`) and every predicate routed through it. The shapes the index is designed for are unaffected: a scalar typed path is reported by its own name, and a dynamic path is reported with all of its components, so both keep using the index — the new test pins that with `force_data_skipping_indices`.

New test: `05198_json_skip_index_typed_path_subcolumn`. Verified in both directions, and a differential run of the `skip_index`/`bloom_filter`/`text_index`/`json_path`/`tokenbf`/`ngrambf` stateless tests (344 tests) shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117938

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119321&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119321](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119321+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
