### PR TITLE
Bump `librdkafka` from 2.14.1 to 2.15.1

### DIFF
--- a/contrib/librdkafka-cmake/CMakeLists.txt
+++ b/contrib/librdkafka-cmake/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRCS
   "${RDKAFKA_SOURCE_DIR}/rdkafka_mock.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_mock_cgrp.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_mock_handlers.c"
+  "${RDKAFKA_SOURCE_DIR}/rdkafka_mock_sharegrp.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_msg.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_msgset_reader.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_msgset_writer.c"
@@ -68,6 +69,7 @@ set(SRCS
 #  "${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_scram.c"     # WITH_SASL_SCRAM, see below
 #  "${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_win32.c"     # WIN32
 #  "${RDKAFKA_SOURCE_DIR}/rdkafka_ssl.c"            # WITH_SSL, see below
+  "${RDKAFKA_SOURCE_DIR}/rdkafka_share_acknowledgement.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_sticky_assignor.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_subscription.c"
   "${RDKAFKA_SOURCE_DIR}/rdkafka_telemetry.c"
@@ -93,6 +95,9 @@ set(SRCS
   "${RDKAFKA_SOURCE_DIR}/rdregex.c"
   "${RDKAFKA_SOURCE_DIR}/rdstring.c"
   "${RDKAFKA_SOURCE_DIR}/rdunittest.c"
+  "${RDKAFKA_SOURCE_DIR}/rdunittest_acknowledge.c"
+  "${RDKAFKA_SOURCE_DIR}/rdunittest_fetcher.c"
+  "${RDKAFKA_SOURCE_DIR}/rdunittest_msgset_errors.c"
   "${RDKAFKA_SOURCE_DIR}/rdvarint.c"
   "${RDKAFKA_SOURCE_DIR}/rdxxhash.c"
   # "${RDKAFKA_SOURCE_DIR}/regexp.c" # NOT HAVE_REGEX

--- a/contrib/librdkafka-cmake/HOW_TO_UPDATE.md
+++ b/contrib/librdkafka-cmake/HOW_TO_UPDATE.md
@@ -1,5 +1,36 @@
 In our fork of librdkafka we have a few patches that are not yet merged to upstream and we might also have to do some thing differently than in upstream librdkafka. For this reasons here are the steps we did to upgrade to new librdkafka versions.
 
+# 2.14.1 -> 2.15.1
+
+## Fixes to apply
+
+Same set as for 2.14.1, except `Fix data race in timers` (https://github.com/confluentinc/librdkafka/pull/5089),
+which is included in upstream 2.15.1 and was dropped together with its `Fix style` follow-up.
+
+- pthread_set_name_np on freebsd - https://github.com/confluentinc/librdkafka/pull/4982 (no CH PR)
+- Do not set _POSIX_C_SOURCE for FreeBSD (makes clang-15 happy) - https://github.com/confluentinc/librdkafka/pull/4157 (no CH PR)
+- Race in rd_kafka_fetch_pos2str - https://github.com/confluentinc/librdkafka/pull/4788 (no CH PR)
+- Fix possible data-race for statistics - https://github.com/confluentinc/librdkafka/pull/4630 (https://github.com/ClickHouse/librdkafka/pull/11)
+- Fix data race in rd_kafka_broker_fetch_toppars - https://github.com/confluentinc/librdkafka/pull/5266 (https://github.com/ClickHouse/librdkafka/pull/14)
+- Fix lock-order-inversion in queue refcount operations - https://github.com/confluentinc/librdkafka/pull/5445 (https://github.com/ClickHouse/librdkafka/pull/15)
+- Fix lock-order-inversion in rd_kafka_q_concat0 and rd_kafka_q_prepend0 - https://github.com/confluentinc/librdkafka/pull/5446 (https://github.com/ClickHouse/librdkafka/pull/16)
+
+## ClickHouse only fixes
+
+- Prefix librdkafka cJSON functions with `kafka_` prefix to separate them from AWS cJSON functions.
+  Upstream 2.15.1 re-imported a newer cJSON, so the rename had to be redone on the new `src/cJSON.[ch]`.
+  Note the newly added non-static helpers, in particular `cJSON_Duplicate_rec`: a missed one is only
+  visible at the final link, as a duplicate symbol against `aws-c-common`'s copy of cJSON.
+- Uncurlify: ClickHouse does not compile `src/rdhttp.c`; `contrib/librdkafka-cmake/rdhttp_poco.c` implements
+  the HTTP client on top of Poco and `src/rdhttp_curl_compat.h` declares the few remaining curl names.
+
+## ClickHouse-side changes
+
+New upstream sources have to be added to `contrib/librdkafka-cmake/CMakeLists.txt`, which lists them explicitly:
+`rdkafka_share_acknowledgement.c`, `rdkafka_mock_sharegrp.c`, `rdunittest_acknowledge.c`, `rdunittest_fetcher.c`
+and `rdunittest_msgset_errors.c`. The `rdunittest_*.c` files are not optional: `rdunittest.c` references their
+symbols.
+
 # 2.8.0 -> 2.14.1
 
 ## Fixes to apply


### PR DESCRIPTION
### ClickHouse-side changes
- `contrib/librdkafka-cmake/CMakeLists.txt` — added the 5 new upstream sources (share-group support and its unit tests); the `rdunittest_*.c` ones are registered in `rdunittest.c`, so the link fails without them.
- `contrib/librdkafka-cmake/HOW_TO_UPDATE.md` — new `2.14.1 -> 2.15.1` section, in the style of the existing ones.

### Fork
Points at fork branch `ClickHouse/v2.15.1`, which carries the existing patch series with two deltas: `Fix data race in timers` is dropped (now upstream), and `Prefix cJSON_Duplicate_rec with kafka_ prefix` is added because upstream re-imported a newer cJSON, so the `kafka_` renaming had to be redone.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `librdkafka` to v2.15.1.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119467&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119467](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119467+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1244` (included in `26.9` and later)
<!-- ch-version-info:end -->