### PR TITLE
Do not treat a non-Nullable CAST as null-propagating in the join order optimizer

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -859,9 +859,9 @@ static bool isNullPropagatingFunction(const ActionsDAG::Node & node)
     const auto & name = node.function_base->getName();
     if (!names.contains(name))
         return false;
-    /// A cast yields `NULL` only when its target type can hold one: casting `NULL` to a
-    /// non-`Nullable` type raises `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` instead of returning
-    /// `NULL`, so such a node is not `NULL` on a null-extended row.
+    /// A cast to a non-`Nullable` type raises `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` rather than
+    /// returning `NULL`; a cast to `Variant`/`Dynamic` returns `NULL` but a join on such a key
+    /// matches `NULL` to `NULL`. Only the `Nullable` wrappers reject a null-extended row here.
     if (name == "CAST" || name == "_CAST")
         return isNullableOrLowCardinalityNullable(node.result_type);
     return true;

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -861,7 +861,7 @@ static bool isNullPropagatingFunction(const ActionsDAG::Node & node)
         return false;
     /// A cast to a non-`Nullable` type raises `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` rather than
     /// returning `NULL`; a cast to `Variant`/`Dynamic` returns `NULL` but a join on such a key
-    /// matches `NULL` to `NULL`. Only the `Nullable` wrappers reject a null-extended row here.
+    /// matches `NULL` to `NULL`. Neither shape rejects a null-extended row, so neither counts.
     if (name == "CAST" || name == "_CAST")
         return isNullableOrLowCardinalityNullable(node.result_type);
     return true;

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -847,17 +847,24 @@ static size_t addChildQueryGraph(QueryGraphBuilder & graph, QueryPlan::Node * no
 /// The set is intentionally small and conservative -- an unknown function is treated as opaque
 /// (contributes nothing), which can only make CD-A miss a valid reordering, never admit an invalid
 /// one. It excludes NULL-blocking functions on purpose (`coalesce`, `ifNull`, `assumeNotNull`, ...).
-static bool isNullPropagatingFunction(const String & name)
+static bool isNullPropagatingFunction(const ActionsDAG::Node & node)
 {
     static const std::unordered_set<std::string_view> names = {
         /// comparisons (the atoms of equi/theta-join predicates)
         "equals", "notEquals", "less", "greater", "lessOrEquals", "greaterOrEquals",
         /// arithmetic that may wrap a column inside a comparison, e.g. `a.x + 1 = b.y`
         "plus", "minus", "multiply", "divide", "modulo", "negate",
-        /// a CAST of NULL is NULL
         "CAST", "_CAST",
     };
-    return names.contains(name);
+    const auto & name = node.function_base->getName();
+    if (!names.contains(name))
+        return false;
+    /// A cast yields `NULL` only when its target type can hold one: casting `NULL` to a
+    /// non-`Nullable` type raises `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` instead of returning
+    /// `NULL`, so such a node is not `NULL` on a null-extended row.
+    if (name == "CAST" || name == "_CAST")
+        return isNullableOrLowCardinalityNullable(node.result_type);
+    return true;
 }
 
 /// Relations R such that `node` evaluates to NULL when all of R's columns are NULL ("strict" on R).
@@ -874,7 +881,7 @@ static BitSet strictOnRelations(const ActionsDAG::Node * node, const JoinExpress
             return node->children.empty() ? BitSet{} : strictOnRelations(node->children.front(), actions);
         case ActionsDAG::ActionType::FUNCTION:
         {
-            if (!node->function_base || !isNullPropagatingFunction(node->function_base->getName()))
+            if (!node->function_base || !isNullPropagatingFunction(*node))
                 return {};
             BitSet result;
             for (const auto * child : node->children)

--- a/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.reference
+++ b/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.reference
@@ -25,3 +25,5 @@ plain         cd_a 	Read(t2)
 plain         cd_a 	Read(t3)
 rows cast-nullable noopt	2	9	9
 rows cast-nullable cd_a 	2	9	9
+rows variant  noopt	2	1	1
+rows variant  cd_a 	2	1	1

--- a/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.reference
+++ b/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.reference
@@ -1,0 +1,27 @@
+baseline           	Join
+baseline           	Join
+baseline           	Read(t1)
+baseline           	Read(t2)
+baseline           	Read(t3)
+cast-int64    cd_a 	Join
+cast-int64    cd_a 	Join
+cast-int64    cd_a 	Read(t1)
+cast-int64    cd_a 	Read(t2)
+cast-int64    cd_a 	Read(t3)
+cast-int64    cd_c 	Join
+cast-int64    cd_c 	Join
+cast-int64    cd_c 	Read(t1)
+cast-int64    cd_c 	Read(t2)
+cast-int64    cd_c 	Read(t3)
+cast-nullable cd_a 	Join
+cast-nullable cd_a 	Read(t1)
+cast-nullable cd_a 	Join
+cast-nullable cd_a 	Read(t2)
+cast-nullable cd_a 	Read(t3)
+plain         cd_a 	Join
+plain         cd_a 	Read(t1)
+plain         cd_a 	Join
+plain         cd_a 	Read(t2)
+plain         cd_a 	Read(t3)
+rows cast-nullable noopt	2	9	9
+rows cast-nullable cd_a 	2	9	9

--- a/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.sql
+++ b/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.sql
@@ -14,6 +14,7 @@
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t3v;
 
 CREATE TABLE t1 (a Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE t2 (a Nullable(Int64), k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
@@ -21,6 +22,13 @@ CREATE TABLE t3 (k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t1 VALUES (1), (2);
 INSERT INTO t2 VALUES (1, 10);
 INSERT INTO t3 VALUES (10);
+
+-- A `Variant` (like a `Dynamic`) join key matches NULL to NULL, so an equality over one does not
+-- reject a null-extended row: `Variant(Int64)` keys that are both NULL join, where `Nullable(Int64)`
+-- keys that are both NULL do not. A cast to such a type therefore carries no null-rejection for the
+-- reorderer to use, even though the cast itself returns NULL on a NULL input.
+CREATE TABLE t3v (k Variant(Int64), tag String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t3v VALUES (10::Int64, 'ten'), (NULL, 'null_key');
 
 SET enable_analyzer = 1, single_join_prefer_left_table = 0;
 -- Pinned because the test asserts on the join plan shape.
@@ -92,6 +100,19 @@ SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
     query_plan_optimize_join_order_algorithm = 'dpsub',
     query_plan_optimize_join_order_use_conflict_detector_a = 1;
 
+-- The null-extended `t1` row reaches `t3v`'s NULL key through the cast, so the reordering the
+-- detector may not take here is the one that would drop that match. Both arms must agree.
+SELECT 'rows variant  noopt', count(), countIf(t3v.tag = 'null_key'), countIf(t3v.tag = 'ten')
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3v ON CAST(t2.k AS Variant(Int64)) = t3v.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0;
+
+SELECT 'rows variant  cd_a ', count(), countIf(t3v.tag = 'null_key'), countIf(t3v.tag = 'ten')
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3v ON CAST(t2.k AS Variant(Int64)) = t3v.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+    query_plan_optimize_join_order_algorithm = 'dpsub',
+    query_plan_optimize_join_order_use_conflict_detector_a = 1;
+
 DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
+DROP TABLE t3v;

--- a/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.sql
+++ b/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.sql
@@ -1,0 +1,97 @@
+-- The join-order conflict detectors reorder outer joins using null-rejection, and the reorderer
+-- decides that by walking the ON expression through functions it believes propagate NULL. A CAST to
+-- a NON-Nullable type does not propagate NULL: on a null-extended row it raises
+-- CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN (349) instead of returning NULL. So such a CAST must not
+-- count, and the plan for `CAST(t2.k AS Int64) = t3.k` must stay the plan the unoptimized query has.
+-- Requested at https://github.com/ClickHouse/ClickHouse/pull/119305#discussion_r3990785321.
+--
+-- The oracle is the Join/Read skeleton of the plan, in depth-first order: for a 3-way join
+-- `Join, Join, Read, Read, Read` is left-deep and `Join, Read, Join, Read, Read` is right-deep.
+-- EXPLAIN only, so no arm can throw. Two arms are non-vacuity controls: `cast-nullable cd_a` must
+-- still reassociate (it reddens if every CAST is rejected instead of only the non-Nullable ones),
+-- and `plain cd_a` must reassociate (it proves the detector is live and is what moves the plan).
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+
+CREATE TABLE t1 (a Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (a Nullable(Int64), k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t3 (k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (1, 10);
+INSERT INTO t3 VALUES (10);
+
+SET enable_analyzer = 1, single_join_prefer_left_table = 0;
+-- Pinned because the test asserts on the join plan shape.
+SET query_plan_optimize_join_order_randomize = 0, use_hash_table_stats_for_join_reordering = 0;
+-- Make t1 look expensive so the detector prefers to reorder t2/t3 to the front.
+SET param__internal_join_table_stat_hints = '{"t1": {"cardinality": 100000, "distinct_keys": {"a": 2}}, "t2": {"cardinality": 1, "distinct_keys": {"a": 1, "k": 1}}, "t3": {"cardinality": 1, "distinct_keys": {"k": 1}}}';
+
+SELECT 'baseline           ' AS arm, s AS step FROM (
+    SELECT replaceRegexpOne(replaceRegexpOne(replaceRegexpOne(explain, '^[^A-Za-z]+', ''),
+        '^Join \(.*$', 'Join'), '^ReadFromMergeTree \([^.]+\.([^)]+)\).*$', 'Read(\1)') AS s
+    FROM (
+        EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k
+        SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0
+    )
+) WHERE s IN ('Join', 'Read(t1)', 'Read(t2)', 'Read(t3)');
+
+SELECT 'cast-int64    cd_a ' AS arm, s AS step FROM (
+    SELECT replaceRegexpOne(replaceRegexpOne(replaceRegexpOne(explain, '^[^A-Za-z]+', ''),
+        '^Join \(.*$', 'Join'), '^ReadFromMergeTree \([^.]+\.([^)]+)\).*$', 'Read(\1)') AS s
+    FROM (
+        EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Int64) = t3.k
+        SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+            query_plan_optimize_join_order_algorithm = 'dpsub',
+            query_plan_optimize_join_order_use_conflict_detector_a = 1
+    )
+) WHERE s IN ('Join', 'Read(t1)', 'Read(t2)', 'Read(t3)');
+
+SELECT 'cast-int64    cd_c ' AS arm, s AS step FROM (
+    SELECT replaceRegexpOne(replaceRegexpOne(replaceRegexpOne(explain, '^[^A-Za-z]+', ''),
+        '^Join \(.*$', 'Join'), '^ReadFromMergeTree \([^.]+\.([^)]+)\).*$', 'Read(\1)') AS s
+    FROM (
+        EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Int64) = t3.k
+        SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+            query_plan_optimize_join_order_algorithm = 'dpsub',
+            query_plan_optimize_join_order_use_conflict_detector_c = 1
+    )
+) WHERE s IN ('Join', 'Read(t1)', 'Read(t2)', 'Read(t3)');
+
+SELECT 'cast-nullable cd_a ' AS arm, s AS step FROM (
+    SELECT replaceRegexpOne(replaceRegexpOne(replaceRegexpOne(explain, '^[^A-Za-z]+', ''),
+        '^Join \(.*$', 'Join'), '^ReadFromMergeTree \([^.]+\.([^)]+)\).*$', 'Read(\1)') AS s
+    FROM (
+        EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Nullable(Int64)) = t3.k
+        SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+            query_plan_optimize_join_order_algorithm = 'dpsub',
+            query_plan_optimize_join_order_use_conflict_detector_a = 1
+    )
+) WHERE s IN ('Join', 'Read(t1)', 'Read(t2)', 'Read(t3)');
+
+SELECT 'plain         cd_a ' AS arm, s AS step FROM (
+    SELECT replaceRegexpOne(replaceRegexpOne(replaceRegexpOne(explain, '^[^A-Za-z]+', ''),
+        '^Join \(.*$', 'Join'), '^ReadFromMergeTree \([^.]+\.([^)]+)\).*$', 'Read(\1)') AS s
+    FROM (
+        EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k
+        SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+            query_plan_optimize_join_order_algorithm = 'dpsub',
+            query_plan_optimize_join_order_use_conflict_detector_a = 1
+    )
+) WHERE s IN ('Join', 'Read(t1)', 'Read(t2)', 'Read(t3)');
+
+-- The reordering that stays permitted must not change the result.
+SELECT 'rows cast-nullable noopt', count(), sum(ifNull(t2.k, -1)), sum(ifNull(t3.k, -1))
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Nullable(Int64)) = t3.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0;
+
+SELECT 'rows cast-nullable cd_a ', count(), sum(ifNull(t2.k, -1)), sum(ifNull(t3.k, -1))
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Nullable(Int64)) = t3.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+    query_plan_optimize_join_order_algorithm = 'dpsub',
+    query_plan_optimize_join_order_use_conflict_detector_a = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;

--- a/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.sql
+++ b/tests/queries/0_stateless/05182_join_order_conflict_detector_cast_null_propagation.sql
@@ -5,9 +5,10 @@
 -- count, and the plan for `CAST(t2.k AS Int64) = t3.k` must stay the plan the unoptimized query has.
 -- Requested at https://github.com/ClickHouse/ClickHouse/pull/119305#discussion_r3990785321.
 --
--- The oracle is the Join/Read skeleton of the plan, in depth-first order: for a 3-way join
+-- The plan arms read the Join/Read skeleton of the plan, in depth-first order: for a 3-way join
 -- `Join, Join, Read, Read, Read` is left-deep and `Join, Read, Join, Read, Read` is right-deep.
--- EXPLAIN only, so no arm can throw. Two arms are non-vacuity controls: `cast-nullable cd_a` must
+-- They use EXPLAIN, so they cannot throw; the executed arms after them assert the exception the
+-- plan choice exists to preserve. Two plan arms are non-vacuity controls: `cast-nullable cd_a` must
 -- still reassociate (it reddens if every CAST is rejected instead of only the non-Nullable ones),
 -- and `plain cd_a` must reassociate (it proves the detector is live and is what moves the plan).
 
@@ -88,6 +89,25 @@ SELECT 'plain         cd_a ' AS arm, s AS step FROM (
             query_plan_optimize_join_order_use_conflict_detector_a = 1
     )
 ) WHERE s IN ('Join', 'Read(t1)', 'Read(t2)', 'Read(t3)');
+
+-- A plan arm cannot see a change that keeps the left-deep skeleton and stops evaluating the cast on
+-- the null-extended row, so the executed query is asserted too: the unoptimized query raises, and
+-- under either detector it must still raise.
+SELECT count(), sum(ifNull(t2.k, -1)), sum(ifNull(t3.k, -1))
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Int64) = t3.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0; -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+
+SELECT count(), sum(ifNull(t2.k, -1)), sum(ifNull(t3.k, -1))
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Int64) = t3.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+    query_plan_optimize_join_order_algorithm = 'dpsub',
+    query_plan_optimize_join_order_use_conflict_detector_a = 1; -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+
+SELECT count(), sum(ifNull(t2.k, -1)), sum(ifNull(t3.k, -1))
+FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON CAST(t2.k AS Int64) = t3.k
+SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
+    query_plan_optimize_join_order_algorithm = 'dpsub',
+    query_plan_optimize_join_order_use_conflict_detector_c = 1; -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
 
 -- The reordering that stays permitted must not change the result.
 SELECT 'rows cast-nullable noopt', count(), sum(ifNull(t2.k, -1)), sum(ifNull(t3.k, -1))


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/119305
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/119305
Requested by @ m-selmi at https://github.com/ClickHouse/ClickHouse/pull/119305#discussion_r3990785321

`isNullPropagatingFunction` in `optimizeJoin.cpp` decided null propagation from the function name,
listing `CAST` / `_CAST` unconditionally. For a cast it is a property of the target type: casting
`NULL` to a non-`Nullable` type raises `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` instead of returning
`NULL`, so `strictOnRelations` reported a relation as null-rejected where the runtime raises and the
DPsub conflict detectors reassociated on that basis. This gates the two cast
names on `isNullableOrLowCardinalityNullable(node.result_type)`, the predicate #119305 adds on
`FunctionConvert` / `ExecutableFunctionCast`, so the two agree by construction.

All columns `Nullable(Int64)`, `t1(a) = {1,2}`, `t2(a,k) = {(1,10)}`, `t3(k) = {10}`:

```sql
SELECT t1.a, t2.k, t3.k FROM t1 LEFT JOIN t2 ON t1.a = t2.a
LEFT JOIN t3 ON CAST(t2.k AS Int64) = t3.k ORDER BY ALL SETTINGS join_use_nulls = 1;
```

| added settings | before | after |
|---|---|---|
| `'dpsub'` + `..._use_conflict_detector_a = 1` | `1 10 10` / `2 \N \N` | `Code: 349` |
| `'dpsub'` + `..._use_conflict_detector_c = 1` | `1 10 10` / `2 \N \N` | `Code: 349` |
| anything else (defaults included) | `Code: 349` | `Code: 349` |

**A hardening for the cast above; a correctness fix for one other shape.** For an `Int64` target a
query that returned rows now raises `Code: 349`. A target that pads
with a *matchable* value gave a wrong result: with `t3.k Variant(Int64)` holding a NULL key,
`CAST(t2.k AS Variant(Int64)) = t3.k` loses that match under CD-A before and keeps it after. A
`Variant` / `Dynamic` join key matches NULL to NULL, so a cast to one carries no null-rejection;
hence `isNullableOrLowCardinalityNullable`, not `canContainNull`. Both detectors default off, with
`greedy` the default solver.

The new test pins the Join/Read plan skeleton per arm at `..._join_order_limit > 0`, with two
non-vacuity controls, two `Variant`-keyed result arms that must agree, and executed arms expecting
`CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` with reordering off and under each detector. Five arms fail
on master. First stateless coverage of `trust_null_rejection = true`; 50/50 with randomization on;
14 neighbour tests unchanged.

<details>
<summary>Query plans, before and after (click to expand)</summary>

`'dpsub'` + `..._use_conflict_detector_a = 1`, before. The cast counts as null-propagating, so the
pair is reassociated and the raising evaluation is skipped:

```
└──Join (JOIN FillRightFirst)
   │  t1[2] ⟕ (t2[1] ⟕ t3[1])
   │  Join conditions: a = a
   ├──ReadFromMergeTree (t1)
   └──Join (JOIN FillRightFirst)
      │  t2[1] ⟕ t3[1]
      │  Join conditions: CAST(CAST(k AS Int64) AS Nullable(Int64)) = k
      ├──ReadFromMergeTree (t2)
      └──ReadFromMergeTree (t3)
```

After this change, identical to the `..._join_order_limit = 0` plan:

```
└──Join (JOIN FillRightFirst)
   │  t1[2] ⟕ t2[1] ⟕ t3[1]
   │  Join conditions: CAST(CAST(k AS Int64) AS Nullable(Int64)) = k
   ├──Join (JOIN FillRightFirst)
   │  │  t1[2] ⟕ t2[1]
   │  │  Join conditions: a = a
   │  ├──ReadFromMergeTree (t1)
   │  └──ReadFromMergeTree (t2)
   └──ReadFromMergeTree (t3)
```

The analyzer nests the cast as `_CAST(CAST(t2.k, 'Int64'), 'Nullable(Int64)')`. The outer alignment
cast is `Nullable` and still passes; recursion descends into the inner non-`Nullable` cast, which is
now rejected, and that is what stops `t2` from being contributed.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119512&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119512](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119512+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


