### PR TITLE
Fix INSERTs failing into a materialized view with a set operation after DETACH/ATTACH or RESTORE

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -100,6 +100,7 @@
 #include <Compression/CompressionFactory.h>
 
 #include <Interpreters/InterpreterDropQuery.h>
+#include <Interpreters/MutationsInterpreter.h>
 #include <Interpreters/QueryLog.h>
 #include <Interpreters/QueryMetadataCache.h>
 #include <Interpreters/FunctionNameNormalizer.h>
@@ -1941,6 +1942,11 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         /// Otherwise server will be unable to start for some old-format of IPv6/IPv4 types
         getContext()->setSetting("cast_ipv4_ipv6_default_on_conversion_error", 1);
     }
+
+    /// Both a definition supplied to this interpreter directly (RESTORE re-parses one from a backup)
+    /// and one the branch above re-parsed from stored metadata arrive un-normalized: parsing fills
+    /// only `list_of_modes`, and the analyzer rejects `union_mode == UNION_DEFAULT`.
+    normalizeSetOperations(query_ptr, getContext());
 
     /// TODO throw exception if !create.attach_short_syntax && !create.attach_from_path && !internal
     if (!create.attach_short_syntax && create.attach_as_replicated.has_value())

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -121,13 +121,8 @@ bool shouldUseAnalyzerForMutations(const ContextPtr & context)
     return context->getSettingsRef()[Setting::allow_experimental_analyzer];
 }
 
-/// A mutation command's predicate and `UPDATE` expressions are stored as serialized SQL text and
-/// re-parsed on execution. Re-parsing resets any set-operation nodes (`UNION`/`INTERSECT`/`EXCEPT`)
-/// to their un-normalized form (`union_mode` becomes `UNION_DEFAULT` and the `is_normalized` flag is
-/// lost), which the analyzer rejects with "UNION mode UNION_DEFAULT must be normalized". Re-run the
-/// same normalization that `executeQuery` applies to top-level queries so set operators work inside
-/// mutations. The serialized text always carries explicit modes, so the `*_default_mode` fallbacks
-/// are not reached in practice; passing the current context settings just mirrors `executeQuery`.
+/// Stored SQL text always carries explicit modes, so the `*_default_mode` fallbacks are not reached in
+/// practice; passing the current context settings just mirrors `executeQuery`.
 void normalizeSetOperations(ASTPtr & ast, const ContextPtr & context)
 {
     const auto & settings = context->getSettingsRef();

--- a/src/Interpreters/MutationsInterpreter.h
+++ b/src/Interpreters/MutationsInterpreter.h
@@ -54,11 +54,11 @@ ASTPtr getPartitionAndPredicateExpressionForMutationCommand(
     ContextPtr context
 );
 
-/// Re-run set-operation normalization (`UNION`/`INTERSECT`/`EXCEPT`) on an AST that was re-parsed from a
-/// serialized mutation command, mirroring what `executeQuery` does for top-level queries. Re-parsing loses
-/// this normalization, so any consumer that feeds a re-parsed mutation predicate or `UPDATE` assignment
-/// into the analyzer (`buildQueryTree`) must call this first; otherwise the analyzer rejects such
-/// subqueries with "UNION mode UNION_DEFAULT must be normalized".
+/// Re-run the set-operation normalization (`UNION`/`INTERSECT`/`EXCEPT`) that `executeQuery` applies to
+/// top-level queries on an AST re-parsed from stored SQL text: a serialized mutation command, a table's
+/// stored `CREATE`. Parsing fills only the syntactic list of modes, so such an AST is un-normalized however
+/// explicit its text was, and every consumer that feeds it to the analyzer (`buildQueryTree`) must call this
+/// first; otherwise the analyzer rejects the set operation with "UNION mode UNION_DEFAULT must be normalized".
 void normalizeSetOperations(ASTPtr & ast, const ContextPtr & context);
 
 /// Create an input stream that will read data from storage and apply mutation commands (UPDATEs, DELETEs, MATERIALIZEs)

--- a/tests/queries/0_stateless/05161_mv_set_operation_metadata_reparse.reference
+++ b/tests/queries/0_stateless/05161_mv_set_operation_metadata_reparse.reference
@@ -1,0 +1,5 @@
+before attach union	[13]
+before attach except	[11]
+after attach union	[13,23]
+after attach except	[11,21]
+after restore	[11,21]

--- a/tests/queries/0_stateless/05161_mv_set_operation_metadata_reparse.sql
+++ b/tests/queries/0_stateless/05161_mv_set_operation_metadata_reparse.sql
@@ -1,0 +1,62 @@
+-- A materialized view whose stored SELECT contains a set operation must keep working after its stored
+-- definition is re-parsed, both by DETACH/ATTACH and by RESTORE. Parsing fills only the syntactic list of
+-- modes, so `ASTSelectWithUnionQuery::union_mode` stays `UNION_DEFAULT`, which the analyzer rejects when
+-- pushing an INSERT to the view.
+-- Related: https://github.com/ClickHouse/ClickHouse/issues/77569
+
+DROP TABLE IF EXISTS t_src;
+DROP TABLE IF EXISTS mv_union;
+DROP TABLE IF EXISTS mv_except;
+DROP TABLE IF EXISTS mv_except_target;
+
+CREATE TABLE t_src (c0 UInt8) ENGINE = MergeTree ORDER BY c0;
+
+-- UNION ALL in a scalar subquery; materialized view with an inner table.
+CREATE MATERIALIZED VIEW mv_union (c0 UInt64) ENGINE = MergeTree ORDER BY c0 AS
+    SELECT c0 + (SELECT sum(y) FROM (SELECT 1 AS y UNION ALL SELECT 2 AS y)) AS c0 FROM t_src;
+
+-- EXCEPT ALL in a CTE; materialized view with an explicit target table.
+CREATE TABLE mv_except_target (c0 UInt64) ENGINE = MergeTree ORDER BY c0;
+CREATE MATERIALIZED VIEW mv_except TO mv_except_target AS
+    WITH x AS ((SELECT 1 AS y) EXCEPT ALL (SELECT 2 AS y))
+    SELECT c0 + (SELECT sum(y) FROM x) AS c0 FROM t_src;
+
+INSERT INTO t_src VALUES (10);
+SELECT 'before attach union', arraySort(groupArray(c0)) FROM mv_union;
+SELECT 'before attach except', arraySort(groupArray(c0)) FROM mv_except_target;
+
+DETACH TABLE mv_union SYNC;
+ATTACH TABLE mv_union;
+DETACH TABLE mv_except SYNC;
+ATTACH TABLE mv_except;
+
+INSERT INTO t_src VALUES (20);
+SELECT 'after attach union', arraySort(groupArray(c0)) FROM mv_union;
+SELECT 'after attach except', arraySort(groupArray(c0)) FROM mv_except_target;
+
+DROP TABLE mv_except;
+DROP TABLE mv_except_target;
+DROP TABLE mv_union;
+DROP TABLE t_src;
+
+-- The same defect reaches a restored view: RESTORE re-parses the stored definition and hands it
+-- straight to InterpreterCreateQuery, bypassing executeQuery.
+CREATE TABLE t_src_restore (c0 UInt8) ENGINE = MergeTree ORDER BY c0;
+CREATE TABLE mv_restore_target (c0 UInt64) ENGINE = MergeTree ORDER BY c0;
+CREATE MATERIALIZED VIEW mv_restore TO mv_restore_target AS
+    SELECT c0 + (SELECT sum(y) FROM (SELECT 1 AS y UNION DISTINCT SELECT 1 AS y)) AS c0 FROM t_src_restore;
+INSERT INTO t_src_restore VALUES (10);
+BACKUP TABLE t_src_restore, TABLE mv_restore, TABLE mv_restore_target
+    TO Memory('backup_05161_mv_set_operation') FORMAT Null;
+DROP TABLE mv_restore SYNC;
+DROP TABLE mv_restore_target SYNC;
+DROP TABLE t_src_restore SYNC;
+RESTORE TABLE t_src_restore, TABLE mv_restore, TABLE mv_restore_target
+    FROM Memory('backup_05161_mv_set_operation') FORMAT Null;
+
+INSERT INTO t_src_restore VALUES (20);
+SELECT 'after restore', arraySort(groupArray(c0)) FROM mv_restore_target;
+
+DROP TABLE mv_restore;
+DROP TABLE mv_restore_target;
+DROP TABLE t_src_restore;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/77569
Related: https://github.com/ClickHouse/ClickHouse/pull/80037
Related: https://github.com/ClickHouse/ClickHouse/pull/100390
Related: https://github.com/ClickHouse/ClickHouse/pull/110196


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a materialized view whose `SELECT` contains a `UNION`, `INTERSECT` or `EXCEPT` in a subquery or CTE breaking after `DETACH TABLE` + `ATTACH TABLE`, or after `RESTORE`: every subsequent `INSERT` into its source table failed with `UNION mode UNION_DEFAULT must be normalized`, and under `enable_analyzer = 0` it was silently evaluated as a plain union, returning wrong results. `ATTACH TABLE` (short form) and `RESTORE` now re-run set-operation normalization on the stored definition.

### Description

`DETACH TABLE mv; ATTACH TABLE mv;` on a materialized view whose stored `SELECT` contains a multi-branch set operation in a subquery or CTE leaves it poisoned: every later `INSERT` into its source table fails with `Code: 36 ... UNION mode UNION_DEFAULT must be normalized`. The `ATTACH` succeeds and `SHOW CREATE` is byte-identical, so the damage is silent and ingestion stays broken until a restart. `RESTORE` produces the same broken view. Under `enable_analyzer = 0` there is no error at all: `EXCEPT ALL` is evaluated as a union and the view returns wrong results.

Root cause: `ASTSelectWithUnionQuery::union_mode` is separate from the parsed `list_of_modes` and only `NormalizeSelectWithUnionQueryMatcher` writes it, so a definition re-parsed from stored SQL text carries `UNION_DEFAULT`, which `UnionNode`'s constructor rejects. Only materialized views are damaged: `StorageView` re-normalizes at the storage layer, `StorageMaterializedView` keeps the AST verbatim.

`InterpreterCreateQuery` now normalizes the definition it is about to execute, whatever produced it, using the helper #110196 extracted. One line covers both un-normalized routes: short `ATTACH`, which re-parses stored metadata, and `RESTORE`, which hands a definition parsed from the backup straight to this interpreter, bypassing `executeQuery`. Definitions arriving through `executeQuery` are already normalized, and both visitors early-return on them.

`registerStorageMaterializedView` is deliberately not also guarded: every producer reaching it goes through either `InterpreterCreateQuery` or a loader that already normalizes. One residual is disclosed rather than fixed: `DatabaseCatalog` builds a partially-dropped table from an un-normalized re-parse, but only to delete it.

New test `05161_mv_set_operation_metadata_reparse` covers both routes. It fails on master and with the fix line deleted, and passes 50/50 randomized and on the old analyzer.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119365&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119365](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119365+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1251` (included in `26.9` and later)
<!-- ch-version-info:end -->