### PR TITLE
distroless: backport base-nossl swap and production-last stage order to 26.4

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -3,8 +3,8 @@
 # The entrypoint is the compiled `clickhouse docker-init --keeper` subcommand.
 #
 # Build targets:
-#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
-#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
+#   production  — gcr.io/distroless/base-nossl-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/base-nossl-debian13:debug-nonroot  (includes busybox shell)
 #
 # Usage:
 #   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-keeper:distroless .
@@ -143,10 +143,11 @@ RUN mkdir -p \
     } > /output/etc/group
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 2: Production distroless image.
+# Stage 2: Debug image — same as production but includes the busybox shell
+#           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:12224264396c6637ae850ff7f82fb5c759115d9aa4c8b55f4aa7d40059c2e6f1 AS debug
 
 COPY --from=ch-builder /output/ /
 
@@ -165,11 +166,10 @@ WORKDIR /var/lib/clickhouse
 ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 3: Debug image — same as production but includes the busybox shell
-#           at /busybox/sh for interactive troubleshooting.
+# Stage 3: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:5cab74e7f8a5e7c5f1c8a9e6268b1f352f053c36c656f493308340bcecbc636c AS production
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -3,8 +3,8 @@
 # The entrypoint is the compiled `clickhouse docker-init` subcommand.
 #
 # Build targets:
-#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
-#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
+#   production  — gcr.io/distroless/base-nossl-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/base-nossl-debian13:debug-nonroot  (includes busybox shell)
 #
 # Usage:
 #   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-server:distroless .
@@ -161,10 +161,11 @@ RUN { \
     } > /output/etc/group
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 2: Production distroless image.
+# Stage 2: Debug image — same as production but includes the busybox shell
+#           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:12224264396c6637ae850ff7f82fb5c759115d9aa4c8b55f4aa7d40059c2e6f1 AS debug
 
 COPY --from=ch-builder /output/ /
 
@@ -183,11 +184,10 @@ WORKDIR /var/lib/clickhouse
 ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 3: Debug image — same as production but includes the busybox shell
-#           at /busybox/sh for interactive troubleshooting.
+# Stage 3: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:5cab74e7f8a5e7c5f1c8a9e6268b1f352f053c36c656f493308340bcecbc636c AS production
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
`26.4` still pins `gcr.io/distroless/cc-debian13`, so every release on this line ships the 7 packages the base-nossl swap (#107837) removed: `gcc-14-base`, `libgcc-s1`, `libgomp1`, `libssl3t64`, `libstdc++6`, `libzstd1`, `zlib1g`. ClickHouse statically links all of them, so none are used at runtime.

That is what put a fixable HIGH on the published images: `CVE-2026-14456` in `libssl3t64 3.5.6-1~deb13u2`. The `26.4-distroless` floating tags were only cleared by rebuilding them off master ([run 34612103488](https://github.com/ClickHouse/ClickHouse/actions/runs/34612103488), 23 layers -> 16, Trivy HIGH/CRITICAL 1 -> 0). Without this backport the next release on this line reintroduces it.

Also reorders the stages so `production` is last. buildx defaults to the final stage when `--target` is omitted, and on this branch that is the busybox `debug` image. Defense in depth, matching master.

Only master's two stage blocks are spliced in. Everything above them is untouched, so the branch's `ARG VERSION` default, wget handling and apt mirror args are preserved. Diff is 18 lines per file, base digests plus stage order and the header comment.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.6.4`
<!-- ch-version-info:end -->