### PR TITLE
Initialize profiler mark caches and handle uncached async loading

### DIFF
--- a/src/Examples/storage_memory_profiler.cpp
+++ b/src/Examples/storage_memory_profiler.cpp
@@ -13,6 +13,7 @@
 #include <Examples/clickhouse_examples.h>
 #include <Examples/storage_memory_profiler.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <iostream>
@@ -342,17 +343,15 @@ void StorageMemoryProfiler::initializeContext()
         const size_t max_cache_size = static_cast<size_t>(static_cast<double>(physical_server_memory) * cache_size_to_ram_max_ratio);
 
         String mark_cache_policy = server_settings[ServerSetting::mark_cache_policy];
-        size_t mark_cache_size = server_settings[ServerSetting::mark_cache_size];
+        const size_t configured_mark_cache_size = server_settings[ServerSetting::mark_cache_size];
+        const size_t mark_cache_size = std::min(configured_mark_cache_size, max_cache_size);
         const double mark_cache_size_ratio = server_settings[ServerSetting::mark_cache_size_ratio];
-        if (mark_cache_size > max_cache_size)
-            mark_cache_size = max_cache_size;
         global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
 
         String index_mark_cache_policy = server_settings[ServerSetting::index_mark_cache_policy];
-        size_t index_mark_cache_size = server_settings[ServerSetting::index_mark_cache_size];
+        const size_t configured_index_mark_cache_size = server_settings[ServerSetting::index_mark_cache_size];
+        const size_t index_mark_cache_size = std::min(configured_index_mark_cache_size, max_cache_size);
         const double index_mark_cache_size_ratio = server_settings[ServerSetting::index_mark_cache_size_ratio];
-        if (index_mark_cache_size > max_cache_size)
-            index_mark_cache_size = max_cache_size;
         global_context->setIndexMarkCache(index_mark_cache_policy, index_mark_cache_size, index_mark_cache_size_ratio);
     }
 

--- a/src/Examples/storage_memory_profiler.cpp
+++ b/src/Examples/storage_memory_profiler.cpp
@@ -129,6 +129,7 @@ void StorageMemoryProfiler::printUsage()
         "  -p, --path DIR          Storage path for persistent data\n"
         "  --prefix PREFIX         Prefix for heap dump files (default: memory_profile_)\n"
         "  --no-system-tables      Skip system tables for faster startup\n"
+        "  --no-mark-caches        Leave mark caches uninitialized (for uncached-read testing)\n"
         "  --symbolize             Symbolize each heap dump immediately\n"
         "  -h, --help              Show this help message\n"
         "\n"
@@ -335,22 +336,25 @@ void StorageMemoryProfiler::initializeContext()
     total_memory_tracker.setDescription("(total)");
     total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
 
-    const double cache_size_to_ram_max_ratio = server_settings[ServerSetting::cache_size_to_ram_max_ratio];
-    const size_t max_cache_size = static_cast<size_t>(static_cast<double>(physical_server_memory) * cache_size_to_ram_max_ratio);
+    if (initialize_mark_caches)
+    {
+        const double cache_size_to_ram_max_ratio = server_settings[ServerSetting::cache_size_to_ram_max_ratio];
+        const size_t max_cache_size = static_cast<size_t>(static_cast<double>(physical_server_memory) * cache_size_to_ram_max_ratio);
 
-    String mark_cache_policy = server_settings[ServerSetting::mark_cache_policy];
-    size_t mark_cache_size = server_settings[ServerSetting::mark_cache_size];
-    const double mark_cache_size_ratio = server_settings[ServerSetting::mark_cache_size_ratio];
-    if (mark_cache_size > max_cache_size)
-        mark_cache_size = max_cache_size;
-    global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
+        String mark_cache_policy = server_settings[ServerSetting::mark_cache_policy];
+        size_t mark_cache_size = server_settings[ServerSetting::mark_cache_size];
+        const double mark_cache_size_ratio = server_settings[ServerSetting::mark_cache_size_ratio];
+        if (mark_cache_size > max_cache_size)
+            mark_cache_size = max_cache_size;
+        global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
 
-    String index_mark_cache_policy = server_settings[ServerSetting::index_mark_cache_policy];
-    size_t index_mark_cache_size = server_settings[ServerSetting::index_mark_cache_size];
-    const double index_mark_cache_size_ratio = server_settings[ServerSetting::index_mark_cache_size_ratio];
-    if (index_mark_cache_size > max_cache_size)
-        index_mark_cache_size = max_cache_size;
-    global_context->setIndexMarkCache(index_mark_cache_policy, index_mark_cache_size, index_mark_cache_size_ratio);
+        String index_mark_cache_policy = server_settings[ServerSetting::index_mark_cache_policy];
+        size_t index_mark_cache_size = server_settings[ServerSetting::index_mark_cache_size];
+        const double index_mark_cache_size_ratio = server_settings[ServerSetting::index_mark_cache_size_ratio];
+        if (index_mark_cache_size > max_cache_size)
+            index_mark_cache_size = max_cache_size;
+        global_context->setIndexMarkCache(index_mark_cache_policy, index_mark_cache_size, index_mark_cache_size_ratio);
+    }
 
     /// Limit on total number of concurrently executing queries.
     global_context->getProcessList().setMaxSize(0);
@@ -514,6 +518,10 @@ int StorageMemoryProfiler::run(const VectorWithMemoryTracking<String> & args)
         else if (arg == "--no-system-tables")
         {
             no_system_tables = true;
+        }
+        else if (arg == "--no-mark-caches")
+        {
+            initialize_mark_caches = false;
         }
         else if (arg == "--symbolize")
         {

--- a/src/Examples/storage_memory_profiler.cpp
+++ b/src/Examples/storage_memory_profiler.cpp
@@ -86,9 +86,13 @@ extern const int SYSTEM_ERROR;
 
 namespace ServerSetting
 {
+extern const ServerSettingsDouble cache_size_to_ram_max_ratio;
 extern const ServerSettingsUInt64 max_server_memory_usage;
 extern const ServerSettingsDouble max_server_memory_usage_to_ram_ratio;
 extern const ServerSettingsUInt64 jemalloc_merge_tree_arenas;
+extern const ServerSettingsString mark_cache_policy;
+extern const ServerSettingsUInt64 mark_cache_size;
+extern const ServerSettingsDouble mark_cache_size_ratio;
 }
 
 namespace
@@ -327,6 +331,16 @@ void StorageMemoryProfiler::initializeContext()
     total_memory_tracker.setHardLimit(max_server_memory_usage);
     total_memory_tracker.setDescription("(total)");
     total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
+
+    const double cache_size_to_ram_max_ratio = server_settings[ServerSetting::cache_size_to_ram_max_ratio];
+    const size_t max_cache_size = static_cast<size_t>(static_cast<double>(physical_server_memory) * cache_size_to_ram_max_ratio);
+
+    String mark_cache_policy = server_settings[ServerSetting::mark_cache_policy];
+    size_t mark_cache_size = server_settings[ServerSetting::mark_cache_size];
+    const double mark_cache_size_ratio = server_settings[ServerSetting::mark_cache_size_ratio];
+    if (mark_cache_size > max_cache_size)
+        mark_cache_size = max_cache_size;
+    global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
 
     /// Limit on total number of concurrently executing queries.
     global_context->getProcessList().setMaxSize(0);

--- a/src/Examples/storage_memory_profiler.cpp
+++ b/src/Examples/storage_memory_profiler.cpp
@@ -87,6 +87,9 @@ extern const int SYSTEM_ERROR;
 namespace ServerSetting
 {
 extern const ServerSettingsDouble cache_size_to_ram_max_ratio;
+extern const ServerSettingsString index_mark_cache_policy;
+extern const ServerSettingsUInt64 index_mark_cache_size;
+extern const ServerSettingsDouble index_mark_cache_size_ratio;
 extern const ServerSettingsUInt64 max_server_memory_usage;
 extern const ServerSettingsDouble max_server_memory_usage_to_ram_ratio;
 extern const ServerSettingsUInt64 jemalloc_merge_tree_arenas;
@@ -341,6 +344,13 @@ void StorageMemoryProfiler::initializeContext()
     if (mark_cache_size > max_cache_size)
         mark_cache_size = max_cache_size;
     global_context->setMarkCache(mark_cache_policy, mark_cache_size, mark_cache_size_ratio);
+
+    String index_mark_cache_policy = server_settings[ServerSetting::index_mark_cache_policy];
+    size_t index_mark_cache_size = server_settings[ServerSetting::index_mark_cache_size];
+    const double index_mark_cache_size_ratio = server_settings[ServerSetting::index_mark_cache_size_ratio];
+    if (index_mark_cache_size > max_cache_size)
+        index_mark_cache_size = max_cache_size;
+    global_context->setIndexMarkCache(index_mark_cache_policy, index_mark_cache_size, index_mark_cache_size_ratio);
 
     /// Limit on total number of concurrently executing queries.
     global_context->getProcessList().setMaxSize(0);

--- a/src/Examples/storage_memory_profiler.h
+++ b/src/Examples/storage_memory_profiler.h
@@ -64,6 +64,7 @@ private:
     std::string data_path;
     bool no_system_tables = false;
     bool symbolize = false;
+    bool initialize_mark_caches = true;
 
     /// Server context
     std::unique_ptr<SharedContextHolder> shared_context;

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -331,14 +331,17 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksSync()
 std::future<MarkCache::MappedPtr> MergeTreeMarksLoader::loadMarksAsync()
 {
     /// Avoid queueing jobs into thread pool if marks are in cache
-    auto data_part_storage = data_part_reader->getDataPartStorage();
-    auto key = MarkCache::hash(data_part_storage->getDiskName() + ":" + (fs::path(data_part_storage->getFullPath()) / mrk_path).string());
-    if (MarkCache::MappedPtr loaded_marks = mark_cache->getForAsyncLoading(key))
+    if (mark_cache)
     {
-        ProfileEvents::increment(ProfileEvents::MarksTasksFromCache);
-        auto promise = std::promise<MarkCache::MappedPtr>();
-        promise.set_value(std::move(loaded_marks));
-        return promise.get_future();
+        auto data_part_storage = data_part_reader->getDataPartStorage();
+        auto key = MarkCache::hash(data_part_storage->getDiskName() + ":" + (fs::path(data_part_storage->getFullPath()) / mrk_path).string());
+        if (MarkCache::MappedPtr loaded_marks = mark_cache->getForAsyncLoading(key))
+        {
+            ProfileEvents::increment(ProfileEvents::MarksTasksFromCache);
+            auto promise = std::promise<MarkCache::MappedPtr>();
+            promise.set_value(std::move(loaded_marks));
+            return promise.get_future();
+        }
     }
 
     return scheduleFromThreadPoolUnsafe<MarkCache::MappedPtr>(

--- a/src/Storages/MergeTree/tests/gtest_merge_tree_marks_loader.cpp
+++ b/src/Storages/MergeTree/tests/gtest_merge_tree_marks_loader.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <Common/CurrentMetrics.h>
+#include <Common/ThreadPool.h>
+#include <Storages/MergeTree/MergeTreeIndexGranularityInfo.h>
+#include <Storages/MergeTree/MergeTreeMarksLoader.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+
+#include <stdexcept>
+
+using namespace DB;
+
+namespace
+{
+
+class EmptyDataPartInfoForReader final : public IMergeTreeDataPartInfoForReader
+{
+public:
+    EmptyDataPartInfoForReader() : IMergeTreeDataPartInfoForReader(ContextPtr{}) { }
+
+    bool isCompactPart() const override { unexpectedCall(); }
+    bool isWidePart() const override { unexpectedCall(); }
+    bool isProjectionPart() const override { unexpectedCall(); }
+    bool hasLightweightDelete() const override { unexpectedCall(); }
+    const String & getPartName() const override { unexpectedCall(); }
+    const MergeTreePartInfo & getPartInfo() const override { unexpectedCall(); }
+    const MergeTreePartition & getPartition() const override { unexpectedCall(); }
+    Int64 getMinDataVersion() const override { unexpectedCall(); }
+    Int64 getMaxDataVersion() const override { unexpectedCall(); }
+    IndexPtr getIndexPtr() const override { unexpectedCall(); }
+    DataPartStoragePtr getDataPartStorage() const override { return {}; }
+    const NamesAndTypesList & getColumns() const override { unexpectedCall(); }
+    const ColumnsDescription & getColumnsDescription() const override { unexpectedCall(); }
+    const ColumnsDescription & getColumnsDescriptionWithCollectedNested() const override { unexpectedCall(); }
+    const ColumnsSubstreams & getColumnsSubstreams() const override { unexpectedCall(); }
+    std::optional<size_t> getColumnPosition(const String &) const override { unexpectedCall(); }
+    std::optional<NameAndTypePair> tryGetColumn(const String &) const override { unexpectedCall(); }
+    bool isSystemColumnInvalidated(const String &) const override { unexpectedCall(); }
+    String getColumnNameWithMinimumCompressedSize(const NamesAndTypesList &) const override { unexpectedCall(); }
+    String getParentPartName() const override { unexpectedCall(); }
+    ColumnSize getColumnSize(const String &) const override { unexpectedCall(); }
+    std::shared_ptr<const std::unordered_map<String, ColumnSize>> getColumnSizes() const override { unexpectedCall(); }
+    CompressionCodecPtr getDefaultCompressionCodec() const override { unexpectedCall(); }
+    ColumnSize getSubcolumnSize(const String &) const override { unexpectedCall(); }
+    MergeTreeSettingsPtr getStorageSettings() const override { unexpectedCall(); }
+    std::shared_ptr<const IMergeTreeDataPart> getDataPart() const override { unexpectedCall(); }
+    const MergeTreeDataPartChecksums & getChecksums() const override { unexpectedCall(); }
+    AlterConversionsPtr getAlterConversions() const override { unexpectedCall(); }
+    size_t getMarksCount() const override { unexpectedCall(); }
+    size_t getFileSizeOrZero(const std::string &) const override { unexpectedCall(); }
+    const MergeTreeIndexGranularityInfo & getIndexGranularityInfo() const override { unexpectedCall(); }
+    const MergeTreeIndexGranularity & getIndexGranularity() const override { unexpectedCall(); }
+    SerializationPtr getSerialization(const NameAndTypePair &) const override { unexpectedCall(); }
+    const SerializationInfoByName & getSerializationInfos() const override { unexpectedCall(); }
+    String getTableName() const override { unexpectedCall(); }
+    void reportBroken() override { unexpectedCall(); }
+    size_t getRowCount() const override { unexpectedCall(); }
+
+private:
+    [[noreturn]] static void unexpectedCall()
+    {
+        throw std::logic_error("Unexpected data part access");
+    }
+};
+
+}
+
+TEST(MergeTreeMarksLoader, AsyncLoadWithoutCache)
+{
+    auto data_part = std::make_shared<EmptyDataPartInfoForReader>();
+    MergeTreeSettings settings;
+    MergeTreeIndexGranularityInfo index_granularity_info(
+        settings,
+        MarkType(/* adaptive_ */ false, /* compressed_ */ false, /* with_substreams_ */ false, MergeTreeDataPartType::Wide));
+    ThreadPool thread_pool(CurrentMetrics::end(), CurrentMetrics::end(), CurrentMetrics::end(), 1);
+
+    MergeTreeMarksLoader loader(
+        data_part,
+        /* mark_cache_ */ nullptr,
+        "empty.mrk",
+        /* marks_count_ */ 0,
+        index_granularity_info,
+        /* save_marks_in_cache_ */ false,
+        ReadSettings{},
+        &thread_pool,
+        /* num_columns_in_mark_ */ 1,
+        /* use_streaming_compression_ */ false);
+
+    loader.startAsyncLoad();
+    auto marks = loader.loadMarks();
+
+    EXPECT_EQ(marks->getNumColumns(), 1);
+}

--- a/utils/storage-memory-profiler/scenarios/03_add_secondary_indexes.sql
+++ b/utils/storage-memory-profiler/scenarios/03_add_secondary_indexes.sql
@@ -8,4 +8,4 @@ ALTER TABLE test_mt MATERIALIZE INDEX idx_value SETTINGS mutations_sync = 2;
 SELECT count()
 FROM test_mt
 WHERE name = 'name_42'
-SETTINGS force_data_skipping_indices = 'idx_name';
+SETTINGS force_data_skipping_indices = 'idx_name', load_marks_asynchronously = 0;

--- a/utils/storage-memory-profiler/scenarios/03_add_secondary_indexes.sql
+++ b/utils/storage-memory-profiler/scenarios/03_add_secondary_indexes.sql
@@ -3,3 +3,9 @@ ALTER TABLE test_mt ADD INDEX idx_name name TYPE bloom_filter GRANULARITY 1;
 ALTER TABLE test_mt ADD INDEX idx_value value TYPE minmax GRANULARITY 1;
 ALTER TABLE test_mt MATERIALIZE INDEX idx_name SETTINGS mutations_sync = 2;
 ALTER TABLE test_mt MATERIALIZE INDEX idx_value SETTINGS mutations_sync = 2;
+
+-- Exercise secondary-index marks loading.
+SELECT count()
+FROM test_mt
+WHERE name = 'name_42'
+SETTINGS force_data_skipping_indices = 'idx_name';


### PR DESCRIPTION
The storage memory profiler creates a lightweight global context but did not initialize its regular or secondary-index mark caches. `MergeTree` reads could therefore pass a null cache pointer into asynchronous mark loading and fail in `pthread_mutex_lock` during the storage scenarios.

Initialize both caches from the server settings and cap them by the configured RAM ratio, matching `clickhouse-local`. `MergeTreeMarksLoader` already supports a missing cache in synchronous loading, so make the asynchronous path equally safe by skipping the cache lookup while preserving uncached loading through the existing thread pool.

Add `--no-mark-caches` as an intentional validation mode. The related CI PR runs a dedicated PR-only scenario with asynchronous mark loading and a forced data-skipping index under this mode, while the shared master/PR comparison stays backward-compatible.

Failing CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119480&sha=0f939338cdc9cacc29a817cef37492e3f8d7e5ba&name_0=PR&name_1=Storage%20memory%20check

Related: https://github.com/ClickHouse/ClickHouse/pull/119480

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119516&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119516](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119516+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1239` (included in `26.9` and later)
<!-- ch-version-info:end -->