### PR TITLE
Do not JIT-compile a lambda body in a plan that is shipped to another node

### DIFF
--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -1071,7 +1071,14 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
         }
     }
 
-    auto expression_actions_settings = ExpressionActionsSettings(planner_context->getQueryContext(), CompileExpressions::yes);
+    /// A lambda's `ExpressionActions` is built here, while planning, so its DAG is the very one that
+    /// gets serialized when this plan is shipped to another node. A JIT-compiled node cannot be
+    /// serialized: its `getName` is a dump of the compiled expression, not a name `FunctionFactory`
+    /// knows, and the receiving node fails with `UNKNOWN_FUNCTION and(UInt8, less(UInt64, 1000 :
+    /// UInt16))`. Leave the body uncompiled in a logical plan - the receiving node compiles it itself
+    /// when it rebuilds the lambda from the serialized plan, so nothing is lost.
+    auto compile_lambda_expression = planner_context->isLogicalPlan() ? CompileExpressions::no : CompileExpressions::yes;
+    auto expression_actions_settings = ExpressionActionsSettings(planner_context->getQueryContext(), compile_lambda_expression);
     auto lambda_node_name = calculateActionNodeName(node, *planner_context);
     auto function_capture = std::make_shared<FunctionCaptureOverloadResolver>(
         std::move(lambda_actions_dag), expression_actions_settings, captured_column_names, lambda_arguments_names_and_types, lambda_node.getExpression()->getResultType(), lambda_expression_node_name, true);

--- a/src/Planner/PlannerContext.cpp
+++ b/src/Planner/PlannerContext.cpp
@@ -78,12 +78,14 @@ PlannerContext::PlannerContext(ContextMutablePtr query_context_, GlobalPlannerCo
     : query_context(std::move(query_context_))
     , global_planner_context(std::move(global_planner_context_))
     , is_ast_level_optimization_allowed(!(query_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY || select_query_options_.ignore_ast_optimizations))
+    , is_logical_plan(select_query_options_.build_logical_plan)
 {}
 
 PlannerContext::PlannerContext(ContextMutablePtr query_context_, PlannerContextPtr planner_context_)
     : query_context(std::move(query_context_))
     , global_planner_context(planner_context_->global_planner_context)
     , is_ast_level_optimization_allowed(planner_context_->is_ast_level_optimization_allowed)
+    , is_logical_plan(planner_context_->is_logical_plan)
 {}
 
 TableExpressionData & PlannerContext::getOrCreateTableExpressionData(const QueryTreeNodePtr & table_expression_node)

--- a/src/Planner/PlannerContext.h
+++ b/src/Planner/PlannerContext.h
@@ -200,6 +200,13 @@ public:
     /// 2. ignore_ast_optimizations is set.
     bool isASTLevelOptimizationAllowed() const { return is_ast_level_optimization_allowed; }
 
+    /// True when this plan is built to be serialized and shipped to another node (a shard under
+    /// `serialize_query_plan`, or a replica in the plan-based parallel replicas mode). Everything
+    /// materialized while planning must then survive serialization, which rules out a JIT-compiled
+    /// expression: a compiled function has no name in `FunctionFactory`, so the receiving node
+    /// cannot resolve it.
+    bool isLogicalPlan() const { return is_logical_plan; }
+
 private:
 
     RawTableExpressionDataMap & getSharedTableExpressionDataMap() noexcept { return global_planner_context->getTableExpressionDataMap(); }
@@ -213,6 +220,8 @@ private:
     GlobalPlannerContextPtr global_planner_context;
 
     bool is_ast_level_optimization_allowed;
+
+    bool is_logical_plan = false;
 
     /// Column node to column identifier
     std::unordered_map<QueryTreeNodePtr, ColumnIdentifier> column_node_to_column_identifier;

--- a/tests/queries/0_stateless/05199_serialize_query_plan_lambda_and.reference
+++ b/tests/queries/0_stateless/05199_serialize_query_plan_lambda_and.reference
@@ -1,0 +1,18 @@
+the plan is shipped
+mapExists	3
+two comparisons	8
+three comparisons	8
+a captured column	9
+arrayExists	8
+arrayMap	8
+a constant that fits UInt8	1
+OR instead of AND	10
+the same, plan not shipped
+mapExists	3
+two comparisons	8
+three comparisons	8
+a captured column	9
+arrayExists	8
+arrayMap	8
+a constant that fits UInt8	1
+OR instead of AND	10

--- a/tests/queries/0_stateless/05199_serialize_query_plan_lambda_and.sql
+++ b/tests/queries/0_stateless/05199_serialize_query_plan_lambda_and.sql
@@ -1,0 +1,39 @@
+-- A lambda body becomes `ExpressionActions` while the query plan is built, so with
+-- `serialize_query_plan = 1` that very DAG is what is shipped to the shard. A JIT-compiled node in it
+-- has no name in `FunctionFactory` - its name is a dump of the compiled expression - and the shard
+-- used to fail with `UNKNOWN_FUNCTION and(UInt8, less(UInt64, 1000 : UInt16))`. The body is left
+-- uncompiled in a plan that is shipped, and the shard compiles it when it rebuilds the lambda.
+
+DROP TABLE IF EXISTS t_05199;
+DROP TABLE IF EXISTS t_05199_dist;
+
+CREATE TABLE t_05199 (id UInt64, col Map(String, UInt64)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05199 SELECT number, map('key' || toString(number % 3), number * 100) FROM numbers(10);
+CREATE TABLE t_05199_dist AS t_05199 ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_05199);
+
+SET prefer_localhost_replica = 0, compile_expressions = 1, min_count_to_compile_expression = 0;
+
+SET serialize_query_plan = 1;
+SELECT 'the plan is shipped';
+SELECT 'mapExists', sum(mapExists((k, v) -> k LIKE '%2' AND v < 1000, col)) FROM t_05199_dist;
+SELECT 'two comparisons', sum(mapExists((k, v) -> v > 100 AND v < 1000, col)) FROM t_05199_dist;
+SELECT 'three comparisons', sum(mapExists((k, v) -> v > 0 AND v < 1000 AND v != 500, col)) FROM t_05199_dist;
+SELECT 'a captured column', sum(mapExists((k, v) -> (v > id) AND (v < id + 1000), col)) FROM t_05199_dist;
+SELECT 'arrayExists', sum(arrayExists(v -> v > 100 AND v < 1000, mapValues(col))) FROM t_05199_dist;
+SELECT 'arrayMap', sum(arraySum(arrayMap(v -> (v > 100 AND v < 1000) ? 1 : 0, mapValues(col)))) FROM t_05199_dist;
+SELECT 'a constant that fits UInt8', sum(mapExists((k, v) -> v > 0 AND v < 200, col)) FROM t_05199_dist;
+SELECT 'OR instead of AND', sum(mapExists((k, v) -> k LIKE '%2' OR v < 1000, col)) FROM t_05199_dist;
+
+SET serialize_query_plan = 0;
+SELECT 'the same, plan not shipped';
+SELECT 'mapExists', sum(mapExists((k, v) -> k LIKE '%2' AND v < 1000, col)) FROM t_05199_dist;
+SELECT 'two comparisons', sum(mapExists((k, v) -> v > 100 AND v < 1000, col)) FROM t_05199_dist;
+SELECT 'three comparisons', sum(mapExists((k, v) -> v > 0 AND v < 1000 AND v != 500, col)) FROM t_05199_dist;
+SELECT 'a captured column', sum(mapExists((k, v) -> (v > id) AND (v < id + 1000), col)) FROM t_05199_dist;
+SELECT 'arrayExists', sum(arrayExists(v -> v > 100 AND v < 1000, mapValues(col))) FROM t_05199_dist;
+SELECT 'arrayMap', sum(arraySum(arrayMap(v -> (v > 100 AND v < 1000) ? 1 : 0, mapValues(col)))) FROM t_05199_dist;
+SELECT 'a constant that fits UInt8', sum(mapExists((k, v) -> v > 0 AND v < 200, col)) FROM t_05199_dist;
+SELECT 'OR instead of AND', sum(mapExists((k, v) -> k LIKE '%2' OR v < 1000, col)) FROM t_05199_dist;
+
+DROP TABLE t_05199_dist;
+DROP TABLE t_05199;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `UNKNOWN_FUNCTION` on a shard for a higher-order function whose lambda body is an `AND` of comparisons when `serialize_query_plan = 1`: a JIT-compiled lambda body was serialized into the plan.

### Documentation entry for user-facing changes

...

With `serialize_query_plan = 1`, a higher-order function whose lambda body is an `AND` of comparisons failed on the shard with

```
Code: 46. Unknown function and(UInt8, less(UInt64, 1000 : UInt16)). (UNKNOWN_FUNCTION)
```

for example

```sql
SELECT mapExists((k, v) -> k LIKE '%2' AND v < 1000, col) FROM dist
SETTINGS prefer_localhost_replica = 0, serialize_query_plan = 1;
```

That "function name" is `CompileDAG::dump` of a JIT-compiled expression. Unlike an ordinary expression, which travels as an `ActionsDAG` and becomes `ExpressionActions` only when the receiving node builds its pipeline, a lambda's `ExpressionActions` is built while the plan is built, so its DAG — already compiled, because JIT happens in the `ExpressionActions` constructor — is the one that gets serialized. `ActionsDAG::serialize` writes `function_base->getName()`, and for a compiled node that name is not something `FunctionFactory` knows. The extra conditions in the report follow from what the JIT accepts: an `AND` of comparisons over native types large enough to be worth compiling, which is also why an all-`UInt8` variant, a single comparison or an `OR` slipped through.

Keep the lambda body uncompiled when the planner is building a logical plan, which is exactly the plan that gets serialized and shipped (a shard under `serialize_query_plan`, or a replica in the plan-based parallel replicas mode). Nothing is lost: that plan is never executed here, and the receiving node rebuilds the lambda's `ExpressionActions` — with compilation enabled — from the serialized DAG.

New test: `05199_serialize_query_plan_lambda_and`. Verified in both directions, and a differential run of the `lambda`/`arrayMap`/`arrayExists`/`mapExists`/`serialize_query_plan`/`compile_expressions`/`distributed_plan` stateless tests shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115310

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119332&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119332](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119332+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
