### PR TITLE
Fix `read_rows` reported as zero when a read step materializes no column from the part

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -1224,11 +1224,14 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
         result.adjustLastGranule();
 
     fillVirtualColumns(result.columns, result);
-    /// When no columns were physically read (e.g., constant PREWHERE expression),
-    /// numReadRows() is 0 but total_rows_per_granule has the correct row count
-    /// from the index granularity. Use it so the reading chain can continue
-    /// to subsequent readers that read actual data columns.
-    result.num_rows = result.numReadRows() > 0 ? result.numReadRows() : result.total_rows_per_granule;
+
+    /// A step that materializes no on-disk column (constant PREWHERE, or a filter over a column
+    /// absent from the part) reports no rows read, though the granule sizes taken from the index
+    /// are correct and those rows flow on through the chain. Only this front step accumulates it.
+    if (result.numReadRows() == 0)
+        result.addRows(result.total_rows_per_granule);
+
+    result.num_rows = result.numReadRows();
 
     updatePerformanceCounters(result.numReadRows());
 

--- a/src/Storages/MergeTree/MergeTreeRangeReader.h
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.h
@@ -405,7 +405,8 @@ public:
         GranuleOffsets granule_offsets;
         /// Sum(rows_per_granule)
         size_t total_rows_per_granule = 0;
-        /// The number of rows was read at first step. May be zero if no read columns present in part.
+        /// The number of rows read at the first step. A step that materializes no on-disk column
+        /// contributes its granule-derived row count, so this is zero only when no granule was read.
         size_t num_read_rows = 0;
 
         /// Diagnostic counters for debugging adjustLastGranule assertions.

--- a/tests/queries/0_stateless/05175_lwu_delete_read_rows_wide_part.reference
+++ b/tests/queries/0_stateless/05175_lwu_delete_read_rows_wide_part.reference
@@ -1,0 +1,22 @@
+part types	t_lwu_rr_compact	['Compact']
+part types	t_lwu_rr_nonadaptive	['Wide']
+part types	t_lwu_rr_v2	['Wide']
+part types	t_lwu_rr_wide	['Wide']
+rows left	t_lwu_rr_wide	995	0
+rows left	t_lwu_rr_compact	995	0
+rows left	t_lwu_rr_v2	995	0
+rows left	t_lwu_rr_nonadaptive	995	0
+scan sum	t_lwu_rr_wide	498840
+scan sum	t_lwu_rr_compact	498840
+scan sum	t_lwu_rr_v2	498840
+scan sum	t_lwu_rr_nonadaptive	498840
+delete read_rows	t_lwu_rr_compact	2
+delete read_rows	t_lwu_rr_compact	8
+delete read_rows	t_lwu_rr_nonadaptive	64
+delete read_rows	t_lwu_rr_nonadaptive	128
+delete read_rows	t_lwu_rr_v2	2
+delete read_rows	t_lwu_rr_v2	8
+delete read_rows	t_lwu_rr_wide	2
+delete read_rows	t_lwu_rr_wide	8
+scan read_rows	4	1	1
+nonadaptive scan read_rows	1000

--- a/tests/queries/0_stateless/05175_lwu_delete_read_rows_wide_part.sql
+++ b/tests/queries/0_stateless/05175_lwu_delete_read_rows_wide_part.sql
@@ -3,6 +3,9 @@
 
 SET enable_lightweight_update = 1;
 SET lightweight_delete_mode = 'lightweight_update_force';
+-- Splitting a read range by primary key makes both layers read the granule that holds the split
+-- boundary, so its rows are counted twice in every exact read_rows assertion below.
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
 
 DROP TABLE IF EXISTS t_lwu_rr_wide SYNC;
 DROP TABLE IF EXISTS t_lwu_rr_compact SYNC;

--- a/tests/queries/0_stateless/05175_lwu_delete_read_rows_wide_part.sql
+++ b/tests/queries/0_stateless/05175_lwu_delete_read_rows_wide_part.sql
@@ -1,0 +1,96 @@
+-- Tags: no-replicated-database
+-- no-replicated-database: read_rows in query_log differs because of replicated database.
+
+SET enable_lightweight_update = 1;
+SET lightweight_delete_mode = 'lightweight_update_force';
+
+DROP TABLE IF EXISTS t_lwu_rr_wide SYNC;
+DROP TABLE IF EXISTS t_lwu_rr_compact SYNC;
+DROP TABLE IF EXISTS t_lwu_rr_v2 SYNC;
+DROP TABLE IF EXISTS t_lwu_rr_nonadaptive SYNC;
+
+-- Once a patch part exists, every read of the table starts with a lightweight-delete step that
+-- requests only _row_exists, which has no file in the part. With patch_parts_version = 'v1' that
+-- step is completed with virtual columns only, so on a Wide part it materializes nothing from disk.
+-- add_minmax_index_for_numeric_columns = 0 keeps the expected read_rows exact.
+CREATE TABLE t_lwu_rr_wide (id UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 1, enable_block_number_column = 1, enable_block_offset_column = 1,
+    add_minmax_index_for_numeric_columns = 0, min_bytes_for_wide_part = 0, patch_parts_version = 'v1';
+
+-- Control: same patch mode over a Compact part, whose reader returns the granularity-derived count.
+CREATE TABLE t_lwu_rr_compact (id UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 1, enable_block_number_column = 1, enable_block_offset_column = 1,
+    add_minmax_index_for_numeric_columns = 0, min_bytes_for_wide_part = 1000000000, patch_parts_version = 'v1';
+
+-- Control: Wide part again, but patch_parts_version = 'v2' adds the physical sorting key to the step.
+CREATE TABLE t_lwu_rr_v2 (id UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 1, enable_block_number_column = 1, enable_block_offset_column = 1,
+    add_minmax_index_for_numeric_columns = 0, min_bytes_for_wide_part = 0, patch_parts_version = 'v2';
+
+-- The same Wide/v1 combination with non-adaptive marks (index_granularity_bytes = 0, which only a
+-- Wide part can have) and a partial final granule: 1000 rows at granularity 64 leave a 40-row tail.
+CREATE TABLE t_lwu_rr_nonadaptive (id UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 64, index_granularity_bytes = 0, min_bytes_for_wide_part = 0,
+    min_bytes_for_full_part_storage = 0, enable_block_number_column = 1,
+    enable_block_offset_column = 1, add_minmax_index_for_numeric_columns = 0,
+    patch_parts_version = 'v1';
+
+INSERT INTO t_lwu_rr_wide SELECT * FROM numbers(1000);
+INSERT INTO t_lwu_rr_compact SELECT * FROM numbers(1000);
+INSERT INTO t_lwu_rr_v2 SELECT * FROM numbers(1000);
+INSERT INTO t_lwu_rr_nonadaptive SELECT * FROM numbers(1000);
+
+DELETE FROM t_lwu_rr_wide WHERE id = 200;
+DELETE FROM t_lwu_rr_wide WHERE id IN (100, 110, 120, 130);
+
+DELETE FROM t_lwu_rr_compact WHERE id = 200;
+DELETE FROM t_lwu_rr_compact WHERE id IN (100, 110, 120, 130);
+
+DELETE FROM t_lwu_rr_v2 WHERE id = 200;
+DELETE FROM t_lwu_rr_v2 WHERE id IN (100, 110, 120, 130);
+
+DELETE FROM t_lwu_rr_nonadaptive WHERE id = 200;
+DELETE FROM t_lwu_rr_nonadaptive WHERE id IN (100, 110, 120, 130);
+
+SELECT 'part types', table, arraySort(arrayDistinct(groupArray(part_type))) FROM system.parts
+WHERE database = currentDatabase() AND table LIKE 't\_lwu\_rr\_%' AND active
+GROUP BY table ORDER BY table;
+
+SELECT 'rows left', 't_lwu_rr_wide', count(), countIf(id IN (100, 110, 120, 130, 200)) FROM t_lwu_rr_wide;
+SELECT 'rows left', 't_lwu_rr_compact', count(), countIf(id IN (100, 110, 120, 130, 200)) FROM t_lwu_rr_compact;
+SELECT 'rows left', 't_lwu_rr_v2', count(), countIf(id IN (100, 110, 120, 130, 200)) FROM t_lwu_rr_v2;
+SELECT 'rows left', 't_lwu_rr_nonadaptive', count(), countIf(id IN (100, 110, 120, 130, 200)) FROM t_lwu_rr_nonadaptive;
+
+-- A plain scan of the patched table is accounted through the same step, so it must report the rows
+-- of the part it read, not zero.
+SELECT 'scan sum', 't_lwu_rr_wide', sum(id) FROM t_lwu_rr_wide SETTINGS log_comment = 'lwu_rr_scan_1_wide';
+SELECT 'scan sum', 't_lwu_rr_compact', sum(id) FROM t_lwu_rr_compact SETTINGS log_comment = 'lwu_rr_scan_2_compact';
+SELECT 'scan sum', 't_lwu_rr_v2', sum(id) FROM t_lwu_rr_v2 SETTINGS log_comment = 'lwu_rr_scan_3_v2';
+SELECT 'scan sum', 't_lwu_rr_nonadaptive', sum(id) FROM t_lwu_rr_nonadaptive SETTINGS log_comment = 'lwu_rr_scan_4_nonadaptive';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT 'delete read_rows', extract(query, 'DELETE FROM (\\w+)') AS name, read_rows FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND is_initial_query
+    AND current_database = currentDatabase() AND query LIKE 'DELETE FROM t\_lwu\_rr\_%'
+ORDER BY name, event_time_microseconds;
+
+-- The four scans read the same rows, so they must report the same non-zero count. This is asserted
+-- against the v2 arm, which reads the physical sorting key, rather than against a literal: the DELETE
+-- counts above are flavour-stable and pinned exactly, a full-scan count has no such precedent.
+SELECT 'scan read_rows', count() AS scans, uniqExact(read_rows) AS distinct_counts,
+    min(read_rows) > 0 AS all_non_zero
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND is_initial_query
+    AND current_database = currentDatabase() AND log_comment LIKE 'lwu\_rr\_scan\_%';
+
+-- The tail arm is pinned to the row count of the INSERT instead: a non-adaptive part's last mark is
+-- padded to a full granule until the part's row count corrects it, which would report 1024 here.
+SELECT 'nonadaptive scan read_rows', read_rows FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND is_initial_query
+    AND current_database = currentDatabase() AND log_comment = 'lwu_rr_scan_4_nonadaptive';
+
+DROP TABLE t_lwu_rr_wide SYNC;
+DROP TABLE t_lwu_rr_compact SYNC;
+DROP TABLE t_lwu_rr_v2 SYNC;
+DROP TABLE t_lwu_rr_nonadaptive SYNC;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/114562

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog: the defect was introduced on master by #114562 and has never shipped in a release, so no released version is affected.

### Description

Any read of a MergeTree part with a pending lightweight update reports `read_rows = 0` when the part is Wide and `patch_parts_version = 'v1'`. The rows are read and the results are correct; the accounting is lost: `system.query_log.read_rows`, query progress, the `SelectedRows` profile events and `read_rows`-derived limits such as `max_rows_to_read`. Measured on `592da49d0a3b6`, plain `MergeTree`, no randomization:

| query | master | this PR |
|---|---|---|
| `DELETE FROM t WHERE id IN (100, 110, 120, 130)` | 0 | 8 |
| `SELECT sum(id) FROM t` | 0 | 1000 |
| `SELECT count() FROM t WHERE id = 500` | 0 | 2 |

Origin: #114562. It removed the minimum-size carrier column from `injectRequiredColumns`, on the premise that a read of no columns still reports the right row count from the index granularity. That premise holds for `ReadResult::num_rows` and fails for `ReadResult::numReadRows()`, the exported counter. `03100_lwu_deletes_4_index` went red on master 23 minutes after that merge, in 5 of the 13 master runs of `592da49d0a3b6` and across four build flavours, against 0 of 12 on its predecessor `bf549ba1b4fe0` and 0 of 7120 over the preceding 20 days.

The fix accounts for the granule-derived rows in `MergeTreeRangeReader::startReadingChain`, after `adjustLastGranule()`, where `num_rows` is already normalized. `continueReadingChain` has always normalized its own count the same way, so this only makes the front step of a readers chain consistent with every later step. Only the front step accumulates the exported counter, so it cannot double count.

The new test fails on `592da49d0a3b6` and passes with the fix, and runs clean 50/50 with and without settings randomization. In a patch mode x part type x granularity matrix measured on both binaries, the fix repairs every zero-reporting cell, including non-adaptive Wide and a partial final granule, and leaves the rest byte-identical.

Master CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=592da49d0a3b6d3408bf646e71d73aec8ac246ee&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119400&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119400](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119400+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1247` (included in `26.9` and later)
<!-- ch-version-info:end -->