### PR TITLE
backfill_distroless: run on amd-medium, amd64 cannot be emulated

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -27,7 +27,16 @@ jobs:
     # `steps: []`), so no distroless rebuild reached Docker Hub for a month.
     # This job only downloads prebuilt release debs and assembles layers, so it
     # does not need release-grade hardware.
-    runs-on: [self-hosted, arm-small]
+    #
+    # It does need to be x86_64. `ch-builder` installs the release debs, and
+    # clickhouse-server's postinst executes the binary to check the CPU. Under
+    # QEMU's amd64 emulation that check fails ("Instruction check fail. The CPU
+    # does not support SSSE3 instruction set."), dpkg --configure exits 1 and
+    # the build dies, so the amd64 image cannot be built on an aarch64 host at
+    # all. Run where amd64 is native and arm64 is the emulated arch, the same
+    # direction as ci/jobs/release_job.py and the amd-tiny docker_server /
+    # docker_keeper jobs that build these same images.
+    runs-on: [self-hosted, amd-medium]
     steps:
       - name: Check out repository code
         uses: ClickHouse/checkout@v1
@@ -44,7 +53,7 @@ jobs:
           # migration in ci/jobs/release_job.py. Two things are needed:
           #
           # 1. QEMU/binfmt registration. Both linux/amd64 and linux/arm64 are
-          #    built in one buildx invocation; this pool is aarch64, so amd64
+          #    built in one buildx invocation; this pool is x86_64, so arm64
           #    is the emulated arch. binfmt is pinned by digest (not `latest`)
           #    because it runs --privileged.
           # 2. A `docker-container` builder with host networking. The default


### PR DESCRIPTION
Follow-up to #118804, which moved this job to `arm-small`. Wrong arch. The dry-run ([34264610898](https://github.com/ClickHouse/ClickHouse/actions/runs/34264610898)) got a runner in under 2 min and cleared buildx, binfmt and Docker Hub login, then died in `ch-builder`:

```
Setting up clickhouse-server (26.4.5.143) ...
Instruction check fail. The CPU does not support SSSE3 instruction set.
dpkg: error processing package clickhouse-server (--configure)
```

`clickhouse-server`'s postinst executes the binary to check CPU features, and QEMU's amd64 emulation doesn't expose SSSE3, so the amd64 image can't be built on an aarch64 host at any runner size.

Moves to `amd-medium`, where amd64 is native and arm64 is emulated. Same direction as `ci/jobs/release_job.py` and the `amd-tiny` `docker_server` / `docker_keeper` jobs that build these images today.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119358&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119358](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119358+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1180` (included in `26.9` and later)
<!-- ch-version-info:end -->