### PR TITLE
Refuse to attach a part whose `metadata_version.txt` is missing

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -418,6 +418,7 @@ namespace ErrorCodes
     extern const int BAD_TTL_EXPRESSION;
     extern const int INCORRECT_FILE_NAME;
     extern const int BAD_DATA_PART_NAME;
+    extern const int NO_FILE_IN_DATA_PART;
     extern const int READONLY_SETTING;
     extern const int ABORTED;
     extern const int UNKNOWN_DISK;
@@ -8303,6 +8304,34 @@ void MergeTreeData::loadPartAndFixMetadataImpl(MergeTreeData::MutableDataPartPtr
 
     IMergeTreeDataPart::writeInvalidatedSystemColumnsFile(*part->getDataPartStoragePtr(), "", IMergeTreeDataPart::getSystemColumnsToInvalidate(part->info), getContext()->getWriteSettings());
     part->loadColumnsChecksumsIndexes(false, true);
+
+    /// The fallback mentioned above is only safe while there is nothing for the part to catch up with.
+    /// A part detached before a metadata-only `ALTER` (`RENAME COLUMN`, `MODIFY COLUMN`) still needs the
+    /// conversions of the versions it has not applied, and its `metadata_version.txt` is the only record
+    /// of how far it got. That file carries no checksum, so its absence is not corruption that anything
+    /// detects: the part would be attached as if it were already at the table's version, the conversions
+    /// would be skipped, and every renamed or modified column would silently read as its default. Refuse
+    /// the attach instead and say what to do about it. A table that never had a metadata-only `ALTER` is
+    /// unaffected, which is also the shape of a genuinely old part written before the file existed.
+    if (part->old_part_with_no_metadata_version_on_disk)
+    {
+        auto table_metadata_snapshot = getInMemoryMetadataPtr(getContext(), false);
+        auto table_metadata_version = table_metadata_snapshot->getMetadataVersion();
+        if (table_metadata_version > 0)
+        {
+            throw Exception(
+                ErrorCodes::NO_FILE_IN_DATA_PART,
+                "Part {} has no {}, so the metadata-only ALTERs it still has to apply cannot be determined, "
+                "while the table is at metadata version {}. Attaching it would read the columns of every "
+                "such ALTER as their defaults. Write the metadata version the part was detached at into "
+                "{}/{} and attach it again",
+                part->name,
+                IMergeTreeDataPart::METADATA_VERSION_FILE_NAME,
+                table_metadata_version,
+                part->getDataPartStorage().getPartDirectory(),
+                IMergeTreeDataPart::METADATA_VERSION_FILE_NAME);
+        }
+    }
     part->modification_time = part->getDataPartStorage().getLastModified().epochTime();
     part->removeDeleteOnDestroyMarker();
     part->removeVersionMetadata();

--- a/tests/integration/test_attach_tampered_detached_parts/test.py
+++ b/tests/integration/test_attach_tampered_detached_parts/test.py
@@ -27,7 +27,7 @@ from helpers.cluster import ClickHouseCluster
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node")
+node = cluster.add_instance("node", with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
@@ -643,3 +643,63 @@ def test_mutate_mixed_legacy_idx_minmax(started_cluster):
     assert node.query("CHECK TABLE t_mixed_minmax_drop SETTINGS check_query_single_value_result = 1") == "1\n"
 
     node.query("DROP TABLE t_mixed_minmax_drop SYNC")
+
+
+def test_attach_part_without_metadata_version(started_cluster):
+    # A part detached before a metadata-only ALTER (here RENAME COLUMN) still has to apply the
+    # conversions of the versions it missed, and its `metadata_version.txt` is the only record of how
+    # far it got. That file carries no checksum, so its absence is not corruption that anything
+    # detects: ATTACH fell back to the table's current version, the rename conversion was skipped and
+    # the renamed column silently read as its default for every row. The attach is refused instead.
+    #
+    # A crash during the detach clone is one way to reach that on-disk state (the clone hard-links the
+    # files one at a time under the final name), and it is emulated here by removing the file.
+    for table, keep_file in (
+        ("t_metadata_version_kept", True),
+        ("t_metadata_version_removed", False),
+    ):
+        node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+        node.query(
+            f"""
+            CREATE TABLE {table} (id UInt64, a UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/{table}', '1')
+            ORDER BY id
+            SETTINGS min_bytes_for_wide_part = 0, storage_policy = 'default'
+            """
+        )
+        node.query(f"INSERT INTO {table} SELECT number, number FROM numbers(1000)")
+        node.query(f"ALTER TABLE {table} DETACH PARTITION tuple()")
+        node.query(f"ALTER TABLE {table} RENAME COLUMN a TO b")
+
+        part_path = (
+            node.query(
+                f"SELECT path FROM system.detached_parts WHERE database = 'default' AND table = '{table}'"
+            )
+            .strip()
+            .rstrip("/")
+        )
+        # The part was written before the rename, so it is one version behind the table.
+        assert exec_root(f"cat {part_path}/metadata_version.txt").strip() == "0"
+
+        if keep_file:
+            node.query(f"ALTER TABLE {table} ATTACH PARTITION tuple()")
+            assert node.query(f"SELECT count(), sum(b) FROM {table}") == "1000\t499500\n"
+        else:
+            exec_root(f"rm {part_path}/metadata_version.txt")
+
+            error = node.query_and_get_error(f"ALTER TABLE {table} ATTACH PARTITION tuple()")
+            assert "has no metadata_version.txt" in error
+            assert node.query(f"SELECT count() FROM {table}") == "0\n"
+            assert (
+                node.query(
+                    f"SELECT count() FROM system.detached_parts WHERE database = 'default' AND table = '{table}'"
+                )
+                == "1\n"
+            )
+
+            # Writing the version the part was detached at back into the file makes it attachable.
+            exec_root(f"echo -n 0 > {part_path}/metadata_version.txt")
+            node.query(f"ALTER TABLE {table} ATTACH PARTITION tuple()")
+            assert node.query(f"SELECT count(), sum(b) FROM {table}") == "1000\t499500\n"
+
+        node.query(f"DROP TABLE {table} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Refuse to `ATTACH` a part that has no `metadata_version.txt` while the table has metadata versions of its own, instead of attaching it as if it were up to date and silently reading every renamed or modified column as its default.

### Documentation entry for user-facing changes

...

A part detached before a metadata-only `ALTER` (`RENAME COLUMN`, `MODIFY COLUMN`) still has to apply the conversions of the versions it missed, and its `metadata_version.txt` is the only record of how far it got. The file carries no checksum — it is in `getFileNamesWithoutChecksums`, because a part can legitimately hold different versions of it on different replicas — so its absence is not corruption that `CHECK TABLE` or the part consistency check detects. `loadColumns` then falls back to the table's current version, which tells the read path that the part is already up to date: `ATTACH` succeeded and every renamed or modified column read as its default, with no error anywhere.

```sql
ALTER TABLE t DETACH PARTITION tuple();
ALTER TABLE t RENAME COLUMN a TO b;
-- rm .../detached/all_0_0_0/metadata_version.txt
ALTER TABLE t ATTACH PARTITION tuple();  -- accepted
SELECT count(), sum(b) FROM t;           -- 1000, 0 (was 1000, 499500)
```

A crash during the detach clone is one way to reach that state: the clone hard-links the part's files one at a time under the final name, so this single not-checksummed file can be the one that is missing while the rest of the part is intact.

Refuse the attach instead, and say which version has to be written into the file to make the part attachable again. A table that never had a metadata-only `ALTER` is unaffected, which is also the shape of a genuinely old part written before the file existed. Only the attach path is changed; a part already in the table that loses the file keeps loading as before.

The fallback matters only where the metadata version is real: on a plain `MergeTree` it stays 0, so the check never fires there. That engine loses the renamed column's data on this sequence whether or not the file is present — a separate defect, reported on the issue with the evidence.

New test: `test_attach_tampered_detached_parts/test.py::test_attach_part_without_metadata_version` (an integration test, because the stateless suite may not modify the server's data on disk). Verified in both directions: on a build from before this change the same sequence returns `1000, 0`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116646

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119362&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119362](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119362+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
