### PR TITLE
Fix JSONPath wildcard dropping non-array values in JSON_QUERY, JSON_VALUE and JSON_EXISTS

### DIFF
--- a/src/Functions/JSONPath/Generator/VisitorJSONPathStar.h
+++ b/src/Functions/JSONPath/Generator/VisitorJSONPathStar.h
@@ -19,21 +19,21 @@ public:
 
     VisitorStatus apply(typename JSONParser::Element & element) const override
     {
-        typename JSONParser::Array array = element.getArray();
-        element = array[current_index];
+        if (element.isArray())
+        {
+            typename JSONParser::Array array = element.getArray();
+            element = array[current_index];
+        }
         return VisitorStatus::Ok;
     }
 
     VisitorStatus visit(typename JSONParser::Element & element) override
     {
-        if (!element.isArray())
-        {
-            this->setExhausted(true);
-            return VisitorStatus::Error;
-        }
+        /// Per RFC 9535 lax semantics, a non-array element is treated as a one-element array containing the element itself.
+        const size_t array_size = element.isArray() ? element.getArray().size() : 1;
 
         VisitorStatus status = {};
-        if (current_index < element.getArray().size())
+        if (current_index < array_size)
         {
             apply(element);
             status = VisitorStatus::Ok;

--- a/tests/queries/0_stateless/05182_json_path_star_scalar_auto_wrap.reference
+++ b/tests/queries/0_stateless/05182_json_path_star_scalar_auto_wrap.reference
@@ -1,0 +1,29 @@
+-- { echo }
+SELECT JSON_QUERY('{"p":3}', '$.p[*]');
+[3]
+SELECT JSON_QUERY('{"arr":[{"p":[1,2]},{"p":3}]}', '$.arr[*].p[*]');
+[1, 2, 3]
+SELECT JSON_QUERY('{"p":"str"}', '$.p[*]');
+["str"]
+SELECT JSON_QUERY('{"p":null}', '$.p[*]');
+[null]
+SELECT JSON_QUERY('{"p":{"x":1}}', '$.p[*]');
+[{"x":1}]
+SELECT JSON_QUERY('{"p":{"x":1}}', '$.p[*].x');
+[1]
+SELECT JSON_QUERY('{"p":{"q":[1,2]}}', '$.p[*].q[*]');
+[1, 2]
+SELECT JSON_QUERY('{"hello":1}', '$[*]');
+[{"hello":1}]
+SELECT JSON_QUERY('{"p":[1,2]}', '$.p[*]');
+[1, 2]
+SELECT JSON_QUERY('{"p":3}', '$.q[*]');
+
+SELECT JSON_VALUE('{"p":3}', '$.p[*]');
+3
+SELECT JSON_VALUE('{"p":"str"}', '$.p[*]');
+str
+SELECT JSON_EXISTS('{"p":3}', '$.p[*]');
+1
+SELECT JSON_EXISTS('{"p":3}', '$.q[*]');
+0

--- a/tests/queries/0_stateless/05182_json_path_star_scalar_auto_wrap.sql
+++ b/tests/queries/0_stateless/05182_json_path_star_scalar_auto_wrap.sql
@@ -1,0 +1,18 @@
+-- Tests for RFC 9535 lax-mode auto-wrapping of non-array values under the JSONPath wildcard `[*]`.
+-- https://github.com/ClickHouse/ClickHouse/issues/118755
+
+-- { echo }
+SELECT JSON_QUERY('{"p":3}', '$.p[*]');
+SELECT JSON_QUERY('{"arr":[{"p":[1,2]},{"p":3}]}', '$.arr[*].p[*]');
+SELECT JSON_QUERY('{"p":"str"}', '$.p[*]');
+SELECT JSON_QUERY('{"p":null}', '$.p[*]');
+SELECT JSON_QUERY('{"p":{"x":1}}', '$.p[*]');
+SELECT JSON_QUERY('{"p":{"x":1}}', '$.p[*].x');
+SELECT JSON_QUERY('{"p":{"q":[1,2]}}', '$.p[*].q[*]');
+SELECT JSON_QUERY('{"hello":1}', '$[*]');
+SELECT JSON_QUERY('{"p":[1,2]}', '$.p[*]');
+SELECT JSON_QUERY('{"p":3}', '$.q[*]');
+SELECT JSON_VALUE('{"p":3}', '$.p[*]');
+SELECT JSON_VALUE('{"p":"str"}', '$.p[*]');
+SELECT JSON_EXISTS('{"p":3}', '$.p[*]');
+SELECT JSON_EXISTS('{"p":3}', '$.q[*]');


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/118755

The JSONPath wildcard `[*]` errored out on non-array values, so they were silently dropped from results:

```sql
SELECT JSON_QUERY('{"arr":[{"p":[1,2]},{"p":3}]}', '$.arr[*].p[*]');
-- before: [1, 2]    after: [1, 2, 3]
```

RFC 9535 lax semantics (and Postgres) say a wildcard on a non-array should treat it as a one-element array. `VisitorJSONPathStar` now does exactly that. Arrays, empty arrays, and missing keys behave as before.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The JSONPath wildcard `[*]` in `JSON_QUERY`, `JSON_VALUE`, and `JSON_EXISTS` now treats a non-array value as a one-element array per RFC 9535 lax semantics, instead of silently dropping it. For example, `JSON_QUERY('{"p":3}', '$.p[*]')` returns `[3]` instead of an empty string. This closes #118755
