### PR TITLE
Fix a crash when a read of a serialized query plan lands on a Merge table through a proxy table

### DIFF
--- a/src/Processors/QueryPlan/resolveStorages.cpp
+++ b/src/Processors/QueryPlan/resolveStorages.cpp
@@ -210,7 +210,7 @@ static QueryPlanResourceHolder replaceReadingFromTable(QueryPlan::Node & node, Q
     /// The `SelectQueryInfo` built above has no query: the step carries only a table name and the
     /// table expression modifiers. Reads that need one get a `SELECT` over that table synthesized
     /// and re-analyzed below; the rest read the storage directly.
-    const bool read_via_interpreter = storage->isRemote() || storage->readsThroughMergeTable();
+    const bool read_via_interpreter = storage->readRequiresAnalyzedQuery();
 
     ASTPtr query;
     if (read_via_interpreter)

--- a/src/Processors/QueryPlan/resolveStorages.cpp
+++ b/src/Processors/QueryPlan/resolveStorages.cpp
@@ -27,7 +27,7 @@
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 
-#include <Storages/StorageMerge.h>
+#include <Storages/IStorage.h>
 #include <Planner/Utils.h>
 #include <Core/Settings.h>
 
@@ -207,9 +207,13 @@ static QueryPlanResourceHolder replaceReadingFromTable(QueryPlan::Node & node, Q
 
     auto table_lock = storage->lockForShare(context->getInitialQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
 
+    /// The `SelectQueryInfo` built above has no query: the step carries only a table name and the
+    /// table expression modifiers. Reads that need one get a `SELECT` over that table synthesized
+    /// and re-analyzed below; the rest read the storage directly.
+    const bool read_via_interpreter = storage->isRemote() || storage->readsThroughMergeTable();
+
     ASTPtr query;
-    bool is_storage_merge = typeid_cast<const StorageMerge *>(storage.get());
-    if (storage->isRemote() || is_storage_merge)
+    if (read_via_interpreter)
     {
         auto table_expression = make_intrusive<ASTTableExpression>();
         if (table_function_ast)
@@ -251,7 +255,7 @@ static QueryPlanResourceHolder replaceReadingFromTable(QueryPlan::Node & node, Q
     }
 
     QueryPlan reading_plan;
-    if (storage->isRemote() || is_storage_merge)
+    if (read_via_interpreter)
     {
         SelectQueryOptions options(QueryProcessingStage::FetchColumns);
         options.ignore_rename_columns = true;

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -118,10 +118,10 @@ public:
     /// Returns true if the storage receives data from a remote server or servers.
     virtual bool isRemote() const { return false; }
 
-    /// Returns true if `read` on this storage reaches a `Merge` table: either this storage is one, or
-    /// it forwards `read` to a table that does. `StorageMerge::read` needs an analyzed query (an AST
-    /// or a query tree) in `SelectQueryInfo`, which not every caller of `read` has.
-    virtual bool readsThroughMergeTable() const { return false; }
+    /// Returns true if `read` is known to require an analyzed query (an AST or a query tree) in
+    /// `SelectQueryInfo`, which not every caller of `read` has: a remote read always does, and so does a
+    /// read that rewrites the query per underlying table. Wrappers answer for the table they forward to.
+    virtual bool readRequiresAnalyzedQuery() const { return isRemote(); }
 
     /// Returns true for storages that do not store data themselves but read it from other tables,
     /// e.g. `Distributed`, `Merge`, `Buffer`, `Alias`. The `_table` and `_database` virtual columns

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -118,6 +118,11 @@ public:
     /// Returns true if the storage receives data from a remote server or servers.
     virtual bool isRemote() const { return false; }
 
+    /// Returns true if `read` on this storage reaches a `Merge` table: either this storage is one, or
+    /// it forwards `read` to a table that does. `StorageMerge::read` needs an analyzed query (an AST
+    /// or a query tree) in `SelectQueryInfo`, which not every caller of `read` has.
+    virtual bool readsThroughMergeTable() const { return false; }
+
     /// Returns true for storages that do not store data themselves but read it from other tables,
     /// e.g. `Distributed`, `Merge`, `Buffer`, `Alias`. The `_table` and `_database` virtual columns
     /// of the rows read from such a storage carry the name of the table that actually produced

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -174,7 +174,7 @@ public:
     bool prefersLargeBlocks() const override { return getTargetTable()->prefersLargeBlocks(); }
     bool areAsynchronousInsertsEnabled() const override { return getTargetTable()->areAsynchronousInsertsEnabled(); }
     bool isRemote() const override { return getTargetTable()->isRemote(); }
-    bool readsThroughMergeTable() const override { return getTargetTable()->readsThroughMergeTable(); }
+    bool readRequiresAnalyzedQuery() const override { return getTargetTable()->readRequiresAnalyzedQuery(); }
     bool isSharedStorage() const override { return getTargetTable()->isSharedStorage(); }
     bool supportsReplication() const override
     {

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -174,6 +174,7 @@ public:
     bool prefersLargeBlocks() const override { return getTargetTable()->prefersLargeBlocks(); }
     bool areAsynchronousInsertsEnabled() const override { return getTargetTable()->areAsynchronousInsertsEnabled(); }
     bool isRemote() const override { return getTargetTable()->isRemote(); }
+    bool readsThroughMergeTable() const override { return getTargetTable()->readsThroughMergeTable(); }
     bool isSharedStorage() const override { return getTargetTable()->isSharedStorage(); }
     bool supportsReplication() const override
     {

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -292,10 +292,10 @@ bool StorageBuffer::isRemote() const
     return destination && destination->isRemote();
 }
 
-bool StorageBuffer::readsThroughMergeTable() const
+bool StorageBuffer::readRequiresAnalyzedQuery() const
 {
     auto destination = getDestinationTable();
-    return destination && destination->readsThroughMergeTable();
+    return destination && destination->readRequiresAnalyzedQuery();
 }
 
 void StorageBuffer::read(

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -292,6 +292,12 @@ bool StorageBuffer::isRemote() const
     return destination && destination->isRemote();
 }
 
+bool StorageBuffer::readsThroughMergeTable() const
+{
+    auto destination = getDestinationTable();
+    return destination && destination->readsThroughMergeTable();
+}
+
 void StorageBuffer::read(
     QueryPlan & query_plan,
     const Names & column_names,

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -88,6 +88,7 @@ public:
         size_t max_block_size,
         size_t num_streams) override;
     bool isRemote() const override;
+    bool readsThroughMergeTable() const override;
     bool readsFromOtherTables() const override { return static_cast<bool>(destination_id); }
 
     bool supportsParallelInsert() const override { return true; }

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -88,7 +88,7 @@ public:
         size_t max_block_size,
         size_t num_streams) override;
     bool isRemote() const override;
-    bool readsThroughMergeTable() const override;
+    bool readRequiresAnalyzedQuery() const override;
     bool readsFromOtherTables() const override { return static_cast<bool>(destination_id); }
 
     bool supportsParallelInsert() const override { return true; }

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -1072,6 +1072,13 @@ bool StorageMaterializedView::isRemote() const
     return false;
 }
 
+bool StorageMaterializedView::readsThroughMergeTable() const
+{
+    if (auto table = tryGetTargetTable())
+        return table->readsThroughMergeTable();
+    return false;
+}
+
 void StorageMaterializedView::onActionLockRemove(StorageActionBlockType action_type)
 {
     if ((action_type == ActionLocks::ViewRefresh || action_type == ActionLocks::ViewRefreshPause) && refresher)

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -1072,10 +1072,10 @@ bool StorageMaterializedView::isRemote() const
     return false;
 }
 
-bool StorageMaterializedView::readsThroughMergeTable() const
+bool StorageMaterializedView::readRequiresAnalyzedQuery() const
 {
     if (auto table = tryGetTargetTable())
-        return table->readsThroughMergeTable();
+        return table->readRequiresAnalyzedQuery();
     return false;
 }
 

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -27,7 +27,7 @@ public:
     std::string getName() const override { return "MaterializedView"; }
     bool isView() const override { return true; }
     bool isRemote() const override;
-    bool readsThroughMergeTable() const override;
+    bool readRequiresAnalyzedQuery() const override;
 
     bool hasInnerTable() const { return has_inner_table; }
 

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -27,6 +27,7 @@ public:
     std::string getName() const override { return "MaterializedView"; }
     bool isView() const override { return true; }
     bool isRemote() const override;
+    bool readsThroughMergeTable() const override;
 
     bool hasInnerTable() const { return has_inner_table; }
 

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -48,6 +48,7 @@ public:
     std::string getName() const override { return "Merge"; }
 
     bool isRemote() const override;
+    bool readsThroughMergeTable() const override { return true; }
     bool readsFromOtherTables() const override { return true; }
 
     /// The check is delayed to the read method. It checks the support of the tables used.

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -48,7 +48,7 @@ public:
     std::string getName() const override { return "Merge"; }
 
     bool isRemote() const override;
-    bool readsThroughMergeTable() const override { return true; }
+    bool readRequiresAnalyzedQuery() const override { return true; }
     bool readsFromOtherTables() const override { return true; }
 
     /// The check is delayed to the read method. It checks the support of the tables used.

--- a/src/Storages/StorageProxy.h
+++ b/src/Storages/StorageProxy.h
@@ -19,6 +19,7 @@ public:
     String getName() const override { return "Proxy"; }
 
     bool isRemote() const override { return getNested()->isRemote(); }
+    bool readsThroughMergeTable() const override { return getNested()->readsThroughMergeTable(); }
     bool isView() const override { return getNested()->isView(); }
     bool supportsTruncate() const override { return getNested()->supportsTruncate(); }
     bool supportsSampling() const override { return getNested()->supportsSampling(); }

--- a/src/Storages/StorageProxy.h
+++ b/src/Storages/StorageProxy.h
@@ -19,7 +19,7 @@ public:
     String getName() const override { return "Proxy"; }
 
     bool isRemote() const override { return getNested()->isRemote(); }
-    bool readsThroughMergeTable() const override { return getNested()->readsThroughMergeTable(); }
+    bool readRequiresAnalyzedQuery() const override { return getNested()->readRequiresAnalyzedQuery(); }
     bool isView() const override { return getNested()->isView(); }
     bool supportsTruncate() const override { return getNested()->supportsTruncate(); }
     bool supportsSampling() const override { return getNested()->supportsSampling(); }

--- a/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan.reference
+++ b/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan.reference
@@ -1,0 +1,5 @@
+alias	3
+buffer	3
+mv	3
+alias, plan-based parallel replicas	3
+merge	3

--- a/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan.sql
+++ b/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan.sql
@@ -1,0 +1,39 @@
+-- A read of a deserialized query plan carries no analyzed query, so it may only be routed straight to
+-- a storage that does not need one. Reading a Merge table through a proxy that forwards its read used
+-- to take that route and crash the server.
+
+DROP TABLE IF EXISTS t_merge_proxy_alias;
+DROP TABLE IF EXISTS t_merge_proxy_buffer;
+DROP VIEW IF EXISTS t_merge_proxy_mv;
+DROP TABLE IF EXISTS t_merge_proxy_merge;
+DROP TABLE IF EXISTS t_merge_proxy_src;
+
+CREATE TABLE t_merge_proxy_src (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t_merge_proxy_src VALUES (1), (2);
+
+CREATE TABLE t_merge_proxy_merge ENGINE = Merge(currentDatabase(), '^t_merge_proxy_src$');
+CREATE TABLE t_merge_proxy_alias ENGINE = Alias(currentDatabase(), t_merge_proxy_merge);
+CREATE TABLE t_merge_proxy_buffer (x UInt64)
+    ENGINE = Buffer(currentDatabase(), t_merge_proxy_merge, 1, 100, 100, 10000, 1000000, 10000000, 100000000);
+CREATE MATERIALIZED VIEW t_merge_proxy_mv TO t_merge_proxy_merge AS SELECT x FROM t_merge_proxy_src;
+
+SET enable_analyzer = 1, serialize_query_plan = 1;
+
+SELECT 'alias', sum(x) FROM remote('127.0.0.2', currentDatabase(), t_merge_proxy_alias);
+SELECT 'buffer', sum(x) FROM remote('127.0.0.2', currentDatabase(), t_merge_proxy_buffer);
+SELECT 'mv', sum(x) FROM remote('127.0.0.2', currentDatabase(), t_merge_proxy_mv);
+
+-- With these two on, the same read reaches an earlier unguarded dereference of the same null query.
+SELECT 'alias, plan-based parallel replicas', sum(x)
+FROM remote('127.0.0.2', currentDatabase(), t_merge_proxy_alias)
+SETTINGS parallel_replicas_plan_based = 1, parallel_replicas_allow_merge_tables = 1;
+
+-- A directly addressed Merge table was already routed correctly, by an exact type test that this
+-- fix replaces; it has to keep working.
+SELECT 'merge', sum(x) FROM remote('127.0.0.2', currentDatabase(), t_merge_proxy_merge);
+
+DROP TABLE t_merge_proxy_alias;
+DROP TABLE t_merge_proxy_buffer;
+DROP VIEW t_merge_proxy_mv;
+DROP TABLE t_merge_proxy_merge;
+DROP TABLE t_merge_proxy_src;

--- a/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan.sql
+++ b/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan.sql
@@ -1,6 +1,8 @@
 -- A read of a deserialized query plan carries no analyzed query, so it may only be routed straight to
 -- a storage that does not need one. Reading a Merge table through a proxy that forwards its read used
 -- to take that route and crash the server.
+-- The lazily loaded `StorageTableProxy` carrier needs a second database, so it lives in
+-- 05183_merge_table_behind_proxy_serialized_plan_2, which is tagged `no-replicated-database`.
 
 DROP TABLE IF EXISTS t_merge_proxy_alias;
 DROP TABLE IF EXISTS t_merge_proxy_buffer;

--- a/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan_2.reference
+++ b/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan_2.reference
@@ -1,0 +1,2 @@
+engine before	TableProxy
+lazy proxy	3

--- a/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan_2.sql
+++ b/tests/queries/0_stateless/05183_merge_table_behind_proxy_serialized_plan_2.sql
@@ -1,0 +1,35 @@
+-- Tags: no-replicated-database
+--       no-replicated-database: `DETACH DATABASE` / `ATTACH DATABASE` of an `Atomic` database with
+--       the `lazy_load_tables` setting.
+
+-- Continuation of 05183_merge_table_behind_proxy_serialized_plan for the one carrier that needs a
+-- second database. In a database with `lazy_load_tables = 1` an unloaded table is a
+-- `StorageTableProxy`, so a `Merge` table reached through one is routed by `StorageProxy`'s own
+-- delegation rather than by any of the concrete `Alias` / `Buffer` / `MaterializedView` classes.
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t05183_src (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t05183_src VALUES (1), (2);
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t05183_merge (x UInt64)
+    ENGINE = Merge({CLICKHOUSE_DATABASE_1:Identifier}, '^t05183_src$');
+
+-- Re-attach the database so its tables become unloaded lazy proxies.
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+
+-- Switch into the lazy database: it makes the query below address it, and the `system.tables`
+-- filter has to be spelled `currentDatabase()` for the style check to recognize it.
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+
+-- Prove the `Merge` table is still an unloaded proxy when the query below runs. Only `engine` is
+-- read, because it is answered by the proxy itself, while a column such as `data_paths` would
+-- materialize the nested storage and defeat the fixture.
+SELECT 'engine before', engine FROM system.tables WHERE database = currentDatabase() AND name = 't05183_merge';
+
+SELECT 'lazy proxy', sum(x) FROM remote('127.0.0.2', currentDatabase(), t05183_merge)
+SETTINGS enable_analyzer = 1, serialize_query_plan = 1;
+
+USE {CLICKHOUSE_DATABASE:Identifier};
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server crash when a `SELECT` with `serialize_query_plan = 1` read a `Merge` table through a table that forwards its reads, such as `Alias`, `Buffer` with a destination, or a `MATERIALIZED VIEW` with a `TO` target. Closes #119899.

### Description

```sql
CREATE TABLE t (x UInt64) ENGINE = MergeTree ORDER BY x;
INSERT INTO t VALUES (1), (2);
CREATE TABLE m ENGINE = Merge(currentDatabase(), '^t$');
CREATE TABLE proxy ENGINE = Alias(currentDatabase(), m);

SET serialize_query_plan = 1;
SELECT sum(x) FROM remote('127.0.0.2', currentDatabase(), proxy);   -- expected 3, crashed the server
```

With `serialize_query_plan = 1` the receiving side rebuilds each read from a step carrying only a table
name, so its `SelectQueryInfo` has no query. Reads needing one get a `SELECT` over the table synthesized
and re-analyzed; the rest read the storage directly.

That route was chosen by `typeid_cast<const StorageMerge *>`, an exact test on the storage *addressed*
rather than the one the read lands on. A table forwarding its read took the direct route, so when it
forwards to a `Merge` table, `StorageMerge::read` got a null `query` and dereferenced it at
`StorageMerge.cpp:1116`. With `parallel_replicas_plan_based` and `parallel_replicas_allow_merge_tables`
on, the same null is dereferenced earlier in the `FINAL` probe (`StorageMerge.cpp:1049`), so guarding
the reported line would only move the crash.

The fix names that precondition once, as `IStorage::readRequiresAnalyzedQuery()`: default
`isRemote()`, since a remote read builds its query tree out of `SelectQueryInfo`; `true` for `Merge`;
delegated by each read-forwarding storage for the table its read lands on, as it already delegates
`isRemote()` on the line above. The routing condition is now that one predicate.

The new test covers the three carriers plus the parallel replicas variant and reddens without this
change; routing for a proxy over a non-`Merge` target is measured unchanged.

Reported on master by `Stress test (amd_asan_ubsan)` at `bf549ba1b4fe0c3de89373f336586671d8af50b8`:
`runtime error: member call on null pointer of type 'DB::TypePromotion<DB::IAST>'` at
`src/Storages/StorageMerge.cpp:1116:57`
([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=bf549ba1b4fe0c3de89373f336586671d8af50b8&name_0=MasterCI&name_1=Stress%20test%20%28amd_asan_ubsan%29)).

Not addressed here: the same sparse `SelectQueryInfo` reaches external-database storages such as
`MySQL`, which report `Query is not analyzed: no query tree` rather than crashing. They answer false to
the new predicate, so that path is unchanged here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119387&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119387](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119387+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

