### PR TITLE
AST fuzzer oracle: do not report a mismatch when the reference read is not reproducible

### DIFF
--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -1464,6 +1464,22 @@ QueryOracleChecker::executeWithSettings(
 }
 
 
+/// An oracle compares one reference read against a rewrite required to be equivalent to it,
+/// over sorted row-sets, so ordering is already normalized out - but the comparison only means
+/// anything while both sides read the same relation. A read whose row-set is a function of
+/// physical state rather than of contents breaks that premise: a merge-collapsing engine read
+/// without `FINAL` (`SummingMergeTree`/`AggregatingMergeTree`/`ReplacingMergeTree`/
+/// `CollapsingMergeTree`), an `AggregateFunction` state column whose serialized bytes are not
+/// canonical, a concurrent `INSERT`. Callers re-read the reference on the mismatch path only,
+/// so this costs nothing when the oracle passes. `std::nullopt` (overflow, or a re-read that
+/// failed) counts as not reproduced: a read never proven stable must not license a mismatch.
+bool QueryOracleChecker::referenceReproduces(
+    const std::optional<std::vector<String>> & again, const std::vector<String> & previous)
+{
+    return again.has_value() && *again == previous;
+}
+
+
 bool QueryOracleChecker::checkTLPWhere(const ASTSelectQuery & select, const ContextMutablePtr & context)
 {
     if (!select.where())
@@ -1514,6 +1530,9 @@ bool QueryOracleChecker::checkTLPWhere(const ASTSelectQuery & select, const Cont
 
     if (ref_rows != part_rows)
     {
+        if (!referenceReproduces(executeAndCollectSortedRows(ref_sql, context), ref_rows))
+            return false;
+
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
 
         String message = fmt::format(
@@ -1632,6 +1651,9 @@ bool QueryOracleChecker::checkNoREC(const ASTSelectQuery & select, const Context
 
     if (opt_count != unopt_count)
     {
+        if (executeScalar(opt_sql, context) != opt_count)
+            return false;
+
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
 
         throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
@@ -1720,6 +1742,9 @@ bool QueryOracleChecker::checkTLPDistinct(const ASTSelectQuery & select, const C
 
     if (ref_rows != part_rows)
     {
+        if (!referenceReproduces(executeAndCollectSortedRows(ref_sql, context), ref_rows))
+            return false;
+
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
         throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
             "TLP DISTINCT oracle mismatch!\n"
@@ -1802,6 +1827,9 @@ bool QueryOracleChecker::checkTLPGroupBy(const ASTSelectQuery & select, const Co
 
     if (ref_rows != part_rows)
     {
+        if (!referenceReproduces(executeAndCollectSortedUniqueRows(ref_sql, context), ref_rows))
+            return false;
+
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
         throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
             "TLP GROUP BY oracle mismatch!\n"
@@ -1870,6 +1898,9 @@ bool QueryOracleChecker::checkTLPHaving(const ASTSelectQuery & select, const Con
 
     if (ref_rows != part_rows)
     {
+        if (!referenceReproduces(executeAndCollectSortedRows(ref_sql, context), ref_rows))
+            return false;
+
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
         throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
             "TLP HAVING oracle mismatch!\n"
@@ -1953,6 +1984,9 @@ bool QueryOracleChecker::checkDQP(const ASTSelectQuery & select, const ContextMu
 
         if (default_rows != variant_rows)
         {
+            if (!referenceReproduces(executeAndCollectSortedRows(query_sql, context), default_rows))
+                return false;
+
             ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
             throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
                 "DQP oracle mismatch! Setting: {}\n"
@@ -2263,6 +2297,9 @@ bool QueryOracleChecker::checkTLPAggregate(const ASTSelectQuery & select, const 
 
     if (ref_rows != meta_rows)
     {
+        if (!referenceReproduces(executeAndCollectSortedRows(ref_sql, context), ref_rows))
+            return false;
+
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
 
         throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
@@ -2403,10 +2440,14 @@ bool QueryOracleChecker::checkIdentityWhere(const ASTSelectQuery & select, const
     auto & v2_rows = *v2_rows_opt;
     auto & v3_rows = *v3_rows_opt;
 
+    /// The three variants share one reference read, so an unreproducible reference disqualifies all three.
     auto check_variant = [&](const String & name, const String & sql, const std::vector<String> & rows)
     {
         if (ref_rows != rows)
         {
+            if (!referenceReproduces(executeAndCollectSortedRows(ref_sql, context), ref_rows))
+                return false;
+
             ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);
             throw Exception(ErrorCodes::AST_FUZZER_ORACLE_MISMATCH,
                 "Identity WHERE ({}) oracle mismatch!\n"
@@ -2414,11 +2455,13 @@ bool QueryOracleChecker::checkIdentityWhere(const ASTSelectQuery & select, const
                 "Variant query ({} rows): {}",
                 name, ref_rows.size(), ref_sql, rows.size(), sql);
         }
+        return true;
     };
 
-    check_variant("NOT(NOT p)", v1_sql, v1_rows);
-    check_variant("p AND 1", v2_sql, v2_rows);
-    check_variant("p OR 0", v3_sql, v3_rows);
+    if (!check_variant("NOT(NOT p)", v1_sql, v1_rows)
+        || !check_variant("p AND 1", v2_sql, v2_rows)
+        || !check_variant("p OR 0", v3_sql, v3_rows))
+        return false;
 
     LOG_TRACE(logger, "Identity WHERE oracle passed ({} rows, 3 variants)", ref_rows.size());
     return true;
@@ -2498,19 +2541,7 @@ bool QueryOracleChecker::checkSubqueryWrap(const ASTSelectQuery & select, const 
 
     if (ref_rows != wrapped_rows)
     {
-        /// Both sides read the very same relation (`T` vs `SELECT * FROM (T)`) and
-        /// the comparison is over sorted row-sets, so ordering is already
-        /// normalized out. A difference can therefore only come from a
-        /// non-deterministic read of the base query itself — e.g. a
-        /// merge-collapsing engine read without `FINAL`
-        /// (`SummingMergeTree`/`AggregatingMergeTree`/`ReplacingMergeTree`/
-        /// `CollapsingMergeTree`), an `AggregateFunction` state column whose
-        /// serialized bytes are not canonical, or a non-deterministic function.
-        /// Re-execute the reference once more: if it is not stable across two
-        /// consecutive runs the query is non-deterministic, so this is an oracle
-        /// false positive rather than a subquery-wrapping bug — skip it.
-        auto ref_rows_again_opt = executeAndCollectSortedRows(ref_sql, context);
-        if (!ref_rows_again_opt || *ref_rows_again_opt != ref_rows)
+        if (!referenceReproduces(executeAndCollectSortedRows(ref_sql, context), ref_rows))
             return false;
 
         ProfileEvents::increment(ProfileEvents::ASTFuzzerOracleMismatches);

--- a/src/Interpreters/QueryOracleChecker.h
+++ b/src/Interpreters/QueryOracleChecker.h
@@ -76,6 +76,10 @@ private:
     /// Execute a scalar query (returns a single value) and return the Field.
     static Field executeScalar(const String & query, const ContextMutablePtr & context);
 
+    /// Whether a repeat execution of a reference read reproduced the rows the first one returned.
+    static bool referenceReproduces(
+        const std::optional<std::vector<String>> & again, const std::vector<String> & previous);
+
     /// Build a fresh context for oracle sub-queries.
     static ContextMutablePtr makeOracleContext(const ContextMutablePtr & base_context);
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117006#issuecomment-5632098889

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`AST fuzzer (amd_release, oracle)` reported a `TLP WHERE oracle mismatch`, 2000 reference vs 3000
partitioned rows over a `Buffer` on a `SummingMergeTree`
([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117006&sha=d2ec1eaef74e8f12048cd4261d262736ce4f5cef&name_0=PR&name_1=AST%20fuzzer%20%28amd_release%2C%20oracle%29));
@ alexey-milovidov asked for a separate fix PR
([comment](https://github.com/ClickHouse/ClickHouse/pull/117006#issuecomment-5632098889)). The TLP
arms (`p` / `NOT p` / `p IS NULL`) are exhaustive, so predicate evaluation can only move a row
between arms, never add one: +1000 rows is one insert unit, so the relation changed.

Each oracle in `QueryOracleChecker` compares a reference query against a metamorphic rewrite, run
as two separate `executeQuery` calls, over sorted row sets. Its premise, unenforced in eight of
nine oracles, is that both sides read the same relation. A row set that is a function of physical
layout rather than contents changes between the two reads, and the oracle blames the rewrite: a
merge-collapsing engine read without `FINAL`, a concurrent `INSERT`, a non-canonical
`AggregateFunction` state.

`checkSubqueryWrap` was fixed for this class in `59efd8be4ca73`: on the mismatch path only,
re-execute the reference and skip if it is not stable. I generalize that to the other eight
comparison sites through one shared helper and refold the inline version onto it, so the invariant
has one shape.

The trade: a wrong-results bug that is itself non-deterministic now makes the oracle skip rather
than report; with no reproducible reference there is nothing to compare against. `Subquery wrap`
has carried this guard since 2026-07-13 and still reported 9 mismatches in the last 30 days
(`amd_release, oracle`), the sampled ones genuine.

No test ships, matching the precedent (`15+ 0-`, none): arming the guard needs a server-global
`PAUSEABLE` failpoint held across a fuzz loop, and the only available assertion, "no mismatch is
thrown", passes vacuously when the random mutation misses the rendezvous. Validated locally in both
directions instead (recipe below); say the word and I will add one.

<details>
<summary>Local validation recipe (both directions)</summary>

`infinite_sleep` is a `PAUSEABLE` failpoint whose call site is inside `FunctionSleep::execute`,
reached before the `max_microseconds` check, so `sleep(0)` pauses; `sleep` is not screened by
the oracle. Pause a read of a merges-stopped `SummingMergeTree`, append one part per pause,
resume. Growth is monotone and keyed to the rendezvous, so the guard's re-read is always
chronologically last.

```
CREATE TABLE s (k UInt32, v UInt32) ENGINE = SummingMergeTree ORDER BY k;
SYSTEM STOP MERGES s;                     -- then 2 x INSERT ... FROM numbers(10)
SYSTEM ENABLE FAILPOINT infinite_sleep;
-- background, oracle on, no FORMAT clause (an explicit format makes the gate skip):
--   SELECT sleep(0), sleep(0), sleep(0), k FROM s WHERE k = 5
--   --ast_fuzzer_runs=300 --ast_fuzzer_oracle=1 --ast_fuzzer_any_query=0
-- driver, each WAIT wrapped in `timeout`: on every pause, INSERT one more part, then
--   SYSTEM NOTIFY FAILPOINT infinite_sleep;
SYSTEM DISABLE FAILPOINT infinite_sleep;
```

Without the guard: `Code: 906 ... TLP WHERE oracle mismatch! Reference query (40 rows) ...
Partitioned query (80 rows)`, on the first attempt in 5 of 5 runs, `ASTFuzzerOracleMismatches`
+1 each time. With the guard: no mismatch in any run, at 10x to 25x the growth-event count that
armed the unguarded binary, while `ASTFuzzerOracleChecks` advanced from 12 to 568 - so the oracles
ran and skipped rather than never running.

Anti-vacuity control, guard present and no failpoint: a genuine `Subquery wrap` mismatch taken
from CIDB (`SELECT 1, * FROM (SELECT 2 AS x) AS a LEFT JOIN (SELECT 1, 3 AS y) AS b ON y = x`,
1 vs 1 rows, reference reads no storage) still throws `Code: 906`. The 12 in-tree
oracle/fuzzer tests pass, 510/510 at `--test-runs 50`, including
`04658_ast_fuzzer_oracle_tlp_aggregate_counter`, which asserts the oracle counter strictly
increases.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119465&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119465](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119465+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
