### PR TITLE
Let the base58 cancellation budget span a whole block of values

### DIFF
--- a/src/Common/Base58.cpp
+++ b/src/Common/Base58.cpp
@@ -627,7 +627,7 @@ std::optional<size_t> decodeBase58Short(const UInt8 * src, size_t body_length, U
 } // anonymous namespace
 
 
-size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation)
+size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation, size_t * shared_work_since_check)
 {
     const char * base58_encoding_alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
@@ -658,7 +658,11 @@ size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std
     /// rather than by outer iterations: the time limit and `KILL QUERY` stay prompt even with the size
     /// limit disabled. The unit counted is one (input element, accumulator element) pair, and one
     /// iteration covers `BASE58_ENCODE_BYTES_PER_PASS * BASE58_ENCODE_WORD_DIGITS` of them, hence the scaling.
-    size_t work_since_check = 0;
+    /// The count carries over between calls when the caller owns it, so the work of values too small to
+    /// reach a check on their own still adds up to one. Writes go through the reference, which keeps the
+    /// caller's count correct on every exit path.
+    size_t own_work_since_check = 0;
+    size_t & work_since_check = shared_work_since_check ? *shared_work_since_check : own_work_since_check;
     static constexpr size_t work_per_check = 1ULL << 20;
 
     /// A short leading pass goes first, so every pass below reads exactly `BASE58_ENCODE_BYTES_PER_PASS` bytes.
@@ -763,7 +767,7 @@ size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std
 }
 
 
-std::optional<size_t> decodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation)
+std::optional<size_t> decodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation, size_t * shared_work_since_check)
 {
     // clang-format off
     static const Int8 map_digits[256] =
@@ -815,8 +819,11 @@ std::optional<size_t> decodeBase58(const UInt8 * src, size_t src_length, UInt8 *
     size_t word_count = 0;
 
     /// As in `encodeBase58`, the check is driven by accumulated inner-loop work, and one iteration
-    /// covers `BASE58_DECODE_CHARS_PER_PASS * sizeof(UInt64)` of the pairs that unit counts.
-    size_t work_since_check = 0;
+    /// covers `BASE58_DECODE_CHARS_PER_PASS * sizeof(UInt64)` of the pairs that unit counts. The count
+    /// likewise carries over between calls when the caller owns it. Going through the reference is what
+    /// keeps the work of a value rejected mid-loop below charged to the caller.
+    size_t own_work_since_check = 0;
+    size_t & work_since_check = shared_work_since_check ? *shared_work_since_check : own_work_since_check;
     static constexpr size_t work_per_check = 1ULL << 20;
 
     /// A short leading pass goes first, so every pass below reads exactly `BASE58_DECODE_CHARS_PER_PASS` characters.

--- a/src/Common/Base58.cpp
+++ b/src/Common/Base58.cpp
@@ -659,8 +659,7 @@ size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std
     /// limit disabled. The unit counted is one (input element, accumulator element) pair, and one
     /// iteration covers `BASE58_ENCODE_BYTES_PER_PASS * BASE58_ENCODE_WORD_DIGITS` of them, hence the scaling.
     /// The count carries over between calls when the caller owns it, so the work of values too small to
-    /// reach a check on their own still adds up to one. Writes go through the reference, which keeps the
-    /// caller's count correct on every exit path.
+    /// reach a check on their own still adds up to one.
     size_t own_work_since_check = 0;
     size_t & work_since_check = shared_work_since_check ? *shared_work_since_check : own_work_since_check;
     static constexpr size_t work_per_check = 1ULL << 20;

--- a/src/Common/Base58.h
+++ b/src/Common/Base58.h
@@ -14,10 +14,15 @@ namespace DB
 /// time, so they accept an optional `check_cancellation` callback that is invoked periodically;
 /// it is expected to throw if the query has been cancelled or exceeded its time limit.
 ///
+/// The work done since the last callback is counted in `shared_work_since_check` when the caller
+/// passes one, so that a caller converting many values checks on their combined work. A value that
+/// completes well within one interval never reaches a check of its own, so a counter that starts
+/// at zero for every value leaves a long run of small values unable to check at all.
+///
 /// `dst` also holds the conversion's intermediate state: it must have room for
 /// `2 * src_length + 1` bytes to encode and `src_length` bytes to decode.
-size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation = {});
-std::optional<size_t> decodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation = {});
+size_t encodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation = {}, size_t * shared_work_since_check = nullptr);
+std::optional<size_t> decodeBase58(const UInt8 * src, size_t src_length, UInt8 * dst, const std::function<void()> & check_cancellation = {}, size_t * shared_work_since_check = nullptr);
 
 /// Maximum base58-encoded lengths for fixed-size inputs.
 /// A 32-byte value uses 9 intermediate digits of radix 58^5, producing at most

--- a/src/Common/Base58.h
+++ b/src/Common/Base58.h
@@ -14,10 +14,9 @@ namespace DB
 /// time, so they accept an optional `check_cancellation` callback that is invoked periodically;
 /// it is expected to throw if the query has been cancelled or exceeded its time limit.
 ///
-/// The work done since the last callback is counted in `shared_work_since_check` when the caller
-/// passes one, so that a caller converting many values checks on their combined work. A value that
-/// completes well within one interval never reaches a check of its own, so a counter that starts
-/// at zero for every value leaves a long run of small values unable to check at all.
+/// A caller converting many values can pass `shared_work_since_check` to have the work counted
+/// across them: a value that completes well within one interval reaches no check of its own, so a
+/// count that restarts at every value leaves a long run of small values uninterruptible.
 ///
 /// `dst` also holds the conversion's intermediate state: it must have room for
 /// `2 * src_length + 1` bytes to encode and `src_length` bytes to decode.

--- a/src/Common/tests/gtest_base58.cpp
+++ b/src/Common/tests/gtest_base58.cpp
@@ -466,6 +466,63 @@ TEST(Base58, GenericCancellationInterval)
         Cancelled);
 }
 
+/// A value that completes well within one check interval reaches no check of its own, so the count has to
+/// survive the value for a run of such values to be interruptible at all. The counts are integer functions
+/// of the exact inputs, so they are asserted exactly.
+TEST(Base58, GenericCancellationCountAcrossValues)
+{
+    /// 1025 bytes converts in about 0.68 of the work between two checks, so eight of them are worth five.
+    constexpr size_t values = 8;
+    constexpr size_t expected_encode_calls = 5;
+    constexpr size_t expected_decode_calls = 5;
+    constexpr size_t expected_rejected_decode_calls = 5;
+
+    const std::string body = bodyOfLength(1025, 0);
+    const auto * body_src = reinterpret_cast<const UInt8 *>(body.data());
+    std::vector<UInt8> encoded(2 * body.size() + 1);
+
+    /// A count of its own dies with the value, so repeating the conversion never reaches a check. This is
+    /// what makes the counts below a property of the shared count rather than of the interval's size.
+    size_t own_encode_calls = 0;
+    size_t encoded_size = 0;
+    for (size_t i = 0; i < values; ++i)
+        encoded_size = encodeBase58(body_src, body.size(), encoded.data(), [&] { ++own_encode_calls; });
+    EXPECT_EQ(own_encode_calls, 0u);
+
+    size_t encode_work = 0;
+    size_t encode_calls = 0;
+    for (size_t i = 0; i < values; ++i)
+        encodeBase58(body_src, body.size(), encoded.data(), [&] { ++encode_calls; }, &encode_work);
+    EXPECT_EQ(encode_calls, expected_encode_calls);
+
+    const std::string encoded_text(reinterpret_cast<const char *>(encoded.data()), encoded_size);
+    const auto * text_src = reinterpret_cast<const UInt8 *>(encoded_text.data());
+    std::vector<UInt8> decoded(encoded_text.size());
+
+    size_t own_decode_calls = 0;
+    for (size_t i = 0; i < values; ++i)
+        decodeBase58(text_src, encoded_text.size(), decoded.data(), [&] { ++own_decode_calls; });
+    EXPECT_EQ(own_decode_calls, 0u);
+
+    size_t decode_work = 0;
+    size_t decode_calls = 0;
+    for (size_t i = 0; i < values; ++i)
+        decodeBase58(text_src, encoded_text.size(), decoded.data(), [&] { ++decode_calls; }, &decode_work);
+    EXPECT_EQ(decode_calls, expected_decode_calls);
+
+    /// A value rejected at its last character has still done the work, and a block of such values is only
+    /// interruptible if that work is charged.
+    std::string rejected = encoded_text;
+    rejected.back() = '0';
+    size_t rejected_work = 0;
+    size_t rejected_calls = 0;
+    for (size_t i = 0; i < values; ++i)
+        EXPECT_FALSE(decodeBase58(reinterpret_cast<const UInt8 *>(rejected.data()), rejected.size(),
+                                  decoded.data(), [&] { ++rejected_calls; }, &rejected_work)
+                         .has_value());
+    EXPECT_EQ(rejected_calls, expected_rejected_decode_calls);
+}
+
 TEST(Base58, DecodeInvalid)
 {
     /// The generic decoder must reject an invalid character wherever it appears, including inside the

--- a/src/Functions/FunctionBase32Conversion.h
+++ b/src/Functions/FunctionBase32Conversion.h
@@ -23,7 +23,7 @@ struct Base32EncodeTraits
     }
 
     /// Base32 conversion is linear in the input length, so the cancellation callback is unused.
-    static size_t perform(std::string_view src, UInt8 * dst, const std::function<void()> & = {})
+    static size_t perform(std::string_view src, UInt8 * dst, const std::function<void()> &, size_t &)
     {
         return encodeBase32(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst);
     }
@@ -44,7 +44,7 @@ struct Base32DecodeTraits
     }
 
     /// Base32 conversion is linear in the input length, so the cancellation callback is unused.
-    static std::optional<size_t> perform(std::string_view src, UInt8 * dst, const std::function<void()> & = {})
+    static std::optional<size_t> perform(std::string_view src, UInt8 * dst, const std::function<void()> &, size_t &)
     {
         return decodeBase32(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst);
     }

--- a/src/Functions/FunctionBase58Conversion.h
+++ b/src/Functions/FunctionBase58Conversion.h
@@ -34,14 +34,14 @@ struct Base58EncodeTraits
         return static_cast<size_t>(ceil(oversize * src_length + 1));
     }
 
-    static size_t perform(std::string_view src, UInt8 * dst, const std::function<void()> & check_cancellation = {})
+    static size_t perform(std::string_view src, UInt8 * dst, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
         if (src.size() == 32)
             return encodeBase58_32(reinterpret_cast<const UInt8 *>(src.data()), dst);
         else if (src.size() == 64)
             return encodeBase58_64(reinterpret_cast<const UInt8 *>(src.data()), dst);
         else
-            return encodeBase58(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst, check_cancellation);
+            return encodeBase58(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst, check_cancellation, &work_since_check);
     }
 };
 
@@ -63,14 +63,14 @@ struct Base58DecodeTraits
         return src_column.getChars().size();
     }
 
-    static std::optional<size_t> perform(std::string_view src, UInt8 * dst, const std::function<void()> & check_cancellation = {})
+    static std::optional<size_t> perform(std::string_view src, UInt8 * dst, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
-        return decodeBase58(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst, check_cancellation);
+        return decodeBase58(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst, check_cancellation, &work_since_check);
     }
 
     /// The size argument is a requirement on the decoded size at every value, not only at the two the
     /// removed fixed-size decoders served. Zero means no requirement and never reaches this function.
-    static std::optional<size_t> performWithSizeHint(std::string_view src, UInt8 * dst, size_t expected_size, const std::function<void()> & check_cancellation = {})
+    static std::optional<size_t> performWithSizeHint(std::string_view src, UInt8 * dst, size_t expected_size, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
         /// An `n`-byte value encodes to between `n` and `maxBase58EncodedLength(n)` characters, so an input
         /// outside that window cannot decode to `expected_size` and is rejected without paying the quadratic
@@ -80,7 +80,7 @@ struct Base58DecodeTraits
             return {};
 
         const std::optional<size_t> decoded_size
-            = decodeBase58(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst, check_cancellation);
+            = decodeBase58(reinterpret_cast<const UInt8 *>(src.data()), src.size(), dst, check_cancellation, &work_since_check);
         if (decoded_size && *decoded_size != expected_size)
             return {};
         return decoded_size;

--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -38,7 +38,7 @@ struct Base64EncodeTraits
     }
 
     /// Base64 conversion is linear in the input length, so the cancellation callback is unused.
-    static size_t perform(std::string_view src, UInt8 * dst, const std::function<void()> & = {})
+    static size_t perform(std::string_view src, UInt8 * dst, const std::function<void()> &, size_t &)
     {
         /// simdutf emits the base64url alphabet ('-' and '_') without padding for the URL variant directly.
         constexpr auto options = (variant == Base64Variant::URL) ? simdutf::base64_url : simdutf::base64_default;
@@ -68,7 +68,7 @@ struct Base64DecodeTraits
     }
 
     /// Base64 conversion is linear in the input length, so the cancellation callback is unused.
-    static std::optional<size_t> perform(std::string_view src, UInt8 * dst, const std::function<void()> & = {})
+    static std::optional<size_t> perform(std::string_view src, UInt8 * dst, const std::function<void()> &, size_t &)
     {
         /// The URL variant decodes the standard/base64url hybrid alphabet: the previous implementation only
         /// translated '-' and '_' before decoding and left '+' and '/' untouched, so it accepted both alphabets

--- a/src/Functions/FunctionBaseXXConversion.h
+++ b/src/Functions/FunctionBaseXXConversion.h
@@ -41,7 +41,7 @@ struct BaseXXEncode
     static constexpr size_t default_max_input_size = Traits::max_input_size;
 
     template <bool /* with_size_optimization */>
-    static void processString(const ColumnString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t, size_t max_input_size, const std::function<void()> & check_cancellation)
+    static void processString(const ColumnString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t, size_t max_input_size, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
         const ColumnString::Offsets & src_offsets = src_column.getOffsets();
 
@@ -81,7 +81,7 @@ struct BaseXXEncode
         {
             size_t current_src_offset = src_offsets[row];
             size_t src_length = current_src_offset - prev_src_offset;
-            size_t encoded_size = Traits::perform({&src[prev_src_offset], src_length}, &dst[current_dst_offset], check_cancellation);
+            size_t encoded_size = Traits::perform({&src[prev_src_offset], src_length}, &dst[current_dst_offset], check_cancellation, work_since_check);
             prev_src_offset = current_src_offset;
             current_dst_offset += encoded_size;
             dst_offsets[row] = current_dst_offset;
@@ -91,7 +91,7 @@ struct BaseXXEncode
     }
 
     template <bool /* with_size_optimization */>
-    static void processFixedString(const ColumnFixedString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t, size_t max_input_size, const std::function<void()> & check_cancellation)
+    static void processFixedString(const ColumnFixedString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t, size_t max_input_size, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
         size_t const N = src_column.getN();
 
@@ -117,7 +117,7 @@ struct BaseXXEncode
 
         for (size_t row = 0; row < input_rows_count; ++row)
         {
-            size_t encoded_size = Traits::perform({&src[row * N], N}, &dst[current_dst_offset], check_cancellation);
+            size_t encoded_size = Traits::perform({&src[row * N], N}, &dst[current_dst_offset], check_cancellation, work_since_check);
             current_dst_offset += encoded_size;
             dst_offsets[row] = current_dst_offset;
         }
@@ -142,7 +142,7 @@ struct BaseXXDecode
     static constexpr size_t default_max_input_size = Traits::max_input_size;
 
     template <bool with_size_optimization>
-    static void processString(const ColumnString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t expected_size, size_t max_input_size, const std::function<void()> & check_cancellation)
+    static void processString(const ColumnString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t expected_size, size_t max_input_size, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
         const ColumnString::Offsets & src_offsets = src_column.getOffsets();
 
@@ -210,8 +210,8 @@ struct BaseXXDecode
             }
             std::optional<size_t> decoded_size = [&]{
                 if constexpr (with_size_optimization)
-                    return Traits::performWithSizeHint({&src[prev_src_offset], src_length}, &dst[current_dst_offset], expected_size, check_cancellation);
-                return Traits::perform({&src[prev_src_offset], src_length}, &dst[current_dst_offset], check_cancellation);
+                    return Traits::performWithSizeHint({&src[prev_src_offset], src_length}, &dst[current_dst_offset], expected_size, check_cancellation, work_since_check);
+                return Traits::perform({&src[prev_src_offset], src_length}, &dst[current_dst_offset], check_cancellation, work_since_check);
             }();
             if (!decoded_size)
             {
@@ -234,7 +234,7 @@ struct BaseXXDecode
     }
 
     template <bool with_size_optimization>
-    static void processFixedString(const ColumnFixedString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t expected_size, size_t max_input_size, const std::function<void()> & check_cancellation)
+    static void processFixedString(const ColumnFixedString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count, size_t expected_size, size_t max_input_size, const std::function<void()> & check_cancellation, size_t & work_since_check)
     {
         auto & dst_data = dst_column->getChars();
         auto & dst_offsets = dst_column->getOffsets();
@@ -274,8 +274,8 @@ struct BaseXXDecode
         {
             std::optional<size_t> decoded_size = [&]{
                 if constexpr (with_size_optimization)
-                    return Traits::performWithSizeHint({&src[row * N], N}, &dst[current_dst_offset], expected_size, check_cancellation);
-                return Traits::perform({&src[row * N], N}, &dst[current_dst_offset], check_cancellation);
+                    return Traits::performWithSizeHint({&src[row * N], N}, &dst[current_dst_offset], expected_size, check_cancellation, work_since_check);
+                return Traits::perform({&src[row * N], N}, &dst[current_dst_offset], check_cancellation, work_since_check);
             }();
             if (!decoded_size)
             {
@@ -369,6 +369,10 @@ public:
                     throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded: elapsed time limit reached in function {}", name);
             };
 
+        /// One count for the whole block: it spans every value converted below, so values individually
+        /// too small to reach a check still add up to one.
+        size_t work_since_check = 0;
+
         size_t expected_size = 0;
         if constexpr (has_size_optimization)
         {
@@ -388,13 +392,13 @@ public:
             if constexpr (has_size_optimization)
             {
                 if (expected_size > 0)
-                    Func::template processString<true>(*col_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation);
+                    Func::template processString<true>(*col_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation, work_since_check);
                 else
-                    Func::template processString<false>(*col_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation);
+                    Func::template processString<false>(*col_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation, work_since_check);
             }
             else
             {
-                Func::template processString<false>(*col_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation);
+                Func::template processString<false>(*col_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation, work_since_check);
             }
             return col_res;
         }
@@ -404,13 +408,13 @@ public:
             if constexpr (has_size_optimization)
             {
                 if (expected_size > 0)
-                    Func::template processFixedString<true>(*col_fixed_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation);
+                    Func::template processFixedString<true>(*col_fixed_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation, work_since_check);
                 else
-                    Func::template processFixedString<false>(*col_fixed_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation);
+                    Func::template processFixedString<false>(*col_fixed_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation, work_since_check);
             }
             else
             {
-                Func::template processFixedString<false>(*col_fixed_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation);
+                Func::template processFixedString<false>(*col_fixed_string, col_res, input_rows_count, expected_size, max_input_size, check_cancellation, work_since_check);
             }
             return col_res;
         }

--- a/src/Functions/tests/gtest_base58_row_loop.cpp
+++ b/src/Functions/tests/gtest_base58_row_loop.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnString.h>
+#include <Functions/FunctionBase58Conversion.h>
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+using namespace DB;
+
+namespace
+{
+
+/// The function names live in anonymous namespaces in base58Encode.cpp and base58Decode.cpp, so the row
+/// loops are instantiated here with local equivalents.
+struct NameBase58Encode
+{
+    static constexpr auto name = "base58Encode";
+};
+
+struct NameBase58Decode
+{
+    static constexpr auto name = "base58Decode";
+};
+
+using Base58EncodeRowLoop = BaseXXEncode<Base58EncodeTraits, NameBase58Encode>;
+using Base58DecodeRowLoop = BaseXXDecode<Base58DecodeTraits, NameBase58Decode, BaseXXDecodeErrorHandling::ThrowException>;
+
+/// The same body gtest_base58.cpp converts, so the counts below are comparable with the ones asserted
+/// there. A non-zero first byte keeps the whole value on the generic path.
+std::string bodyOfLength(size_t length)
+{
+    std::string body(length, '\0');
+    for (size_t i = 0; i < length; ++i)
+        body[i] = static_cast<char>(i == 0 ? 1 : (i * 137 + 29) % 256);
+    return body;
+}
+
+}
+
+/// The count spans the block's rows, so values individually too small to reach a check of their own still
+/// add up to one. The counts are integer functions of the exact input, so they are asserted exactly.
+TEST(Base58RowLoop, CancellationCountAcrossRows)
+{
+    /// 1025 bytes converts in about 0.68 of the work between two checks, so eight rows are worth five.
+    constexpr size_t rows = 8;
+    constexpr size_t length = 1025;
+    constexpr size_t expected_encode_calls = 5;
+    constexpr size_t expected_decode_calls = 5;
+
+    const std::string body = bodyOfLength(length);
+
+    auto src_fixed = ColumnFixedString::create(length);
+    for (size_t row = 0; row < rows; ++row)
+        src_fixed->insertData(body.data(), body.size());
+
+    ColumnString::MutablePtr encoded = ColumnString::create();
+    size_t encode_work = 0;
+    size_t encode_calls = 0;
+    Base58EncodeRowLoop::processFixedString<false>(
+        *src_fixed, encoded, rows, 0, Base58EncodeTraits::max_input_size, [&] { ++encode_calls; }, encode_work);
+    ASSERT_EQ(encoded->size(), rows);
+    EXPECT_EQ(encode_calls, expected_encode_calls);
+
+    const std::string encoded_text(encoded->getDataAt(0));
+
+    auto src_string = ColumnString::create();
+    for (size_t row = 0; row < rows; ++row)
+        src_string->insertData(encoded_text.data(), encoded_text.size());
+
+    ColumnString::MutablePtr decoded = ColumnString::create();
+    size_t decode_work = 0;
+    size_t decode_calls = 0;
+    Base58DecodeRowLoop::processString<false>(
+        *src_string, decoded, rows, 0, Base58DecodeTraits::max_input_size, [&] { ++decode_calls; }, decode_work);
+    ASSERT_EQ(decoded->size(), rows);
+    ASSERT_EQ(decoded->getDataAt(rows - 1), std::string_view(body));
+    EXPECT_EQ(decode_calls, expected_decode_calls);
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `max_execution_time` and `KILL QUERY` being ignored while `base58Encode` or `base58Decode` converts a block of values that are each too small to reach the cancellation checkpoint. One 1025-byte conversion accumulates about 70% of the work between two checks, so a block of 65,536 of them ran uninterrupted for minutes. `base58Encode` of exactly 32 or 64 bytes uses a fixed-size encoder and is unchanged.

### Description

Requested by @ alexey-milovidov in https://github.com/ClickHouse/ClickHouse/pull/118222#issuecomment-5625770598. His [report](https://s3.amazonaws.com/clickhouse-test-reports/PRs/118222/b385904c816bd0bc648596467c02df87716616cb/pr/stress_test_amd_tsan/hung_check.log): an AST fuzzer mutation of `04027_base58_optimized.sql` over 1025-byte values, `is_cancelled: 1`, `elapsed: 762 s`.

**Root cause.** `work_since_check` in `encodeBase58` and `decodeBase58` was call-local, so the budget restarted at every value. Encoding `n` bytes costs `0.683 * n^2` units against `work_per_check = 1 << 20`, so the first checkpoint arrives near 1239 bytes: a 1025-byte value gets zero checks and the count dies with it, leaving that 65,509-row block uninterruptible. `function_base58_max_input_size` bounds one value, never the block, and 1025 bytes is well inside its 10 KB default.

**The change.** Both conversions take a defaulted `size_t * shared_work_since_check`, bound as a reference so every exit path stays charged. `FunctionBaseXXConversion::executeImpl` owns one counter and threads it through its four row loops. Callback, interval and per-value cadence are unchanged: `GenericCancellationInterval` still reports exactly 63 calls.

**Validation.** Debug, 65536 rows, server elapsed, 50 ms deadline: encode 2097.1 ms to 50.6 ms, decode 509.9 ms to 50.5 ms. Two unit tests: eight sub-threshold values reach 0 checks with a per-call count and 5 with a shared one (encode, decode, and values rejected at their last character), and the two row loops, driven directly, make the same 5, or 0 if a row gets its own count. Only `executeImpl`'s own counter rests on those numbers. `tests/performance/base58.xml` is unchanged.

**Disclosed, not fixed here.** `base58Encode` of exactly 32 or 64 bytes takes a fixed-size encoder with no checkpoint, so such a block keeps ordinary per-block granularity: 10M rows notice a deadline 0.6 s (32 B) or 1.8 s (64 B) late on debug, and `SHA256` 2.1 s late on the same block. With `function_base58_max_input_size = 0`, an all-zero or all-`'1'` value of hundreds of megabytes runs an O(n) prologue with no checkpoint. Both are absent checks, not wrong-lifetime counts.

Related: https://github.com/ClickHouse/ClickHouse/issues/112203

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119388&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119388](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119388+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
