### PR TITLE
Fix the Iceberg manifest-list partition summary written for bucket partitions

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
@@ -6,7 +6,10 @@
 #include <Functions/FunctionFactory.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnConst.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/castColumn.h>
 #include <Core/Settings.h>
 #include <Interpreters/Context_fwd.h>
 
@@ -23,6 +26,23 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+}
+
+namespace
+{
+
+/// The Iceberg type of a partition field, which the transform fixes independently of the ClickHouse
+/// function computing it: `bucket[N]` is an `int`, and every value `icebergBucket` produces fits one,
+/// because `N` is validated to be in `(0, INT32_MAX]` and the result is in `[0, N)`.
+DataTypePtr icebergPartitionFieldType(const String & transform_function_name, const DataTypePtr & transform_result_type)
+{
+    if (transform_function_name != "icebergBucket")
+        return transform_result_type;
+
+    DataTypePtr field_type = std::make_shared<DataTypeInt32>();
+    return transform_result_type->isNullable() ? makeNullable(field_type) : field_type;
+}
+
 }
 
 ChunkPartitioner::ChunkPartitioner(
@@ -63,7 +83,9 @@ ChunkPartitioner::ChunkPartitioner(
             columns_for_function.push_back(ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeUInt64>(), ""));
         columns_for_function.push_back(sample_block_->getByName(column_name));
 
-        result_data_types.push_back(function->getReturnType(columns_for_function));
+        auto transform_result_type = function->getReturnType(columns_for_function);
+        transform_result_data_types.push_back(transform_result_type);
+        result_data_types.push_back(icebergPartitionFieldType(transform_and_argument->transform_name, transform_result_type));
         functions.push_back(function);
         function_params.push_back(transform_and_argument->argument);
         columns_to_apply.push_back(column_name);
@@ -109,8 +131,14 @@ ChunkPartitioner::partitionChunk(const Chunk & chunk)
             arguments.push_back(ColumnWithTypeAndName(const_column->clone(), type, "#"));
         }
         arguments.push_back(name_to_column[columns_to_apply[transform_ind]]);
+        const auto & transform_result_type = transform_result_data_types[transform_ind];
+        const auto & partition_field_type = result_data_types[transform_ind];
         auto result
-            = functions[transform_ind]->build(arguments)->execute(arguments, result_data_types[transform_ind], chunk.getNumRows(), false);
+            = functions[transform_ind]->build(arguments)->execute(arguments, transform_result_type, chunk.getNumRows(), false);
+        /// Convert before the partition keys and the scatter selector are taken from the column, so that
+        /// the stored value, the published type and the grouping all agree.
+        if (!transform_result_type->equals(*partition_field_type))
+            result = castColumn(ColumnWithTypeAndName(result, transform_result_type, ""), partition_field_type);
         functions_columns.push_back(result);
         raw_columns.push_back(result.get());
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
@@ -31,9 +31,9 @@ namespace ErrorCodes
 namespace
 {
 
-/// The Iceberg type of a partition field, which the transform fixes independently of the ClickHouse
-/// function computing it: `bucket[N]` is an `int`, and every value `icebergBucket` produces fits one,
-/// because `N` is validated to be in `(0, INT32_MAX]` and the result is in `[0, N)`.
+/// The Iceberg type of a `bucket[N]` partition field, `int`; any other transform keeps the type of the
+/// ClickHouse function computing it. Every value `icebergBucket` produces fits an `int`, because `N` is
+/// validated to be in `(0, INT32_MAX]` and the result is in `[0, N)`.
 DataTypePtr icebergPartitionFieldType(const String & transform_function_name, const DataTypePtr & transform_result_type)
 {
     if (transform_function_name != "icebergBucket")

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
@@ -37,9 +37,9 @@ public:
 
     const std::vector<String> & getColumns() const { return columns_to_apply; }
 
-    /// The Iceberg partition field types. A transform fixes that type independently of the ClickHouse
-    /// function computing it: `bucket[N]` is an Iceberg `int`. The partition keys `partitionChunk`
-    /// returns hold values of these types.
+    /// The types of the partition key values `partitionChunk` returns: the Iceberg `int` for a
+    /// `bucket[N]` field, and otherwise the type of the ClickHouse function computing the transform,
+    /// which for the temporal transforms is an unsigned type the Iceberg specification does not have.
     const DataTypes & getResultTypes() const { return result_data_types; }
 
 private:

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
@@ -37,6 +37,9 @@ public:
 
     const std::vector<String> & getColumns() const { return columns_to_apply; }
 
+    /// The Iceberg partition field types. A transform fixes that type independently of the ClickHouse
+    /// function computing it: `bucket[N]` is an Iceberg `int`. The partition keys `partitionChunk`
+    /// returns hold values of these types.
     const DataTypes & getResultTypes() const { return result_data_types; }
 
 private:
@@ -46,6 +49,8 @@ private:
     std::vector<std::optional<size_t>> function_params;
     std::vector<String> columns_to_apply;
     DataTypes result_data_types;
+    /// The transform functions' own return types, which executing them requires.
+    DataTypes transform_result_data_types;
 
     size_t max_partitions_count;
 };

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -159,6 +159,54 @@ bool isNaNPartitionValue(const Field & field, DataTypePtr type)
     }
 }
 
+/// Whether every field of a partition tuple can be described truthfully in a manifest-list field
+/// summary. A summary saying `contains_null = false` with no bounds states that the field holds no
+/// orderable value at all, which makes a spec-compliant reader skip the entire manifest.
+bool canWritePartitionSummary(const std::vector<std::pair<Field, DataTypePtr>> & partition_summary)
+{
+    for (const auto & [partition_value, partition_type] : partition_summary)
+    {
+        if (partition_value.isNull() || isNaNPartitionValue(partition_value, partition_type))
+            continue;
+        if (!canDumpIcebergStats(partition_value, partition_type))
+            return false;
+    }
+    return true;
+}
+
+/// Whether a parent manifest-list entry's `partitions` summaries can be carried forward unchanged.
+/// Copying the empty-range claim above keeps a reader skipping that manifest forever. Fails closed,
+/// which is safe because `partitions` is optional: its absence only costs a reader an unskippable manifest.
+bool canCarryForwardPartitionSummaries(const avro::GenericDatum & partitions)
+{
+    if (partitions.type() == avro::AVRO_NULL)
+        return true;
+    if (partitions.type() != avro::AVRO_ARRAY)
+        return false;
+
+    for (const auto & summary_datum : partitions.value<avro::GenericArray>().value())
+    {
+        if (summary_datum.type() != avro::AVRO_RECORD)
+            return false;
+        const auto & summary = summary_datum.value<avro::GenericRecord>();
+
+        if (!summary.hasField(Iceberg::f_contains_null) || !summary.hasField(Iceberg::f_lower_bound)
+            || !summary.hasField(Iceberg::f_upper_bound))
+            return false;
+        if (summary.field(Iceberg::f_contains_null).type() != avro::AVRO_BOOL)
+            return false;
+        if (summary.field(Iceberg::f_contains_null).value<bool>())
+            continue;
+        if (summary.hasField(Iceberg::f_contains_nan) && summary.field(Iceberg::f_contains_nan).type() == avro::AVRO_BOOL
+            && summary.field(Iceberg::f_contains_nan).value<bool>())
+            continue;
+        if (summary.field(Iceberg::f_lower_bound).type() != avro::AVRO_BYTES
+            || summary.field(Iceberg::f_upper_bound).type() != avro::AVRO_BYTES)
+            return false;
+    }
+    return true;
+}
+
 template <typename T>
 std::vector<uint8_t> dumpValue(T value)
 {
@@ -788,6 +836,8 @@ void generateManifestList(
     {
         if (entry_partition_summaries.empty())
             return;
+        if (!canWritePartitionSummary(entry_partition_summaries[entry_idx]))
+            return;
 
         auto & partitions_field = entry.field(Iceberg::f_partitions);
         partitions_field.selectBranch(1);
@@ -808,7 +858,7 @@ void generateManifestList(
                     contains_nan.selectBranch(1);
                     contains_nan.value<bool>() = true;
                 }
-                else if (canDumpIcebergStats(partition_value, partition_type))
+                else
                 {
                     auto bound = dumpFieldToBytes(partition_value, partition_type);
                     auto & lower = summary_record.field(Iceberg::f_lower_bound);
@@ -818,7 +868,6 @@ void generateManifestList(
                     upper.selectBranch(1);
                     upper.value<std::vector<uint8_t>>() = bound;
                 }
-                /// else: a partition type whose bounds we cannot serialize (e.g. `Float`); leave the bounds null, matching the data-file statistics path.
             }
             summaries.value().push_back(summary_datum);
         }
@@ -897,7 +946,9 @@ void generateManifestList(
                         add_field_to_datum(Iceberg::f_added_files_count);
                         add_field_to_datum(Iceberg::f_existing_files_count);
                         add_field_to_datum(Iceberg::f_deleted_files_count);
-                        add_field_to_datum(Iceberg::f_partitions);
+                        if (old_entry.hasField(Iceberg::f_partitions)
+                            && canCarryForwardPartitionSummaries(old_entry.field(Iceberg::f_partitions)))
+                            new_entry.field(Iceberg::f_partitions) = old_entry.field(Iceberg::f_partitions);
                         add_field_to_datum(Iceberg::f_added_rows_count);
                         add_field_to_datum(Iceberg::f_existing_rows_count);
                         add_field_to_datum(Iceberg::f_deleted_rows_count);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_chunk_partitioner.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_chunk_partitioner.cpp
@@ -4,10 +4,14 @@
 
 #if USE_AVRO
 
+#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Common/tests/gtest_global_register.h>
 #include <Core/Block.h>
+#include <Core/Field.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <Poco/JSON/Array.h>
 #include <Poco/JSON/Object.h>
@@ -17,7 +21,7 @@ using namespace DB;
 namespace
 {
 
-/// Single-column schema `c0 String`, partitioned by `identity(c0)`.
+/// Single-column schema `c0 String`, partitioned by `identity(c0)` unless another transform is asked for.
 struct PartitionerFixture
 {
     Poco::JSON::Array::Ptr schema = new Poco::JSON::Array;
@@ -25,7 +29,7 @@ struct PartitionerFixture
     SharedHeader header;
     ContextPtr context;
 
-    PartitionerFixture()
+    explicit PartitionerFixture(const String & transform = "identity", bool nullable_source = false)
     {
         tryRegisterFunctions();
         context = getContext().context;
@@ -36,11 +40,14 @@ struct PartitionerFixture
         schema->add(field);
 
         Poco::JSON::Object::Ptr spec_field = new Poco::JSON::Object;
-        spec_field->set("transform", "identity");
+        spec_field->set("transform", transform);
         spec_field->set("source-id", 1);
         spec->add(spec_field);
 
-        header = std::make_shared<const Block>(Block{{ColumnString::create(), std::make_shared<DataTypeString>(), "c0"}});
+        DataTypePtr source_type = std::make_shared<DataTypeString>();
+        if (nullable_source)
+            source_type = makeNullable(source_type);
+        header = std::make_shared<const Block>(Block{{source_type->createColumn(), source_type, "c0"}});
     }
 
     /// A chunk with columns but zero rows - what a block whose rows were all position-deleted
@@ -58,6 +65,25 @@ struct PartitionerFixture
         size_t num_rows = values.size();
         Columns columns;
         columns.push_back(std::move(col));
+        return Chunk(std::move(columns), num_rows);
+    }
+
+    /// A `std::nullopt` element becomes a NULL row.
+    static Chunk nullableChunkWithValues(const std::vector<std::optional<String>> & values)
+    {
+        auto nested = ColumnString::create();
+        auto null_map = ColumnUInt8::create();
+        for (const auto & value : values)
+        {
+            if (value)
+                nested->insertData(value->data(), value->size());
+            else
+                nested->insertDefault();
+            null_map->insertValue(value ? 0 : 1);
+        }
+        size_t num_rows = values.size();
+        Columns columns;
+        columns.push_back(ColumnNullable::create(std::move(nested), std::move(null_map)));
         return Chunk(std::move(columns), num_rows);
     }
 };
@@ -106,6 +132,54 @@ TEST(IcebergChunkPartitioner, CalculatorSkipsRowlessChunks)
     EXPECT_NO_THROW(calculator.transform(data));
     ASSERT_EQ(calculator.getPartitionValue().size(), 1u);
     EXPECT_EQ(calculator.getPartitionValue()[0].safeGet<String>(), "a");
+}
+
+TEST(IcebergChunkPartitioner, BucketKeyIsPublishedAsIcebergInt)
+{
+    PartitionerFixture fx("bucket[16]");
+    ChunkPartitioner partitioner(fx.spec, fx.schema, fx.context, fx.header);
+
+    ASSERT_EQ(partitioner.getResultTypes().size(), 1u);
+    EXPECT_EQ(partitioner.getResultTypes()[0]->getTypeId(), TypeIndex::Int32);
+
+    auto chunk = PartitionerFixture::chunkWithValues({"eu", "us"});
+    auto result = partitioner.partitionChunk(chunk);
+    ASSERT_EQ(result.size(), 2u);
+
+    for (const auto & [key, _] : result)
+    {
+        ASSERT_EQ(key.size(), 1u);
+        /// The keys carry the published type, not the transform function's `UInt32`. Both hold the
+        /// same number, so only the Field's own tag distinguishes them.
+        EXPECT_EQ(key[0].getType(), Field::Types::Int64);
+        EXPECT_GE(key[0].safeGet<Int64>(), 0);
+        EXPECT_LT(key[0].safeGet<Int64>(), 16);
+    }
+}
+
+TEST(IcebergChunkPartitioner, NullableBucketKeyIsPublishedAsNullableIcebergInt)
+{
+    PartitionerFixture fx("bucket[16]", /*nullable_source=*/true);
+    ChunkPartitioner partitioner(fx.spec, fx.schema, fx.context, fx.header);
+
+    ASSERT_EQ(partitioner.getResultTypes().size(), 1u);
+    EXPECT_TRUE(partitioner.getResultTypes()[0]->isNullable());
+    EXPECT_EQ(removeNullable(partitioner.getResultTypes()[0])->getTypeId(), TypeIndex::Int32);
+
+    auto chunk = PartitionerFixture::nullableChunkWithValues({"eu", std::nullopt});
+    auto result = partitioner.partitionChunk(chunk);
+    ASSERT_EQ(result.size(), 2u);
+
+    size_t null_keys = 0;
+    for (const auto & [key, _] : result)
+    {
+        ASSERT_EQ(key.size(), 1u);
+        if (key[0].getType() == Field::Types::Null)
+            ++null_keys;
+        else
+            EXPECT_EQ(key[0].getType(), Field::Types::Int64);
+    }
+    EXPECT_EQ(null_keys, 1u);
 }
 
 }

--- a/tests/integration/test_storage_iceberg_interoperability_local/test_interoperability.py
+++ b/tests/integration/test_storage_iceberg_interoperability_local/test_interoperability.py
@@ -489,3 +489,60 @@ def test_ch_write_pyiceberg_read_bound_width(started_cluster_iceberg):
         assert len(table.scan(row_filter=row_filter).to_arrow()) == 0, row_filter
 
     assert len(table.scan().to_arrow()) == 1
+
+
+def test_ch_write_pyiceberg_read_bucket_partition(started_cluster_iceberg):
+    """
+    ClickHouse writes a bucket-partitioned Iceberg table, pyiceberg scans it with a
+    row filter.
+
+    Regression for issue #118905: the manifest-list field summary of a
+    transform-bearing partition spec carried `contains_null = false` with no
+    lower/upper bound. A spec-compliant manifest evaluator reads a missing bound
+    next to "no nulls" as "this field holds no value", answers ROWS_CANNOT_MATCH,
+    and skips the whole manifest, so a filtered scan of a table full of data
+    returned nothing. ClickHouse's own reader substitutes infinities for a missing
+    bound, which is why only an external reader saw it.
+    """
+    node1 = started_cluster_iceberg.instances["node1"]
+
+    TABLE_NAME = "test_pyiceberg_bucket_partition_" + get_uuid_str()
+    table_dir = f"{ICEBERG_DIR_NODE1}/default/{TABLE_NAME}"
+    ch_settings = {"allow_insert_into_iceberg": 1}
+
+    node1.query(
+        f"""
+        CREATE TABLE {TABLE_NAME} (s String, id Int32)
+        ENGINE=IcebergLocal(local,
+            path = '{table_dir}', format=Parquet)
+        PARTITION BY (icebergBucket(16, s))
+        ORDER BY (id)
+        """,
+        settings=ch_settings,
+    )
+    node1.query(
+        f"INSERT INTO {TABLE_NAME} VALUES ('eu', 1), ('us', 2)",
+        settings=ch_settings,
+    )
+    assert int(node1.query(f"SELECT count() FROM {TABLE_NAME}")) == 2
+
+    # external_dirs mounts the container path at the same absolute path on the host,
+    # so pyiceberg opens the very table ClickHouse just wrote.
+    table = StaticTable.from_metadata(latest_metadata_file(table_dir))
+
+    # Control: an unfiltered scan never consults the summaries, so it passed before
+    # the fix too. It fails first if the table itself is unreadable, which keeps the
+    # filtered assertions from passing for the wrong reason.
+    assert len(table.scan().to_arrow()) == 2
+
+    # pyiceberg projects `s == 'eu'` through the bucket transform onto the partition
+    # field, so this reaches the manifest evaluator and reads the bounds. Before the
+    # fix it returned 0.
+    assert len(table.scan(row_filter="s == 'eu'").to_arrow()) == 1
+    assert len(table.scan(row_filter="s == 'us'").to_arrow()) == 1
+
+    # The bounds are usable and not merely present: 'nowhere' is in bucket 14 while the
+    # table holds buckets 6 ('eu') and 8 ('us'), so both manifests are pruned. This
+    # also returned 0 before the fix, for the opposite reason (everything was pruned),
+    # so it is a control on pruning being active, not a regression check.
+    assert len(table.scan(row_filter="s == 'nowhere'").to_arrow()) == 0

--- a/tests/integration/test_storage_iceberg_interoperability_local/test_interoperability.py
+++ b/tests/integration/test_storage_iceberg_interoperability_local/test_interoperability.py
@@ -541,8 +541,6 @@ def test_ch_write_pyiceberg_read_bucket_partition(started_cluster_iceberg):
     assert len(table.scan(row_filter="s == 'eu'").to_arrow()) == 1
     assert len(table.scan(row_filter="s == 'us'").to_arrow()) == 1
 
-    # The bounds are usable and not merely present: 'nowhere' is in bucket 14 while the
-    # table holds buckets 6 ('eu') and 8 ('us'), so both manifests are pruned. This
-    # also returned 0 before the fix, for the opposite reason (everything was pruned),
-    # so it is a control on pruning being active, not a regression check.
+    # A key absent from the table returns nothing. ('nowhere' is bucket 14, while the table
+    # holds buckets 6 and 8, so a correct evaluator also prunes both manifests.)
     assert len(table.scan(row_filter="s == 'nowhere'").to_arrow()) == 0

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_manifest_list_partition_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_manifest_list_partition_summary.py
@@ -319,6 +319,12 @@ def test_writes_manifest_list_partition_summary_bucket_transform(
     # bound's width and the declared type agree.
     assert _declared_partition_types(table_path) == [[("s", "int")], [("s", "int")]]
 
+    # These bounds are also what ClickHouse's own manifest-list pruner reads. Without a bound it
+    # substitutes infinities and never skips a bucket manifest, so this path only becomes live here.
+    assert instance.query(f"SELECT id FROM {TABLE_NAME} WHERE s = 'eu'") == "1\n"
+    assert instance.query(f"SELECT id FROM {TABLE_NAME} WHERE s = 'us'") == "2\n"
+    assert instance.query(f"SELECT count() FROM {TABLE_NAME} WHERE s = 'nowhere'") == "0\n"
+
 
 @pytest.mark.parametrize("storage_type", ["s3", "local"])
 def test_writes_manifest_list_no_summary_when_value_has_no_bound(

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_manifest_list_partition_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_manifest_list_partition_summary.py
@@ -1,11 +1,20 @@
 """Every manifest that an INSERT or a DELETE writes holds exactly one partition tuple, so its
 manifest-list entry must carry a field summary pinned to that tuple: `lower_bound == upper_bound`
 per partition field. Without the summary a reader cannot skip a manifest by partition and has to
-open all of them."""
+open all of them.
+
+A summary must never be worse than absent, either: one that says `contains_null = false` and carries
+no bounds states that the partition field holds no orderable value, and a spec-compliant reader
+answers `ROWS_CANNOT_MATCH` and skips the whole manifest. The `partitions` list is optional, so a
+tuple that cannot be described is left without one."""
 
 import glob
+import json
+import math
 import os
+import shutil
 import struct
+import tempfile
 
 import avro.datafile
 import avro.io
@@ -81,6 +90,68 @@ def _expected_summary(partition):
         (False, None, _encode_bound(value), _encode_bound(value))
         for value in partition.values()
     ]
+
+
+def _declared_partition_types(table_path):
+    """The Avro type each manifest declares for its partition fields, read from the id-carrying
+    `avro.schema` header the writer stores. A bound is only decodable by a reader if it is the width
+    of the type declared here, so the two are asserted together."""
+    declared = []
+    for entry in _read_avro(_manifest_list_of_last_snapshot(table_path)):
+        manifest = os.path.join(
+            table_path, "metadata", os.path.basename(unescape_path(entry["manifest_path"]))
+        )
+        with open(manifest, "rb") as f:
+            reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+            schema = json.loads(dict(reader.meta)["avro.schema"])
+            reader.close()
+        data_file = next(f for f in schema["fields"] if f["name"] == "data_file")
+        partition = next(f for f in data_file["type"]["fields"] if f["name"] == "partition")
+        declared.append(
+            [
+                (field["name"], tuple(field["type"]) if isinstance(field["type"], list) else field["type"])
+                for field in partition["type"]["fields"]
+            ]
+        )
+    return declared
+
+
+def _drop_bounds_in_manifest_list(instance, table_path, manifest_list, drop_bounds):
+    """Rewrite a manifest list in the node's own filesystem so its field summaries keep
+    `contains_null = false` but lose their bounds, which is what a writer without the check under
+    test produced. With `upper_only` just the upper bound goes, which is the same claim to a reader
+    that consults both. Returns the number of rewritten entries, which the caller asserts."""
+    with open(manifest_list, "rb") as f:
+        reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+        schema = reader.datum_reader.writers_schema
+        metadata = dict(reader.meta)
+        records = list(reader)
+        reader.close()
+
+    patched = 0
+    for record in records:
+        for summary in record["partitions"] or []:
+            assert summary["lower_bound"] is not None
+            if drop_bounds == "both":
+                summary["lower_bound"] = None
+            summary["upper_bound"] = None
+            patched += 1
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        local_path = os.path.join(temp_dir, os.path.basename(manifest_list))
+        with open(local_path, "wb") as f:
+            writer = avro.datafile.DataFileWriter(f, avro.io.DatumWriter(), schema)
+            for key, value in metadata.items():
+                if not key.startswith("avro."):
+                    writer.set_meta(key, value)
+            for record in records:
+                writer.append(record)
+            writer.close()
+        instance.copy_file_to_container(local_path, manifest_list)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    return patched
 
 
 @pytest.mark.parametrize("format_version", [1, 2])
@@ -201,5 +272,213 @@ def test_writes_manifest_list_partition_summary_after_delete(
     for _, partition, summary in entries:
         assert summary is not None
         assert _summary_tuples(summary) == _expected_summary(partition)
+
+    assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == "us\t2\n"
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_manifest_list_partition_summary_bucket_transform(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    TABLE_NAME = (
+        "test_writes_manifest_list_partition_summary_bucket_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_no_spark,
+        "(s String, id Int32)",
+        2,
+        partition_by="(icebergBucket(16, s))",
+        order_by="id",
+    )
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES ('eu', 1), ('us', 2);",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    table_path = _download_table(
+        started_cluster_iceberg_no_spark, storage_type, TABLE_NAME
+    )
+    entries = _entries_of_last_snapshot(table_path)
+
+    # The Iceberg partition field of a `bucket[N]` transform is an `int`, so its bound is the four
+    # little-endian bytes of the bucket number stored in the manifest.
+    assert len(entries) == 2
+    for _, partition, summary in entries:
+        assert summary is not None
+        assert _summary_tuples(summary) == _expected_summary(partition)
+
+    # Pin: the manifest declares that field as Avro `"int"` both before and after this fix, so the
+    # bound's width and the declared type agree.
+    assert _declared_partition_types(table_path) == [[("s", "int")], [("s", "int")]]
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_manifest_list_no_summary_when_value_has_no_bound(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    TABLE_NAME = (
+        "test_writes_manifest_list_no_summary_when_value_has_no_bound_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_no_spark,
+        "(f Float64, id Int32)",
+        2,
+        partition_by="(f)",
+        order_by="id",
+    )
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (1.5, 1), (nan, 2);",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    entries = _entries_of_last_snapshot(
+        _download_table(started_cluster_iceberg_no_spark, storage_type, TABLE_NAME)
+    )
+    assert len(entries) == 2
+    summaries = {
+        ("nan" if math.isnan(partition["f"]) else "value"): summary
+        for _, partition, summary in entries
+    }
+
+    # A `Float64` bound is not serialized, so the tuple holding 1.5 gets no summary at all rather
+    # than one claiming the field holds nothing.
+    assert summaries["value"] is None
+    # Negative control: a NaN partition value genuinely has no orderable bound, which `contains_nan`
+    # states truthfully, so its list is kept. Dropping it here would mean the check fires on any
+    # missing bound instead of on the contradiction.
+    assert _summary_tuples(summaries["nan"]) == [(False, True, None, None)]
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_manifest_list_partition_summary_nullable_bucket(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    TABLE_NAME = (
+        "test_writes_manifest_list_partition_summary_nullable_bucket_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_no_spark,
+        "(s Nullable(String), id Int32)",
+        2,
+        partition_by="(icebergBucket(16, s))",
+        order_by="id",
+    )
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES ('eu', 1), (NULL, 2);",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    table_path = _download_table(
+        started_cluster_iceberg_no_spark, storage_type, TABLE_NAME
+    )
+    entries = _entries_of_last_snapshot(table_path)
+    assert len(entries) == 2
+    summaries = {
+        ("null" if partition["s"] is None else "value"): summary
+        for _, partition, summary in entries
+    }
+
+    # A nullable partition source keeps its bound, and the NULL tuple keeps a summary of its own:
+    # `contains_null` alone is a complete description of it. 6 is `bucket[16]` of 'eu', which the
+    # Iceberg spec fixes, so the expected bound is stated rather than read back out of the manifest.
+    assert _summary_tuples(summaries["value"]) == [
+        (False, None, _encode_bound(6), _encode_bound(6))
+    ]
+    assert _summary_tuples(summaries["null"]) == [(True, None, None, None)]
+
+    # The nullable source keeps the Avro `["null", "int"]` union of the partition field.
+    assert _declared_partition_types(table_path) == [
+        [("s", ("null", "int"))],
+        [("s", ("null", "int"))],
+    ]
+
+
+@pytest.mark.parametrize(
+    "drop_bounds", ["both", "upper_only"], ids=["both_bounds", "upper_bound_only"]
+)
+def test_writes_manifest_list_partition_summary_carry_forward_sanitizes(
+    started_cluster_iceberg_no_spark, drop_bounds
+):
+    """A manifest list written by a build without the check above holds the contradictory summary,
+    and every later snapshot copies its entries verbatim. The copy must drop such a list instead of
+    republishing it, which is the only way an existing table stops being pruned to empty.
+
+    The sanitizer works off the copied Avro datum, so it is storage independent; this runs on local
+    storage, where the file can be rewritten in place to stand in for that older writer.
+    """
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    TABLE_NAME = (
+        "test_writes_manifest_list_partition_summary_carry_forward_"
+        + drop_bounds
+        + "_"
+        + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        "local",
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_no_spark,
+        "(region String, id Int32)",
+        2,
+        partition_by="(region)",
+        order_by="id",
+    )
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES ('eu', 1), ('us', 2);",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    table_path = _download_table(started_cluster_iceberg_no_spark, "local", TABLE_NAME)
+    written = _entries_of_last_snapshot(table_path)
+    assert len(written) == 2
+    for _, partition, summary in written:
+        assert _summary_tuples(summary) == _expected_summary(partition)
+
+    patched = _drop_bounds_in_manifest_list(
+        instance, table_path, _manifest_list_of_last_snapshot(table_path), drop_bounds
+    )
+    assert patched == 2
+
+    instance.query(
+        f"ALTER TABLE {TABLE_NAME} DELETE WHERE id = 1;",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    entries = _entries_of_last_snapshot(
+        _download_table(started_cluster_iceberg_no_spark, "local", TABLE_NAME)
+    )
+    assert sorted(content for content, _, _ in entries) == [0, 0, 1]
+    for content, partition, summary in entries:
+        if content == 0:
+            # Carried forward from the patched list: the contradiction is dropped, not propagated.
+            assert summary is None
+        else:
+            # Written by this DELETE, so it carries a real bound.
+            assert _summary_tuples(summary) == _expected_summary(partition)
 
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == "us\t2\n"

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_manifest_list_partition_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_manifest_list_partition_summary.py
@@ -12,6 +12,7 @@ import glob
 import json
 import math
 import os
+import re
 import shutil
 import struct
 import tempfile
@@ -49,6 +50,28 @@ def _manifest_list_of_last_snapshot(table_path):
     return matches[0]
 
 
+def _manifest_list_of_newest_metadata(table_path):
+    """The manifest list of the newest snapshot, resolved by `(last-updated-ms, metadata version)`.
+    `get_last_snapshot` compares timestamps alone, so two commits that land in the same millisecond
+    leave the winner to `os.listdir` order."""
+    metadata_dir = f"{table_path}/metadata"
+    best_key = None
+    snapshot_id = None
+    for filename in os.listdir(metadata_dir):
+        if not filename.endswith(".json"):
+            continue
+        with open(os.path.join(metadata_dir, filename)) as f:
+            data = json.load(f)
+        version = re.match(r"v?0*(\d+)", filename)
+        key = (data.get("last-updated-ms", 0), int(version.group(1)) if version else 0)
+        if best_key is None or key > best_key:
+            best_key = key
+            snapshot_id = data.get("current-snapshot-id")
+    matches = glob.glob(f"{table_path}/metadata/snap-{snapshot_id}-*.avro")
+    assert len(matches) == 1, matches
+    return matches[0]
+
+
 def _encode_bound(value):
     """A single-value bound as Iceberg serializes it: UTF-8 for a string, little-endian two's
     complement for an int."""
@@ -57,12 +80,12 @@ def _encode_bound(value):
     return struct.pack("<i", value)
 
 
-def _entries_of_last_snapshot(table_path):
+def _entries_of_last_snapshot(table_path, manifest_list=None):
     """Every manifest-list entry of the newest snapshot, paired with the partition tuple stored
     inside the manifest it points at. Pairing by manifest path is what makes a summary attached to
     the wrong entry visible."""
     entries = []
-    for entry in _read_avro(_manifest_list_of_last_snapshot(table_path)):
+    for entry in _read_avro(manifest_list or _manifest_list_of_last_snapshot(table_path)):
         manifest = os.path.join(
             table_path, "metadata", os.path.basename(unescape_path(entry["manifest_path"]))
         )
@@ -324,6 +347,71 @@ def test_writes_manifest_list_partition_summary_bucket_transform(
     assert instance.query(f"SELECT id FROM {TABLE_NAME} WHERE s = 'eu'") == "1\n"
     assert instance.query(f"SELECT id FROM {TABLE_NAME} WHERE s = 'us'") == "2\n"
     assert instance.query(f"SELECT count() FROM {TABLE_NAME} WHERE s = 'nowhere'") == "0\n"
+
+
+@pytest.mark.parametrize("storage_type", ["local"])
+def test_writes_manifest_list_partition_summary_after_compaction(
+    started_cluster_iceberg_no_spark, storage_type
+):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    TABLE_NAME = (
+        "test_writes_manifest_list_partition_summary_compaction_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_no_spark,
+        "(s String, id Int32)",
+        2,
+        partition_by="(icebergBucket(16, s))",
+        order_by="id",
+    )
+    for values in ("('eu', 1), ('us', 2)", "('eu', 3), ('us', 4)"):
+        instance.query(
+            f"INSERT INTO {TABLE_NAME} VALUES {values};",
+            settings={"allow_insert_into_iceberg": 1},
+        )
+    # One manifest per INSERT per bucket. Pinning this count and the manifest-list name is what
+    # makes the assertions below read a list that compaction wrote: a compaction that silently does
+    # nothing leaves these four entries, whose summaries satisfy the same oracle.
+    before_path = _download_table(
+        started_cluster_iceberg_no_spark, storage_type, TABLE_NAME
+    )
+    before_list = _manifest_list_of_newest_metadata(before_path)
+    assert len(_entries_of_last_snapshot(before_path, before_list)) == 4
+
+    instance.query(
+        f"OPTIMIZE TABLE {TABLE_NAME} MANIFEST",
+        settings={
+            "allow_experimental_iceberg_compaction": 1,
+            "iceberg_manifest_min_count_to_compact": 2,
+        },
+    )
+
+    table_path = _download_table(
+        started_cluster_iceberg_no_spark, storage_type, TABLE_NAME
+    )
+    after_list = _manifest_list_of_newest_metadata(table_path)
+    assert os.path.basename(after_list) != os.path.basename(before_list)
+    entries = _entries_of_last_snapshot(table_path, after_list)
+    assert len(entries) == 2
+
+    # Compaction rewrites the manifest list through its own `generateManifestList` call, so a
+    # rewritten entry carries the same four-byte bucket bound the insert path writes.
+    for _, partition, summary in entries:
+        assert summary is not None
+        assert _summary_tuples(summary) == _expected_summary(partition)
+
+    assert (
+        instance.query(f"SELECT id FROM {TABLE_NAME} WHERE s = 'eu' ORDER BY id")
+        == "1\n3\n"
+    )
+    assert instance.query(f"SELECT count() FROM {TABLE_NAME}") == "4\n"
 
 
 @pytest.mark.parametrize("storage_type", ["s3", "local"])

--- a/tests/integration/test_storage_iceberg_with_spark/test_manifest_compaction.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_manifest_compaction.py
@@ -648,10 +648,10 @@ def test_optimize_manifest_files_dropped_partition_source_column_schema_header(
 def test_optimize_manifest_files_bucket_partition(started_cluster_iceberg_with_spark, storage_type):
     """
     OPTIMIZE TABLE ... MANIFEST on a bucket-partitioned table must recompute the manifest-list
-    partition summary for the bucket value. The `icebergBucket` transform resolves to ClickHouse
-    `UInt32`, which `getAvroType` maps to Avro `int`; the byte encoder must serialize that unsigned
-    type instead of throwing 'Can not dump such stats', otherwise a valid Iceberg bucket partition
-    cannot be compacted.
+    partition summary for the bucket value. Compaction takes the partition type from
+    `ChunkPartitioner::getResultTypes()`, which publishes the Iceberg `int` a `bucket[N]` field has;
+    the byte encoder must serialize it instead of throwing 'Can not dump such stats', otherwise a
+    valid Iceberg bucket partition cannot be compacted.
     """
     instance = started_cluster_iceberg_with_spark.instances["node1"]
     spark = started_cluster_iceberg_with_spark.spark_session


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/118905


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The manifest-list field summary that ClickHouse writes for an Iceberg `bucket` partition carried null bounds next to `contains_null = false`, which a spec-compliant reader reads as "this field holds no values" and uses to skip the whole manifest, so a filtered scan of such a table returned no rows. A `bucket` partition field is now described as the Iceberg `int` the specification gives it, so its bounds are written, and a summary whose bounds cannot be serialized is omitted instead of claiming an empty range, on newly written and on carried-forward manifest-list entries alike.

### Description

A field summary with `contains_null = false` and no `lower_bound` states that the partition field holds no orderable value, so a manifest evaluator answers `ROWS_CANNOT_MATCH` and skips the manifest. ClickHouse wrote exactly that for a `bucket` spec: bounds are written only when `canDumpIcebergStats` accepts the partition type, and `icebergBucket` returns `UInt32`, which it does not. Measured with pyiceberg 0.11.1 on a two-row bucket-partitioned table: `scan()` returns 2 rows, `scan(row_filter="s == 'eu'")` returns **0**. ClickHouse's own reader substitutes infinities for a missing bound, which is why CI never saw it.

Two changes:

* `ChunkPartitioner` publishes the Iceberg field type of a `bucket[N]` transform, `int`, and converts the transform result to it. The conversion is exact: `N` is validated to `(0, INT32_MAX]` and the result is in `[0, N)`. Neither the encoded value nor the declared Avro type changes (`getAvroType` maps both to `"int"`), so existing tables read back unchanged.
* `generateManifestList` no longer publishes an empty-range claim: a tuple whose bound cannot be serialized gets no `partitions` list (that field is optional), and a list carried forward from the parent snapshot is dropped rather than copied when it makes that claim. Without the second half an affected table keeps republishing its bad summaries through every later INSERT, DELETE and UPDATE. NULL and NaN are unchanged.

The issue's other half, the `truncate` bound width, is left out and the issue stays open for it: `icebergTruncate` stores a *wrong partition value* for a negative source (`WHERE i32 = -1` returns 0 rows on a table holding `-1`), so narrowing that bound first would trade a loud reader error for a silently pruned manifest. The width follows that fix. `year`/`month`/`day`/`hour` hit the same accept-list: this PR omits their `partitions` list rather than an empty-range claim; open #118583 gives them bounds via `Int32`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119514&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119514](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119514+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

