### PR TITLE
feat: do not deliver empty Vortex splits, and count what a scan does

### DIFF
--- a/rust/workspace/vortex/include/vortex_ffi.h
+++ b/rust/workspace/vortex/include/vortex_ffi.h
@@ -172,6 +172,11 @@ struct FFI_VortexScanOptions
     /// running ahead of the caller; the reads underneath are bounded separately by
     /// `io_concurrency` and `coalesce_max_read_bytes`.
     uint32_t max_splits_in_flight;
+    /// Whether a split the filter emptied is still handed to `on_chunk` as a null array. It only
+    /// tells the caller that the file order moved on, so a caller that does not restore the file
+    /// order has nothing to do with it - and on a selective scan almost every split is empty, so
+    /// reporting them costs far more than the rows do.
+    bool report_empty_splits;
 };
 
 /// The callbacks a scan reports to. Both run on the caller's own threads, possibly several at a
@@ -186,8 +191,8 @@ struct FFI_VortexScanCallbacks
     /// Delivers one chunk: an Arrow struct array in the scan's schema, together with the position
     /// of its split in the file. The array is borrowed for the duration of the call - the callback
     /// takes the data out of it (or releases it) before returning, and must not keep the pointer.
-    /// A null array means the split matched no rows; it is still reported so that the caller can
-    /// restore the file order. Returning non-zero stops the scan; it is the only way `on_chunk` has
+    /// A null array means the split matched no rows; it is reported only when
+    /// `report_empty_splits` is set, so that a caller restoring the file order can see the gap. Returning non-zero stops the scan; it is the only way `on_chunk` has
     /// to stop it, and it surfaces from `on_finish` as an error.
     int32_t (*on_chunk)(void *context, ArrowArray *array, uint64_t split_index);
     /// Reports the end of the scan, exactly once: null if every split was delivered, otherwise

--- a/rust/workspace/vortex/src/lib.rs
+++ b/rust/workspace/vortex/src/lib.rs
@@ -658,6 +658,12 @@ pub struct FFI_VortexScanOptions {
     /// running ahead of the caller; the reads underneath are bounded separately by
     /// `io_concurrency` and `coalesce_max_read_bytes`.
     pub max_splits_in_flight: u32,
+
+    /// Whether a split the filter emptied is still handed to `on_chunk` as a null array. It only
+    /// tells the caller that the file order moved on, so a caller that does not restore the file
+    /// order has nothing to do with it - and on a selective scan almost every split is empty, so
+    /// reporting them costs far more than the rows do.
+    pub report_empty_splits: bool,
 }
 
 /// The callbacks a scan reports to. Both run on the caller's own threads, possibly several at a
@@ -673,8 +679,8 @@ pub struct FFI_VortexScanCallbacks {
     /// Delivers one chunk: an Arrow struct array in the scan's schema, together with the position
     /// of its split in the file. The array is borrowed for the duration of the call - the callback
     /// takes the data out of it (or releases it) before returning, and must not keep the pointer.
-    /// A null array means the split matched no rows; it is still reported so that the caller can
-    /// restore the file order. Returning non-zero stops the scan; it is the only way `on_chunk` has
+    /// A null array means the split matched no rows; it is reported only when
+    /// `report_empty_splits` is set, so that a caller restoring the file order can see the gap. Returning non-zero stops the scan; it is the only way `on_chunk` has
     /// to stop it, and it surfaces from `on_finish` as an error.
     pub on_chunk: unsafe extern "C" fn(
         context: *mut c_void,
@@ -698,11 +704,15 @@ struct ScanCallbacks {
     context: usize,
     on_chunk: unsafe extern "C" fn(*mut c_void, *mut FFI_ArrowArray, u64) -> i32,
     on_finish: unsafe extern "C" fn(*mut c_void, *const c_char),
+    report_empty_splits: bool,
 }
 
 impl ScanCallbacks {
     fn deliver(&self, array: Option<FFI_ArrowArray>, split_index: u64) -> VortexResult<()> {
         let empty = array.is_none();
+        if empty && !self.report_empty_splits {
+            return Ok(());
+        }
         let result = match array {
             None => unsafe {
                 (self.on_chunk)(
@@ -812,6 +822,7 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
 
             let mut schema = reader.schema.clone();
             let mut max_splits_in_flight = DEFAULT_MAX_SPLITS_IN_FLIGHT;
+            let mut report_empty_splits = false;
 
             if !options.is_null() {
                 let options = &*options;
@@ -904,6 +915,8 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
                 if options.max_splits_in_flight != 0 {
                     max_splits_in_flight = options.max_splits_in_flight as usize;
                 }
+
+                report_empty_splits = options.report_empty_splits;
             }
 
             let callbacks = {
@@ -912,6 +925,7 @@ pub unsafe extern "C" fn vortex_ffi_scan_create(
                     context: callbacks.context as usize,
                     on_chunk: callbacks.on_chunk,
                     on_finish: callbacks.on_finish,
+                    report_empty_splits,
                 }
             };
 
@@ -1894,6 +1908,8 @@ mod tests {
             row_selection_len: 0,
             row_index_column: false,
             max_splits_in_flight: 0,
+            // The tests below assert on the split sequence, so they ask for the empty ones too.
+            report_empty_splits: true,
         }
     }
 

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1621,6 +1621,10 @@ The server successfully detected this situation and will download merged part fr
     M(VortexFilterPushdownConjunctsDropped, "Number of top-level WHERE conjuncts that could not be translated for a Vortex scan and are only applied by ClickHouse afterwards", ValueType::Number) \
     M(VortexScanSplits, "Number of splits delivered by Vortex scans", ValueType::Number) \
     M(VortexScanEmptySplits, "Number of Vortex scan splits whose rows were all dropped by the pushed-down filter", ValueType::Number) \
+    M(VortexReadRequests, "Number of read requests a Vortex scan issued through the ClickHouse read buffer", ValueType::Number) \
+    M(VortexReadBytes, "Number of bytes a Vortex scan read through the ClickHouse read buffer", ValueType::Bytes) \
+    M(VortexConvertMicroseconds, "Time spent turning the Arrow arrays a Vortex scan delivers into ClickHouse columns", ValueType::Microseconds) \
+    M(VortexReadWaitMicroseconds, "Time the pipeline spent waiting for a Vortex scan to deliver the next split", ValueType::Microseconds) \
     M(FilterTransformPassedRows, "Number of rows that passed the filter in the query", ValueType::Number) \
     M(FilterTransformPassedBytes, "Number of bytes that passed the filter in the query", ValueType::Bytes) \
     \

--- a/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexBlockInputFormat.cpp
@@ -16,6 +16,7 @@
 #include <Common/Exception.h>
 #include <Common/assert_cast.h>
 #include <Common/ProfileEvents.h>
+#include <Common/Stopwatch.h>
 #include <Common/setThreadName.h>
 #include <Common/threadPoolCallbackRunner.h>
 
@@ -33,6 +34,8 @@ namespace ProfileEvents
 {
 extern const Event VortexScanSplits;
 extern const Event VortexScanEmptySplits;
+extern const Event VortexConvertMicroseconds;
+extern const Event VortexReadWaitMicroseconds;
 }
 
 namespace DB
@@ -250,6 +253,9 @@ int32_t VortexBlockInputFormat::onChunk(::ArrowArray * array, UInt64 split_index
 
         if (array)
         {
+            Stopwatch convert_watch;
+            SCOPE_EXIT({ ProfileEvents::increment(ProfileEvents::VortexConvertMicroseconds, convert_watch.elapsedMicroseconds()); });
+
             /// The array is borrowed for the duration of this callback; importing it moves the
             /// data out and marks the struct released, which is how it is handed back.
             auto batch = arrow::ImportRecordBatch(array, scan_schema);
@@ -485,6 +491,9 @@ void VortexBlockInputFormat::prepareReader()
     FFI_VortexScanOptions options{};
 
     preserve_order = format_settings.vortex.preserve_order || plan.rows_to_read;
+    /// A split the filter emptied only tells us that the file order moved on, and on a selective
+    /// scan nearly every split is empty - so ask for them only when the order is what we restore.
+    options.report_empty_splits = preserve_order;
 
     if (plan.rows_to_read)
     {
@@ -676,7 +685,10 @@ Chunk VortexBlockInputFormat::read()
         /// The timeout is a safety net: the protocol between the notifications and the drivers
         /// should never leave a runnable task without a driver, but a bug there has to cost a stall
         /// rather than a query that never returns.
-        if (delivery_cv.wait_for(lock, PROGRESS_CHECK_PERIOD) != std::cv_status::timeout)
+        Stopwatch wait_watch;
+        const auto wait_status = delivery_cv.wait_for(lock, PROGRESS_CHECK_PERIOD);
+        ProfileEvents::increment(ProfileEvents::VortexReadWaitMicroseconds, wait_watch.elapsedMicroseconds());
+        if (wait_status != std::cv_status::timeout)
             continue;
 
         const bool idle = running_drivers[static_cast<size_t>(FFI_VortexTaskQueue::CPU)].load(std::memory_order_relaxed) == 0

--- a/src/Processors/Formats/Impl/Vortex/VortexFFIHelpers.cpp
+++ b/src/Processors/Formats/Impl/Vortex/VortexFFIHelpers.cpp
@@ -5,6 +5,7 @@
 #include <IO/ReadBuffer.h>
 #include <Processors/Formats/Impl/ArrowBufferedStreams.h>
 #include <Common/Exception.h>
+#include <Common/ProfileEvents.h>
 
 #include <arrow/c/bridge.h>
 #include <arrow/io/interfaces.h>
@@ -14,6 +15,12 @@
 #include <algorithm>
 
 #include <vortex_ffi.h>
+
+namespace ProfileEvents
+{
+extern const Event VortexReadRequests;
+extern const Event VortexReadBytes;
+}
 
 namespace DB
 {
@@ -55,6 +62,8 @@ extern "C" int32_t vortexFFIReadCallback(void * context, uint64_t offset, uint64
                 length,
                 offset);
         ctx->bytes_read.fetch_add(length, std::memory_order_relaxed);
+        ProfileEvents::increment(ProfileEvents::VortexReadRequests);
+        ProfileEvents::increment(ProfileEvents::VortexReadBytes, length);
         return 0;
     }
     catch (...)


### PR DESCRIPTION
A split that the pushed-down filter emptied is handed to `on_chunk` as a null array. The only thing
the caller does with it is move the file order forward, and it does that only when it restores the
file order at all - which is off by default. On a selective scan almost every split is empty, so this
was mostly work done for nothing: on ClickBench q39 over `hits`, 4962 of 5010 splits.

`FFI_VortexScanOptions` gets `report_empty_splits`, the reader sets it to `preserve_order`, and the
scan skips the callback otherwise. On q39:

```
VortexScanSplits       5010 -> 48
VortexScanEmptySplits  4962 -> 0
```

Query time does not change. The empty splits were cheap to deliver; what they cost is upstream of the
callback, in the tasks that produce them. This removes the pointless half of that and makes the rest
visible, it is not a speedup.

The same change adds the counters that made this measurable, since the reader had almost none:

* `VortexReadRequests` / `VortexReadBytes` - what a scan actually reads through the ClickHouse read
  buffer, rather than the `bytes_read` proxy that `StorageFile` falls back to;
* `VortexConvertMicroseconds` - time turning the delivered Arrow arrays into ClickHouse columns,
  which on a scan-heavy query such as ClickBench q21 turns out to be 8.2 s of 20.7 s of CPU;
* `VortexReadWaitMicroseconds` - time the pipeline spent waiting for the next split.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
