### PR TITLE
Add a regression test for the `const / variable` NaN-endpoint monotonicity guard

### DIFF
--- a/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.reference
+++ b/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.reference
@@ -1,5 +1,7 @@
-the statistics pruner is live for this table
+the statistics pruner analyzes a constant dividend over this key
 1
+and keeps every part once an endpoint maps to NaN
+0
 a constant dividend whose range endpoint maps to NaN
 3
 3
@@ -13,3 +15,7 @@ pruning still applies with a constant dividend and a finite range
 49
 49
 1
+the statistics pruner analyzes a constant multiplier over this key
+1
+0
+0

--- a/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.reference
+++ b/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.reference
@@ -1,3 +1,5 @@
+the statistics pruner is live for this table
+1
 a constant dividend whose range endpoint maps to NaN
 3
 3

--- a/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.reference
+++ b/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.reference
@@ -1,0 +1,13 @@
+a constant dividend whose range endpoint maps to NaN
+3
+3
+each pruning layer on its own
+3
+3
+a constant multiplier that maps the inf endpoint to NaN
+3
+3
+pruning still applies with a constant dividend and a finite range
+49
+49
+1

--- a/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.sql
+++ b/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.sql
@@ -5,8 +5,9 @@
 -- every part and granule and silently return no rows.
 
 -- `EXPLAIN indexes = 1` below reads the local plan, so keep the plan local when the test runner enables
--- parallel replicas.
+-- parallel replicas, and pin the plan printer the `%Statistics%` / `Granules:` matches parse.
 SET parallel_replicas_local_plan = 1;
+SET explain_query_plan_default = 'legacy';
 
 -- Statistics pruning reads the column min/max that a `basic` statistic holds, and the test runner
 -- randomizes both `auto_statistics_types` and `materialize_statistics_on_insert`. Pin them, otherwise a
@@ -18,11 +19,16 @@ DROP TABLE IF EXISTS t_monotonicity_nan_const_dividend;
 CREATE TABLE t_monotonicity_nan_const_dividend (k Float64) ENGINE = MergeTree ORDER BY k SETTINGS auto_statistics_types = 'basic';
 INSERT INTO t_monotonicity_nan_const_dividend VALUES (1), (2), (3), (inf);
 
-SELECT 'the statistics pruner is live for this table';
--- A predicate that falls outside the part's `[1, +inf]` statistics range does prune the part, so the
--- statistics layer is reachable here; the queries below then show it stops pruning once an endpoint of the
--- transformed range becomes `NaN`.
-SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_nan_const_dividend WHERE k < 0) WHERE explain LIKE '%Statistics%' SETTINGS use_primary_key = 0;
+SELECT 'the statistics pruner analyzes a constant dividend over this key';
+-- `100 / k` over `[1, +inf]` transforms to `[0, 100]`: finite at both ends, so the guard does not fire and
+-- the transform stays monotonic. `> 200` cannot match, so the part must be pruned and `EXPLAIN` must report
+-- a `Statistics` entry. Without this, a `const / variable` chain that the statistics pruner stopped
+-- analyzing would make every `use_primary_key = 0` query below pass by full scan.
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_nan_const_dividend WHERE 100 / k > 200) WHERE explain LIKE '%Statistics%' SETTINGS use_primary_key = 0;
+
+SELECT 'and keeps every part once an endpoint maps to NaN';
+-- The pruner records an entry only when it drops a part, so the guard holding means no `Statistics` entry.
+SELECT count() FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf) WHERE explain LIKE '%Statistics%' SETTINGS use_primary_key = 0;
 
 SELECT 'a constant dividend whose range endpoint maps to NaN';
 SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf;
@@ -47,6 +53,15 @@ SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2 SETTI
 SELECT toUInt64OrZero(extract(explain, 'Granules: (\\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \\d+/(\\d+)')) AS granules_pruned
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2)
 WHERE explain LIKE '%Granules: %/%';
+
+SELECT 'the statistics pruner analyzes a constant multiplier over this key';
+-- The `multiply` counterpart of the probe above needs a range without `+inf`, since `0 * inf` is exactly
+-- the `NaN` the guard declines. Over `[1, 100]`, `0 * k` is the constant 0, so `= 5` cannot match and the
+-- part must be pruned. (A non-zero multiplier would not do: the overflow check in
+-- `FunctionBinaryArithmetic::getMonotonicityForRange` has no `Float` case and so always declines.)
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 0 * k = 5) WHERE explain LIKE '%Statistics%' SETTINGS use_primary_key = 0;
+SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 0 * k = 5 SETTINGS use_primary_key = 0;
+SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 0 * k = 5 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
 
 DROP TABLE t_monotonicity_const_dividend_finite;
 DROP TABLE t_monotonicity_nan_const_dividend;

--- a/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.sql
+++ b/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.sql
@@ -4,9 +4,25 @@
 -- range and the `NaN` becomes the left bound - the same shape that made index and statistics pruning drop
 -- every part and granule and silently return no rows.
 
+-- `EXPLAIN indexes = 1` below reads the local plan, so keep the plan local when the test runner enables
+-- parallel replicas.
+SET parallel_replicas_local_plan = 1;
+
+-- Statistics pruning reads the column min/max that a `basic` statistic holds, and the test runner
+-- randomizes both `auto_statistics_types` and `materialize_statistics_on_insert`. Pin them, otherwise a
+-- run without materialized `basic` statistics never reaches the statistics pruner and the
+-- `use_primary_key = 0` queries below cover nothing.
+SET materialize_statistics_on_insert = 1;
+
 DROP TABLE IF EXISTS t_monotonicity_nan_const_dividend;
-CREATE TABLE t_monotonicity_nan_const_dividend (k Float64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t_monotonicity_nan_const_dividend (k Float64) ENGINE = MergeTree ORDER BY k SETTINGS auto_statistics_types = 'basic';
 INSERT INTO t_monotonicity_nan_const_dividend VALUES (1), (2), (3), (inf);
+
+SELECT 'the statistics pruner is live for this table';
+-- A predicate that falls outside the part's `[1, +inf]` statistics range does prune the part, so the
+-- statistics layer is reachable here; the queries below then show it stops pruning once an endpoint of the
+-- transformed range becomes `NaN`.
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_nan_const_dividend WHERE k < 0) WHERE explain LIKE '%Statistics%' SETTINGS use_primary_key = 0;
 
 SELECT 'a constant dividend whose range endpoint maps to NaN';
 SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf;
@@ -22,7 +38,7 @@ SELECT count() FROM t_monotonicity_nan_const_dividend WHERE 0 * k = 0 SETTINGS u
 
 SELECT 'pruning still applies with a constant dividend and a finite range';
 DROP TABLE IF EXISTS t_monotonicity_const_dividend_finite;
-CREATE TABLE t_monotonicity_const_dividend_finite (k Float64) ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 1;
+CREATE TABLE t_monotonicity_const_dividend_finite (k Float64) ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 1, auto_statistics_types = 'basic';
 INSERT INTO t_monotonicity_const_dividend_finite SELECT number + 1 FROM numbers(100);
 SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2;
 SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;

--- a/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.sql
+++ b/tests/queries/0_stateless/05182_arithmetic_monotonicity_nan_const_dividend.sql
@@ -1,0 +1,36 @@
+-- The `NaN`-endpoint guard on `divide`/`multiply` monotonicity also covers the `const / variable` and
+-- `const * variable` branches, where the constant is the left operand. `inf / k` over a range whose right
+-- end is `+inf` maps that endpoint to `NaN`; the transform is decreasing, so `KeyCondition` inverts the
+-- range and the `NaN` becomes the left bound - the same shape that made index and statistics pruning drop
+-- every part and granule and silently return no rows.
+
+DROP TABLE IF EXISTS t_monotonicity_nan_const_dividend;
+CREATE TABLE t_monotonicity_nan_const_dividend (k Float64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_monotonicity_nan_const_dividend VALUES (1), (2), (3), (inf);
+
+SELECT 'a constant dividend whose range endpoint maps to NaN';
+SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf;
+SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+
+SELECT 'each pruning layer on its own';
+SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf SETTINGS use_statistics_for_part_pruning = 0;
+SELECT count() FROM t_monotonicity_nan_const_dividend WHERE inf / k = inf SETTINGS use_primary_key = 0;
+
+SELECT 'a constant multiplier that maps the inf endpoint to NaN';
+SELECT count() FROM t_monotonicity_nan_const_dividend WHERE 0 * k = 0;
+SELECT count() FROM t_monotonicity_nan_const_dividend WHERE 0 * k = 0 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+
+SELECT 'pruning still applies with a constant dividend and a finite range';
+DROP TABLE IF EXISTS t_monotonicity_const_dividend_finite;
+CREATE TABLE t_monotonicity_const_dividend_finite (k Float64) ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 1;
+INSERT INTO t_monotonicity_const_dividend_finite SELECT number + 1 FROM numbers(100);
+SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2;
+SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2 SETTINGS use_primary_key = 0, use_statistics_for_part_pruning = 0;
+-- Granule counts depend on settings the test runner randomizes, so compare the two numbers rather than
+-- pinning them: the point is that some granules are still skipped when no endpoint becomes `NaN`.
+SELECT toUInt64OrZero(extract(explain, 'Granules: (\\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \\d+/(\\d+)')) AS granules_pruned
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_monotonicity_const_dividend_finite WHERE 100 / k > 2)
+WHERE explain LIKE '%Granules: %/%';
+
+DROP TABLE t_monotonicity_const_dividend_finite;
+DROP TABLE t_monotonicity_nan_const_dividend;


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/118468, which declined `divide`/`multiply` monotonicity when a range endpoint maps to `NaN`. The guard there covers both operand orders, but its test `05113_arithmetic_monotonicity_nan_endpoint` only exercised `variable / const`.

The `const / variable` branch has its own false-pruning shape. For `inf / k` over a range whose right end is `+inf`, `inf / inf` is `NaN`; the transform is decreasing, so `KeyCondition` inverts the range and the transformed `NaN` becomes the left bound — the same "no point compares into the range, prune everything" outcome, reached from the other side.

Verified against a binary built from current `master`, with positive and negative controls:

- with the guard, `EXPLAIN indexes = 1` for `WHERE inf / k = inf` reports `Granules: 100/100` (nothing pruned) and the query returns all matching rows;
- a finite constant dividend, `WHERE 100 / k > 2`, still prunes to `Granules: 49/100`, so pruning for ranges that stay finite is unaffected.

The test also covers `const * variable` (`0 * k`) and each pruning layer — the primary key index and `use_statistics_for_part_pruning` — on its own. `basic` column statistics are pinned on both tables and materialized on insert, because `clickhouse-test` randomizes `auto_statistics_types` and `materialize_statistics_on_insert` and `StatisticsPartPruner` is inert without a materialized `basic` or `minmax` statistic; the test also asserts that the pruner actually analyzes these transforms rather than assuming it. Since `filterPartsByStatistics` records an `IndexStat` only when it drops a part, that probe has to be the same transform shape with endpoints that stay finite, so the guard does not fire and pruning is allowed: `100 / k > 200` over `[1, +inf]` and, for `multiply`, `0 * k = 5` over `[1, 100]` — both must report a `Statistics` entry in `EXPLAIN indexes = 1`, while `inf / k = inf` must report none. Granule counts are compared rather than pinned, since the test runner randomizes the settings they depend on. Test only; no behavior change.

Addresses the review comment on https://github.com/ClickHouse/ClickHouse/pull/118468#discussion_r3455940695

Related: https://github.com/ClickHouse/ClickHouse/pull/118468
Related: https://github.com/ClickHouse/ClickHouse/issues/118121

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119461&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119461](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119461+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


