### PR TITLE
Fix `UNKNOWN_ELEMENT_OF_ENUM` for string functions over `Nullable(Enum)`

### DIFF
--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -206,6 +206,19 @@ namespace
 /// value. With `only_enums` the other argument types are left alone, which is what the paths that
 /// discard the values of null rows afterwards want; the path that has to produce `f(default(input))`
 /// for a null row (see below) passes false and normalizes everything.
+///
+/// `only_enums` is deliberately not "every type whose payload some function might reject". An `Enum`
+/// payload is outside the domain of its own type - no valid `Enum` column can hold it - so
+/// `createBlockWithNestedColumns` hands the function a malformed column, and installing the type's
+/// default repairs a type invariant. A `String` or a number under a null map, in contrast, is a well
+/// formed value of its type, and a function that rejects it - `match` handed an invalid regular
+/// expression, `hasToken` handed a token separator - rejects it as data, exactly as it would in a
+/// non-null row. Installing the type default there would only swap one arbitrary value for another,
+/// while costing a per-row copy of every `Nullable` argument on paths whose whole point is to avoid
+/// even a `countBytesInFilter`. The fix for that family is to stop evaluating the discarded rows,
+/// which is what the short-circuit branch below already does when
+/// `short_circuit_function_evaluation_for_nulls_threshold` lets it;
+/// see https://github.com/ClickHouse/ClickHouse/issues/119614.
 void patchNullSlots(
     const ColumnsWithTypeAndName & args, ColumnsWithTypeAndName & nested_args, size_t input_rows_count, bool only_enums)
 {

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -191,6 +191,69 @@ ColumnPtr IExecutableFunction::defaultImplementationForConstantArguments(
 }
 
 
+namespace
+{
+
+/// `createBlockWithNestedColumns` only strips the null map, it does not touch the values under it, so
+/// the nested value of a null slot is whatever happened to be stored there. For a `Nullable(Enum)`
+/// that value is usually not a member of the type: both `INSERT ... VALUES (NULL)` and the padding of
+/// non-joined rows in a `LEFT JOIN` leave a raw 0 there, and 0 is a declared value only if the enum
+/// happens to define it. A function that reads the nested column of such an argument - `like`,
+/// `match`, anything that turns an `Enum` into its name - is then handed a code that does not exist
+/// and throws `UNKNOWN_ELEMENT_OF_ENUM` for a row whose result is NULL anyway.
+///
+/// Normalize the null slots to the default of the nested type, which for an `Enum` is a declared
+/// value. With `only_enums` the other argument types are left alone, which is what the paths that
+/// discard the values of null rows afterwards want; the path that has to produce `f(default(input))`
+/// for a null row (see below) passes false and normalizes everything.
+void patchNullSlots(
+    const ColumnsWithTypeAndName & args, ColumnsWithTypeAndName & nested_args, size_t input_rows_count, bool only_enums)
+{
+    for (size_t i = 0; i < args.size(); ++i)
+    {
+        if (!args[i].type->isNullable())
+            continue;
+        if (only_enums && !isEnum(removeNullable(args[i].type)))
+            continue;
+
+        const auto & nested_type = nested_args[i].type;
+
+        if (isColumnConst(*args[i].column))
+        {
+            if (args[i].column->onlyNull())
+                nested_args[i].column = nested_type->createColumnConstWithDefaultValue(input_rows_count);
+            continue;
+        }
+
+        const auto & null_map = assert_cast<const ColumnNullable &>(*args[i].column).getNullMapData();
+
+        bool has_any_null = false;
+        for (size_t row = 0; row < input_rows_count; ++row)
+        {
+            if (null_map[row])
+            {
+                has_any_null = true;
+                break;
+            }
+        }
+        if (!has_any_null)
+            continue;
+
+        auto patched = nested_type->createColumn();
+        patched->reserve(input_rows_count);
+        for (size_t row = 0; row < input_rows_count; ++row)
+        {
+            if (null_map[row])
+                nested_type->insertDefaultInto(*patched);
+            else
+                patched->insertFrom(*nested_args[i].column, row);
+        }
+        nested_args[i].column = std::move(patched);
+    }
+}
+
+}
+
 ColumnPtr IExecutableFunction::defaultImplementationForNulls(
     const ColumnsWithTypeAndName & args, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
 {
@@ -245,47 +308,8 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
             /// produces a Nullable column whose nested data still contains `'x'`, so running the
             /// function on it would return `f('x')` instead of the desired `f('')`.
             ColumnsWithTypeAndName patched_columns = createBlockWithNestedColumns(args);
+            patchNullSlots(args, patched_columns, input_rows_count, /*only_enums=*/ false);
             auto temporary_result_type = removeNullable(result_type);
-
-            for (size_t i = 0; i < args.size(); ++i)
-            {
-                if (!args[i].type->isNullable())
-                    continue;
-                const auto & nested_type = patched_columns[i].type;
-
-                if (isColumnConst(*args[i].column))
-                {
-                    if (args[i].column->onlyNull())
-                        patched_columns[i].column = nested_type->createColumnConstWithDefaultValue(input_rows_count);
-                    continue;
-                }
-
-                const auto & nullable = assert_cast<const ColumnNullable &>(*args[i].column);
-                const auto & null_map = nullable.getNullMapData();
-
-                bool has_any_null = false;
-                for (size_t r = 0; r < input_rows_count; ++r)
-                {
-                    if (null_map[r])
-                    {
-                        has_any_null = true;
-                        break;
-                    }
-                }
-                if (!has_any_null)
-                    continue;
-
-                auto patched = nested_type->createColumn();
-                patched->reserve(input_rows_count);
-                for (size_t r = 0; r < input_rows_count; ++r)
-                {
-                    if (null_map[r])
-                        patched->insertDefault();
-                    else
-                        patched->insertFrom(*patched_columns[i].column, r);
-                }
-                patched_columns[i].column = std::move(patched);
-            }
 
             return executeWithoutLowCardinalityColumns(patched_columns, temporary_result_type, input_rows_count, dry_run);
         }
@@ -323,6 +347,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
             /// When all columns are constant or numeric, the cost of [[countBytesInFilter]] or [[ColumnUInt8::create]] should not be ignored.
             /// That's why we add a fast path for this case.
             ColumnsWithTypeAndName temporary_columns = createBlockWithNestedColumns(args);
+            patchNullSlots(args, temporary_columns, input_rows_count, /*only_enums=*/ true);
             auto temporary_result_type = removeNullable(result_type);
 
             auto res = executeWithoutLowCardinalityColumns(temporary_columns, temporary_result_type, input_rows_count, dry_run);
@@ -369,6 +394,7 @@ ColumnPtr IExecutableFunction::defaultImplementationForNulls(
             && null_ratio >= short_circuit_function_evaluation_for_nulls_threshold;
 
         ColumnsWithTypeAndName temporary_columns = createBlockWithNestedColumns(args);
+        patchNullSlots(args, temporary_columns, input_rows_count, /*only_enums=*/ true);
         auto temporary_result_type = removeNullable(result_type);
 
         if (!should_short_circuit)

--- a/tests/queries/0_stateless/05207_nullable_enum_string_search.reference
+++ b/tests/queries/0_stateless/05207_nullable_enum_string_search.reference
@@ -14,6 +14,11 @@ a	1	1
 b	0	0
 short circuit off	1
 short circuit on	1
+Enum16	1
+an enum that declares 0	1
+\N	\N
+z	1
+a	0
 a constant NULL	\N
 hash	15
 parallel_hash	15

--- a/tests/queries/0_stateless/05207_nullable_enum_string_search.reference
+++ b/tests/queries/0_stateless/05207_nullable_enum_string_search.reference
@@ -1,0 +1,22 @@
+the NULL slot holds a value that is not in the enum	0
+LIKE	1
+ILIKE	1
+NOT LIKE	1
+match	1
+position	1
+hasToken	1
+countSubstrings	1
+toString and LIKE	1
+equals	1
+IN	1
+\N	\N	\N
+a	1	1
+b	0	0
+short circuit off	1
+short circuit on	1
+a constant NULL	\N
+hash	15
+parallel_hash	15
+full_sorting_merge	15
+grace_hash	15
+above the join	16

--- a/tests/queries/0_stateless/05207_nullable_enum_string_search.sql
+++ b/tests/queries/0_stateless/05207_nullable_enum_string_search.sql
@@ -1,0 +1,61 @@
+-- The nested value of a NULL slot is unspecified, and for a `Nullable(Enum)` it is usually not a
+-- member of the type: `INSERT ... VALUES (NULL)` and the padding of non-joined rows under
+-- `join_use_nulls = 1` both leave a raw 0 there. `LIKE`, `ILIKE`, `NOT LIKE`, `match` and the other
+-- string searches read the nested column without the null map, so a single NULL row made them throw
+-- `UNKNOWN_ELEMENT_OF_ENUM` (`Unexpected value 0 in enum`), while `toString`, `=` and `IN` on the
+-- same rows worked. Those slots now hold the enum's default before a function sees them.
+
+DROP TABLE IF EXISTS t_05207;
+CREATE TABLE t_05207 (e Nullable(Enum8('a' = 1, 'b' = 2))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_05207 VALUES (NULL), ('a'), ('b');
+
+SELECT DISTINCT 'the NULL slot holds a value that is not in the enum', toInt8(assumeNotNull(e)) FROM t_05207 WHERE e IS NULL;
+
+SELECT 'LIKE', count() FROM t_05207 WHERE e LIKE 'a%';
+SELECT 'ILIKE', count() FROM t_05207 WHERE e ILIKE 'A%';
+SELECT 'NOT LIKE', count() FROM t_05207 WHERE e NOT LIKE 'a%';
+SELECT 'match', count() FROM t_05207 WHERE match(e, '^a');
+SELECT 'position', count() FROM t_05207 WHERE position(e, 'a') > 0;
+SELECT 'hasToken', count() FROM t_05207 WHERE hasToken(e, 'a');
+SELECT 'countSubstrings', sum(countSubstrings(e, 'a')) FROM t_05207;
+
+-- The same answers as the paths that were already null-aware.
+SELECT 'toString and LIKE', count() FROM t_05207 WHERE toString(e) LIKE 'a%';
+SELECT 'equals', count() FROM t_05207 WHERE e = 'a';
+SELECT 'IN', count() FROM t_05207 WHERE e IN ('a');
+
+-- Every row of the whole column, so the NULL row's own result is visible.
+SELECT e, e LIKE 'a%', match(e, '^a') FROM t_05207 ORDER BY e NULLS FIRST;
+
+-- Whether the null rows are filtered out before the function runs must not matter.
+SELECT 'short circuit off', count() FROM t_05207 WHERE e LIKE 'a%' SETTINGS short_circuit_function_evaluation_for_nulls = 0;
+SELECT 'short circuit on', count() FROM t_05207 WHERE e LIKE 'a%'
+SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 0;
+
+-- A constant NULL of an enum type takes the same path.
+SELECT 'a constant NULL', CAST(NULL AS Nullable(Enum8('a' = 1, 'b' = 2))) LIKE 'a%';
+
+-- The padding of non-joined rows is the other producer of such a slot, in every join algorithm.
+DROP TABLE IF EXISTS t_05207_left;
+DROP TABLE IF EXISTS t_05207_right;
+CREATE TABLE t_05207_left (k UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t_05207_right (k UInt64, e Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_05207_left SELECT number FROM numbers(100);
+INSERT INTO t_05207_right SELECT number * 2, if(number % 2 = 0, 'a', 'b') FROM numbers(30);
+
+SELECT 'hash', countIf(r.e LIKE 'a%') FROM t_05207_left AS l LEFT JOIN t_05207_right AS r ON l.k = r.k
+SETTINGS join_use_nulls = 1, join_algorithm = 'hash';
+SELECT 'parallel_hash', countIf(r.e LIKE 'a%') FROM t_05207_left AS l LEFT JOIN t_05207_right AS r ON l.k = r.k
+SETTINGS join_use_nulls = 1, join_algorithm = 'parallel_hash';
+SELECT 'full_sorting_merge', countIf(r.e LIKE 'a%') FROM t_05207_left AS l LEFT JOIN t_05207_right AS r ON l.k = r.k
+SETTINGS join_use_nulls = 1, join_algorithm = 'full_sorting_merge';
+SELECT 'grace_hash', countIf(r.e LIKE 'a%') FROM t_05207_left AS l LEFT JOIN t_05207_right AS r ON l.k = r.k
+SETTINGS join_use_nulls = 1, join_algorithm = 'grace_hash';
+
+-- The filter above the join and the same filter pushed below it agree.
+SELECT 'above the join', count() FROM t_05207_left AS l LEFT JOIN t_05207_right AS r ON l.k = r.k
+WHERE r.e LIKE 'a%' OR l.k = 1 SETTINGS join_use_nulls = 1;
+
+DROP TABLE t_05207_right;
+DROP TABLE t_05207_left;
+DROP TABLE t_05207;

--- a/tests/queries/0_stateless/05207_nullable_enum_string_search.sql
+++ b/tests/queries/0_stateless/05207_nullable_enum_string_search.sql
@@ -32,6 +32,22 @@ SELECT 'short circuit off', count() FROM t_05207 WHERE e LIKE 'a%' SETTINGS shor
 SELECT 'short circuit on', count() FROM t_05207 WHERE e LIKE 'a%'
 SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 0;
 
+-- `Enum16` stores the code in two bytes and is otherwise the same.
+DROP TABLE IF EXISTS t_05207_16;
+CREATE TABLE t_05207_16 (e Nullable(Enum16('a' = 1, 'b' = 2))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_05207_16 VALUES (NULL), ('a'), ('b');
+SELECT 'Enum16', count() FROM t_05207_16 WHERE e LIKE 'a%';
+DROP TABLE t_05207_16;
+
+-- An enum that declares 0 never had the problem, because the value the null slot holds is a member
+-- of the type. Normalizing the slot must not change what such a column answers.
+DROP TABLE IF EXISTS t_05207_zero;
+CREATE TABLE t_05207_zero (e Nullable(Enum8('z' = 0, 'a' = 1))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_05207_zero VALUES (NULL), ('z'), ('a');
+SELECT 'an enum that declares 0', count() FROM t_05207_zero WHERE e LIKE 'z%';
+SELECT e, e LIKE 'z%' FROM t_05207_zero ORDER BY e NULLS FIRST;
+DROP TABLE t_05207_zero;
+
 -- A constant NULL of an enum type takes the same path.
 SELECT 'a constant NULL', CAST(NULL AS Nullable(Enum8('a' = 1, 'b' = 2))) LIKE 'a%';
 


### PR DESCRIPTION
`LIKE`, `match`, `position` and other string functions threw `Code: 691. Unexpected value 0 in enum` when applied to a `Nullable(Enum)` column containing NULLs:

```sql
CREATE TABLE t (x Nullable(Enum8('a' = 1, 'b' = 2))) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ('a'), (NULL), ('b');
SELECT x LIKE 'a' FROM t; -- Code: 691
```

`createBlockWithNestedColumns` removes the null map of an argument but leaves the values under it untouched, so the nested value of a null slot is whatever happened to be stored there. For a `Nullable(Enum)` that value is usually not a member of the type: both `INSERT ... VALUES (NULL)` and the padding of non-joined rows in a `LEFT JOIN` with `join_use_nulls = 1` leave a raw 0 there, and 0 is a declared value only if the enum happens to define it. A function that reads the nested column of such an argument is then handed a code that does not exist, and it throws for a row whose result is NULL anyway.

The fix normalizes the null slots of `Enum` arguments to the default of the enum, which is a declared value, before the function sees them. The `!result_is_nullable` branch of `IExecutableFunction::defaultImplementationForNulls` already did this for every argument type, so both paths now share one `patchNullSlots` helper; the difference is only whether non-`Enum` arguments are normalized too, which that branch needs because it must produce `f(default(input))` for a null row. Only `Enum` arguments that actually contain a NULL are copied, so this costs nothing for the other types.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119219
Related: https://github.com/ClickHouse/ClickHouse/issues/71397
Related: https://github.com/ClickHouse/ClickHouse/issues/41793
Related: https://github.com/ClickHouse/ClickHouse/issues/111184
Related: https://github.com/ClickHouse/ClickHouse/issues/119614

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Unexpected value 0 in enum` thrown by string functions such as `LIKE`, `match` and `position` when applied to a `Nullable(Enum)` value that is NULL, including the NULLs produced by a `LEFT JOIN` with `join_use_nulls = 1`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119513&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119513](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119513+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1428` (included in `26.9` and later)
<!-- ch-version-info:end -->