### PR TITLE
Fix text and token skip indexes over-pruning a map element whose default matches the predicate

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -547,6 +547,16 @@ bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG
     return negating ? !default_matches : default_matches;
 }
 
+bool indexedKeyIsTextComparable(const DataTypePtr & index_data_type)
+{
+    DataTypePtr key_type = index_data_type;
+    if (const auto * array_type = typeid_cast<const DataTypeArray *>(key_type.get()))
+        key_type = array_type->getNestedType();
+    if (const auto * low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(key_type.get()))
+        key_type = low_cardinality_type->getDictionaryType();
+    return WhichDataType(key_type).isStringOrFixedString();
+}
+
 }
 
 bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
@@ -663,6 +673,11 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
 
             /// Same restriction as the `arrayElement` branch: the substituted key is not an `Array`.
             if (map_keys_index && value_data_type.isArray())
+                return false;
+
+            /// The substituted probe is the key serialized as text, while the index tokenizes the key column's
+            /// raw bytes. Those differ for any key type that is not a string, so the probe cannot match.
+            if (map_keys_index && !indexedKeyIsTextComparable(index_data_types[*map_keys_index]))
                 return false;
 
             /// The subcolumn reads the map value type's default for an absent key, as `arrayElement` does.

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -610,6 +610,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
 
     const auto column_name = key_node.getColumnName();
     auto key_index = getKeyIndex(column_name);
+    bool substituted_map_key = false;
     const auto map_key_index = getKeyIndex(fmt::format("mapKeys({})", column_name));
     const auto map_value_index = getKeyIndex(fmt::format("mapValues({})", column_name));
 
@@ -644,6 +645,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
                     return false;
 
                 key_index = map_keys_index;
+                substituted_map_key = true;
 
                 auto unwrapped_const_type = removeLowCardinality(const_type);
                 if (!const_value.isNull())
@@ -688,6 +690,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
             {
                 key_index = map_keys_index;
                 const_value = serialized_key;
+                substituted_map_key = true;
             }
             else
             {
@@ -816,6 +819,17 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
             return false;
         out.key_column = *key_index;
         out.function = RPNElement::FUNCTION_EQUALS;
+        out.bloom_filter = std::make_unique<BloomFilter>(params);
+        const auto & value = const_value.safeGet<String>();
+        tokenizer->stringToBloomFilter(value.data(), value.size(), *out.bloom_filter);
+        return true;
+    }
+    /// The `mapKeys` probe is the map key, a literal. A pattern tokenizer would consume its escape
+    /// characters and build a probe the index cannot hold, pruning the granule that has the key.
+    if (substituted_map_key && (function_name == "like" || function_name == "notLike" || function_name == "match"))
+    {
+        out.key_column = *key_index;
+        out.function = function_name == "notLike" ? RPNElement::FUNCTION_NOT_EQUALS : RPNElement::FUNCTION_EQUALS;
         out.bloom_filter = std::make_unique<BloomFilter>(params);
         const auto & value = const_value.safeGet<String>();
         tokenizer->stringToBloomFilter(value.data(), value.size(), *out.bloom_filter);

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -617,6 +617,11 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
             if (!map_keys_index && !map_values_index)
                 return false;
 
+            /// A `mapKeys` probe searches for the key, so it replaces the needle below; the array-consuming
+            /// atoms (`has` with an array, `hasAny`, `hasAll`, `multiSearchAny`) would read that key as an `Array`.
+            if (map_keys_index && value_data_type.isArray())
+                return false;
+
             /// `arrayElement` returns the map value type's default for a key the row does not have.
             if (mapElementDefaultBreaksIndex(function_name, predicate_node))
                 return false;
@@ -654,6 +659,10 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
             const auto map_keys_index = getKeyIndex(fmt::format("mapKeys({})", map_column_name));
             const auto map_values_index = getKeyIndex(fmt::format("mapValues({})", map_column_name));
             if (!map_keys_index && !map_values_index)
+                return false;
+
+            /// Same restriction as the `arrayElement` branch: the substituted key is not an `Array`.
+            if (map_keys_index && value_data_type.isArray())
                 return false;
 
             /// The subcolumn reads the map value type's default for an absent key, as `arrayElement` does.

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -14,13 +14,16 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Functions/IFunction.h>
 #include <Interpreters/Set.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/ActionsDAG.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/PreparedSets.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/misc.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Storages/MergeTree/MergeTreeData.h>
@@ -539,10 +542,22 @@ bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG
     if (required_columns.size() != 1 || outputs.size() != 1)
         return true;
 
+    const auto & required_column = required_columns.front();
+    const auto output_name = outputs.front()->result_name;
+
+    /// The evaluation below runs the predicate's own functions, so a predicate holding one that analysis
+    /// may not run is declined instead; `sleep` refuses constant folding for exactly that reason.
     /// A Set the predicate reads is built later during execution, so it must be prepared before the evaluation below.
     /// Readiness is all the evaluation needs; the elements the build stores are for range analysis and may be dropped.
     for (const auto & node : subdag.getNodes())
     {
+        if (node.type == ActionsDAG::ActionType::FUNCTION)
+        {
+            if (!node.function_base->isDeterministic() || !node.function_base->isSuitableForConstantFolding())
+                return true;
+            continue;
+        }
+
         if (node.type != ActionsDAG::ActionType::COLUMN)
             continue;
 
@@ -559,11 +574,26 @@ bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG
             return true;
     }
 
-    const auto & required_column = required_columns.front();
-    const auto output_name = outputs.front()->result_name;
-
     Block block{{required_column.type->createColumnConstWithDefaultValue(1), required_column.type, required_column.name}};
-    ExpressionActions(std::move(subdag)).execute(block);
+
+    /// A function reading the map can throw on the substituted default although no stored row reaches
+    /// that input, such as a division by a length that is zero only for an empty map. Analysis must
+    /// raise nothing the scan itself would not.
+    try
+    {
+        ExpressionActions(std::move(subdag)).execute(block);
+    }
+    catch (const Exception &)
+    {
+        /// A killed or timed-out query must report that, not an index it could not use. The check throws
+        /// for a killed one, and returns false once the deadline passed under `break`, which the
+        /// cancellation check inside a function reports by throwing too.
+        if (auto process_list_element = context->getProcessListElementSafe())
+            if (!process_list_element->checkTimeLimit())
+                throw;
+        return true;
+    }
+
     const bool default_matches = block.getByName(output_name).column->getBool(0);
     return negating ? !default_matches : default_matches;
 }

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -540,6 +540,7 @@ bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG
         return true;
 
     /// A Set the predicate reads is built later during execution, so it must be prepared before the evaluation below.
+    /// Readiness is all the evaluation needs; the elements the build stores are for range analysis and may be dropped.
     for (const auto & node : subdag.getNodes())
     {
         if (node.type != ActionsDAG::ActionType::COLUMN)
@@ -553,8 +554,8 @@ bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG
         if (!future_set)
             return true;
 
-        auto prepared_set = future_set->buildOrderedSetInplace(context);
-        if (!prepared_set || !prepared_set->hasExplicitSetElements())
+        future_set->buildOrderedSetInplace(context);
+        if (!future_set->get())
             return true;
     }
 

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/MergeTreeIndexBloomFilterText.h>
 
 #include <Columns/ColumnArray.h>
+#include <Columns/ColumnSet.h>
 #include <Common/StringUtils.h>
 #include <Common/OptimizedRegularExpression.h>
 #include <Common/likePatternToRegexp.h>
@@ -524,7 +525,7 @@ bool functionIgnoresFixedStringPadding(const String & function_name)
 /// granule mask claiming "nothing here matches" when the key term is absent, so it must not be used when the default
 /// matches; a negating atom builds the mirrored mask, claiming "everything here matches", so it must not be used when
 /// the default does not match. A shape this cannot evaluate declines the index, which only costs pruning.
-bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG::Node * predicate_node)
+bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG::Node * predicate_node, const ContextPtr & context)
 {
     const bool negating = function_name == "notEquals" || function_name == "notLike";
 
@@ -537,6 +538,25 @@ bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG
     const auto & outputs = subdag.getOutputs();
     if (required_columns.size() != 1 || outputs.size() != 1)
         return true;
+
+    /// A Set the predicate reads is built later during execution, so it must be prepared before the evaluation below.
+    for (const auto & node : subdag.getNodes())
+    {
+        if (node.type != ActionsDAG::ActionType::COLUMN)
+            continue;
+
+        const auto * column_set = checkAndGetColumn<const ColumnSet>(&node.column->getDataColumn());
+        if (!column_set)
+            continue;
+
+        auto future_set = column_set->getData();
+        if (!future_set)
+            return true;
+
+        auto prepared_set = future_set->buildOrderedSetInplace(context);
+        if (!prepared_set || !prepared_set->hasExplicitSetElements())
+            return true;
+    }
 
     const auto & required_column = required_columns.front();
     const auto output_name = outputs.front()->result_name;
@@ -634,7 +654,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
                 return false;
 
             /// `arrayElement` returns the map value type's default for a key the row does not have.
-            if (mapElementDefaultBreaksIndex(function_name, predicate_node))
+            if (mapElementDefaultBreaksIndex(function_name, predicate_node, key_node.getTreeContext().getQueryContext()))
                 return false;
 
             if (map_keys_index)
@@ -683,7 +703,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
                 return false;
 
             /// The subcolumn reads the map value type's default for an absent key, as `arrayElement` does.
-            if (mapElementDefaultBreaksIndex(function_name, predicate_node))
+            if (mapElementDefaultBreaksIndex(function_name, predicate_node, key_node.getTreeContext().getQueryContext()))
                 return false;
 
             if (map_keys_index)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -16,6 +16,8 @@
 #include <Interpreters/Set.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/PreparedSets.h>
 #include <Interpreters/misc.h>
@@ -409,7 +411,7 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
 
                 Field rewritten_field(likePatternWithCustomEscapeToLikePattern(
                     pattern_field.safeGet<String>(), escape_str[0]));
-                if (traverseTreeEquals(function_name, lhs_argument, pattern_type, rewritten_field, out))
+                if (traverseTreeEquals(function_name, lhs_argument, pattern_type, rewritten_field, out, function_node.getDAGNode()))
                     return true;
             }
             return false;
@@ -460,13 +462,13 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
 
             if (right_argument.tryGetConstant(const_value, const_type))
             {
-                if (traverseTreeEquals(function_name, left_argument, const_type, const_value, out))
+                if (traverseTreeEquals(function_name, left_argument, const_type, const_value, out, function_node.getDAGNode()))
                     return true;
             }
             else if (left_argument.tryGetConstant(const_value, const_type) &&
                 (function_name == "equals" || function_name == "has" || function_name == "hasAny" || function_name == "notEquals"))
             {
-                if (traverseTreeEquals(function_name, right_argument, const_type, const_value, out))
+                if (traverseTreeEquals(function_name, right_argument, const_type, const_value, out, function_node.getDAGNode()))
                     return true;
             }
         }
@@ -518,6 +520,33 @@ bool functionIgnoresFixedStringPadding(const String & function_name)
     return function_name == "equals" || function_name == "notEquals" || function_name == "hasAny" || function_name == "hasAll";
 }
 
+/// A key the row does not have reads as the map value type's default. A matching atom (`equals`, `like`, ...) builds a
+/// granule mask claiming "nothing here matches" when the key term is absent, so it must not be used when the default
+/// matches; a negating atom builds the mirrored mask, claiming "everything here matches", so it must not be used when
+/// the default does not match. A shape this cannot evaluate declines the index, which only costs pruning.
+bool mapElementDefaultBreaksIndex(const String & function_name, const ActionsDAG::Node * predicate_node)
+{
+    const bool negating = function_name == "notEquals" || function_name == "notLike";
+
+    if (!predicate_node || !predicate_node->function_base || !predicate_node->isDeterministic()
+        || !WhichDataType(removeNullable(predicate_node->result_type)).isUInt8())
+        return true;
+
+    auto subdag = ActionsDAG::cloneSubDAG({predicate_node}, /* remove_aliases = */ true);
+    const auto required_columns = subdag.getRequiredColumns();
+    const auto & outputs = subdag.getOutputs();
+    if (required_columns.size() != 1 || outputs.size() != 1)
+        return true;
+
+    const auto & required_column = required_columns.front();
+    const auto output_name = outputs.front()->result_name;
+
+    Block block{{required_column.type->createColumnConstWithDefaultValue(1), required_column.type, required_column.name}};
+    ExpressionActions(std::move(subdag)).execute(block);
+    const bool default_matches = block.getByName(output_name).column->getBool(0);
+    return negating ? !default_matches : default_matches;
+}
+
 }
 
 bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
@@ -525,7 +554,8 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
     const RPNBuilderTreeNode & key_node,
     const DataTypePtr & value_type,
     const Field & value_field,
-    RPNElement & out)
+    RPNElement & out,
+    const ActionsDAG::Node * predicate_node)
 {
     /// Try JSON subcolumn detection early, before the string-type check.
     /// JSON path comparison values may not be strings (e.g., json.a.b = 1 where value is UInt8),
@@ -580,48 +610,37 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
 
         if (key_function_node_function_name == "arrayElement")
         {
-            /** Try to parse arrayElement for mapKeys index.
-              * It is important to ignore keys like column_map['Key'] = '' because if key does not exist in the map
-              * we return default the value for arrayElement.
-              *
-              * We cannot skip keys that does not exist in map if comparison is with default type value because
-              * that way we skip necessary granules where map key does not exist.
-              */
-            /// Unwrapped default: LC(Nullable(String)) default is NULL, but arrayElement returns '' for a missing key.
-            if (value_field == unwrapped_value_type->getDefault())
-                return false;
-
             auto first_argument = key_function_node.getArgumentAt(0);
             const auto map_column_name = first_argument.getColumnName();
-            if (const auto map_keys_index = getKeyIndex(fmt::format("mapKeys({})", map_column_name)))
+            const auto map_keys_index = getKeyIndex(fmt::format("mapKeys({})", map_column_name));
+            const auto map_values_index = getKeyIndex(fmt::format("mapValues({})", map_column_name));
+            if (!map_keys_index && !map_values_index)
+                return false;
+
+            /// `arrayElement` returns the map value type's default for a key the row does not have.
+            if (mapElementDefaultBreaksIndex(function_name, predicate_node))
+                return false;
+
+            if (map_keys_index)
             {
                 auto second_argument = key_function_node.getArgumentAt(1);
                 DataTypePtr const_type;
-
-                if (second_argument.tryGetConstant(const_value, const_type))
-                {
-                    key_index = map_keys_index;
-
-                    auto unwrapped_const_type = removeLowCardinality(const_type);
-                    if (!const_value.isNull())
-                        unwrapped_const_type = removeNullable(unwrapped_const_type);
-
-                    auto const_data_type = WhichDataType(unwrapped_const_type);
-                    if (const_value.isNull() || (!const_data_type.isStringOrFixedString() && !const_data_type.isArray()))
-                        return false;
-                }
-                else
-                {
+                if (!second_argument.tryGetConstant(const_value, const_type))
                     return false;
-                }
-            }
-            else if (const auto map_values_exists = getKeyIndex(fmt::format("mapValues({})", map_column_name)))
-            {
-                key_index = map_values_exists;
+
+                key_index = map_keys_index;
+
+                auto unwrapped_const_type = removeLowCardinality(const_type);
+                if (!const_value.isNull())
+                    unwrapped_const_type = removeNullable(unwrapped_const_type);
+
+                auto const_data_type = WhichDataType(unwrapped_const_type);
+                if (const_value.isNull() || (!const_data_type.isStringOrFixedString() && !const_data_type.isArray()))
+                    return false;
             }
             else
             {
-                return false;
+                key_index = map_values_index;
             }
         }
     }
@@ -632,25 +651,23 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
         if (auto parsed = tryParseMapSubcolumnName(column_name))
         {
             auto & [map_column_name, serialized_key] = *parsed;
-
-            /// Same as arrayElement: skip when comparing with default value because
-            /// the subcolumn returns default for keys that don't exist in the map.
-            /// Unwrapped default: LC(Nullable(String)) default is NULL, but the subcolumn returns '' for a missing key.
-            if (value_field == unwrapped_value_type->getDefault())
+            const auto map_keys_index = getKeyIndex(fmt::format("mapKeys({})", map_column_name));
+            const auto map_values_index = getKeyIndex(fmt::format("mapValues({})", map_column_name));
+            if (!map_keys_index && !map_values_index)
                 return false;
 
-            if (const auto map_keys_index = getKeyIndex(fmt::format("mapKeys({})", map_column_name)))
+            /// The subcolumn reads the map value type's default for an absent key, as `arrayElement` does.
+            if (mapElementDefaultBreaksIndex(function_name, predicate_node))
+                return false;
+
+            if (map_keys_index)
             {
                 key_index = map_keys_index;
                 const_value = serialized_key;
             }
-            else if (const auto map_values_idx = getKeyIndex(fmt::format("mapValues({})", map_column_name)))
-            {
-                key_index = map_values_idx;
-            }
             else
             {
-                return false;
+                key_index = map_values_index;
             }
         }
     }

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
@@ -138,7 +138,8 @@ private:
         const RPNBuilderTreeNode & key_node,
         const DataTypePtr & value_type,
         const Field & value_field,
-        RPNElement & out);
+        RPNElement & out,
+        const ActionsDAG::Node * predicate_node);
 
     std::optional<size_t> getKeyIndex(const std::string & key_column_name);
     bool tryPrepareSetBloomFilter(const RPNBuilderTreeNode & left_argument, const RPNBuilderTreeNode & right_argument, RPNElement & out);

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -18,6 +18,16 @@
 -- equality with the String default keeps working
 1
 1
+-- an array needle cannot be served by a mapKeys probe
+0
+0
+1
+1
+1
+-- hasAny and hasAll reach the same substitution
+1
+1
+0
 -- a NULL default is not a match, so the index stays usable
 0
 0

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -59,7 +59,8 @@
 -- the mapValues carrier reads the same default
 1
 1
--- and a set inside the subscript on that carrier too
+-- and a set inside the subscript on that carrier too, whether or not its elements are stored
+1
 1
 -- the mapValues carrier over a non-String domain, arrayElement spelling
 1

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -21,8 +21,12 @@
 -- a NULL default is not a match, so the index stays usable
 0
 0
+0
 1
 -- the mapValues carrier reads the same default
+1
+1
+-- the mapValues carrier over a non-String domain
 1
 1
 -- tokenbf_v1 shares the condition class

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -12,6 +12,8 @@
 1
 0
 -- evaluating the predicate raises what the scan raises
+-- an error only the substituted default raises declines the index instead
+1
 -- the whole predicate decides, not equality with the default
 1
 1
@@ -61,6 +63,8 @@
 1
 -- and a set inside the subscript on that carrier too, whether or not its elements are stored
 1
+1
+-- a subscript analysis may not evaluate declines the carrier
 1
 -- the mapValues carrier over a non-String domain, arrayElement spelling
 1

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -38,6 +38,14 @@
 0
 0
 1
+-- a mapKeys index over a non-String key cannot serve the probe
+1
+1
+1
+-- so it is declined for either spelling and for an absent key
+-- a FixedString key is that representation, so it stays indexed
+1
+1
 -- the mapValues carrier reads the same default
 1
 1

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -1,0 +1,30 @@
+-- absent key reads as the IPv6 default, arrayElement spelling
+1
+1
+-- the same through the map subcolumn spelling
+1
+1
+-- a constant the default cannot satisfy still prunes
+1
+1
+1
+-- a negating predicate needs the mirrored condition
+1
+0
+-- evaluating the predicate raises what the scan raises
+-- the whole predicate decides, not equality with the default
+1
+1
+-- equality with the String default keeps working
+1
+1
+-- a NULL default is not a match, so the index stays usable
+0
+0
+1
+-- the mapValues carrier reads the same default
+1
+1
+-- tokenbf_v1 shares the condition class
+1
+1

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -29,6 +29,14 @@
 1
 1
 1
+-- a map key is a literal, not a pattern
+1
+1
+1
+1
+-- and the same key under a pattern the value satisfies
+1
+1
 -- hasAny and hasAll reach the same substitution
 1
 1

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -36,7 +36,10 @@
 -- the mapValues carrier reads the same default
 1
 1
--- the mapValues carrier over a non-String domain
+-- the mapValues carrier over a non-String domain, arrayElement spelling
+1
+1
+-- and the same through the map subcolumn spelling
 1
 1
 -- tokenbf_v1 shares the condition class

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -29,6 +29,8 @@
 1
 1
 1
+-- a set inside the subscript is prepared, not executed unready
+1
 -- a map key is a literal, not a pattern
 1
 1
@@ -56,6 +58,8 @@
 1
 -- the mapValues carrier reads the same default
 1
+1
+-- and a set inside the subscript on that carrier too
 1
 -- the mapValues carrier over a non-String domain, arrayElement spelling
 1

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.reference
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.reference
@@ -18,6 +18,11 @@
 -- equality with the String default keeps working
 1
 1
+-- a pattern the default does not satisfy still prunes
+0
+-- notLike declines on the mirrored condition
+0
+1
 -- an array needle cannot be served by a mapKeys probe
 0
 0

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -98,9 +98,13 @@ INSERT INTO tab_values_ip VALUES (map('abc', toIPv6('2001:db8:1:2:3:4:5:6')));
 
 -- The constant spells the IPv6 default as 15 characters, so the probe has trigrams to build. `'::'`
 -- is shorter than the 3-gram width, which makes the probe empty and the granule survive regardless.
-SELECT '-- the mapValues carrier over a non-String domain';
-SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0';
-SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0' SETTINGS ignore_data_skipping_indices = 'idx';
+SELECT '-- the mapValues carrier over a non-String domain, arrayElement spelling';
+SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0' SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0' SETTINGS optimize_functions_to_subcolumns = 0, ignore_data_skipping_indices = 'idx';
+
+SELECT '-- and the same through the map subcolumn spelling';
+SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0' SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0' SETTINGS optimize_functions_to_subcolumns = 1, ignore_data_skipping_indices = 'idx';
 
 DROP TABLE tab_values_ip;
 

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -45,6 +45,16 @@ SELECT '-- equality with the String default keeps working';
 SELECT count() FROM tab_str WHERE m['nokey'] = '';
 SELECT count() FROM tab_str WHERE m['nokey'] = '' SETTINGS ignore_data_skipping_indices = 'idx';
 
+-- A perfect-affix pattern such as `zzz%` is rewritten to `startsWith` before index analysis, so it
+-- never reaches the `like` / `notLike` branches. An inner wildcard keeps the pattern a `like`.
+SELECT '-- a pattern the default does not satisfy still prunes';
+SELECT count() FROM tab_str WHERE m['nokey'] LIKE '%zzz%' SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT '-- notLike declines on the mirrored condition';
+SELECT count() FROM tab_str WHERE m['nokey'] NOT LIKE '%' SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT count() FROM tab_str WHERE m['nokey'] NOT LIKE '%' SETTINGS ignore_data_skipping_indices = 'idx';
+SELECT count() FROM tab_str WHERE m['nokey'] NOT LIKE '%zzz%' SETTINGS force_data_skipping_indices = 'idx';
+
 SELECT '-- an array needle cannot be served by a mapKeys probe';
 SELECT count() FROM tab_str WHERE multiSearchAny(m['nokey'], CAST([], 'Array(String)')) SETTINGS optimize_functions_to_subcolumns = 0;
 SELECT count() FROM tab_str WHERE multiSearchAny(m['nokey'], CAST([], 'Array(String)')) SETTINGS optimize_functions_to_subcolumns = 1;

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -45,7 +45,27 @@ SELECT '-- equality with the String default keeps working';
 SELECT count() FROM tab_str WHERE m['nokey'] = '';
 SELECT count() FROM tab_str WHERE m['nokey'] = '' SETTINGS ignore_data_skipping_indices = 'idx';
 
+SELECT '-- an array needle cannot be served by a mapKeys probe';
+SELECT count() FROM tab_str WHERE multiSearchAny(m['nokey'], CAST([], 'Array(String)')) SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_str WHERE multiSearchAny(m['nokey'], CAST([], 'Array(String)')) SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_str WHERE multiSearchAny(m['nokey'], CAST([], 'Array(String)')) SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT count() FROM tab_str WHERE multiSearchAny(m['abc'], ['hello']) SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_str WHERE multiSearchAny(m['abc'], ['hello']) SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_str WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
+
 DROP TABLE tab_str;
+
+DROP TABLE IF EXISTS tab_arr;
+CREATE TABLE tab_arr (m Map(String, Array(String)), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_arr VALUES (map('abc', ['hello']));
+
+SELECT '-- hasAny and hasAll reach the same substitution';
+SELECT count() FROM tab_arr WHERE hasAny(m['abc'], ['hello']);
+SELECT count() FROM tab_arr WHERE hasAll(m['abc'], ['hello']);
+SELECT count() FROM tab_arr WHERE hasAny(m['nokey'], CAST([], 'Array(String)'));
+
+DROP TABLE tab_arr;
 
 DROP TABLE IF EXISTS tab_null;
 CREATE TABLE tab_null (m Map(String, Nullable(String)), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -76,8 +76,8 @@ INSERT INTO tab_key_escape VALUES (map('abc\\+def', ''));
 SELECT '-- a map key is a literal, not a pattern';
 SELECT count() FROM tab_key_escape WHERE m['abc\\+def'] LIKE '' SETTINGS optimize_functions_to_subcolumns = 0;
 SELECT count() FROM tab_key_escape WHERE m['abc\\+def'] LIKE '' SETTINGS optimize_functions_to_subcolumns = 1;
-SELECT count() FROM tab_key_escape WHERE match(m['abc\\+def'], '') SETTINGS optimize_functions_to_subcolumns = 0;
-SELECT count() FROM tab_key_escape WHERE match(m['abc\\+def'], '') SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_key_escape WHERE match(m['abc\\+def'], '') SETTINGS optimize_functions_to_subcolumns = 0, force_data_skipping_indices = 'idx';
+SELECT count() FROM tab_key_escape WHERE match(m['abc\\+def'], '') SETTINGS optimize_functions_to_subcolumns = 1, force_data_skipping_indices = 'idx';
 
 DROP TABLE tab_key_escape;
 
@@ -87,8 +87,8 @@ ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
 INSERT INTO tab_key_escape_str VALUES (map('abc\\+def', 'zzz'));
 
 SELECT '-- and the same key under a pattern the value satisfies';
-SELECT count() FROM tab_key_escape_str WHERE m['abc\\+def'] LIKE '%zzz%' SETTINGS optimize_functions_to_subcolumns = 0;
-SELECT count() FROM tab_key_escape_str WHERE m['abc\\+def'] LIKE '%zzz%' SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_key_escape_str WHERE m['abc\\+def'] LIKE '%zzz%' SETTINGS optimize_functions_to_subcolumns = 0, force_data_skipping_indices = 'idx';
+SELECT count() FROM tab_key_escape_str WHERE m['abc\\+def'] LIKE '%zzz%' SETTINGS optimize_functions_to_subcolumns = 1, force_data_skipping_indices = 'idx';
 
 DROP TABLE tab_key_escape_str;
 

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -63,6 +63,9 @@ SELECT count() FROM tab_str WHERE multiSearchAny(m['abc'], ['hello']) SETTINGS o
 SELECT count() FROM tab_str WHERE multiSearchAny(m['abc'], ['hello']) SETTINGS optimize_functions_to_subcolumns = 1;
 SELECT count() FROM tab_str WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
 
+SELECT '-- a set inside the subscript is prepared, not executed unready';
+SELECT count() FROM tab_str WHERE m[if(0 IN (SELECT number FROM numbers(1)), 'abc', 'zzz')] = 'hello';
+
 DROP TABLE tab_str;
 
 DROP TABLE IF EXISTS tab_key_escape;
@@ -156,6 +159,9 @@ INSERT INTO tab_values VALUES (map('abc', 'hello'));
 SELECT '-- the mapValues carrier reads the same default';
 SELECT count() FROM tab_values WHERE m['nokey'] = '';
 SELECT count() FROM tab_values WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT '-- and a set inside the subscript on that carrier too';
+SELECT count() FROM tab_values WHERE m[if(0 IN (SELECT number FROM numbers(1)), 'abc', 'zzz')] = 'hello';
 
 DROP TABLE tab_values;
 

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -160,8 +160,10 @@ SELECT '-- the mapValues carrier reads the same default';
 SELECT count() FROM tab_values WHERE m['nokey'] = '';
 SELECT count() FROM tab_values WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
 
-SELECT '-- and a set inside the subscript on that carrier too';
+SELECT '-- and a set inside the subscript on that carrier too, whether or not its elements are stored';
 SELECT count() FROM tab_values WHERE m[if(0 IN (SELECT number FROM numbers(1)), 'abc', 'zzz')] = 'hello';
+SELECT count() FROM tab_values WHERE m[if(0 IN (SELECT number FROM numbers(5)), 'abc', 'zzz')] = 'hello'
+SETTINGS use_index_for_in_with_subqueries_max_values = 1, force_data_skipping_indices = 'idx';
 
 DROP TABLE tab_values;
 

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -30,6 +30,11 @@ SELECT '-- evaluating the predicate raises what the scan raises';
 SELECT count() FROM tab_ip WHERE m['nokey'] != 'zzz'; -- { serverError CANNOT_PARSE_IPV6 }
 SELECT count() FROM tab_ip WHERE m['nokey'] != 'zzz' SETTINGS ignore_data_skipping_indices = 'idx'; -- { serverError CANNOT_PARSE_IPV6 }
 
+-- The subscript divides by a length that is zero only for the empty map the evaluation substitutes.
+SELECT '-- an error only the substituted default raises declines the index instead';
+SELECT count() FROM tab_ip WHERE m[if(intDiv(1, length(toString(m)) - 2) = 0, 'abc', 'zzz')] = '2001:db8:1:2:3:4:5:6';
+SELECT count() FROM tab_ip WHERE m[if(intDiv(1, length(toString(m)) - 2) = 0, 'abc', 'zzz')] = '2001:db8:1:2:3:4:5:6' SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
 DROP TABLE tab_ip;
 
 DROP TABLE IF EXISTS tab_str;
@@ -164,6 +169,11 @@ SELECT '-- and a set inside the subscript on that carrier too, whether or not it
 SELECT count() FROM tab_values WHERE m[if(0 IN (SELECT number FROM numbers(1)), 'abc', 'zzz')] = 'hello';
 SELECT count() FROM tab_values WHERE m[if(0 IN (SELECT number FROM numbers(5)), 'abc', 'zzz')] = 'hello'
 SETTINGS use_index_for_in_with_subqueries_max_values = 1, force_data_skipping_indices = 'idx';
+
+-- `sleep` refuses constant folding so that query analysis cannot run it, which the guard would.
+SELECT '-- a subscript analysis may not evaluate declines the carrier';
+SELECT count() FROM tab_values WHERE m[if(sleep(0) = 0, 'abc', 'zzz')] = 'hello';
+SELECT count() FROM tab_values WHERE m[if(sleep(0) = 0, 'abc', 'zzz')] = 'hello' SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
 
 DROP TABLE tab_values;
 

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -1,0 +1,82 @@
+-- Random settings limits: index_granularity=(8192, None)
+
+-- A key the row does not have reads as the map value type's default, so a `mapKeys` / `mapValues`
+-- bloom filter index must not prune a granule when the predicate accepts that default.
+
+DROP TABLE IF EXISTS tab_ip;
+CREATE TABLE tab_ip (m Map(String, IPv6), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_ip VALUES (map('abc', toIPv6('2001:db8:1:2:3:4:5:6')));
+
+SELECT '-- absent key reads as the IPv6 default, arrayElement spelling';
+SELECT count() FROM tab_ip WHERE m['nokey'] = '::' SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_ip WHERE m['nokey'] = '::' SETTINGS optimize_functions_to_subcolumns = 0, ignore_data_skipping_indices = 'idx';
+
+SELECT '-- the same through the map subcolumn spelling';
+SELECT count() FROM tab_ip WHERE m['nokey'] = '::' SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_ip WHERE m['nokey'] = '::' SETTINGS optimize_functions_to_subcolumns = 1, ignore_data_skipping_indices = 'idx';
+
+SELECT '-- a constant the default cannot satisfy still prunes';
+SELECT count() FROM (EXPLAIN indexes = 1 SELECT count() FROM tab_ip WHERE m['zzz'] = 'dead:beef::1') WHERE explain ILIKE '%Granules: 0/1%';
+SELECT count() FROM tab_ip WHERE m['abc'] = '2001:db8:1:2:3:4:5:6' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_ip WHERE m['abc'] = '2001:db8:1:2:3:4:5:6' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 1;
+
+SELECT '-- a negating predicate needs the mirrored condition';
+SELECT count() FROM tab_ip WHERE m['nokey'] != 'dead:beef::1' SETTINGS force_data_skipping_indices = 'idx';
+SELECT count() FROM tab_ip WHERE m['nokey'] != '::' SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT count() FROM tab_ip WHERE m['nokey'] != '::' SETTINGS ignore_data_skipping_indices = 'idx';
+
+SELECT '-- evaluating the predicate raises what the scan raises';
+SELECT count() FROM tab_ip WHERE m['nokey'] != 'zzz'; -- { serverError CANNOT_PARSE_IPV6 }
+SELECT count() FROM tab_ip WHERE m['nokey'] != 'zzz' SETTINGS ignore_data_skipping_indices = 'idx'; -- { serverError CANNOT_PARSE_IPV6 }
+
+DROP TABLE tab_ip;
+
+DROP TABLE IF EXISTS tab_str;
+CREATE TABLE tab_str (m Map(String, String), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_str VALUES (map('abc', 'hello'));
+
+SELECT '-- the whole predicate decides, not equality with the default';
+SELECT count() FROM tab_str WHERE m['nokey'] LIKE '%';
+SELECT count() FROM tab_str WHERE m['nokey'] LIKE '%' SETTINGS ignore_data_skipping_indices = 'idx';
+
+SELECT '-- equality with the String default keeps working';
+SELECT count() FROM tab_str WHERE m['nokey'] = '';
+SELECT count() FROM tab_str WHERE m['nokey'] = '' SETTINGS ignore_data_skipping_indices = 'idx';
+
+DROP TABLE tab_str;
+
+DROP TABLE IF EXISTS tab_null;
+CREATE TABLE tab_null (m Map(String, Nullable(String)), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_null VALUES (map('abc', 'hello'));
+
+SELECT '-- a NULL default is not a match, so the index stays usable';
+SELECT count() FROM tab_null WHERE m['nokey'] = '';
+SELECT count() FROM tab_null WHERE m['nokey'] = '' SETTINGS ignore_data_skipping_indices = 'idx';
+SELECT count() FROM tab_null WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
+
+DROP TABLE tab_null;
+
+DROP TABLE IF EXISTS tab_values;
+CREATE TABLE tab_values (m Map(String, String), INDEX idx mapValues(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_values VALUES (map('abc', 'hello'));
+
+SELECT '-- the mapValues carrier reads the same default';
+SELECT count() FROM tab_values WHERE m['nokey'] = '';
+SELECT count() FROM tab_values WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
+
+DROP TABLE tab_values;
+
+DROP TABLE IF EXISTS tab_token;
+CREATE TABLE tab_token (m Map(String, UInt32), INDEX idx mapKeys(m) TYPE tokenbf_v1(512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_token VALUES (map('abc', 42));
+
+SELECT '-- tokenbf_v1 shares the condition class';
+SELECT count() FROM tab_token WHERE m['nokey'] = '0';
+SELECT count() FROM tab_token WHERE m['nokey'] = '0' SETTINGS ignore_data_skipping_indices = 'idx';
+
+DROP TABLE tab_token;

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -90,6 +90,40 @@ SELECT count() FROM tab_null WHERE m['abc'] = 'hello' SETTINGS force_data_skippi
 
 DROP TABLE tab_null;
 
+DROP TABLE IF EXISTS tab_ip_key;
+CREATE TABLE tab_ip_key (m Map(IPv6, Nullable(String)), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_ip_key VALUES (map(toIPv6('2001:db8:1:2:3:4:5:6'), ''));
+
+-- The map subcolumn spelling probes for the key serialized as text, while the index holds the raw
+-- bytes of the key column, so a key that is not a string cannot be looked up in the index at all.
+SELECT '-- a mapKeys index over a non-String key cannot serve the probe';
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('2001:db8:1:2:3:4:5:6')] = '' SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('2001:db8:1:2:3:4:5:6')] = '' SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('2001:db8:1:2:3:4:5:6')] = '' SETTINGS ignore_data_skipping_indices = 'idx';
+
+-- Assert the disposition: both counts above are the same whether the index is declined or merely
+-- fails to prune, and an absent key answers 0 either way.
+SELECT '-- so it is declined for either spelling and for an absent key';
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('2001:db8:1:2:3:4:5:6')] = '' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 0; -- { serverError INDEX_NOT_USED }
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('2001:db8:1:2:3:4:5:6')] = '' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 1; -- { serverError INDEX_NOT_USED }
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('dead:beef::1')] = '' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 0; -- { serverError INDEX_NOT_USED }
+SELECT count() FROM tab_ip_key WHERE m[toIPv6('dead:beef::1')] = '' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 1; -- { serverError INDEX_NOT_USED }
+
+DROP TABLE tab_ip_key;
+
+DROP TABLE IF EXISTS tab_fs_key;
+CREATE TABLE tab_fs_key (m Map(FixedString(4), String), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_fs_key VALUES (map(toFixedString('abcd', 4), 'hello'));
+
+-- A key filling the whole `FixedString(4)` is the same byte string in the probe and in the index.
+SELECT '-- a FixedString key is that representation, so it stays indexed';
+SELECT count() FROM tab_fs_key WHERE m[toFixedString('abcd', 4)] = 'hello' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_fs_key WHERE m[toFixedString('abcd', 4)] = 'hello' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 1;
+
+DROP TABLE tab_fs_key;
+
 DROP TABLE IF EXISTS tab_values;
 CREATE TABLE tab_values (m Map(String, String), INDEX idx mapValues(m) TYPE ngrambf_v1(3, 512, 3, 0))
 ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -65,6 +65,30 @@ SELECT count() FROM tab_str WHERE m['abc'] = 'hello' SETTINGS force_data_skippin
 
 DROP TABLE tab_str;
 
+DROP TABLE IF EXISTS tab_key_escape;
+CREATE TABLE tab_key_escape (m Map(String, Nullable(String)), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_key_escape VALUES (map('abc\\+def', ''));
+
+SELECT '-- a map key is a literal, not a pattern';
+SELECT count() FROM tab_key_escape WHERE m['abc\\+def'] LIKE '' SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_key_escape WHERE m['abc\\+def'] LIKE '' SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count() FROM tab_key_escape WHERE match(m['abc\\+def'], '') SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_key_escape WHERE match(m['abc\\+def'], '') SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE tab_key_escape;
+
+DROP TABLE IF EXISTS tab_key_escape_str;
+CREATE TABLE tab_key_escape_str (m Map(String, String), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_key_escape_str VALUES (map('abc\\+def', 'zzz'));
+
+SELECT '-- and the same key under a pattern the value satisfies';
+SELECT count() FROM tab_key_escape_str WHERE m['abc\\+def'] LIKE '%zzz%' SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count() FROM tab_key_escape_str WHERE m['abc\\+def'] LIKE '%zzz%' SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE tab_key_escape_str;
+
 DROP TABLE IF EXISTS tab_arr;
 CREATE TABLE tab_arr (m Map(String, Array(String)), INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0))
 ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;

--- a/tests/queries/0_stateless/05186_text_index_map_element_default.sql
+++ b/tests/queries/0_stateless/05186_text_index_map_element_default.sql
@@ -17,7 +17,7 @@ SELECT count() FROM tab_ip WHERE m['nokey'] = '::' SETTINGS optimize_functions_t
 SELECT count() FROM tab_ip WHERE m['nokey'] = '::' SETTINGS optimize_functions_to_subcolumns = 1, ignore_data_skipping_indices = 'idx';
 
 SELECT '-- a constant the default cannot satisfy still prunes';
-SELECT count() FROM (EXPLAIN indexes = 1 SELECT count() FROM tab_ip WHERE m['zzz'] = 'dead:beef::1') WHERE explain ILIKE '%Granules: 0/1%';
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM tab_ip WHERE m['zzz'] = 'dead:beef::1') WHERE explain ILIKE '%Granules: 0/1%';
 SELECT count() FROM tab_ip WHERE m['abc'] = '2001:db8:1:2:3:4:5:6' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 0;
 SELECT count() FROM tab_ip WHERE m['abc'] = '2001:db8:1:2:3:4:5:6' SETTINGS force_data_skipping_indices = 'idx', optimize_functions_to_subcolumns = 1;
 
@@ -55,6 +55,7 @@ INSERT INTO tab_null VALUES (map('abc', 'hello'));
 SELECT '-- a NULL default is not a match, so the index stays usable';
 SELECT count() FROM tab_null WHERE m['nokey'] = '';
 SELECT count() FROM tab_null WHERE m['nokey'] = '' SETTINGS ignore_data_skipping_indices = 'idx';
+SELECT count() FROM tab_null WHERE m['nokey'] = '' SETTINGS force_data_skipping_indices = 'idx';
 SELECT count() FROM tab_null WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
 
 DROP TABLE tab_null;
@@ -69,6 +70,19 @@ SELECT count() FROM tab_values WHERE m['nokey'] = '';
 SELECT count() FROM tab_values WHERE m['abc'] = 'hello' SETTINGS force_data_skipping_indices = 'idx';
 
 DROP TABLE tab_values;
+
+DROP TABLE IF EXISTS tab_values_ip;
+CREATE TABLE tab_values_ip (m Map(String, IPv6), INDEX idx mapValues(m) TYPE ngrambf_v1(3, 512, 3, 0))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO tab_values_ip VALUES (map('abc', toIPv6('2001:db8:1:2:3:4:5:6')));
+
+-- The constant spells the IPv6 default as 15 characters, so the probe has trigrams to build. `'::'`
+-- is shorter than the 3-gram width, which makes the probe empty and the granule survive regardless.
+SELECT '-- the mapValues carrier over a non-String domain';
+SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0';
+SELECT count() FROM tab_values_ip WHERE m['nokey'] = '0:0:0:0:0:0:0:0' SETTINGS ignore_data_skipping_indices = 'idx';
+
+DROP TABLE tab_values_ip;
 
 DROP TABLE IF EXISTS tab_token;
 CREATE TABLE tab_token (m Map(String, UInt32), INDEX idx mapKeys(m) TYPE tokenbf_v1(512, 3, 0))


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113157

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `ngrambf_v1`, `tokenbf_v1` and `sparse_grams` skip indexes over `mapKeys` or `mapValues` returning too few rows for a predicate on a map key the row does not have, for example `m['missing_key'] = '::'` on a `Map(String, IPv6)` column: such a key reads as the map value type's default, so the row matches, while index analysis took that default from the compared constant's type and only tested equality, affecting every non-`String` map value type and patterns such as `LIKE`. Rows were also dropped for a map key containing a backslash, such as `m['abc\\+def'] LIKE '%zzz%'`, tokenized as a pattern rather than as a literal. The same analysis raised `Code: 170 BAD_GET` on an array needle over a map element, such as `hasAny(m['key'], ['a'])`.

### Description

`MergeTreeConditionBloomFilterText::traverseTreeEquals` must decline the index when a row lacking the map
key would satisfy the predicate: the `mapKeys` probe is built from the key and misses in exactly that
granule. The old guard derived that default from the compared constant's type and tested only equality, so
it missed both non-`String` map value types and patterns such as `m['nokey'] LIKE '%'`, in either
spelling.

It now evaluates the predicate against a default-valued instance of the column actually read, as the newer
`text` index does. `notEquals` and `notLike` build the mirrored mask, so they decline on the opposite
condition.

It also stops `like`, `notLike` and `match` from tokenizing a substituted key as a pattern, which
consumed escapes against an index holding the key's raw bytes and lost the row for `m['abc\\+def'] LIKE
'%zzz%'` on master.

The old guard also rejected an array needle as `Array(String)`'s default, and that mattered: with the key
substituted, `hasAny`, `hasAll` and `multiSearchAny` read that `String` as an `Array` and raised `Code:
170 BAD_GET`. They now decline this carrier explicitly, as do a subscript reading a second column with
only a `mapValues` index, a predicate function analysis may not run, and a predicate that raises only on
the substituted default. No decline can drop a row.

Known limitation, as on master: a physical column named like a map subcolumn (`m.key_x` beside map `m`) is
read as that subcolumn, so `mapKeys` pruning drops its rows. Master answers `= ''` right only
through the constant-typed default this fix removes, and separating the two needs the column list this
condition never receives.

#113157 rewrites the same lines and this guard subsumes its `mapValues` one; whichever lands first, I
rebase the other. `MergeTreeIndexBloomFilter.cpp` has the same defect class, left to #107076 and #117318.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119336&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119336](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119336+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


