### PR TITLE
Bump `openldap` from OPENLDAP_REL_ENG_2_6_14 to OPENLDAP_REL_ENG_2_6_15

### DIFF
--- a/contrib/openldap-cmake/CMakeLists.txt
+++ b/contrib/openldap-cmake/CMakeLists.txt
@@ -34,7 +34,7 @@ set(OPENLDAP_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/openldap")
 # How these lists were generated?
 # I compiled the original OpenLDAP with it's original build system and copied the list of source files from build commands.
 
-set(OPENLDAP_VERSION_STRING "2.6.14")
+set(OPENLDAP_VERSION_STRING "2.6.15")
 
 macro(mkversion _lib_name)
     add_custom_command(


### PR DESCRIPTION
Bumps `openldap` to `OPENLDAP_REL_ENG_2_6_15`, the latest release on the pinned 2.6 line, which fixes two memory leaks in `libldap/result.c` (ITS#10584, ITS#10577) and OpenSSL error-stack handling in the `tls_o.c` backend ClickHouse uses (ITS#10578).

### ClickHouse-side changes
- `contrib/openldap-cmake/CMakeLists.txt` — `OPENLDAP_VERSION_STRING` 2.6.14 -> 2.6.15; `mkversion` bakes it into `lber-version.c` and `ldap-version.c`, so it must track the pin.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `openldap` to 2.6.15.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119359&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119359](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119359+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1211` (included in `26.9` and later)
<!-- ch-version-info:end -->