### PR TITLE
Docs: clarify BYOB backup retention

### DIFF
--- a/docs/products/cloud/features/backups/overview.mdx
+++ b/docs/products/cloud/features/backups/overview.mdx
@@ -53,6 +53,7 @@ See ["Configure backup schedules"](/products/cloud/guides/backups/configurable-b
 
 ClickHouse Cloud allows exporting backups to your own cloud service provider (CSP) account storage (AWS S3, Google Cloud Storage, or Azure Blob Storage).
 If you configure backups to your own bucket, ClickHouse Cloud also continues to take its own backups by default.
+The backup retention setting applies to backups written to your bucket. Backups managed by ClickHouse Cloud use the default retention policy.
 
 For details of how ClickHouse Cloud backups work, see the [backups](/products/cloud/guides/backups/review-and-restore-backups) docs.
 
@@ -90,7 +91,7 @@ You can use [SQL commands](/products/cloud/guides/backups/bring-your-own-backup/
 </Steps>
 
 <Warning>
-ClickHouse Cloud won't manage the lifecycle of backups in customer buckets.
-Customers are responsible for ensuring that backups in their bucket are managed appropriately for adhering to compliance standards as well as managing cost.
+ClickHouse Cloud doesn't manage the lifecycle of backups exported using SQL commands.
+Customers are responsible for ensuring that these backups are managed appropriately for adhering to compliance standards as well as managing cost.
 If the backups are corrupted, they won't be able to be restored.
 </Warning>

--- a/docs/products/cloud/guides/backups/bring-your-own-backup/backup-restore-from-ui.mdx
+++ b/docs/products/cloud/guides/backups/bring-your-own-backup/backup-restore-from-ui.mdx
@@ -126,9 +126,9 @@ Click on “Save External Bucket” to save the settings
 
 External Backups will now happen in your bucket on the default schedule.
 Alternatively, you can configure the backup schedule from the “Settings” page.
-If configured differently, the custom schedule is used to write backups to your
-bucket and the default schedule (backups every 24 hours) is used for backups in
-the ClickHouse cloud owned bucket.
+If configured differently, the custom schedule and retention setting apply to
+backups written to your bucket. Backups in the ClickHouse Cloud-managed bucket
+use the default schedule (backups every 24 hours) and default retention policy.
 </Step>
 <Step title="View backups stored in your bucket" id="view-backups-stored-in-your-bucket">
 
@@ -246,9 +246,9 @@ Click on `Save External Bucket` to save the settings.
 
 External Backups will now happen in your bucket on the default schedule. 
 Alternatively, you can configure the backup schedule from the `Settings` page. 
-If configured differently, the custom schedule is used to write backups to your 
-bucket and the default schedule (backups every 24 hours) is used for backups in 
-ClickHouse cloud owned bucket.
+If configured differently, the custom schedule and retention setting apply to
+backups written to your bucket. Backups in the ClickHouse Cloud-managed bucket
+use the default schedule (backups every 24 hours) and default retention policy.
 </Step>
 <Step title="View backups stored in your bucket" id="gcp-view-backups-stored-in-your-bucket">
 
@@ -348,8 +348,9 @@ Click on `Save External Bucket` to save the settings
 
 External Backups will now happen in your bucket on the default schedule. Alternatively,
 you can configure the backup schedule from the “Settings” page. If configured differently,
-the custom schedule is used to write backups to your bucket and the default schedule
-(backups every 24 hours) is used for backups in ClickHouse cloud owned bucket.
+the custom schedule and retention setting apply to backups written to your bucket.
+Backups in the ClickHouse Cloud-managed bucket use the default schedule (backups every
+24 hours) and default retention policy.
 </Step>
 <Step title="View backups stored in your bucket" id="azure-view-backups-stored-in-your-bucket">
 

--- a/docs/products/cloud/guides/backups/bring-your-own-backup/backup-restore-from-ui.mdx
+++ b/docs/products/cloud/guides/backups/bring-your-own-backup/backup-restore-from-ui.mdx
@@ -10,7 +10,7 @@ keywords: ['backups', 'disaster recovery', 'data protection', 'restore', 'cloud 
 import { Image } from "/snippets/components/Image.jsx";
 
 <Note>
-Automated backups to your external bucket are full, independent backups. They follow the backup frequency and start time configured for the service (every 24 hours by default; supported frequencies are every 24, 36, or 48 hours). ClickHouse also creates a separate backup in a ClickHouse-managed bucket every 24 hours; that cadence is fixed.
+Automated backups to your external bucket are full, independent backups. They follow the backup frequency and start time configured for the service (every 24 hours by default). ClickHouse also creates a separate backup in a ClickHouse-managed bucket every 24 hours; that cadence is fixed.
 </Note>
 
 ## AWS {#AWS}

--- a/docs/products/cloud/guides/backups/bring-your-own-backup/backup-restore-from-ui.mdx
+++ b/docs/products/cloud/guides/backups/bring-your-own-backup/backup-restore-from-ui.mdx
@@ -10,7 +10,7 @@ keywords: ['backups', 'disaster recovery', 'data protection', 'restore', 'cloud 
 import { Image } from "/snippets/components/Image.jsx";
 
 <Note>
-Automated backups to your external bucket are configured to run as "full" backups every 24 hours, and the frequency is not configurable.  
+Automated backups to your external bucket are full, independent backups. They follow the backup frequency and start time configured for the service (every 24 hours by default; supported frequencies are every 24, 36, or 48 hours). ClickHouse also creates a separate backup in a ClickHouse-managed bucket every 24 hours; that cadence is fixed.
 </Note>
 
 ## AWS {#AWS}


### PR DESCRIPTION
Clarifies that configured BYOB retention applies to backups in the external bucket, while ClickHouse Cloud-managed backups retain the default policy. Aligns the AWS, GCP, and Azure setup instructions and scopes the lifecycle warning to SQL-exported backups.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119460&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119460](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119460+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1227` (included in `26.9` and later)
<!-- ch-version-info:end -->