### PR TITLE
Fix distributed planning calling selectRangesToRead() multiple times

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
+++ b/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
@@ -790,7 +790,7 @@ void tryMakeDistributedRead(QueryPlan::Node & node, QueryPlan::Nodes & nodes, co
     {
         /// Check if table is big enough for distributed read
         /// TODO: implement better logic for choosing number of parallel readers
-        auto analysis_result = read_from_merge_tree_step->selectRangesToRead();
+        auto analysis_result = read_from_merge_tree_step->getOrCreateAnalyzedResult();
         if (analysis_result && analysis_result->selected_rows <= optimization_settings.distributed_plan_max_rows_to_broadcast)
             return;
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -6220,7 +6220,7 @@ size_t ReadFromMergeTree::setupDistributedReadBuckets(size_t target_buckets, siz
     /// below) so a deduplication group stays within one bucket.
     if (!isQueryWithFinal() || data.merging_params.mode == MergeTreeData::MergingParams::Ordinary)
     {
-        auto analysis = selectRangesToRead();
+        auto analysis = getOrCreateAnalyzedResult();
         if (!analysis || analysis->parts_with_ranges.empty())
         {
             LOG_TRACE(log, "Distributed read not bucketed: nothing to read");
@@ -6274,7 +6274,7 @@ size_t ReadFromMergeTree::setupDistributedReadBuckets(size_t target_buckets, siz
         return 0;
     }
 
-    auto analysis = selectRangesToRead();
+    auto analysis = getOrCreateAnalyzedResult();
     if (!analysis || analysis->parts_with_ranges.empty())
     {
         LOG_TRACE(log, "Distributed read not bucketed: nothing to read");
@@ -6428,7 +6428,7 @@ Strings ReadFromMergeTree::getShardsForDistributedRead() const
     if (distributed_read_bucket_count == 0)
         return default_shard_list;
 
-    auto analysis_result = selectRangesToRead();
+    auto analysis_result = getOrCreateAnalyzedResult();
     if (!analysis_result)
         return default_shard_list;
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -392,6 +392,7 @@ public:
     AnalysisResultPtr getAnalyzedResult() const { return analyzed_result_ptr; }
     void setAnalyzedResult(AnalysisResultPtr analyzed_result_ptr_) { analyzed_result_ptr = std::move(analyzed_result_ptr_); }
 
+    /// selectRangesToRead() will always re-analyze
     AnalysisResultPtr getOrCreateAnalyzedResult() const { return analyzed_result_ptr ? analyzed_result_ptr : selectRangesToRead(); }
 
     const RangesInDataParts & getParts() const { return analyzed_result_ptr ? analyzed_result_ptr->parts_with_ranges : *prepared_parts; }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -392,6 +392,8 @@ public:
     AnalysisResultPtr getAnalyzedResult() const { return analyzed_result_ptr; }
     void setAnalyzedResult(AnalysisResultPtr analyzed_result_ptr_) { analyzed_result_ptr = std::move(analyzed_result_ptr_); }
 
+    AnalysisResultPtr getOrCreateAnalyzedResult() const { return analyzed_result_ptr ? analyzed_result_ptr : selectRangesToRead(); }
+
     const RangesInDataParts & getParts() const { return analyzed_result_ptr ? analyzed_result_ptr->parts_with_ranges : *prepared_parts; }
     MergeTreeData::MutationsSnapshotPtr getMutationsSnapshot() const { return mutations_snapshot; }
 

--- a/tests/queries/0_stateless/05175_distributed_plan_index_analysis_once.sql
+++ b/tests/queries/0_stateless/05175_distributed_plan_index_analysis_once.sql
@@ -1,0 +1,49 @@
+-- Tags: no-old-analyzer, no-parallel-replicas
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+-- no-parallel-replicas: the assertion is about the analysis the coordinator does for a distributed plan.
+
+-- A distributed read used to analyze the index twice on the coordinator: `tryMakeDistributedRead`
+-- analyzed once to compare the selected rows against `distributed_plan_max_rows_to_broadcast`, and
+-- `setupDistributedReadBuckets` analyzed again to cut the read into mark buckets. The second analysis
+-- re-ran over the ranges the first one had already narrowed, so it returned the same answer while
+-- reading the indexes again - for a part on object storage, one blocking round trip per surviving mark
+-- range. The logs showed it as two `Filtering marks by primary and secondary keys` passes, the second
+-- one over the mark count the first one had selected.
+
+DROP TABLE IF EXISTS t_distributed_plan_index_analysis;
+
+CREATE TABLE t_distributed_plan_index_analysis (a UInt64, s String)
+ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1024, index_granularity_bytes = 0;
+
+INSERT INTO t_distributed_plan_index_analysis SELECT number, toString(number) FROM numbers(200000);
+
+-- Distributed aggregation rejects a nonzero limit (randomized setting).
+SET max_rows_to_group_by = 0;
+-- A cached verdict would prune granules before analysis and hide how many marks it processes.
+SET use_query_condition_cache = 0;
+
+SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0, distributed_plan_default_reader_bucket_count = 4;
+
+-- The filter must leave something behind, otherwise a second analysis would have nothing to process.
+SELECT count() FROM t_distributed_plan_index_analysis WHERE a < 100000
+SETTINGS log_comment = '05175_distributed_plan_index_analysis_once' FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- One pass over the index visits every mark of the table at most once. Analyzing twice processes the
+-- marks selected by the first pass on top of that, which exceeds the table's mark count.
+WITH (
+    SELECT sum(marks)
+    FROM system.parts
+    WHERE database = currentDatabase() AND table = 't_distributed_plan_index_analysis' AND active
+) AS total_marks
+SELECT throwIf(ProfileEvents['FilteringMarksWithPrimaryKeyProcessedMarks'] > total_marks)
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND log_comment = '05175_distributed_plan_index_analysis_once'
+  AND query LIKE '%count()%'
+  AND type = 'QueryFinish'
+FORMAT Null;
+
+DROP TABLE t_distributed_plan_index_analysis;

--- a/tests/queries/0_stateless/05175_distributed_plan_index_analysis_once.sql
+++ b/tests/queries/0_stateless/05175_distributed_plan_index_analysis_once.sql
@@ -2,32 +2,35 @@
 -- no-old-analyzer: make_distributed_plan requires the analyzer.
 -- no-parallel-replicas: the assertion is about the analysis the coordinator does for a distributed plan.
 
--- A distributed read used to analyze the index twice on the coordinator: `tryMakeDistributedRead`
--- analyzed once to compare the selected rows against `distributed_plan_max_rows_to_broadcast`, and
--- `setupDistributedReadBuckets` analyzed again to cut the read into mark buckets. The second analysis
--- re-ran over the ranges the first one had already narrowed, so it returned the same answer while
--- reading the indexes again - for a part on object storage, one blocking round trip per surviving mark
--- range. The logs showed it as two `Filtering marks by primary and secondary keys` passes, the second
--- one over the mark count the first one had selected.
+-- Planning a distributed read used to analyze the index three times on the coordinator, because
+-- `selectRangesToRead` re-analyzes on every call: once to compare the selected rows against
+-- `distributed_plan_max_rows_to_broadcast`, once in `setupDistributedReadBuckets` to cut the read into
+-- mark buckets, and once in `getShardsForDistributedRead`. Only the first pass did any work; the other
+-- two re-ran over the ranges it had already narrowed and returned the same answer, while reading the
+-- indexes again - for a part on object storage, one blocking round trip per surviving mark range. In
+-- the logs it looked like three `Filtering marks by primary and secondary keys` passes, the second and
+-- third over the mark count the first one had selected (196, then 98, then 98 granules here).
 
 DROP TABLE IF EXISTS t_distributed_plan_index_analysis;
 
 CREATE TABLE t_distributed_plan_index_analysis (a UInt64, s String)
-ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1024, index_granularity_bytes = 0;
+ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1024;
 
 INSERT INTO t_distributed_plan_index_analysis SELECT number, toString(number) FROM numbers(200000);
+-- One part, so a background merge cannot change the mark count the assertion compares against.
+OPTIMIZE TABLE t_distributed_plan_index_analysis FINAL;
 
--- Distributed aggregation rejects a nonzero limit (randomized setting).
-SET max_rows_to_group_by = 0;
--- A cached verdict would prune granules before analysis and hide how many marks it processes.
-SET use_query_condition_cache = 0;
-
-SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
-    distributed_plan_max_rows_to_broadcast = 0, distributed_plan_default_reader_bucket_count = 4;
-
+-- The settings stay on this query: reading `system.query_log` below cannot be distributed.
+-- `max_rows_to_group_by = 0`: distributed aggregation rejects a nonzero limit (randomized setting).
+-- `use_query_condition_cache = 0`: a cached verdict would prune granules before analysis and hide how
+-- many marks it processes.
 -- The filter must leave something behind, otherwise a second analysis would have nothing to process.
 SELECT count() FROM t_distributed_plan_index_analysis WHERE a < 100000
-SETTINGS log_comment = '05175_distributed_plan_index_analysis_once' FORMAT Null;
+SETTINGS make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0, distributed_plan_default_reader_bucket_count = 4,
+    max_rows_to_group_by = 0, use_query_condition_cache = 0,
+    log_comment = '05175_distributed_plan_index_analysis_once'
+FORMAT Null;
 
 SYSTEM FLUSH LOGS query_log;
 
@@ -38,7 +41,10 @@ WITH (
     FROM system.parts
     WHERE database = currentDatabase() AND table = 't_distributed_plan_index_analysis' AND active
 ) AS total_marks
-SELECT throwIf(ProfileEvents['FilteringMarksWithPrimaryKeyProcessedMarks'] > total_marks)
+SELECT
+    throwIf(count() = 0, 'the measured query is missing from query_log'),
+    throwIf(max(ProfileEvents['FilteringMarksWithPrimaryKeyProcessedMarks']) > total_marks,
+            'index analysis processed more marks than the table has, so it ran more than once')
 FROM system.query_log
 WHERE current_database = currentDatabase()
   AND log_comment = '05175_distributed_plan_index_analysis_once'

--- a/tests/queries/0_stateless/05175_distributed_plan_index_analysis_once.sql
+++ b/tests/queries/0_stateless/05175_distributed_plan_index_analysis_once.sql
@@ -2,14 +2,7 @@
 -- no-old-analyzer: make_distributed_plan requires the analyzer.
 -- no-parallel-replicas: the assertion is about the analysis the coordinator does for a distributed plan.
 
--- Planning a distributed read used to analyze the index three times on the coordinator, because
--- `selectRangesToRead` re-analyzes on every call: once to compare the selected rows against
--- `distributed_plan_max_rows_to_broadcast`, once in `setupDistributedReadBuckets` to cut the read into
--- mark buckets, and once in `getShardsForDistributedRead`. Only the first pass did any work; the other
--- two re-ran over the ranges it had already narrowed and returned the same answer, while reading the
--- indexes again - for a part on object storage, one blocking round trip per surviving mark range. In
--- the logs it looked like three `Filtering marks by primary and secondary keys` passes, the second and
--- third over the mark count the first one had selected (196, then 98, then 98 granules here).
+-- Test to snure that distributed query planning does not repeat index analysis twice or more
 
 DROP TABLE IF EXISTS t_distributed_plan_index_analysis;
 
@@ -20,10 +13,6 @@ INSERT INTO t_distributed_plan_index_analysis SELECT number, toString(number) FR
 -- One part, so a background merge cannot change the mark count the assertion compares against.
 OPTIMIZE TABLE t_distributed_plan_index_analysis FINAL;
 
--- The settings stay on this query: reading `system.query_log` below cannot be distributed.
--- `max_rows_to_group_by = 0`: distributed aggregation rejects a nonzero limit (randomized setting).
--- `use_query_condition_cache = 0`: a cached verdict would prune granules before analysis and hide how
--- many marks it processes.
 -- The filter must leave something behind, otherwise a second analysis would have nothing to process.
 SELECT count() FROM t_distributed_plan_index_analysis WHERE a < 100000
 SETTINGS make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/119399. The index analysis done first time by `tryMakeDistributedRead() `has to be used in all subsequent stages in the planning.

### Changelog category
- Not for Changelog

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119403&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119403](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119403+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1225` (included in `26.9` and later)
<!-- ch-version-info:end -->