### PR TITLE
Do not record the async-metrics readonly checks in system.errors

### DIFF
--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -73,6 +73,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int TABLE_IS_READ_ONLY;
+    extern const int TABLE_IS_PERMANENTLY_READ_ONLY;
 }
 
 namespace
@@ -550,16 +551,18 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                     calculateMaxAndSum(max_inserts_in_queue, sum_inserts_in_queue, status.queue.inserts_in_queue);
                     calculateMaxAndSum(max_merges_in_queue, sum_merges_in_queue, status.queue.merges_in_queue);
 
-                    if (!status.is_readonly)
+                    /// `status.is_readonly` is only the transient flag, while `getReplicaDelays`
+                    /// also rejects static storage; `isTableReadOnly()` covers both states.
+                    if (!table_replicated_merge_tree->isTableReadOnly())
                     {
                         try
                         {
                             time_t absolute_delay = 0;
                             time_t relative_delay = 0;
                             {
-                                /// The table can turn readonly between the `status.is_readonly` check
-                                /// above and this call, which then throws before doing any work. That
-                                /// race is not an error of this server, so it must not reach `system.errors`.
+                                /// The table can turn readonly between the check above and this
+                                /// call, which then throws before doing any work. That race is not
+                                /// an error of this server, so it must not reach `system.errors`.
                                 Exception::SuppressErrorCodesScope suppress_error_codes;
                                 table_replicated_merge_tree->getReplicaDelays(absolute_delay, relative_delay);
                             }
@@ -569,19 +572,17 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                         }
                         catch (Exception & e)
                         {
+                            const bool benign_readonly = e.code() == ErrorCodes::TABLE_IS_READ_ONLY
+                                || e.code() == ErrorCodes::TABLE_IS_PERMANENTLY_READ_ONLY;
+
                             /// The same call also talks to Keeper, and those failures are real
                             /// operational errors that belong in `system.errors`.
-                            if (e.code() != ErrorCodes::TABLE_IS_READ_ONLY)
+                            if (!benign_readonly)
                                 e.recordToSystemErrors();
 
-                            /// The readonly race is benign for a background metrics thread, so do not
-                            /// pollute the error log / stderr with it.
-                            auto level = e.code() == ErrorCodes::TABLE_IS_READ_ONLY
-                                ? LogsLevel::debug
-                                : LogsLevel::error;
                             tryLogCurrentException(__PRETTY_FUNCTION__,
                                 "Cannot get replica delay for table: " + backQuoteIfNeed(db.first) + "." + backQuoteIfNeed(iterator->name()),
-                                level);
+                                benign_readonly ? LogsLevel::debug : LogsLevel::error);
                         }
                         catch (...)
                         {

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -556,24 +556,37 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                         {
                             time_t absolute_delay = 0;
                             time_t relative_delay = 0;
-                            table_replicated_merge_tree->getReplicaDelays(absolute_delay, relative_delay);
+                            {
+                                /// The table can turn readonly between the `status.is_readonly` check
+                                /// above and this call, which then throws before doing any work. That
+                                /// race is not an error of this server, so it must not reach `system.errors`.
+                                Exception::SuppressErrorCodesScope suppress_error_codes;
+                                table_replicated_merge_tree->getReplicaDelays(absolute_delay, relative_delay);
+                            }
 
                             calculateMax(max_absolute_delay, absolute_delay);
                             calculateMax(max_relative_delay, relative_delay);
                         }
-                        catch (...)
+                        catch (Exception & e)
                         {
-                            /// The table can transition to readonly between the `status.is_readonly`
-                            /// check above and the call to `getReplicaDelays` (which calls
-                            /// `assertNotReadonly` internally). This is a benign race for a
-                            /// background metrics thread, so do not pollute the error log /
-                            /// stderr with `TABLE_IS_READ_ONLY` exceptions caused by it.
-                            auto level = getCurrentExceptionCode() == ErrorCodes::TABLE_IS_READ_ONLY
+                            /// The same call also talks to Keeper, and those failures are real
+                            /// operational errors that belong in `system.errors`.
+                            if (e.code() != ErrorCodes::TABLE_IS_READ_ONLY)
+                                e.recordToSystemErrors();
+
+                            /// The readonly race is benign for a background metrics thread, so do not
+                            /// pollute the error log / stderr with it.
+                            auto level = e.code() == ErrorCodes::TABLE_IS_READ_ONLY
                                 ? LogsLevel::debug
                                 : LogsLevel::error;
                             tryLogCurrentException(__PRETTY_FUNCTION__,
                                 "Cannot get replica delay for table: " + backQuoteIfNeed(db.first) + "." + backQuoteIfNeed(iterator->name()),
                                 level);
+                        }
+                        catch (...)
+                        {
+                            tryLogCurrentException(__PRETTY_FUNCTION__,
+                                "Cannot get replica delay for table: " + backQuoteIfNeed(db.first) + "." + backQuoteIfNeed(iterator->name()));
                         }
                     }
                 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: #118928, #111845


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Do not count a `ReplicatedMergeTree` replica's read-only state as an error in `system.errors` and `system.error_log` when the asynchronous metrics thread reads its replication delay. Previously a dropped or restarted replica recorded `TABLE_IS_READ_ONLY`, and a replica on static storage recorded `TABLE_IS_PERMANENTLY_READ_ONLY` and logged an error once per `asynchronous_metrics_update_period_s`, with no query having failed.

### Description

Requested by @ alexey-milovidov in [#93111](https://github.com/ClickHouse/ClickHouse/pull/93111#issuecomment-5631046538). Seen as `test_cancel_backup.py::test_cancel_restore` at `:547` ([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=93111&sha=1febfa0155b57449e476bc55b5455cadb1d6ead3&name_0=PR&name_1=Integration%20tests%20(amd_tsan%2C%202%2F6))); `test_different_versions.py:105` has the same producer. No open issue exists.

`ServerAsynchronousMetrics::updateImpl` guards `getReplicaDelays` with `status.is_readonly`, but the callee starts with `assertNotReadonly()`, which rejects more than that flag, so it throws before doing any work in two ways:

1. a concurrent `DROP TABLE` or `SYSTEM RESTART REPLICA` flips `is_readonly` after the check: `TABLE_IS_READ_ONLY`;
2. `assertNotReadonly()` also checks static storage, which that flag does not reflect, so a replica on a read-only or write-once disk gets `TABLE_IS_PERMANENTLY_READ_ONLY`. That one is not a race and never stops: the restarting thread clears `is_readonly` after startup while the disk stays static, so it fired on every tick, at error level, only the transient code having been demoted.

The counter is incremented in the exception constructor, before any `catch` runs, and is cumulative.

#104981 named case 1 but only demoted its log level. This completes it: the call is wrapped in `Exception::SuppressErrorCodesScope`, the guard now uses `isTableReadOnly()` (`is_readonly || isStaticStorage()`, what `assertNotReadonly()` enforces and what `ReplicasStatusHandler` already uses), and the handler re-records every code except the two readonly ones, so Keeper failures stay visible.

No test ships. Case 1 has no failpoint; case 2 is deterministic, but its fixture needs a static-storage `ReplicatedMergeTree`, which in a stateless test means a deprecated `Ordinary` database plus s3_plain, as in `02980_s3_plain_DROP_TABLE_ReplicatedMergeTree.sh`. I could not validate that locally and would rather not add an unvalidated test here; happy to add one if wanted.

<details>
<summary>Validation, both directions on a debug build</summary>

Case 1, a probe widening the window identically on both binaries, 12 forced flips:
`system.errors[TABLE_IS_READ_ONLY]` moves by +12 before the fix and by 0 after, while the
`Cannot get replica delay` line for this call site appears 12 times on both, so the race still
happens and is still reported. With Keeper's port blocked, `KEEPER_EXCEPTION` rises by +8 on both.

Case 2, a `ReplicatedMergeTree` restarted onto a `read_only` disk so the policy is static,
sampled over 20 s with `system.replicas.is_readonly = 0`, i.e. with the branch reachable:
the `Cannot get replica delay` line for that table appears 21 times at error level before the fix
and 0 times after. `system.errors[TABLE_IS_PERMANENTLY_READ_ONLY]` moves by +61 and +40, the
21 difference being this call site; the rest is the replica's own `queueUpdatingTask`,
`mutationsFinalizingTask` and `mergeSelectingTask`, a separate producer not touched here.

Not over-suppressed: after the fix, a healthy replica with `min_relative_delay_to_measure = 0`
and Keeper unreachable still logs this call site and still adds +11 to
`KEEPER_EXCEPTION`/`NO_ZOOKEEPER`, so tables that should be measured still are.

`test_different_versions` passes 50/50.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119448&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119448](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119448+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

