### PR TITLE
Bump `libpqxx` from 7.10.0 to 8.0.2

### DIFF
--- a/contrib/libpqxx-cmake/CMakeLists.txt
+++ b/contrib/libpqxx-cmake/CMakeLists.txt
@@ -2,7 +2,6 @@ set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/libpqxx")
 
 set (SRCS
     "${LIBRARY_DIR}/src/array.cxx"
-    "${LIBRARY_DIR}/src/binarystring.cxx"
     "${LIBRARY_DIR}/src/blob.cxx"
     "${LIBRARY_DIR}/src/connection.cxx"
     "${LIBRARY_DIR}/src/cursor.cxx"
@@ -25,13 +24,15 @@ set (SRCS
     "${LIBRARY_DIR}/src/time.cxx"
     "${LIBRARY_DIR}/src/transaction.cxx"
     "${LIBRARY_DIR}/src/transaction_base.cxx"
+    "${LIBRARY_DIR}/src/types.cxx"
     "${LIBRARY_DIR}/src/util.cxx"
-    "${LIBRARY_DIR}/src/version.cxx"
     "${LIBRARY_DIR}/src/wait.cxx"
 )
 
-configure_file(${LIBRARY_DIR}/include/pqxx/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/pqxx/config-internal-compiler.h @ONLY)
-configure_file(${LIBRARY_DIR}/include/pqxx/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/pqxx/config-public-compiler.h @ONLY)
+# The template only contains `#undef PQXX_HAVE_*` lines; copying it verbatim leaves every optional
+# feature disabled, which matches how the library was configured before and keeps the build hermetic
+# (no try_compile feature probes).
+configure_file(${LIBRARY_DIR}/include/pqxx/internal/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/pqxx/internal/config.h @ONLY)
 
 add_library(_libpqxx ${SRCS})
 target_link_libraries(_libpqxx PUBLIC ch_contrib::libpq)

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -194,7 +194,7 @@ Chunk PostgreSQLSource<T>::generate()
 
     while (!isCancelled() && !stop_requested.load())
     {
-        const std::vector<pqxx::zview> * row{stream->read_row()};
+        const std::vector<std::string_view> * row{stream->read_row()};
 
         /// row is nullptr if pqxx::stream_from is finished
         if (!row)
@@ -209,8 +209,8 @@ Chunk PostgreSQLSource<T>::generate()
         {
             const auto & sample = description.sample_block.getByPosition(idx);
 
-            /// if got NULL type, then pqxx::zview will return nullptr in c_str()
-            if ((*row)[idx].c_str())
+            /// A SQL NULL is reported as a view with a null data pointer.
+            if ((*row)[idx].data())
             {
                 if (description.types[idx].second)
                 {

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -1376,7 +1376,7 @@ bool MaterializedPostgreSQLConsumer::consume()
 
         while (true)
         {
-            const std::vector<pqxx::zview> * row{stream.read_row()};
+            const std::vector<std::string_view> * row{stream.read_row()};
 
             if (!row)
             {
@@ -1398,7 +1398,7 @@ bool MaterializedPostgreSQLConsumer::consume()
             try
             {
                 /// LOG_DEBUG(log, "Current message: {}", (*row)[1]);
-                processReplicationMessage((*row)[1].c_str(), (*row)[1].size());
+                processReplicationMessage((*row)[1].data(), (*row)[1].size());
             }
             catch (const Exception & e)
             {

--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -515,7 +515,8 @@ void PostgreSQLReplicationHandler::adoptLegacyReplicationIdentityIfNeeded(pqxx::
                 "the legacy publication {} publishes no tables, so the schema-blind legacy replication slot "
                 "cannot be proven to belong to this engine's schema '{}'",
                 doubleQuoteString(legacy_publication_name), postgres_schema);
-        for (const auto & row : result)
+        /// `pqxx::result` iteration yields `pqxx::row_ref` proxies by value.
+        for (const auto row : result)
         {
             if (row[0].as<std::string>() != postgres_schema)
             {


### PR DESCRIPTION
Bumps the `libpqxx` fork from 7.10.0 to 8.0.2; 8.x moves the generated feature-macro header and changes the `stream_from`/`result` APIs that the PostgreSQL integration uses, so the bump needs ClickHouse-side adjustments.

### ClickHouse-side changes
- `contrib/libpqxx-cmake/CMakeLists.txt` — source list follows 8.0 (`types.cxx` added, `binarystring.cxx` and `version.cxx` removed); a single `configure_file` now generates `pqxx/internal/config.h`, keeping every `PQXX_HAVE_*` undefined as before.
- `src/Processors/Sources/PostgreSQLSource.cpp`, `src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp` — `stream_from::read_row` now returns `std::vector<std::string_view> const *`; NULL is detected via `.data()` instead of `zview::c_str()`.
- `src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp` — range loop over `pqxx::result` binds the `row_ref` proxy by value.

### Fork
Carries the same three ClickHouse patches as 7.10.0 (`connection::reset`, public `stream_from::close`, darwin `timeval` cast in `wait.cxx`), rebased onto 8.0.2 in fork PR #12.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `libpqxx` to 8.0.2.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119327&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119327](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119327+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
