### PR TITLE
Do not add serialize_query_plan to the upgrade check's randomized options

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -506,8 +506,10 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
         client_options.append("max_parallel_replicas=3")
         client_options.append("cluster_for_parallel_replicas='parallel_replicas'")
         client_options.append("parallel_replicas_for_non_replicated_merge_tree=1")
-        if random.random() < 1 / 2:
-            # Ship serialized query plans to the replicas instead of query text.
+        # Ship serialized query plans to the replicas instead of query text. The upgrade
+        # check's only test load runs against the previous release, so a failure on this
+        # path there cannot be fixed by any change to master.
+        if random.random() < 1 / 2 and not upgrade_check:
             client_options.append("serialize_query_plan=1")
 
     if random.random() < 0.2:


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/110518
Related: https://github.com/ClickHouse/ClickHouse/issues/118093
Related: https://github.com/ClickHouse/ClickHouse/issues/119372
Related: https://github.com/ClickHouse/ClickHouse/pull/116783


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The stress option generator no longer sends `serialize_query_plan=1` to the upgrade check's pre-upgrade load, whose server is a frozen previous release that aborts on that path.


### Description

`Upgrade check (amd_release)` runs on every PR and lost its server on ~18% of them today.
By distinct `commit_sha`: 0 of the 3454 shas running the check from 08-30 to 09-10
carry `Got read request from replica 0 for unknown stream ...`
(`ParallelReplicasReadingCoordinator.cpp:1316`), then 24 of 133 today to 08:00Z. The abort
kills the server, so the job reports "Server died" and loses its remaining assertions
([run](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119315&sha=323cbd6720165aa2ed51ebf7016dabfd36cd9075&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29)).

#116783, merged 2026-09-10 14:19Z, hours before the first affected run, added a nested
`serialize_query_plan=1` draw to the option generator's parallel-replicas arm without the
`not upgrade_check` guard its siblings carry. Its only test load runs against the **previous
release** server (now v26.8.2.7), which aborts on that path: no change to master can clear it
here. This closes the generated route: `--no-random-settings` is passed under `upgrade_check`,
and the server-side profile needs `--parallel-rep`, never passed here. Two tests in the
replayed corpus do set it themselves (04043, 04227), but they pin their own cluster, sat
unchanged across the clean 3454 shas, and in 90 days no `unknown stream` abort in any check
names their tables. #116783's 50x `memory_tracker_fault_probability` raise scales to ~2 runs
a day, not 24.

The guard matches the sibling arms in the same function, including #116783's own
`enable_cascades_optimizer`. Coverage stays where a failure is actionable: the draw keeps
firing in `Stress test (*)` against the PR's own build (0 of 265 shas since).

Validation: 4000 `get_options` draws per condition move `serialize_query_plan` 388 -> 0 under
`upgrade_check`, leaving `enable_parallel_replicas` and the `upgrade_check=False` counts
unchanged. The abort does not reproduce in a local single-process pseudo-cluster (~1500
queries), so the case rests on the measurement above; #119372 has a deterministic reproducer.

cc @PedroTadim (#116783's author): the coverage it added is fine; this only keeps the setting
out of the one job that reaches a frozen release.
<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119406&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119406](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119406+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1192` (included in `26.9` and later)
<!-- ch-version-info:end -->