### PR TITLE
Remove `s3_disable_checksum`, since checksum calculation for S3 does not read the source anymore

### DIFF
--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -38,7 +38,6 @@ namespace Setting
     extern const SettingsUInt64 backup_restore_s3_retry_max_backoff_ms;
     extern const SettingsFloat backup_restore_s3_retry_jitter_factor;
     extern const SettingsBool enable_s3_requests_logging;
-    extern const SettingsBool s3_disable_checksum;
     extern const SettingsUInt64 s3_max_connections;
     extern const SettingsBool s3_slow_all_threads_after_network_error;
     extern const SettingsBool backup_slow_all_threads_after_retryable_s3_error;
@@ -259,7 +258,6 @@ private:
 
         S3::ClientSettings client_settings{
             .use_virtual_addressing = s3_uri.is_virtual_hosted_style,
-            .disable_checksum = local_settings[Setting::s3_disable_checksum],
             .gcs_issue_compose_request = context->getConfigRef().getBool("s3.gcs_issue_compose_request", false),
             .is_s3express_bucket = S3::isS3ExpressEndpoint(s3_uri.endpoint),
         };

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -66,7 +66,6 @@ namespace Setting
 {
     extern const SettingsUInt64 readonly;
     extern const SettingsBool resumable_backup_from_snapshot;
-    extern const SettingsBool s3_disable_checksum;
 }
 
 namespace ServerSetting
@@ -477,23 +476,6 @@ struct BackupsWorker::BackupStarter
         auto process_list_element = backup_context->getProcessListElement();
         if (process_list_element)
             process_list_element_holder = process_list_element->getProcessListEntry();
-
-        // If user has customized backup bandwidth with S3 checksum enabled,
-        // warn for the effective bandwidth mismatch with user's setup
-        if (!query_context->getSettingsRef()[Setting::s3_disable_checksum]
-            && backup_info.backup_engine_name == "S3"
-            && query_context->getBackupsThrottler())
-        {
-            UInt64 queryMaxSpeed = query_context->getBackupsThrottler()->getMaxSpeed();
-            // Note: With S3 checksum enabled, each file is read twice — once for checksum, once for upload.
-            // This effectively halves the usable bandwidth relative to max_backup_bandwidth.
-            LOG_WARNING(
-                log,
-                "S3 checksum is enabled (s3_disable_checksum = 0): each file will be read twice — once for checksum and once for upload. "
-                "This effectively reduces the usable bandwidth to about half of max_backup_bandwidth (currently: {}). "
-                "To mitigate this, either disable checksum (SET s3_disable_checksum = 1) or increase max_backup_bandwidth.",
-                formatReadableSizeWithBinarySuffix(static_cast<double>(queryMaxSpeed), 0));
-        }
     }
 
     std::pair<bool, BackupStatus> addInfo()

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -1675,7 +1675,6 @@ static std::unordered_map<String, CHSetting> serverSettings2 = {
     {"s3_allow_server_credentials_in_user_queries", trueOrFalseSettingNoOracle},
     {"s3_check_objects_after_upload", trueOrFalseSettingNoOracle},
     {"s3_create_new_file_on_insert", trueOrFalseSettingNoOracle},
-    {"s3_disable_checksum", trueOrFalseSettingNoOracle},
     {"s3_ignore_file_doesnt_exist", trueOrFalseSettingNoOracle},
     {"s3_skip_empty_files", trueOrFalseSettingNoOracle},
     {"s3_slow_all_threads_after_network_error", trueOrFalseSettingNoOracle},

--- a/src/Coordination/KeeperSnapshotManagerS3.cpp
+++ b/src/Coordination/KeeperSnapshotManagerS3.cpp
@@ -131,7 +131,6 @@ void KeeperSnapshotManagerS3::updateS3Configuration(const Poco::Util::AbstractCo
 
         S3::ClientSettings client_settings{
             .use_virtual_addressing = new_uri.is_virtual_hosted_style,
-            .disable_checksum = false,
             .gcs_issue_compose_request = false,
             .is_s3express_bucket = S3::isS3ExpressEndpoint(new_uri.endpoint),
         };

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -778,15 +778,12 @@ Compatibility: when enabled, folds pre-signed URL query parameters (e.g. X-Amz-*
 so '?' acts as a wildcard in the path. When disabled (default), pre-signed URL query parameters are kept in the URL query
 to avoid interpreting '?' as a wildcard.
 )", 0) \
-    DECLARE(Bool, s3_disable_checksum, S3::DEFAULT_DISABLE_CHECKSUM, R"(
-Do not calculate a checksum when sending a file to S3. This speeds up writes by avoiding excessive processing passes on a file. It is mostly safe as the data of MergeTree tables is checksummed by ClickHouse anyway, and when S3 is accessed with HTTPS, the TLS layer already provides integrity while transferring through the network. While additional checksums on S3 give defense in depth.
-)", 0) \
     DECLARE(String, s3_upload_checksum_algorithm, "", R"(
 The checksum algorithm used when ClickHouse uploads data to `S3`. `CRC32` and `SHA256` are sent as flexible `x-amz-checksum-*` headers, while `MD5` is sent as a `Content-MD5` header.
 
 By default the value is empty and ClickHouse lets the AWS SDK compute `Content-MD5`. In FIPS mode `MD5` is unavailable, so the SDK silently omits it and the upload carries no checksum at all: set `CRC32` or `SHA256` to attach a flexible checksum instead. Where this setting applies, an explicit `MD5` is then rejected.
 
-For non-`S3Express` buckets, `s3_disable_checksum` suppresses this setting. It takes effect when the `S3` client is created, so it applies to query-scoped uses such as the `s3` table function and `BACKUP ... TO S3`; a later per-query `SET` does not reconfigure an already-created long-lived client such as an `S3` disk.
+It takes effect when the `S3` client is created, so it applies to query-scoped uses such as the `s3` table function and `BACKUP ... TO S3`; a later per-query `SET` does not reconfigure an already-created long-lived client such as an `S3` disk.
 
 `S3Express` buckets require a flexible checksum and do not accept `Content-MD5`: an explicit `CRC32` or `SHA256` is honored, an empty value uses `CRC32`, and an explicit `MD5` is rejected.
 
@@ -9359,6 +9356,7 @@ Enable experimental table function `eval`.
 #define OBSOLETE_SETTINGS(M, ALIAS) \
     /** Obsolete settings which are kept around for compatibility reasons. They have no effect anymore. */ \
     MAKE_OBSOLETE(M, Bool, enable_sharding_aggregator, false) \
+    MAKE_OBSOLETE(M, Bool, s3_disable_checksum, false) \
     MAKE_OBSOLETE(M, Bool, distributed_cache_use_clients_cache_for_write, false) \
     MAKE_OBSOLETE(M, String, function_implementation, "") \
     MAKE_OBSOLETE(M, Bool, allow_experimental_query_deduplication, false) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,6 +43,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.9",
         {
+            {"s3_disable_checksum", false, false, "Obsolete setting: checksum calculation no longer re-reads the source"},
             {"session_query_ids_history_size", 0, 1000, "New setting limiting the size of the session-local query id history exposed through the new `system.session_query_ids` system table. The previous value `0` (recording disabled) reproduces the pre-26.9 behavior."},
             {"query_plan_optimize_join_order_use_conflict_detector_a", false, false, "New setting to use the conflict detector A for join reordering validity in the DPsub join order algorithm."},
             {"query_plan_optimize_join_order_use_conflict_detector_c", false, false, "New setting to use the (correct and complete) conflict detector C for join reordering validity in the DPsub join order algorithm."},

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -52,7 +52,6 @@ namespace S3AuthSetting
 {
     extern const S3AuthSettingsString access_key_id;
     extern const S3AuthSettingsUInt64 connect_timeout_ms;
-    extern const S3AuthSettingsBool disable_checksum;
     extern const S3AuthSettingsUInt64 expiration_window_seconds;
     extern const S3AuthSettingsBool gcs_issue_compose_request;
     extern const S3AuthSettingsUInt64 http_keep_alive_max_requests;
@@ -194,7 +193,6 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
 
     S3::ClientSettings client_settings{
         .use_virtual_addressing = url.is_virtual_hosted_style,
-        .disable_checksum = auth_settings[S3AuthSetting::disable_checksum],
         .gcs_issue_compose_request = auth_settings[S3AuthSetting::gcs_issue_compose_request],
         .is_s3express_bucket = is_s3_express_bucket
     };

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -680,11 +680,8 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
     const auto & bucket = request.GetBucket();
     request.setApiMode(api_mode);
 
-    /// We have to use checksums for S3Express buckets, so the order of checks should be the following
     if (client_settings.is_s3express_bucket)
         request.setIsS3ExpressBucket();
-    else if (client_settings.disable_checksum)
-        request.disableChecksum();
 
     if (auto region = getRegionForBucket(bucket); !region.empty())
     {

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -98,8 +98,6 @@ bool isS3ExpressEndpoint(const std::string & endpoint);
 struct ClientSettings
 {
     bool use_virtual_addressing = false;
-    /// Disable checksum to avoid extra read of the input stream
-    bool disable_checksum = false;
     /// Should client send ComposeObject request after upload to GCS.
     ///
     /// Previously ComposeObject request was required to make Copy possible,
@@ -233,8 +231,6 @@ public:
     bool supportsMultiPartCopy() const;
 
     bool isS3ExpressBucket() const { return client_settings.is_s3express_bucket; }
-
-    bool isChecksumDisabled() const { return client_settings.disable_checksum; }
 
     bool isClientForDisk() const
     {

--- a/src/IO/S3/Requests.h
+++ b/src/IO/S3/Requests.h
@@ -132,19 +132,6 @@ public:
         return params;
     }
 
-    Aws::String GetChecksumAlgorithmName() const override
-    {
-        chassert(!is_s3express_bucket || checksum);
-
-        /// Return empty string is enough to disable checksums (see
-        /// AWSClient::AddChecksumToRequest [1] for more details).
-        ///
-        ///   [1]: https://github.com/aws/aws-sdk-cpp/blob/b0ee1c0d336dbb371c34358b68fba6c56aae2c92/src/aws-cpp-sdk-core/source/client/AWSClient.cpp#L783-L839
-        if (!hasFlexibleChecksum() && !checksum)
-            return "";
-        return BaseRequest::GetChecksumAlgorithmName();
-    }
-
     /// TODO Understand what is it. Maybe we need it...
     bool IsStreaming() const override
     {
@@ -176,9 +163,6 @@ public:
         api_mode = api_mode_;
     }
 
-    /// Disable checksum to avoid extra read of the input stream
-    void disableChecksum() const { checksum = false; }
-
     void setIsS3ExpressBucket()
     {
         is_s3express_bucket = true;
@@ -207,7 +191,6 @@ protected:
     mutable std::string region_override;
     mutable std::optional<S3::URI> uri_override;
     mutable ApiMode api_mode{ApiMode::AWS};
-    mutable bool checksum = true;
     bool is_s3express_bucket = false;
     RequestChecksum::Algorithm upload_checksum_algorithm = RequestChecksum::Algorithm::MD5;
 };
@@ -234,14 +217,14 @@ class UploadPartRequest : public ExtendedRequest<Model::UploadPartRequest>
 public:
     void SetAdditionalCustomHeaderValue(const Aws::String& headerName, const Aws::String& headerValue) override;
     bool RequestChecksumRequired() const override { return hasFlexibleChecksum(); }
-    bool ShouldComputeContentMd5() const override { return !hasFlexibleChecksum() && checksum; }
+    bool ShouldComputeContentMd5() const override { return !hasFlexibleChecksum(); }
 };
 
 class PutObjectRequest : public ExtendedRequest<Model::PutObjectRequest>
 {
 public:
     bool RequestChecksumRequired() const override { return hasFlexibleChecksum(); }
-    bool ShouldComputeContentMd5() const override { return !hasFlexibleChecksum() && checksum; }
+    bool ShouldComputeContentMd5() const override { return !hasFlexibleChecksum(); }
 };
 
 class CompleteMultipartUploadRequest : public ExtendedRequest<Model::CompleteMultipartUploadRequest>
@@ -259,14 +242,14 @@ class DeleteObjectRequest : public ExtendedRequest<Model::DeleteObjectRequest>
 {
 public:
     bool RequestChecksumRequired() const override { return is_s3express_bucket; }
-    bool ShouldComputeContentMd5() const override { return !is_s3express_bucket && checksum; }
+    bool ShouldComputeContentMd5() const override { return !is_s3express_bucket; }
 };
 
 class DeleteObjectsRequest : public ExtendedRequest<Model::DeleteObjectsRequest>
 {
 public:
     bool RequestChecksumRequired() const override { return is_s3express_bucket; }
-    bool ShouldComputeContentMd5() const override { return !is_s3express_bucket && checksum; }
+    bool ShouldComputeContentMd5() const override { return !is_s3express_bucket; }
 };
 
 class ComposeObjectRequest : public ExtendedRequest<Aws::S3::S3Request>

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -102,7 +102,6 @@ namespace
             /// `GCS`. `GCS` is never an `S3Express` bucket, so this is independent of the `S3Express` handling.
             , upload_checksum_algorithm(
                 use_upload_checksum_algorithm_ && !client_ptr->isClientForGCS()
-                        && (!client_ptr->isChecksumDisabled() || client_ptr->isS3ExpressBucket())
                     ? std::make_optional(S3::RequestChecksum::getUploadChecksumAlgorithm(request_settings, client_ptr->isS3ExpressBucket()))
                     : std::nullopt)
             , num_parts(0)

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -130,7 +130,6 @@ using RequestFn = std::function<void(std::shared_ptr<const DB::S3::Client>, cons
 
 static void testServerSideEncryption(
     RequestFn do_request,
-    bool disable_checksum,
     String server_side_encryption_customer_key_base64,
     DB::S3::ServerSideEncryptionKMSConfig sse_kms_config,
     String expected_headers,
@@ -170,7 +169,6 @@ static void testServerSideEncryption(
 
     DB::S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
-        .disable_checksum = disable_checksum,
         .gcs_issue_compose_request = false,
         .is_s3express_bucket = is_s3express_bucket,
     };
@@ -203,7 +201,6 @@ TEST(IOTestAwsS3Client, AppendExtraSSECHeadersRead)
     /// See https://github.com/ClickHouse/ClickHouse/pull/19748
     testServerSideEncryption(
         doReadRequest,
-        /* disable_checksum= */ false,
         "Kv/gDqdWVGIT4iDqg+btQvV3lc1idlm4WI+MMOyHOAw=",
         {},
         "authorization: ... SignedHeaders="
@@ -228,7 +225,6 @@ TEST(IOTestAwsS3Client, AppendExtraSSECHeadersWrite)
     /// See https://github.com/ClickHouse/ClickHouse/pull/19748
     testServerSideEncryption(
         doWriteRequest,
-        /* disable_checksum= */ false,
         "Kv/gDqdWVGIT4iDqg+btQvV3lc1idlm4WI+MMOyHOAw=",
         {},
         "authorization: ... SignedHeaders="
@@ -236,30 +232,6 @@ TEST(IOTestAwsS3Client, AppendExtraSSECHeadersWrite)
         "amz-sdk-request;"
         "content-length;"
         "content-md5;"
-        "content-type;"
-        "host;"
-        "x-amz-content-sha256;"
-        "x-amz-date;"
-        "x-amz-server-side-encryption-customer-algorithm;"
-        "x-amz-server-side-encryption-customer-key;"
-        "x-amz-server-side-encryption-customer-key-md5, ...\n"
-        "x-amz-server-side-encryption-customer-algorithm: AES256\n"
-        "x-amz-server-side-encryption-customer-key: Kv/gDqdWVGIT4iDqg+btQvV3lc1idlm4WI+MMOyHOAw=\n"
-        "x-amz-server-side-encryption-customer-key-md5: fMNuOw6OLU5GG2vc6RTA+g==\n");
-}
-
-TEST(IOTestAwsS3Client, AppendExtraSSECHeadersWriteDisableChecksum)
-{
-    /// See https://github.com/ClickHouse/ClickHouse/pull/19748
-    testServerSideEncryption(
-        doWriteRequest,
-        /* disable_checksum= */ true,
-        "Kv/gDqdWVGIT4iDqg+btQvV3lc1idlm4WI+MMOyHOAw=",
-        {},
-        "authorization: ... SignedHeaders="
-        "amz-sdk-invocation-id;"
-        "amz-sdk-request;"
-        "content-length;"
         "content-type;"
         "host;"
         "x-amz-content-sha256;"
@@ -281,7 +253,6 @@ TEST(IOTestAwsS3Client, AppendExtraSSEKMSHeadersRead)
     // KMS headers shouldn't be set on a read request
     testServerSideEncryption(
         doReadRequest,
-        /* disable_checksum= */ false,
         "",
         sse_kms_config,
         "authorization: ... SignedHeaders="
@@ -303,7 +274,6 @@ TEST(IOTestAwsS3Client, AppendExtraSSEKMSHeadersWrite)
     sse_kms_config.bucket_key_enabled = true;
     testServerSideEncryption(
         doWriteRequest,
-        /* disable_checksum= */ false,
         "",
         sse_kms_config,
         "authorization: ... SignedHeaders="
@@ -331,7 +301,6 @@ TEST(IOTestAwsS3Client, ChecksumHeaderIsPresentForS3Express)
     /// See https://github.com/ClickHouse/ClickHouse/pull/19748
     testServerSideEncryption(
         doWriteRequest,
-        /* disable_checksum= */ true,
         "",
         {},
         "authorization: ... SignedHeaders="
@@ -375,7 +344,6 @@ TEST(IOTestAwsS3Client, DetectRegionFromS3ExpressEndpoint)
     DB::HTTPHeaderEntries headers;
     DB::S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
-        .disable_checksum = false,
         .gcs_issue_compose_request = false,
         .is_s3express_bucket = DB::S3::isS3ExpressEndpoint(uri.endpoint),
     };
@@ -529,7 +497,6 @@ TEST(IOTestAwsS3Client, AssumeRole)
     {
         DB::S3::ClientSettings client_settings{
             .use_virtual_addressing = uri.is_virtual_hosted_style,
-            .disable_checksum = false,
         };
 
         std::shared_ptr<DB::S3::Client> client = DB::S3::ClientFactory::instance().create(
@@ -672,7 +639,6 @@ TEST(IOTestAwsS3Client, ClientSharesCacheWithClone)
 
     DB::S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
-        .disable_checksum = false,
         .gcs_issue_compose_request = false,
         .is_s3express_bucket = false,
     };
@@ -956,7 +922,6 @@ std::shared_ptr<DB::S3::Client> createTestS3Client(const DB::S3::URI & uri)
 
     DB::S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
-        .disable_checksum = false,
         .gcs_issue_compose_request = false,
         .is_s3express_bucket = false,
     };

--- a/src/IO/S3AuthSettings.cpp
+++ b/src/IO/S3AuthSettings.cpp
@@ -26,7 +26,6 @@ namespace DB
     DECLARE(Bool, use_insecure_imds_request, false, "", 0) \
     DECLARE(Bool, use_adaptive_timeouts, S3::DEFAULT_USE_ADAPTIVE_TIMEOUTS, "", 0) \
     DECLARE(Bool, is_virtual_hosted_style, false, "", 0) \
-    DECLARE(Bool, disable_checksum, S3::DEFAULT_DISABLE_CHECKSUM, "", 0) \
     DECLARE(Bool, gcs_issue_compose_request, false, "", 0) \
     DECLARE(S3UriStyle, uri_style, S3UriStyle::AUTO, "", 0)
 

--- a/src/IO/S3Defines.h
+++ b/src/IO/S3Defines.h
@@ -17,7 +17,6 @@ inline static constexpr uint64_t DEFAULT_KEEP_ALIVE_MAX_REQUESTS = 100;
 
 inline static constexpr bool DEFAULT_USE_ENVIRONMENT_CREDENTIALS = true;
 inline static constexpr bool DEFAULT_NO_SIGN_REQUEST = false;
-inline static constexpr bool DEFAULT_DISABLE_CHECKSUM = false;
 inline static constexpr bool DEFAULT_USE_ADAPTIVE_TIMEOUTS = true;
 
 /// Upload settings.

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -253,8 +253,8 @@ void S3RequestSettings::validateUploadSettings()
             "Setting upload_checksum_algorithm has invalid value {} which only supports {}",
             upload_checksum_algorithm, S3::RequestChecksum::supportedAlgorithms());
 
-    /// Only the name is validated: usability depends on the client (`s3_disable_checksum` and `GCS` send no
-    /// checksum at all), so the FIPS `MD5` rejection lives in `RequestChecksum::getUploadChecksumAlgorithm`.
+    /// Only the name is validated: usability depends on the client (`GCS` sends no flexible checksum at all),
+    /// so the FIPS `MD5` rejection lives in `RequestChecksum::getUploadChecksumAlgorithm`.
 
     /// TODO: it's possible to set too small limits.
     /// We can check that max possible object size is not too small.

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -518,9 +518,6 @@ std::optional<S3::RequestChecksum::Algorithm> WriteBufferFromS3::getUploadChecks
     if (client_ptr->isClientForGCS())
         return std::nullopt;
 
-    if (client_ptr->isChecksumDisabled() && !client_ptr->isS3ExpressBucket())
-        return std::nullopt;
-
     return S3::RequestChecksum::getUploadChecksumAlgorithm(request_settings, client_ptr->isS3ExpressBucket());
 }
 

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -271,7 +271,6 @@ struct Client : DB::S3::Client
 
     explicit Client(
         std::shared_ptr<S3MemStrore> mock_s3_store,
-        bool disable_checksum = false,
         bool is_s3express_bucket = false,
         std::string_view endpoint = {})
         : DB::S3::Client(
@@ -282,7 +281,6 @@ struct Client : DB::S3::Client
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
             DB::S3::ClientSettings{
                 .use_virtual_addressing = true,
-                .disable_checksum = disable_checksum,
                 .gcs_issue_compose_request = false,
                 .is_s3express_bucket = is_s3express_bucket,
             })
@@ -291,13 +289,12 @@ struct Client : DB::S3::Client
 
     static std::shared_ptr<Client> CreateClient(
         String bucket = "mock-s3-bucket",
-        bool disable_checksum = false,
         bool is_s3express_bucket = false,
         std::string_view endpoint = {})
     {
         auto s3store = std::make_shared<S3MemStrore>();
         s3store->CreateBucket(bucket);
-        return std::make_shared<Client>(s3store, disable_checksum, is_s3express_bucket, endpoint);
+        return std::make_shared<Client>(s3store, is_s3express_bucket, endpoint);
     }
 
     static DB::S3::PocoHTTPClientConfiguration GetClientConfiguration(std::string_view endpoint = {})
@@ -1346,31 +1343,6 @@ TEST_F(WBS3Test, UploadChecksumAlgorithmDefaults)
     }
 }
 
-TEST_F(WBS3Test, DisabledChecksumAcceptsMD5UnderFIPS)
-{
-    /// `s3_disable_checksum` sends no checksum at all, so `MD5` must not be rejected here even under FIPS.
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ true);
-
-    getSettings()[Setting::s3_upload_checksum_algorithm] = "MD5";
-
-    S3::S3RequestSettings request_settings;
-    request_settings.updateFromSettings(getSettings(), /* if_changed */ true, /* validate_settings */ true);
-    ASSERT_EQ("MD5", request_settings[S3RequestSetting::upload_checksum_algorithm].value);
-
-    auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
-    setInjectionModel(injection);
-
-    auto buffer = getWriteBuffer("checksum_disabled_md5_fips");
-    writeAsOneBlock(*buffer, 10);
-
-    getAsyncPolicy().setAutoExecute(true);
-    buffer->finalize();
-
-    ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::NOT_SET, injection->put_object_algorithm);
-    ASSERT_FALSE(injection->put_object_request_checksum_required);
-    ASSERT_FALSE(injection->put_object_should_compute_content_md5);
-}
-
 TEST_F(WBS3Test, UploadChecksumAlgorithmRuntimeValidation)
 {
     S3::S3RequestSettings request_settings;
@@ -1433,8 +1405,7 @@ TEST_F(WBS3Test, UploadChecksumAlgorithmGCSIgnoresSetting)
 {
     /// `GCS` requires `x-goog-*` and rejects `SigV4`-signed requests carrying `x-amz-checksum-*`, so even
     /// an explicit algorithm must not reach the request.
-    client = MockS3::Client::CreateClient(
-        bucket, /* disable_checksum */ false, /* is_s3express_bucket */ false, MockS3::Client::gcs_endpoint);
+    client = MockS3::Client::CreateClient(bucket, /* is_s3express_bucket */ false, MockS3::Client::gcs_endpoint);
     ASSERT_TRUE(client->isClientForGCS());
 
     auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
@@ -1474,117 +1445,11 @@ TEST_F(WBS3Test, UploadChecksumAlgorithmMD5Singlepart)
     ASSERT_TRUE(injection->put_object_should_compute_content_md5);
 }
 
-TEST_F(WBS3Test, UploadChecksumAlgorithmEmptyDefaultDisabledChecksumSinglepart)
-{
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ true);
-
-    auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
-    setInjectionModel(injection);
-
-    auto buffer = getWriteBuffer("checksum_empty_default_disabled_singlepart");
-    writeAsOneBlock(*buffer, 10);
-
-    getAsyncPolicy().setAutoExecute(true);
-    buffer->finalize();
-
-    ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::NOT_SET, injection->put_object_algorithm);
-    ASSERT_FALSE(injection->put_object_request_checksum_required);
-    ASSERT_FALSE(injection->put_object_should_compute_content_md5);
-}
-
-TEST_F(WBS3Test, DisabledChecksumTakesPrecedenceOverUploadChecksumAlgorithm)
-{
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ true);
-
-    auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
-    setInjectionModel(injection);
-
-    getSettings()[Setting::s3_upload_checksum_algorithm] = "SHA256";
-
-    auto buffer = getWriteBuffer("checksum_disabled_precedence");
-    writeAsOneBlock(*buffer, 10);
-
-    getAsyncPolicy().setAutoExecute(true);
-    buffer->finalize();
-
-    ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::NOT_SET, injection->put_object_algorithm);
-    ASSERT_FALSE(injection->put_object_request_checksum_required);
-    ASSERT_FALSE(injection->put_object_should_compute_content_md5);
-}
-
-TEST_P(SyncAsync, DisabledChecksumTakesPrecedenceOverUploadChecksumAlgorithmMultipart)
-{
-    /// The multipart requests are built separately from `PutObject`, so the precedence has to be asserted here too.
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ true);
-
-    auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
-    setInjectionModel(injection);
-
-    getSettings()[Setting::s3_upload_checksum_algorithm] = "SHA256";
-    getSettings()[Setting::s3_max_single_part_upload_size] = 0;
-    getSettings()[Setting::s3_min_upload_part_size] = 1;
-
-    auto buffer = getWriteBuffer("checksum_disabled_precedence_multipart");
-    writeAsOneBlock(*buffer, 10);
-
-    getAsyncPolicy().setAutoExecute(true);
-    buffer->finalize();
-
-    ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::NOT_SET, injection->create_multipart_upload_algorithm);
-    ASSERT_THAT(injection->upload_part_algorithms, testing::Not(testing::IsEmpty()));
-    ASSERT_THAT(injection->upload_part_algorithms, testing::Each(Aws::S3::Model::ChecksumAlgorithm::NOT_SET));
-    ASSERT_THAT(injection->upload_part_sha256_checksums, testing::Each(testing::IsEmpty()));
-    ASSERT_THAT(injection->complete_part_sha256_checksums, testing::Each(testing::IsEmpty()));
-    ASSERT_THAT(injection->complete_part_crc32_checksums, testing::Each(testing::IsEmpty()));
-}
-
-TEST_F(WBS3Test, CopyDataDisabledChecksumTakesPrecedenceOverUploadChecksumAlgorithmMultipart)
-{
-    /// `copyDataToS3File` has its own request builder, so it needs the same assertion as `WriteBufferFromS3`.
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ true);
-
-    auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
-    setInjectionModel(injection);
-
-    getSettings()[Setting::s3_upload_checksum_algorithm] = "SHA256";
-    getSettings()[Setting::s3_max_single_part_upload_size] = 0;
-    getSettings()[Setting::s3_min_upload_part_size] = 1;
-
-    const String data(10, 'a');
-    CreateReadBuffer create_read_buffer = [data]() -> std::unique_ptr<SeekableReadBuffer>
-    {
-        return std::make_unique<ReadBufferFromString>(data);
-    };
-
-    S3::S3RequestSettings request_settings;
-    request_settings.updateFromSettings(getSettings(), /* if_changed */ true, /* validate_settings */ false);
-
-    copyDataToS3File(
-        create_read_buffer,
-        0,
-        data.size(),
-        client,
-        bucket,
-        "copy_checksum_disabled_precedence_multipart",
-        request_settings,
-        nullptr,
-        getAsyncPolicy().getScheduler(),
-        std::nullopt);
-
-    ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::NOT_SET, injection->create_multipart_upload_algorithm);
-    ASSERT_THAT(injection->upload_part_algorithms, testing::Not(testing::IsEmpty()));
-    ASSERT_THAT(injection->upload_part_algorithms, testing::Each(Aws::S3::Model::ChecksumAlgorithm::NOT_SET));
-    ASSERT_THAT(injection->upload_part_sha256_checksums, testing::Each(testing::IsEmpty()));
-    ASSERT_THAT(injection->complete_part_sha256_checksums, testing::Each(testing::IsEmpty()));
-    ASSERT_THAT(injection->complete_part_crc32_checksums, testing::Each(testing::IsEmpty()));
-    ASSERT_EQ(data, client->store->GetBucketStore(bucket).objects["copy_checksum_disabled_precedence_multipart"]);
-}
-
 TEST_F(WBS3Test, S3ExpressHonorsExplicitUploadChecksumAlgorithm)
 {
     /// S3Express forces CRC32 only as a default; an explicit SHA256 must survive `setIsS3ExpressBucket`,
     /// which is applied when the request is sent (after the upload algorithm has been chosen).
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ false, /* is_s3express_bucket */ true);
+    client = MockS3::Client::CreateClient(bucket, /* is_s3express_bucket */ true);
 
     auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
     setInjectionModel(injection);
@@ -1599,29 +1464,6 @@ TEST_F(WBS3Test, S3ExpressHonorsExplicitUploadChecksumAlgorithm)
 
     ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::SHA256, injection->put_object_algorithm);
     ASSERT_TRUE(injection->put_object_request_checksum_required);
-}
-
-TEST_P(SyncAsync, S3ExpressDisabledChecksumKeepsMultipartChecksums)
-{
-    client = MockS3::Client::CreateClient(bucket, /* disable_checksum */ true, /* is_s3express_bucket */ true);
-
-    auto injection = std::make_shared<MockS3::ChecksumRecordingInjection>();
-    setInjectionModel(injection);
-
-    getSettings()[Setting::s3_max_single_part_upload_size] = 0;
-    getSettings()[Setting::s3_min_upload_part_size] = 1;
-
-    auto buffer = getWriteBuffer("s3express_disabled_checksum_multipart");
-    writeAsOneBlock(*buffer, 10);
-
-    getAsyncPolicy().setAutoExecute(true);
-    buffer->finalize();
-
-    ASSERT_EQ(Aws::S3::Model::ChecksumAlgorithm::CRC32, injection->create_multipart_upload_algorithm);
-    ASSERT_THAT(injection->upload_part_algorithms, testing::Not(testing::IsEmpty()));
-    ASSERT_THAT(injection->upload_part_algorithms, testing::Each(Aws::S3::Model::ChecksumAlgorithm::CRC32));
-    ASSERT_EQ(injection->upload_part_crc32_checksums, injection->complete_part_crc32_checksums);
-    ASSERT_THAT(injection->complete_part_crc32_checksums, testing::Each(testing::Not(testing::IsEmpty())));
 }
 
 TEST_P(SyncAsync, ExceptionOnCompleteMPU) {

--- a/src/Interpreters/MecabDictionaryManager.cpp
+++ b/src/Interpreters/MecabDictionaryManager.cpp
@@ -156,7 +156,6 @@ std::unique_ptr<ReadBuffer> openS3Source(const String & location, const ContextP
 
     S3::ClientSettings client_settings{
         .use_virtual_addressing = uri.is_virtual_hosted_style,
-        .disable_checksum = false,
         .gcs_issue_compose_request = false,
         .is_s3express_bucket = S3::isS3ExpressEndpoint(uri.endpoint),
     };

--- a/tests/integration/test_throttling/configs/users_overrides_persistent.xml
+++ b/tests/integration/test_throttling/configs/users_overrides_persistent.xml
@@ -1,7 +1,0 @@
-<clickhouse>
-    <profiles>
-        <default>
-            <s3_disable_checksum>true</s3_disable_checksum>
-        </default>
-    </profiles>
-</clickhouse>

--- a/tests/integration/test_throttling/test.py
+++ b/tests/integration/test_throttling/test.py
@@ -58,7 +58,6 @@ node = cluster.add_instance(
     ],
     user_configs=[
         "configs/users_overrides.xml",
-        "configs/users_overrides_persistent.xml",
     ],
     with_minio=True,
     minio_certs_dir="minio_certs",


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove `s3_disable_checksum`, since checksum calculation for S3 does not read the source second time anymore (previously the problem was that sources has been read twice, once for sending data, second for checksum calculation)

Double read was fixed in https://github.com/ClickHouse/ClickHouse/pull/108573

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119496&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119496](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119496+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

_Note: marked as `Backward Incompatible Change` only to highlight in changelog_


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1228` (included in `26.9` and later)
<!-- ch-version-info:end -->