### PR TITLE
Bump `cassandra` from 2.16.2 to 2.17.1

### DIFF
--- a/contrib/cassandra-cmake/CMakeLists.txt
+++ b/contrib/cassandra-cmake/CMakeLists.txt
@@ -15,9 +15,6 @@ if (APPLE)
     set(CMAKE_MACOSX_RPATH ON)
 endif()
 
-# Need to use C++17 since the compilation is not possible with C++20 currently.
-set (CMAKE_CXX_STANDARD 17)
-
 set(CASS_ROOT_DIR ${PROJECT_SOURCE_DIR}/contrib/cassandra)
 set(CASS_SRC_DIR "${CASS_ROOT_DIR}/src")
 set(CASS_INCLUDE_DIR "${CASS_ROOT_DIR}/include")


### PR DESCRIPTION
Bumps `contrib/cassandra` (ClickHouse fork of the DataStax C++ driver) from 2.16.2 to 2.17.1, picking up the upstream fix for duplicate v1 UUIDs from `cass_uuid_gen_time` (CPP-988) and C++20-compatible atomics (PR #533).

### ClickHouse-side changes
- `contrib/cassandra-cmake/CMakeLists.txt` — drop the `set (CMAKE_CXX_STANDARD 17)` override; the `MemoryOrder` initialisation that blocked C++20 was fixed upstream, so the driver now builds at the project-wide standard.

### Fork
The ClickHouse patch series is rebased onto the `2.17.1` tag: the OpenSSL patch ("Do not touch process-global OpenSSL state from the driver") is kept, since the driver still calls `CRYPTO_set_mem_functions` unconditionally; "update cmake_minimum_required" is dropped because upstream 2.17.0 does it itself (CPP-919).

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `cassandra` to 2.17.1.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119326&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119326](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119326+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
