### PR TITLE
Do not read a physical column as a map subcolumn when analysing skip indexes

### DIFF
--- a/src/DataTypes/DataTypeMapHelpers.cpp
+++ b/src/DataTypes/DataTypeMapHelpers.cpp
@@ -453,7 +453,7 @@ constexpr std::string_view map_key_marker = ".key_";
 
 bool looksLikeMapSubcolumnName(const String & column_name)
 {
-    return column_name.find(map_key_marker) != String::npos;
+    return column_name.contains(map_key_marker);
 }
 
 std::optional<std::pair<String, String>> tryParseMapSubcolumnName(

--- a/src/DataTypes/DataTypeMapHelpers.cpp
+++ b/src/DataTypes/DataTypeMapHelpers.cpp
@@ -444,16 +444,30 @@ void extractKeyValueFromMap(
     extractValuesDispatch(values_column, result, matched_positions);
 }
 
-std::optional<std::pair<String, String>> tryParseMapSubcolumnName(const String & column_name)
+namespace
 {
-    static constexpr std::string_view key_marker = ".key_";
 
-    auto pos = column_name.find(key_marker);
+constexpr std::string_view map_key_marker = ".key_";
+
+}
+
+bool looksLikeMapSubcolumnName(const String & column_name)
+{
+    return column_name.find(map_key_marker) != String::npos;
+}
+
+std::optional<std::pair<String, String>> tryParseMapSubcolumnName(
+    const String & column_name, const NameSet & shadowing_columns)
+{
+    auto pos = column_name.find(map_key_marker);
     if (pos == String::npos)
         return std::nullopt;
 
+    if (shadowing_columns.contains(column_name))
+        return std::nullopt;
+
     auto map_column_name = column_name.substr(0, pos);
-    auto serialized_key = column_name.substr(pos + key_marker.size());
+    auto serialized_key = column_name.substr(pos + map_key_marker.size());
     return std::pair{std::move(map_column_name), std::move(serialized_key)};
 }
 

--- a/src/DataTypes/DataTypeMapHelpers.h
+++ b/src/DataTypes/DataTypeMapHelpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/IColumn.h>
+#include <Core/Names.h>
 #include <base/types.h>
 
 #include <optional>
@@ -22,8 +23,16 @@ void extractKeyValueFromMap(
     size_t start,
     size_t end);
 
+/// Whether the name has the `map.key_<serialized_key>` shape used for a single Map key subcolumn.
+bool looksLikeMapSubcolumnName(const String & column_name);
+
 /// Try to parse a Map subcolumn reference like `map.key_<serialized_key>`.
 /// Returns {map_column_name, serialized_key} if the column name has the expected format.
-std::optional<std::pair<String, String>> tryParseMapSubcolumnName(const String & column_name);
+///
+/// Dots are legal in column names, so a real column `m.key_x` may exist beside a Map `m`. It shadows
+/// the subcolumn: a predicate reads that column, not the map, so pass such names in
+/// `shadowing_columns` and the shape is refused.
+std::optional<std::pair<String, String>> tryParseMapSubcolumnName(
+    const String & column_name, const NameSet & shadowing_columns);
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -254,9 +254,10 @@ std::optional<MapIndexInfo> tryResolveMapIndexInfo(const String & map_column_nam
 /// Try to parse a Map subcolumn reference like `map.key_<serialized_key>` and resolve it
 /// against the bloom filter index header. The subcolumn name format is produced by
 /// `FunctionToSubcolumnsPass`.
-std::optional<MapIndexInfo> tryParseMapSubcolumn(const String & column_name, const Block & header)
+std::optional<MapIndexInfo> tryParseMapSubcolumn(
+    const String & column_name, const Block & header, const NameSet & shadowing_columns)
 {
-    auto parsed = tryParseMapSubcolumnName(column_name);
+    auto parsed = tryParseMapSubcolumnName(column_name, shadowing_columns);
     if (!parsed)
         return std::nullopt;
 
@@ -284,7 +285,8 @@ std::optional<MapIndexInfo> tryParseMapSubcolumn(const String & column_name, con
 
 /// Try to resolve a `MapIndexInfo` from a key node that is either an `arrayElement(map, key)`
 /// function call or a `map.key_<serialized_key>` subcolumn reference.
-std::optional<MapIndexInfo> tryResolveMapInfoFromNode(const RPNBuilderTreeNode & key_node, const Block & header)
+std::optional<MapIndexInfo> tryResolveMapInfoFromNode(
+    const RPNBuilderTreeNode & key_node, const Block & header, const NameSet & shadowing_columns)
 {
     if (key_node.isFunction())
     {
@@ -303,14 +305,21 @@ std::optional<MapIndexInfo> tryResolveMapInfoFromNode(const RPNBuilderTreeNode &
         }
     }
 
-    return tryParseMapSubcolumn(key_node.getColumnName(), header);
+    return tryParseMapSubcolumn(key_node.getColumnName(), header, shadowing_columns);
 }
 
 }
 
 MergeTreeIndexConditionBloomFilter::MergeTreeIndexConditionBloomFilter(
-    const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_)
-    : WithContext(context_), header(header_), hash_functions(hash_functions_)
+    const ActionsDAG::Node * predicate,
+    ContextPtr context_,
+    const Block & header_,
+    size_t hash_functions_,
+    NameSet columns_shadowing_map_subcolumns_)
+    : WithContext(context_)
+    , header(header_)
+    , hash_functions(hash_functions_)
+    , columns_shadowing_map_subcolumns(std::move(columns_shadowing_map_subcolumns_))
 {
     if (!predicate)
     {
@@ -683,7 +692,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
     }
 
     /// Handle both `arrayElement(map, 'key') IN (set)` and `map.key_<serialized_key> IN (set)`.
-    if (auto map_info = tryResolveMapInfoFromNode(key_node, header))
+    if (auto map_info = tryResolveMapInfoFromNode(key_node, header, columns_shadowing_map_subcolumns))
     {
         /** It is important to ignore keys like column_map['Key'] IN ('') because if the key does not exist in the map
           * we return the default value for arrayElement.
@@ -1188,7 +1197,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
     /// Handle both `arrayElement(map, 'key') = value` and `map.key_<serialized_key> = value`.
     if (function_name == "equals")
     {
-        if (auto map_info = tryResolveMapInfoFromNode(key_node, header))
+        if (auto map_info = tryResolveMapInfoFromNode(key_node, header, columns_shadowing_map_subcolumns))
         {
             /** It is important to ignore keys like column_map['Key'] = '' because if the key does not exist in the map
               * we return the default value for arrayElement.
@@ -1304,7 +1313,8 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilter::createIndexAggregator() c
 
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilter::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionBloomFilter>(predicate, context, index.sample_block, hash_functions);
+    return std::make_shared<MergeTreeIndexConditionBloomFilter>(
+        predicate, context, index.sample_block, hash_functions, getColumnsShadowingMapSubcolumns());
 }
 
 static void assertIndexColumnsType(const Block & header)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -72,7 +72,12 @@ public:
         std::vector<std::pair<size_t, ColumnPtr>> predicate;
     };
 
-    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_);
+    MergeTreeIndexConditionBloomFilter(
+        const ActionsDAG::Node * predicate,
+        ContextPtr context_,
+        const Block & header_,
+        size_t hash_functions_,
+        NameSet columns_shadowing_map_subcolumns_);
 
     bool alwaysUnknownOrTrue() const override;
 
@@ -89,6 +94,7 @@ public:
 private:
     const Block & header;
     const size_t hash_functions;
+    const NameSet columns_shadowing_map_subcolumns;
     std::vector<RPNElement> rpn;
 
     bool mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -157,12 +157,14 @@ MergeTreeConditionBloomFilterText::MergeTreeConditionBloomFilterText(
     ContextPtr context,
     const Block & index_sample_block,
     const BloomFilterParameters & params_,
-    TokenizerPtr token_extactor_)
+    TokenizerPtr token_extactor_,
+    NameSet columns_shadowing_map_subcolumns_)
     : index_columns(index_sample_block.getNames())
     , index_data_types(index_sample_block.getNamesAndTypesList().getTypes())
     , params(params_)
     , owned_tokenizer(token_extactor_ && token_extactor_->isStateful() ? token_extactor_->clone() : nullptr)
     , tokenizer(owned_tokenizer ? owned_tokenizer.get() : token_extactor_)
+    , columns_shadowing_map_subcolumns(std::move(columns_shadowing_map_subcolumns_))
 {
     if (!predicate)
     {
@@ -630,7 +632,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
     /// Try to parse map subcolumn reference like `map.key_<serialized_key>`.
     if (!key_index)
     {
-        if (auto parsed = tryParseMapSubcolumnName(column_name))
+        if (auto parsed = tryParseMapSubcolumnName(column_name, columns_shadowing_map_subcolumns))
         {
             auto & [map_column_name, serialized_key] = *parsed;
 
@@ -977,7 +979,8 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilterText::createIndexAggregator
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilterText::createIndexCondition(
         const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeConditionBloomFilterText>(predicate, context, index.sample_block, params, tokenizer.get());
+    return std::make_shared<MergeTreeConditionBloomFilterText>(
+        predicate, context, index.sample_block, params, tokenizer.get(), getColumnsShadowingMapSubcolumns());
 }
 
 MergeTreeIndexPtr bloomFilterIndexTextCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & /*settings*/)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
@@ -70,7 +70,8 @@ public:
             ContextPtr context,
             const Block & index_sample_block,
             const BloomFilterParameters & params_,
-            TokenizerPtr token_extactor_);
+            TokenizerPtr token_extactor_,
+            NameSet columns_shadowing_map_subcolumns_);
 
     ~MergeTreeConditionBloomFilterText() override = default;
 
@@ -152,6 +153,7 @@ private:
 
     std::unique_ptr<ITokenizer> owned_tokenizer;
     TokenizerPtr tokenizer;
+    NameSet columns_shadowing_map_subcolumns;
 
     RPN rpn;
 };

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -141,10 +141,12 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     TokenizerPtr tokenizer_,
     MergeTreeIndexTextPreprocessorPtr preprocessor_,
     MergeTreeIndexTextPostprocessorPtr postprocessor_,
-    bool has_positions_)
+    bool has_positions_,
+    NameSet columns_shadowing_map_subcolumns_)
     : WithContext(context_)
     , header(index_sample_block)
     , normalized_index_column_name(normalized_index_column_name_)
+    , columns_shadowing_map_subcolumns(std::move(columns_shadowing_map_subcolumns_))
     , owned_tokenizer(tokenizer_ && tokenizer_->isStateful() ? std::shared_ptr<const ITokenizer>(tokenizer_->clone()) : nullptr)
     , tokenizer(owned_tokenizer ? owned_tokenizer.get() : tokenizer_)
     , preprocessor(preprocessor_)
@@ -1119,7 +1121,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     /// Try to parse map subcolumn reference like `map.key_<serialized_key>` for `mapValues` index.
     if (!has_index_column && !has_map_keys_column && !has_map_values_column)
     {
-        if (auto parsed = tryParseMapSubcolumnName(index_column_name))
+        if (auto parsed = tryParseMapSubcolumnName(index_column_name, columns_shadowing_map_subcolumns))
         {
             auto & [map_column_name, _] = *parsed;
             if (header.has(fmt::format("mapValues({})", map_column_name))
@@ -1813,7 +1815,7 @@ bool MergeTreeIndexConditionText::traverseMapElementKeyNode(const RPNBuilderFunc
     else
     {
         /// Try to parse map subcolumn reference like `map.key_<serialized_key>`.
-        auto parsed = tryParseMapSubcolumnName(required_column.name);
+        auto parsed = tryParseMapSubcolumnName(required_column.name, columns_shadowing_map_subcolumns);
         if (!parsed)
             return false;
 
@@ -1861,7 +1863,7 @@ bool MergeTreeIndexConditionText::hasIndexForMapElementValue(const RPNBuilderTre
     }
 
     /// Handle `map.key_<serialized_key>` subcolumn form.
-    auto parsed = tryParseMapSubcolumnName(node.getColumnName());
+    auto parsed = tryParseMapSubcolumnName(node.getColumnName(), columns_shadowing_map_subcolumns);
     if (!parsed)
         return false;
     auto & [map_column_name, serialized_key] = *parsed;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -97,7 +97,8 @@ public:
         TokenizerPtr tokenizer_,
         MergeTreeIndexTextPreprocessorPtr preprocessor_,
         MergeTreeIndexTextPostprocessorPtr postprocessor_,
-        bool has_positions_);
+        bool has_positions_,
+        NameSet columns_shadowing_map_subcolumns_);
 
     ~MergeTreeIndexConditionText() override = default;
     static bool isSupportedFunction(const String & function_name);
@@ -207,6 +208,7 @@ private:
 
     Block header;
     std::optional<String> normalized_index_column_name;
+    NameSet columns_shadowing_map_subcolumns;
     /// A private clone of the index tokenizer when it is stateful, so concurrent conditions do not
     /// share mutable parsing state; null otherwise.
     std::shared_ptr<const ITokenizer> owned_tokenizer;

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -2053,7 +2053,9 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexText::createIndexAggregator() const
 
 MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, normalized_index_column_name, tokenizer.get(), preprocessor, postprocessor, params.positions);
+    return std::make_shared<MergeTreeIndexConditionText>(
+        predicate, context, index.sample_block, normalized_index_column_name, tokenizer.get(),
+        preprocessor, postprocessor, params.positions, getColumnsShadowingMapSubcolumns());
 }
 
 DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -13,6 +13,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/NestedUtils.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Common/escapeForFileName.h>
@@ -91,9 +92,11 @@ const NamesAndTypesList & IMergeTreeIndex::getColumnsWithTypesRequiredForIndexCa
 NameSet IMergeTreeIndex::getColumnsShadowingMapSubcolumns() const
 {
     NameSet result;
-    /// getAll() (ordinary + materialized + aliases + ephemeral) is the same set the producer of these
-    /// names checks, so a MATERIALIZED or ALIAS column of that name shadows the subcolumn too.
-    for (const auto & column : metadata_snapshot->getColumns().getAll())
+    /// Subcolumn names are flat, so a Tuple element or a typed JSON path can claim `<map>.key_<k>`
+    /// just as a top-level column can, and a predicate on that name reads the claimant. A genuine Map
+    /// key subcolumn is generated per key on demand, so it is absent here and stays parseable.
+    auto options = GetColumnsOptions(GetColumnsOptions::All).withSubcolumns();
+    for (const auto & column : metadata_snapshot->getColumns().get(options))
         if (looksLikeMapSubcolumnName(column.name))
             result.insert(column.name);
     return result;

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -4,11 +4,11 @@
 
 #include <Columns/IColumn.h>
 #include <DataTypes/DataTypeArray.h>
-#include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/NestedUtils.h>

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -4,6 +4,7 @@
 
 #include <Columns/IColumn.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeMapHelpers.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeEnum.h>
@@ -85,6 +86,17 @@ Names IMergeTreeIndex::getColumnsRequiredForIndexCalc() const
 const NamesAndTypesList & IMergeTreeIndex::getColumnsWithTypesRequiredForIndexCalc() const
 {
     return index.expression->getRequiredColumnsWithTypes();
+}
+
+NameSet IMergeTreeIndex::getColumnsShadowingMapSubcolumns() const
+{
+    NameSet result;
+    /// getAll() (ordinary + materialized + aliases + ephemeral) is the same set the producer of these
+    /// names checks, so a MATERIALIZED or ALIAS column of that name shadows the subcolumn too.
+    for (const auto & column : metadata_snapshot->getColumns().getAll())
+        if (looksLikeMapSubcolumnName(column.name))
+            result.insert(column.name);
+    return result;
 }
 
 namespace

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -355,6 +355,8 @@ struct IMergeTreeIndex
     Names getColumnsRequiredForIndexCalc() const;
     const NamesAndTypesList & getColumnsWithTypesRequiredForIndexCalc() const;
 
+    NameSet getColumnsShadowingMapSubcolumns() const;
+
     StorageMetadataPtr metadata_snapshot;
     const IndexDescription & index;
 };

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
@@ -6,6 +6,8 @@ bloom_filter over mapValues	1
 text over mapKeys	1
 text over mapValues	1
 ngrambf_v1 over mapKeys, tuple element	1
+ngrambf_v1 over mapKeys, typed JSON path	1
 genuine key subcolumn still prunes	Granules: 0/1
 index applied: shadowed, genuine	0	1
 nested genuine key subcolumn still prunes	1	1
+json genuine key subcolumn still prunes	1	1

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
@@ -1,0 +1,6 @@
+ngrambf_v1 over mapKeys	1
+bloom_filter over mapKeys, equals	1
+bloom_filter over mapKeys, in	1
+text over mapKeys	1
+text over mapValues	1
+genuine key subcolumn still prunes	Granules: 0/1

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
@@ -5,5 +5,7 @@ bloom_filter over mapKeys, in	1
 bloom_filter over mapValues	1
 text over mapKeys	1
 text over mapValues	1
+ngrambf_v1 over mapKeys, tuple element	1
 genuine key subcolumn still prunes	Granules: 0/1
 index applied: shadowed, genuine	0	1
+nested genuine key subcolumn still prunes	1	1

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.reference
@@ -1,6 +1,9 @@
 ngrambf_v1 over mapKeys	1
+ngrambf_v1 over mapValues	1
 bloom_filter over mapKeys, equals	1
 bloom_filter over mapKeys, in	1
+bloom_filter over mapValues	1
 text over mapKeys	1
 text over mapValues	1
 genuine key subcolumn still prunes	Granules: 0/1
+index applied: shadowed, genuine	0	1

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
@@ -75,7 +75,7 @@ INSERT INTO t_shadow_text_values VALUES ({'abc' : 'x'}, 'hello');
 SELECT 'text over mapValues', count() FROM t_shadow_text_values WHERE `m.key_nokey` = 'hello';
 
 -- Subcolumn names are flat, so the claimant of the name need not be a top-level column: a Tuple element
--- (or a typed JSON path) named `m.key_nokey` claims it too, and the predicate reads that element.
+-- named `m.key_nokey` claims it too, and the predicate reads that element.
 DROP TABLE IF EXISTS t_shadow_tuple_element;
 CREATE TABLE t_shadow_tuple_element
 (
@@ -85,6 +85,19 @@ CREATE TABLE t_shadow_tuple_element
 ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_shadow_tuple_element VALUES (({'abc' : 'x'}, 'hello'));
 SELECT 'ngrambf_v1 over mapKeys, tuple element', count() FROM t_shadow_tuple_element WHERE t.`m.key_nokey` = 'hello';
+
+-- A typed JSON path is enumerated as a subcolumn by a different serialization than a Tuple element, so it
+-- claims the name through its own code path. Dots separate JSON paths, so the claiming path is a sub-path
+-- of the map path: the map itself stays empty and every key probe misses.
+DROP TABLE IF EXISTS t_shadow_json_path;
+CREATE TABLE t_shadow_json_path
+(
+    j JSON(m Map(String, String), `m.key_nokey` String),
+    INDEX idx mapKeys(j.m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_json_path VALUES ('{"m.key_nokey":"hello"}');
+SELECT 'ngrambf_v1 over mapKeys, typed JSON path', count() FROM t_shadow_json_path WHERE j.`m.key_nokey` = 'hello';
 
 -- Only the shadowed name loses the index. A genuine key subcolumn of the same map, in the same table,
 -- must still prune: `m.key_zzz` is not a declared column, and the map has no key `zzz`.
@@ -113,6 +126,15 @@ SELECT 'nested genuine key subcolumn still prunes',
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_tuple_element WHERE t.m.key_zzz = 'x')
 SETTINGS explain_query_plan_default = 'legacy', enable_parallel_replicas = 0;
 
+-- Same for the JSON carrier, whose count arm passes just as well if the guard over-refuses and no key
+-- subcolumn beneath a JSON column stays indexable: `j.m.key_zzz` is a genuine key subcolumn of the typed
+-- map path, claimed by nothing, and the map has no key `zzz`. Expecting `1 1`.
+SELECT 'json genuine key subcolumn still prunes',
+       countIf(trim(explain) ILIKE 'Name: idx'),
+       countIf(trim(explain) ILIKE 'Granules: 0/1')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_json_path WHERE j.m.key_zzz = 'x')
+SETTINGS explain_query_plan_default = 'legacy', enable_parallel_replicas = 0;
+
 DROP TABLE t_shadow_ngrambf;
 DROP TABLE t_shadow_ngrambf_values;
 DROP TABLE t_shadow_bloom_filter;
@@ -120,3 +142,4 @@ DROP TABLE t_shadow_bloom_filter_values;
 DROP TABLE t_shadow_text_keys;
 DROP TABLE t_shadow_text_values;
 DROP TABLE t_shadow_tuple_element;
+DROP TABLE t_shadow_json_path;

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
@@ -1,0 +1,61 @@
+-- Dots are legal in column names, so a table may declare both a Map `m` and a physical column named
+-- exactly `m.key_nokey`. Skip-index analysis used to read that name as the map's element for the key
+-- `nokey` and prune every granule whose map lacks that key, dropping rows the predicate matches.
+-- One arm per skip-index condition class; every count must find the inserted row.
+
+DROP TABLE IF EXISTS t_shadow_ngrambf;
+CREATE TABLE t_shadow_ngrambf
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_ngrambf VALUES ({'abc' : 'x'}, 'hello');
+SELECT 'ngrambf_v1 over mapKeys', count() FROM t_shadow_ngrambf WHERE `m.key_nokey` = 'hello';
+
+DROP TABLE IF EXISTS t_shadow_bloom_filter;
+CREATE TABLE t_shadow_bloom_filter
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapKeys(m) TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_bloom_filter VALUES ({'abc' : 'x'}, 'hello');
+SELECT 'bloom_filter over mapKeys, equals', count() FROM t_shadow_bloom_filter WHERE `m.key_nokey` = 'hello';
+SELECT 'bloom_filter over mapKeys, in', count() FROM t_shadow_bloom_filter WHERE `m.key_nokey` IN ('hello', 'zzz');
+
+DROP TABLE IF EXISTS t_shadow_text_keys;
+CREATE TABLE t_shadow_text_keys
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapKeys(m) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_text_keys VALUES ({'abc' : 'x'}, 'hello');
+SELECT 'text over mapKeys', count() FROM t_shadow_text_keys WHERE `m.key_nokey` = 'hello';
+
+DROP TABLE IF EXISTS t_shadow_text_values;
+CREATE TABLE t_shadow_text_values
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapValues(m) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_text_values VALUES ({'abc' : 'x'}, 'hello');
+SELECT 'text over mapValues', count() FROM t_shadow_text_values WHERE `m.key_nokey` = 'hello';
+
+-- Only the shadowed name loses the index. A genuine key subcolumn of the same map, in the same table,
+-- must still prune: `m.key_zzz` is not a declared column, and the map has no key `zzz`.
+SELECT 'genuine key subcolumn still prunes', trim(explain)
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE m.key_zzz = 'x')
+WHERE trim(explain) ILIKE 'Granules:%'
+SETTINGS explain_query_plan_default = 'legacy';
+
+DROP TABLE t_shadow_ngrambf;
+DROP TABLE t_shadow_bloom_filter;
+DROP TABLE t_shadow_text_keys;
+DROP TABLE t_shadow_text_values;

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
@@ -76,10 +76,12 @@ SELECT 'text over mapValues', count() FROM t_shadow_text_values WHERE `m.key_nok
 
 -- Only the shadowed name loses the index. A genuine key subcolumn of the same map, in the same table,
 -- must still prune: `m.key_zzz` is not a declared column, and the map has no key `zzz`.
+-- Parallel replicas can plan the read entirely remotely, and EXPLAIN then reports no Indexes section
+-- at all, so both plan assertions pin enable_parallel_replicas = 0.
 SELECT 'genuine key subcolumn still prunes', trim(explain)
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE m.key_zzz = 'x')
 WHERE trim(explain) ILIKE 'Granules:%'
-SETTINGS explain_query_plan_default = 'legacy';
+SETTINGS explain_query_plan_default = 'legacy', enable_parallel_replicas = 0;
 
 -- The counts above also pass whenever the index is merely absent from the plan, so pin the plan too.
 -- Both values come from one row, so the line reddens if EXPLAIN stops reporting an index at all.
@@ -88,7 +90,7 @@ SELECT 'index applied: shadowed, genuine',
         FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE `m.key_nokey` = 'hello')),
        (SELECT countIf(trim(explain) ILIKE 'Name: idx')
         FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE m.key_zzz = 'x'))
-SETTINGS explain_query_plan_default = 'legacy';
+SETTINGS explain_query_plan_default = 'legacy', enable_parallel_replicas = 0;
 
 DROP TABLE t_shadow_ngrambf;
 DROP TABLE t_shadow_ngrambf_values;

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
@@ -1,7 +1,11 @@
 -- Dots are legal in column names, so a table may declare both a Map `m` and a physical column named
 -- exactly `m.key_nokey`. Skip-index analysis used to read that name as the map's element for the key
 -- `nokey` and prune every granule whose map lacks that key, dropping rows the predicate matches.
--- One arm per skip-index condition class; every count must find the inserted row.
+-- One arm per condition class per index expression: an index over mapValues resolves through a
+-- different branch, which probes the filter with the predicate's own value instead of the map key.
+-- Every count must find the inserted row.
+
+SET use_skip_indexes = 1;
 
 DROP TABLE IF EXISTS t_shadow_ngrambf;
 CREATE TABLE t_shadow_ngrambf
@@ -14,6 +18,17 @@ ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_shadow_ngrambf VALUES ({'abc' : 'x'}, 'hello');
 SELECT 'ngrambf_v1 over mapKeys', count() FROM t_shadow_ngrambf WHERE `m.key_nokey` = 'hello';
 
+DROP TABLE IF EXISTS t_shadow_ngrambf_values;
+CREATE TABLE t_shadow_ngrambf_values
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapValues(m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_ngrambf_values VALUES ({'abc' : 'x'}, 'hello');
+SELECT 'ngrambf_v1 over mapValues', count() FROM t_shadow_ngrambf_values WHERE `m.key_nokey` = 'hello';
+
 DROP TABLE IF EXISTS t_shadow_bloom_filter;
 CREATE TABLE t_shadow_bloom_filter
 (
@@ -25,6 +40,17 @@ ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_shadow_bloom_filter VALUES ({'abc' : 'x'}, 'hello');
 SELECT 'bloom_filter over mapKeys, equals', count() FROM t_shadow_bloom_filter WHERE `m.key_nokey` = 'hello';
 SELECT 'bloom_filter over mapKeys, in', count() FROM t_shadow_bloom_filter WHERE `m.key_nokey` IN ('hello', 'zzz');
+
+DROP TABLE IF EXISTS t_shadow_bloom_filter_values;
+CREATE TABLE t_shadow_bloom_filter_values
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapValues(m) TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_bloom_filter_values VALUES ({'abc' : 'x'}, 'hello');
+SELECT 'bloom_filter over mapValues', count() FROM t_shadow_bloom_filter_values WHERE `m.key_nokey` = 'hello';
 
 DROP TABLE IF EXISTS t_shadow_text_keys;
 CREATE TABLE t_shadow_text_keys
@@ -55,7 +81,18 @@ FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE m.key_zzz =
 WHERE trim(explain) ILIKE 'Granules:%'
 SETTINGS explain_query_plan_default = 'legacy';
 
+-- The counts above also pass whenever the index is merely absent from the plan, so pin the plan too.
+-- Both values come from one row, so the line reddens if EXPLAIN stops reporting an index at all.
+SELECT 'index applied: shadowed, genuine',
+       (SELECT countIf(trim(explain) ILIKE 'Name: idx')
+        FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE `m.key_nokey` = 'hello')),
+       (SELECT countIf(trim(explain) ILIKE 'Name: idx')
+        FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE m.key_zzz = 'x'))
+SETTINGS explain_query_plan_default = 'legacy';
+
 DROP TABLE t_shadow_ngrambf;
+DROP TABLE t_shadow_ngrambf_values;
 DROP TABLE t_shadow_bloom_filter;
+DROP TABLE t_shadow_bloom_filter_values;
 DROP TABLE t_shadow_text_keys;
 DROP TABLE t_shadow_text_values;

--- a/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
+++ b/tests/queries/0_stateless/05188_map_subcolumn_shadowed_by_physical_column.sql
@@ -74,6 +74,18 @@ ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_shadow_text_values VALUES ({'abc' : 'x'}, 'hello');
 SELECT 'text over mapValues', count() FROM t_shadow_text_values WHERE `m.key_nokey` = 'hello';
 
+-- Subcolumn names are flat, so the claimant of the name need not be a top-level column: a Tuple element
+-- (or a typed JSON path) named `m.key_nokey` claims it too, and the predicate reads that element.
+DROP TABLE IF EXISTS t_shadow_tuple_element;
+CREATE TABLE t_shadow_tuple_element
+(
+    t Tuple(m Map(String, String), `m.key_nokey` String),
+    INDEX idx mapKeys(t.m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_shadow_tuple_element VALUES (({'abc' : 'x'}, 'hello'));
+SELECT 'ngrambf_v1 over mapKeys, tuple element', count() FROM t_shadow_tuple_element WHERE t.`m.key_nokey` = 'hello';
+
 -- Only the shadowed name loses the index. A genuine key subcolumn of the same map, in the same table,
 -- must still prune: `m.key_zzz` is not a declared column, and the map has no key `zzz`.
 -- Parallel replicas can plan the read entirely remotely, and EXPLAIN then reports no Indexes section
@@ -92,9 +104,19 @@ SELECT 'index applied: shadowed, genuine',
         FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_ngrambf WHERE m.key_zzz = 'x'))
 SETTINGS explain_query_plan_default = 'legacy', enable_parallel_replicas = 0;
 
+-- The count arm of the Tuple case passes just as well if every key subcolumn of a nested map stopped
+-- being indexable, so assert the other side there too: `t.m.key_zzz` is claimed by nothing, and the map
+-- has no key `zzz`, so the index must be applied and must prune. Expecting `1 1`.
+SELECT 'nested genuine key subcolumn still prunes',
+       countIf(trim(explain) ILIKE 'Name: idx'),
+       countIf(trim(explain) ILIKE 'Granules: 0/1')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_shadow_tuple_element WHERE t.m.key_zzz = 'x')
+SETTINGS explain_query_plan_default = 'legacy', enable_parallel_replicas = 0;
+
 DROP TABLE t_shadow_ngrambf;
 DROP TABLE t_shadow_ngrambf_values;
 DROP TABLE t_shadow_bloom_filter;
 DROP TABLE t_shadow_bloom_filter_values;
 DROP TABLE t_shadow_text_keys;
 DROP TABLE t_shadow_text_values;
+DROP TABLE t_shadow_tuple_element;


### PR DESCRIPTION
Do not read a physical column as a map subcolumn when analysing skip indexes

Related: https://github.com/ClickHouse/ClickHouse/pull/119336
Related: https://github.com/ClickHouse/ClickHouse/pull/99200

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results when a table declares both a `Map` column `m` and a column named exactly `` `m.key_<key>` `` (dots are legal in column names), or has that name claimed by a subcolumn such as a `Tuple` element or a typed JSON path. Skip-index analysis read the name as the map's key subcolumn and pruned every granule whose map lacks `<key>`, so a `mapKeys` or `mapValues` index (`ngrambf_v1`, `tokenbf_v1`, `sparse_grams`, `bloom_filter`, `text`) dropped rows that matched the predicate.

### Description

Skip-index conditions resolve a name shaped `m.key_nokey` to "the map `m`'s element at key `nokey`" with a textual split (`tryParseMapSubcolumnName`) and no column list to check against. Where the name belongs to something else, `mapKeys(m)` was still probed for `nokey` and the granule pruned.

Reproducer:

```sql
CREATE TABLE t (m Map(String, String), `m.key_nokey` String,
                INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1)
ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ({'abc' : 'x'}, 'hello');

SELECT count() FROM t WHERE `m.key_nokey` = 'hello'; -- 0, wrong
SELECT count() FROM t WHERE `m.key_nokey` = 'hello' SETTINGS use_skip_indexes = 0; -- 1
```

`FunctionToSubcolumnsPass`, which produces these names, already guards this via the storage snapshot. `IMergeTreeIndex::getColumnsShadowingMapSubcolumns()` derives the same set from the `metadata_snapshot` the index holds, and the three condition classes get it from their `createIndexCondition` factories. All five call sites fail safe: a shadowed name resolves to nothing, so the index does not apply.

Subcolumn names are flat, so the claimant need not be top-level: the set covers the metadata's columns and their subcolumns, because a `Tuple` element or typed JSON path named `m.key_nokey` claims the name just as a column does (both measured). A genuine key subcolumn is generated on demand, so it is absent there and still prunes.

Measured 0 before, 1 after: `ngrambf_v1`, `tokenbf_v1`, `sparse_grams`, `bloom_filter` (`=` and `IN`) and `text`, over `mapKeys` and `mapValues`; `set` was never affected.

Residuals, pre-existing and unchanged here: a `JSON` column `j` beside a `Map` column `` `j.m` ``, where `j.m.key_nokey` resolves under `j` as a dynamic path while the split reads map `j.m` (no enumerated set can cover a dynamic path); and Map columns `a` and `a.key_b`, unreproduced and behind the `arrayElement` rewrite #114150 puts under a default-off setting.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119457&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119457](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119457+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

