### PR TITLE
Ignore a column absent from the table when mutating a Compact part

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -569,6 +569,18 @@ static void splitAndModifyMutationCommands(
                                         "in table {} with metadata version {}",
                                         part->name, part_metadata_version, column.name,
                                         part->storage.getStorageID().getNameForLogs(), table_metadata_version);
+
+                    /// Without a metadata version to reason with there is nothing else to go on: the column
+                    /// is on disk, the table does not have it, and reads and merges already ignore it. This is
+                    /// what a partition that was detached before `DROP COLUMN` and re-attached after it looks
+                    /// like. Reading it would add a `READ_COLUMN` command below, whose identifier the mutation
+                    /// then resolves against the table and fails with `UNKNOWN_IDENTIFIER` - for every mutation
+                    /// of that part, so the mutation queue stays wedged until the part is merged or dropped.
+                    /// Skip the column here as well and let the rewrite drop it.
+                    LOG_WARNING(log, "Ignoring column {} from part {} because there is no such column in table {}. "
+                                     "Assuming the column was dropped", column.name, part->name,
+                                part->storage.getStorageID().getNameForLogs());
+                    continue;
                 }
 
                 for_interpreter.emplace_back(

--- a/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.reference
+++ b/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.reference
@@ -1,0 +1,11 @@
+the part type	Compact
+the part still has the dropped column	1
+reads are fine	100
+rows after the delete	99
+the rewrite dropped the column	0
+unfinished mutations	0
+1
+after a second mutation	4946
+the wide part type	Wide
+rows after the delete	99
+the rewrite dropped the column	0

--- a/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.sql
+++ b/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.sql
@@ -1,0 +1,58 @@
+-- A partition detached before `DROP COLUMN` and re-attached after it comes back with a part that still
+-- carries the dropped column on disk. Reads and merges ignore such a column, but a mutation of a
+-- Compact part read it as a `READ_COLUMN` command, whose identifier does not resolve against the table
+-- any more: the mutation failed with `UNKNOWN_IDENTIFIER` and, because the part is what is poisoned,
+-- every later mutation failed the same way, wedging the table's mutation queue. Only a merge or
+-- dropping the partition recovered.
+
+DROP TABLE IF EXISTS t_05202;
+CREATE TABLE t_05202 (id UInt64, val UInt64, p UInt8) ENGINE = MergeTree PARTITION BY p ORDER BY id;
+ALTER TABLE t_05202 ADD COLUMN c UInt32;
+INSERT INTO t_05202 SELECT number, number, 1, 42 FROM numbers(100);
+
+ALTER TABLE t_05202 DETACH PARTITION 1;
+-- No attached part has the column, so the drop is metadata-only.
+ALTER TABLE t_05202 DROP COLUMN c;
+ALTER TABLE t_05202 ATTACH PARTITION 1;
+
+SELECT 'the part type', any(part_type) FROM system.parts
+WHERE database = currentDatabase() AND table = 't_05202' AND active;
+SELECT 'the part still has the dropped column', countIf(column = 'c') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_05202' AND active;
+SELECT 'reads are fine', count() FROM t_05202;
+
+ALTER TABLE t_05202 DELETE WHERE id = 5 SETTINGS mutations_sync = 2;
+
+SELECT 'rows after the delete', count() FROM t_05202;
+SELECT 'the rewrite dropped the column', countIf(column = 'c') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_05202' AND active;
+SELECT 'unfinished mutations', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_05202' AND NOT is_done;
+CHECK TABLE t_05202 SETTINGS check_query_single_value_result = 1;
+
+-- A second mutation still works: the part is no longer poisoned.
+ALTER TABLE t_05202 UPDATE val = val + 1 WHERE id = 7 SETTINGS mutations_sync = 2;
+SELECT 'after a second mutation', sum(val) FROM t_05202;
+
+DROP TABLE t_05202;
+
+-- The same with a Wide part, which was never affected.
+DROP TABLE IF EXISTS t_05202_wide;
+CREATE TABLE t_05202_wide (id UInt64, val UInt64, p UInt8) ENGINE = MergeTree PARTITION BY p ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0;
+ALTER TABLE t_05202_wide ADD COLUMN c UInt32;
+INSERT INTO t_05202_wide SELECT number, number, 1, 42 FROM numbers(100);
+
+ALTER TABLE t_05202_wide DETACH PARTITION 1;
+ALTER TABLE t_05202_wide DROP COLUMN c;
+ALTER TABLE t_05202_wide ATTACH PARTITION 1;
+
+SELECT 'the wide part type', any(part_type) FROM system.parts
+WHERE database = currentDatabase() AND table = 't_05202_wide' AND active;
+
+ALTER TABLE t_05202_wide DELETE WHERE id = 5 SETTINGS mutations_sync = 2;
+SELECT 'rows after the delete', count() FROM t_05202_wide;
+SELECT 'the rewrite dropped the column', countIf(column = 'c') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_05202_wide' AND active;
+
+DROP TABLE t_05202_wide;

--- a/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.sql
+++ b/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.sql
@@ -6,7 +6,10 @@
 -- dropping the partition recovered.
 
 DROP TABLE IF EXISTS t_05202;
-CREATE TABLE t_05202 (id UInt64, val UInt64, p UInt8) ENGINE = MergeTree PARTITION BY p ORDER BY id;
+-- The part type is what decides which branch of the mutation command split runs, so pin it here
+-- rather than leave it to the randomized `min_bytes_for_wide_part` of the test run.
+CREATE TABLE t_05202 (id UInt64, val UInt64, p UInt8) ENGINE = MergeTree PARTITION BY p ORDER BY id
+SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
 ALTER TABLE t_05202 ADD COLUMN c UInt32;
 INSERT INTO t_05202 SELECT number, number, 1, 42 FROM numbers(100);
 
@@ -39,7 +42,7 @@ DROP TABLE t_05202;
 -- The same with a Wide part, which was never affected.
 DROP TABLE IF EXISTS t_05202_wide;
 CREATE TABLE t_05202_wide (id UInt64, val UInt64, p UInt8) ENGINE = MergeTree PARTITION BY p ORDER BY id
-SETTINGS min_bytes_for_wide_part = 0;
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
 ALTER TABLE t_05202_wide ADD COLUMN c UInt32;
 INSERT INTO t_05202_wide SELECT number, number, 1, 42 FROM numbers(100);
 

--- a/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.sql
+++ b/tests/queries/0_stateless/05202_mutation_of_attached_part_with_dropped_column.sql
@@ -1,3 +1,9 @@
+-- Tags: no-shared-merge-tree
+-- no-shared-merge-tree: the fix below is for a table that has no metadata version to reason
+--   with, so it is reached only when the storage does not support replication. An engine
+--   substituted for `MergeTree` does, and keeps throwing the logical error the check above it
+--   deliberately throws.
+
 -- A partition detached before `DROP COLUMN` and re-attached after it comes back with a part that still
 -- carries the dropped column on disk. Reads and merges ignore such a column, but a mutation of a
 -- Compact part read it as a `READ_COLUMN` command, whose identifier does not resolve against the table


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a wedged mutation queue after `ATTACH PARTITION` of a partition that was detached before a `DROP COLUMN`: mutations of a Compact part carrying the dropped column failed with `UNKNOWN_IDENTIFIER` and kept failing for every later mutation.

### Documentation entry for user-facing changes

...

A partition detached before `DROP COLUMN` and re-attached after it comes back with a part that still carries the dropped column on disk. Reads and merges ignore such a column, but every mutation of that part failed:

```
Code: 341. Exception happened during execution of mutation 'mutation_4.txt' with part '1_3_3_0'
reason: 'Code: 47. Unknown expression identifier `c`. (UNKNOWN_IDENTIFIER)'
```

and, because what is poisoned is the part and not the mutation, `KILL MUTATION` did not help: the next mutation failed identically, so the table's mutation queue stayed wedged and any client using `mutations_sync >= 1` got `UNFINISHED`. Only `OPTIMIZE ... FINAL` (a merge rewrites the part) or dropping the partition recovered, and a partition with no insert traffic never gets merged.

A Compact part cannot leave a column behind, so `splitAndModifyMutationCommands` turns every column of the part that the mutation does not touch into a `READ_COLUMN` command — including a column the table no longer has, which the mutation then tries to resolve as an identifier against the table. There is already a guard for this: if the part's metadata version is behind the table's, the column is logged and skipped as dropped. A plain `MergeTree` has no metadata versions, so the guard never fires there (and the `LOGICAL_ERROR` below it is only raised for a replicated table, where the version-based branch handles the case — the same reproducer on `ReplicatedMergeTree` completes). Skip the column in that case too and let the rewrite drop it, which is what reads and merges do.

Wide parts were never affected: they take the other branch of `splitAndModifyMutationCommands`, which rewrites only the columns the mutation touches. The new test pins both part types.

New test: `05202_mutation_of_attached_part_with_dropped_column`. Verified in both directions, and a differential run of the `mutation`/`attach_partition`/`detach`/`drop_column`/`compact_part`/`alter_column` stateless tests (343 tests) shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115416

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119354&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119354](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119354+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
