### PR TITLE
Keep a part with a since-dropped projection passing `CHECK TABLE`

### DIFF
--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -437,14 +437,34 @@ static IMergeTreeDataPart::Checksums checkDataPart(
 
     /// Handle unknown projections: on disk and in checksums but not in the
     /// part's projection list (e.g. a projection was dropped while the part
-    /// was detached, then re-attached).  Remove them from checksums_txt so
-    /// that the checkEqual below does not fail, and mark the part as having
-    /// a broken projection so the caller can handle it gracefully.
+    /// was detached, then re-attached, or an INSERT that had started before
+    /// `DROP PROJECTION` committed wrote the part afterwards).  Remove them
+    /// from checksums_txt so that the checkEqual below does not fail, and mark
+    /// the part as having a broken projection so the caller can handle it
+    /// gracefully.
     if (!projections_on_disk.empty())
     {
         is_broken_projection = true;
-        for (const auto & projection_file : projections_on_disk)
-            checksums_txt.remove(projection_file);
+
+        for (auto it = projections_on_disk.begin(); it != projections_on_disk.end();)
+        {
+            /// A directory the part itself lists in its `checksums.txt` was written deliberately, with
+            /// a projection the table has since dropped; the part is intact and has to keep passing the
+            /// check. Drop it from the unexpected set as well, or the `require_checksums` branch below
+            /// reports the part as broken - which is what happens to every mutation descendant of such
+            /// a part, because a mutation hardlinks the directory and is checked with checksums
+            /// required. A directory that the part does not list is a leftover nobody wrote as part of
+            /// it, so it stays unexpected.
+            if (checksums_txt.files.contains(*it))
+            {
+                checksums_txt.remove(*it);
+                it = projections_on_disk.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
     }
 
     /// Also handle leftover checksums entries for projections that are unknown to the current metadata

--- a/tests/queries/0_stateless/03145_non_loaded_projection_backup.reference
+++ b/tests/queries/0_stateless/03145_non_loaded_projection_backup.reference
@@ -1,7 +1,5 @@
 7
-Found unexpected projection directories: pp.proj
 BACKUP_CREATED
 RESTORED
 7
-Found unexpected projection directories: pp.proj
-0
+1

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
@@ -1,6 +1,5 @@
 === Replicated MergeTree ===
 7
-Found unexpected projection directories: pp.proj
 21	21
 7
 21	21
@@ -8,5 +7,4 @@ Found unexpected projection directories: pp.proj
 21	21
 === MergeTree ===
 7
-Found unexpected projection directories: pp.proj
 7

--- a/tests/queries/0_stateless/05201_check_table_dropped_projection.reference
+++ b/tests/queries/0_stateless/05201_check_table_dropped_projection.reference
@@ -1,0 +1,7 @@
+a part kept the dropped projection
+rows: 100
+check before a mutation: 1
+rows after the mutation: 100
+check after the mutation: 1
+parts reported broken: 0
+sum: 5000

--- a/tests/queries/0_stateless/05201_check_table_dropped_projection.sh
+++ b/tests/queries/0_stateless/05201_check_table_dropped_projection.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# An `INSERT` keeps the metadata snapshot it took at query start, so the parts it writes after a
+# concurrent `ALTER TABLE ... DROP PROJECTION` commits still materialize the dropped projection, both
+# as a `.proj` directory and as an entry in the part's `checksums.txt`. Nothing rewrites those parts
+# afterwards - the drop's own cleanup mutation was created before their block numbers - and every later
+# mutation hardlinks the directory into the mutated part. `checkDataPart` tolerates a projection
+# directory that the current metadata does not know, but it used to leave it in the unexpected-files
+# set, so a mutated part (checked with checksums required) was reported broken forever although every
+# data file is intact.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+orphaned=0
+
+for _ in {1..10}; do
+    ${CLICKHOUSE_CLIENT} -q "
+        DROP TABLE IF EXISTS t_05201;
+        -- Keep the affected parts around: a merge would rebuild them without the dropped projection.
+        CREATE TABLE t_05201 (id UInt64, val UInt64, part UInt8) ENGINE = MergeTree PARTITION BY part ORDER BY id
+        SETTINGS max_bytes_to_merge_at_max_space_in_pool = 1;
+        ALTER TABLE t_05201 ADD PROJECTION p1 (SELECT part, sum(val) GROUP BY part);
+    "
+
+    ${CLICKHOUSE_CLIENT} -q "
+        INSERT INTO t_05201 SELECT number, sleepEachRow(0.05) * 0 + number, 0 FROM numbers(100)
+        SETTINGS max_block_size = 10, min_insert_block_size_rows = 10, max_insert_threads = 1
+    " &
+    insert_pid=$!
+
+    sleep 1.5
+    ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_05201 DROP PROJECTION p1"
+    wait $insert_pid
+
+    orphaned=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT countIf(has(projections, 'p1')) FROM system.parts
+        WHERE database = currentDatabase() AND table = 't_05201' AND active
+    ")
+
+    [ "$orphaned" -gt 0 ] && break
+done
+
+if [ "$orphaned" -gt 0 ]; then echo "a part kept the dropped projection"; else echo "the race did not happen"; fi
+
+echo "rows: $(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_05201")"
+echo "check before a mutation: $(${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_05201 SETTINGS check_query_single_value_result = 1")"
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_05201 UPDATE val = val + 1 WHERE id < 50 SETTINGS mutations_sync = 2"
+
+echo "rows after the mutation: $(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_05201")"
+echo "check after the mutation: $(${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_05201 SETTINGS check_query_single_value_result = 1")"
+echo "parts reported broken: $(${CLICKHOUSE_CLIENT} -q "CHECK TABLE t_05201 SETTINGS check_query_single_value_result = 0" | awk -F'\t' '$2 == 0' | wc -l | tr -d ' ')"
+
+# The projection is gone from the table, so a query cannot use it, and reading is unaffected.
+echo "sum: $(${CLICKHOUSE_CLIENT} -q "SELECT sum(val) FROM t_05201")"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_05201"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `CHECK TABLE` permanently reporting a part broken with `Found unexpected projection directories` after a mutation, when the part carries a projection that the table has since dropped (for example a part written by an `INSERT` that was still running when `DROP PROJECTION` committed).

### Documentation entry for user-facing changes

...

An `INSERT` keeps the metadata snapshot it took at query start, so the parts it writes after a concurrent `ALTER TABLE ... DROP PROJECTION` commits still materialize the dropped projection, as a `.proj` directory and as an entry in the part's `checksums.txt`. Nothing rewrites those parts afterwards: the drop's own cleanup mutation was created before their block numbers, and every later mutation hardlinks the directory into the mutated part. From the first such mutation on, `CHECK TABLE` reported the part broken forever — `Found unexpected projection directories: p1.proj` (`UNEXPECTED_FILE_IN_DATA_PART`) — although every data file is intact and all rows are readable, and on `ReplicatedMergeTree` the part check thread logged the same on every replica.

`checkDataPart` already tolerates a projection directory the current metadata does not know: it removes it from the in-memory `checksums.txt` and marks the part with `is_broken_projection` so the caller can handle it gracefully. But it left the directory in the unexpected-files set, so the `require_checksums` branch right below threw anyway — which is exactly the path a mutated part takes, hence the symptom appearing at the first mutation. Erase such a directory from that set too, but only when the part itself lists it in its `checksums.txt`: that means the part was written deliberately, with a projection the table has since dropped. A directory the part does not list is a leftover nobody wrote as part of it and stays unexpected.

Two existing tests recorded the old behaviour and are updated: `03822_attach_with_unknown_projection`, whose own comment says that attaching a partition with a since-dropped projection "must not mark the part as broken or lost", no longer prints `Found unexpected projection directories`, and `03145_non_loaded_projection_backup` now reports the restored table as healthy (`1`) instead of broken (`0`).

The other half of the report — `OPTIMIZE` failing with `CANNOT_ASSIGN_OPTIMIZE: Parts have different projection sets` in a partition that mixes affected and clean parts — does not reproduce on master: with the same repro (10 parts, 8 of them carrying the orphaned projection), both the forced `OPTIMIZE ... PARTITION ... FINAL` and the background merge of that partition succeed.

New test: `05201_check_table_dropped_projection`. Verified in both directions, and a differential run of the `projection`/`check_table`/`broken_projection`/`check_part` stateless tests (261 tests) shows no failures other than the two references updated here.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115506

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119348&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119348](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119348+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1351` (included in `26.9` and later)
<!-- ch-version-info:end -->