### PR TITLE
Do not restrict a vector search to index rows when a delete is pending

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -15,6 +15,8 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/SortingStep.h>
+#include <Storages/MergeTree/AlterConversions.h>
+#include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 
 namespace DB
@@ -389,6 +391,44 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
 
     ActionsDAG & expression = expression_step->getExpression();
 
+    /// A `DELETE` that the parts do not carry yet is invisible to the vector index: it keeps returning
+    /// the row ids of deleted rows. Both optimizations below then restrict the read to exactly the rows
+    /// the index returned, so `_row_exists` (or the on-the-fly delete filter) drops the deleted ones with
+    /// nothing to take their place: the query returns fewer rows than its `LIMIT` and misses the true
+    /// neighbours that a deleted candidate shadowed. Fall back to reading the candidates' granules, where
+    /// the surviving rows are rescored, until a merge or a mutation rebuilds the index.
+    auto has_deletes_unknown_to_vector_index = [&](const auto & analyzed_result)
+    {
+        auto mutations_snapshot = read_from_mergetree_step->getMutationsSnapshot();
+
+        /// A patch part can carry an update of `_row_exists`, and which rows it hides is only known
+        /// once it is applied, so do not look any closer in that case.
+        if (mutations_snapshot && mutations_snapshot->hasPatchParts())
+            return true;
+
+        for (const auto & part_with_ranges : analyzed_result->parts_with_ranges)
+        {
+            if (part_with_ranges.ranges.empty())
+                continue;
+
+            /// A materialized lightweight delete: the part carries a `_row_exists` column.
+            if (part_with_ranges.data_part->hasLightweightDelete())
+                return true;
+
+            /// A delete that is still a pending mutation, applied on the fly at read time.
+            if (mutations_snapshot)
+            {
+                auto alter_conversions = MergeTreeData::getAlterConversionsForPart(
+                    part_with_ranges.data_part, mutations_snapshot, read_from_mergetree_step->getContext());
+
+                if (alter_conversions->hasLightweightDelete() || alter_conversions->hasDeleteMutation())
+                    return true;
+            }
+        }
+
+        return false;
+    };
+
     bool optimize_plan = !settings.vector_search_with_rescoring;
     /// FINAL may add PK-overlapping ranges after vector index analysis. In that case,
     /// vector row hints only describe the original candidates and must not filter
@@ -429,6 +469,9 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
                     }
                 }
             }
+
+            if (optimize_plan && has_deletes_unknown_to_vector_index(analyzed_result))
+                optimize_plan = false;
         }
 
         if (optimize_plan)
@@ -506,7 +549,7 @@ bool optimizeVectorSearchWithVectorIndexSecondPass(QueryPlan::Node & /*root*/, S
         auto analyzed_result = read_from_mergetree_step->getAnalyzedResult();
         analyzed_result = analyzed_result ? analyzed_result : read_from_mergetree_step->selectRangesToRead();
 
-        bool can_apply_row_filter = analyzed_result != nullptr;
+        bool can_apply_row_filter = analyzed_result != nullptr && !has_deletes_unknown_to_vector_index(analyzed_result);
         if (can_apply_row_filter)
         {
             for (const auto & part_with_ranges : analyzed_result->parts_with_ranges)

--- a/tests/queries/0_stateless/04491_vector_search_rescoring_lightweight_delete_filter.reference
+++ b/tests/queries/0_stateless/04491_vector_search_rescoring_lightweight_delete_filter.reference
@@ -1,4 +1,4 @@
 bruteforce reads a surviving granule mate
 1
-rescoring row filter excludes the granule mate
-0
+the same answer with the index
+[0,2,4]

--- a/tests/queries/0_stateless/04491_vector_search_rescoring_lightweight_delete_filter.sql
+++ b/tests/queries/0_stateless/04491_vector_search_rescoring_lightweight_delete_filter.sql
@@ -34,14 +34,19 @@ FROM
     SETTINGS use_skip_indexes = 0
 );
 
-SELECT 'rescoring row filter excludes the granule mate';
+-- The row filter restricts the read to the rows the vector index returned, and the index still holds
+-- the deleted ones, so applying it while a lightweight delete is unmaterialized would drop candidates
+-- with nothing to take their place - the query would return fewer rows than its LIMIT and miss the
+-- neighbours a deleted candidate shadowed. The filter is skipped in that case, so the granule mate is
+-- rescored and the answer is the same as the bruteforce one.
+SELECT 'the same answer with the index';
 WITH [1.0, 0.0] AS reference_vec
-SELECT throwIf(has(groupArray(id), 4), 'Vector search row filter was not applied after lightweight delete')
+SELECT groupArray(id)
 FROM
 (
     SELECT id
     FROM tab
-    ORDER BY L2Distance(vec, reference_vec)
+    ORDER BY L2Distance(vec, reference_vec), id
     LIMIT 3
     SETTINGS vector_search_with_rescoring = 1,
              parallel_replicas_local_plan = 1,

--- a/tests/queries/0_stateless/05205_vector_search_lightweight_delete_limit.reference
+++ b/tests/queries/0_stateless/05205_vector_search_lightweight_delete_limit.reference
@@ -1,0 +1,9 @@
+rows left	9996
+with the index	10
+without the index	10
+without rescoring	10
+with rescoring	10
+the index answer	[780,781,2236,2237,3787,3788,5243,5244,6794,6795]
+the bruteforce answer	[780,781,2236,2237,3787,3788,5243,5244,6794,6795]
+a deleted cluster	3
+a pending delete	10

--- a/tests/queries/0_stateless/05205_vector_search_lightweight_delete_limit.sql
+++ b/tests/queries/0_stateless/05205_vector_search_lightweight_delete_limit.sql
@@ -1,0 +1,58 @@
+-- Tags: no-fasttest, no-ordinary-database, no-parallel-replicas
+-- no-fasttest: the vector similarity index is not built in the fast test.
+-- no-parallel-replicas: vector-search read hints are produced during local index analysis.
+
+-- A lightweight `DELETE` does not rebuild a vector index, so the index keeps returning the row ids of
+-- deleted rows. Restricting the read to exactly those rows then drops the deleted candidates with
+-- nothing to take their place: the query returned fewer rows than its `LIMIT` and missed the true
+-- neighbours that a deleted candidate shadowed, down to an empty result when a whole cluster of near
+-- neighbours is deleted. The read falls back to the candidates' granules until a merge or a mutation
+-- rebuilds the index.
+
+SET enable_analyzer = 1;
+SET lightweight_deletes_sync = 2;
+SET mutations_sync = 2;
+SET parallel_replicas_local_plan = 1;
+
+DROP TABLE IF EXISTS t_05205;
+CREATE TABLE t_05205 (id UInt64, v Array(Float32), INDEX vidx v TYPE vector_similarity('hnsw', 'L2Distance', 2))
+ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05205 SELECT number, [toFloat32(number % 97), toFloat32(number % 31)] FROM numbers(10000);
+
+-- The four exact matches of the reference vector.
+DELETE FROM t_05205 WHERE id IN (5, 3012, 6019, 9026);
+
+SELECT 'rows left', count() FROM t_05205;
+SELECT 'with the index', count() FROM (SELECT id FROM t_05205 ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 10);
+SELECT 'without the index', count() FROM (SELECT id FROM t_05205 ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 10 SETTINGS use_skip_indexes = 0);
+SELECT 'without rescoring', count() FROM (SELECT id FROM t_05205 ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 10 SETTINGS vector_search_with_rescoring = 0);
+SELECT 'with rescoring', count() FROM (SELECT id FROM t_05205 ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 10 SETTINGS vector_search_with_rescoring = 1);
+
+-- And they are the same neighbours the bruteforce scan finds.
+SELECT 'the index answer', groupArray(id) FROM (SELECT id FROM t_05205 ORDER BY L2Distance(v, [5.0, 5.0]), id LIMIT 10);
+SELECT 'the bruteforce answer', groupArray(id) FROM (SELECT id FROM t_05205 ORDER BY L2Distance(v, [5.0, 5.0]), id LIMIT 10 SETTINGS use_skip_indexes = 0);
+
+-- Deleting a whole cluster of near neighbours used to empty the result.
+DROP TABLE IF EXISTS t_05205_cluster;
+CREATE TABLE t_05205_cluster (id UInt64, v Array(Float32), INDEX vidx v TYPE vector_similarity('hnsw', 'L2Distance', 2))
+ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05205_cluster SELECT number, [toFloat32(number % 97), toFloat32(number % 31)] FROM numbers(10000);
+DELETE FROM t_05205_cluster WHERE L2Distance(v, [5.0, 5.0]) < 3;
+
+SELECT 'a deleted cluster', count() FROM (SELECT id FROM t_05205_cluster ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 3);
+
+-- A delete that is still a pending mutation, applied on the fly, has the same effect on the index.
+DROP TABLE IF EXISTS t_05205_on_fly;
+CREATE TABLE t_05205_on_fly (id UInt64, v Array(Float32), INDEX vidx v TYPE vector_similarity('hnsw', 'L2Distance', 2))
+ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_05205_on_fly SELECT number, [toFloat32(number % 97), toFloat32(number % 31)] FROM numbers(10000);
+SYSTEM STOP MERGES t_05205_on_fly;
+ALTER TABLE t_05205_on_fly DELETE WHERE id IN (5, 3012, 6019, 9026) SETTINGS mutations_sync = 0, alter_sync = 0;
+
+SELECT 'a pending delete', count() FROM (SELECT id FROM t_05205_on_fly ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 10 SETTINGS apply_mutations_on_fly = 1);
+
+SYSTEM START MERGES t_05205_on_fly;
+
+DROP TABLE t_05205_on_fly;
+DROP TABLE t_05205_cluster;
+DROP TABLE t_05205;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a vector search returning fewer rows than its `LIMIT`, and missing true nearest neighbours, after a lightweight `DELETE` (or with a delete mutation applied on the fly): the read is no longer restricted to the rows the vector index returned while the index still holds deleted rows.

### Documentation entry for user-facing changes

...

After a lightweight `DELETE`, a vector search returned fewer rows than its `LIMIT` and missed true nearest neighbours:

```sql
INSERT INTO hv SELECT number, [toFloat32(number % 97), toFloat32(number % 31)] FROM numbers(10000);
DELETE FROM hv WHERE id IN (5, 3012, 6019, 9026);       -- the exact matches of [5, 5]
SELECT count() FROM (SELECT id FROM hv ORDER BY L2Distance(v, [5.0, 5.0]) LIMIT 10);  -- 6
```

Deleting a whole cluster of near neighbours emptied the result. The rows that were returned were also not the nearest survivors: the deleted candidates shadowed them.

A lightweight delete does not rebuild a secondary index, so the vector index keeps returning the row ids of deleted rows. Both vector-search optimizations then restrict the read to exactly those rows — the rewritten plan without rescoring, and the exact row filter with rescoring — so `_row_exists` removes the deleted candidates afterwards with nothing left to take their place. Before exact row filtering was added (#108846, 26.7) the read covered the candidates' granules, so the surviving rows there were rescored and the query still satisfied its `LIMIT`.

Skip both optimizations for a query whose parts have a delete the index does not know about: a materialized lightweight delete, a delete mutation that is applied on the fly, or a patch part attached to the part that updates `_row_exists` (a lightweight update may delete rows). The check is per part, so a patch part in another partition does not affect the query. The read then falls back to the candidates' granules, as before 26.7, until a merge or a mutation rebuilds the index.

`04491_vector_search_rescoring_lightweight_delete_filter` asserted the old behaviour — that the row filter excludes a surviving granule mate after a lightweight delete, without checking that the `LIMIT` is still satisfied — and now asserts that the index answer equals the bruteforce one.

New test: `05205_vector_search_lightweight_delete_limit`, covering both rescoring modes, the emptied-cluster case, a pending delete applied on the fly and a delete written as a patch part. It uses ten copies of a 10x10 grid (1000 rows) with a small HNSW graph, because every index build ran for more than a minute under ASan in the flaky check; the ten exact matches of the reference vector are the whole result of a `LIMIT 10`, so deleting them emptied the result before the fix. Verified in both directions, and a differential run of the `vector_search`/`vector_similarity`/`lightweight_delete` stateless tests shows no new failures.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117286
Caused by: https://github.com/ClickHouse/ClickHouse/pull/108846

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119371&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119371](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119371+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

