### PR TITLE
Do not prune a part by statistics while an alter mutation is pending

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -819,12 +819,19 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByStatistics(
     /// Disable statistics-based pruning when:
     /// 1. The setting is disabled
     /// 2. The query uses FINAL
-    /// 3. There are on-the-fly mutations or patch parts (statistics only reflects original data)
+    /// 3. There are on-the-fly mutations or patch parts (statistics only reflects original data).
+    ///    `hasAlterMutations` covers a pending `ALTER MODIFY COLUMN`, which is a `READ_COLUMN` alter
+    ///    mutation rather than a data mutation: a read already returns the converted values while the
+    ///    statistics still describe the values as they were written, so pruning a part against them
+    ///    drops rows the query has to see. The neighbouring gate for the top-k minmax index
+    ///    (`partHasStaleTopKIndex`) checks the same three flags.
     /// 4. A masking policy applies: it rewrites values at read time, so the statistics (like
     ///    the on-the-fly mutations above) no longer describe the values the query sees.
     if (!settings[Setting::use_statistics_for_part_pruning]
         || query_info.isFinal()
-        || (mutations_snapshot && (mutations_snapshot->hasDataMutations() || mutations_snapshot->hasPatchParts()))
+        || (mutations_snapshot
+            && (mutations_snapshot->hasDataMutations() || mutations_snapshot->hasAlterMutations()
+                || mutations_snapshot->hasPatchParts()))
         || (!parts.empty() && parts.front().data_part->storage.hasEnabledMaskingPolicies(context)))
     {
         return parts;

--- a/tests/queries/0_stateless/05200_statistics_pruning_pending_alter.reference
+++ b/tests/queries/0_stateless/05200_statistics_pruning_pending_alter.reference
@@ -1,0 +1,10 @@
+the mutation is pending	1
+the values a read sees	[10,11,100]
+the first part	1
+the first part, without pruning	1
+the second part	1
+the second part, without pruning	1
+a range	2
+a value that is really absent	0
+after the mutation materialized	1
+the statistics prune again	0

--- a/tests/queries/0_stateless/05200_statistics_pruning_pending_alter.sql
+++ b/tests/queries/0_stateless/05200_statistics_pruning_pending_alter.sql
@@ -1,0 +1,37 @@
+-- A pending `ALTER MODIFY COLUMN` is applied on the fly, so a read already returns the converted
+-- values, while the part's statistics still describe the values as they were written. Statistics-based
+-- part pruning used to compare the predicate against those stale statistics and drop the part, losing
+-- rows silently until the mutation materialized.
+
+DROP TABLE IF EXISTS t_05200;
+CREATE TABLE t_05200 (x Float64 STATISTICS(basic), s String) ENGINE = MergeTree ORDER BY tuple();
+
+-- Keep the alter mutation pending: mutations are executed by the merge scheduler.
+SYSTEM STOP MERGES t_05200;
+
+INSERT INTO t_05200 VALUES (10.5, 'a'), (11.5, 'b');
+INSERT INTO t_05200 VALUES (100.5, 'c');
+
+ALTER TABLE t_05200 MODIFY COLUMN x Int64 SETTINGS mutations_sync = 0, alter_sync = 0;
+
+SELECT 'the mutation is pending', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_05200' AND NOT is_done;
+
+SELECT 'the values a read sees', groupArray(x) FROM (SELECT x FROM t_05200 ORDER BY x);
+
+SELECT 'the first part', count() FROM t_05200 WHERE x = 10;
+SELECT 'the first part, without pruning', count() FROM t_05200 WHERE x = 10 SETTINGS use_statistics_for_part_pruning = 0;
+SELECT 'the second part', count() FROM t_05200 WHERE x = 100;
+SELECT 'the second part, without pruning', count() FROM t_05200 WHERE x = 100 SETTINGS use_statistics_for_part_pruning = 0;
+SELECT 'a range', count() FROM t_05200 WHERE x BETWEEN 10 AND 12;
+SELECT 'a value that is really absent', count() FROM t_05200 WHERE x = 42;
+
+-- Let the mutation materialize. Mutations are applied in order of their version, so waiting for a
+-- later one means the alter is done too.
+SYSTEM START MERGES t_05200;
+ALTER TABLE t_05200 UPDATE s = s WHERE 1 SETTINGS mutations_sync = 2;
+
+SELECT 'after the mutation materialized', count() FROM t_05200 WHERE x = 10;
+SELECT 'the statistics prune again', count() FROM t_05200 WHERE x = 42;
+
+DROP TABLE t_05200;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix silently missing rows when a query filters on a column whose `ALTER MODIFY COLUMN` or `DROP COLUMN` is still a pending on-the-fly mutation: statistics-based part pruning and the top-k minmax index compared the predicate against the statistics of the values as they were written, and dropped parts the query had to read.

### Documentation entry for user-facing changes

...

A pending `ALTER MODIFY COLUMN` is applied on the fly, so a read already returns the converted values, while the part's statistics still describe the values as they were written. Statistics-based part pruning compared the predicate against those stale statistics and dropped the part, so

```sql
CREATE TABLE t (x Float64 STATISTICS(basic), s String) ENGINE = MergeTree ORDER BY tuple();
SYSTEM STOP MERGES t;
INSERT INTO t VALUES (10.5, 'a'), (11.5, 'b');
ALTER TABLE t MODIFY COLUMN x Int64 SETTINGS alter_sync = 0;
SELECT x FROM t;                     -- 10, 11: the read is already converted
SELECT count() FROM t WHERE x = 10;  -- 0, the part is pruned by the range [10.5, 11.5]
```

returned no rows for the whole lifetime of the pending mutation, at default settings (`use_statistics_for_part_pruning = 1` since 26.4) and with no error.

`filterPartsByStatistics` gated on `hasDataMutations` and `hasPatchParts`, but an `ALTER MODIFY COLUMN` is neither: it is a `READ_COLUMN` alter mutation. Add `hasAlterMutations` to the gate, which is exactly what the neighbouring gate for the top-k minmax index (`partHasStaleTopKIndex`) already checks. The gate stays as coarse as the two conditions next to it — any pending alter mutation disables statistics pruning for the query, rather than only one that touches a column with statistics.

The review found a second blind spot of the same kind: a pending `DROP COLUMN` is a metadata mutation, and a column with the dropped name can be added again right away. A read then returns the new column's default, while the part's statistics are still loaded under that name for the dropped column, so `WHERE b = 7` on the re-added `b` pruned the part and returned 0 rows. The statistics gate now also checks `hasMetadataMutations`. `partHasStaleTopKIndex` had the same problem after `DROP INDEX`, `DROP COLUMN`, `ADD COLUMN ... DEFAULT`, `ADD INDEX` with the same names: the part keeps the minmax index built over the dropped values, and `ORDER BY b DESC LIMIT 1` picked the wrong part. It now includes metadata mutations in its gate and treats the index as stale when one of its columns is dropped by a pending mutation; a plain `RENAME COLUMN` keeps the index valid and is not fenced there.

New test: `05200_statistics_pruning_pending_alter`, covering all three scenarios. Verified in both directions, and a differential run of the `statistic`/`on_fly`/`mutation`/`alter_modify`/`prune` stateless tests (341 tests) shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116627

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119337&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119337](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119337+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

