### PR TITLE
Check the read source grant and the host filter when a `HDFS` database serves a table from its cache

### DIFF
--- a/src/Databases/DatabaseHDFS.cpp
+++ b/src/Databases/DatabaseHDFS.cpp
@@ -13,6 +13,7 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Storages/ObjectStorage/HDFS/HDFSCommon.h>
 #include <Storages/IStorage.h>
+#include <TableFunctions/ITableFunction.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Common/Logger.h>
 #include <Common/quoteString.h>
@@ -103,15 +104,29 @@ bool DatabaseHDFS::checkUrl(const std::string & url, ContextPtr context_, bool t
 
 bool DatabaseHDFS::isTableExist(const String & name, ContextPtr context_) const
 {
-    std::lock_guard lock(mutex);
-    if (loaded_tables.contains(name))
-        return true;
+    /// A name exists when it forms a URL this database may use, which needs no HDFS request. The cache
+    /// must not answer it: that reports which names other callers resolved, past any filter tightening.
+    if (source.empty() && !name.starts_with("hdfs://"))
+        return false;
 
-    return checkUrl(name, context_, false);
+    return checkUrl(getTablePath(name), context_, false);
 }
 
 StoragePtr DatabaseHDFS::getTableImpl(const String & name, ContextPtr context_) const
 {
+    auto url = getTablePath(name);
+    auto args = makeASTFunction("hdfs", make_intrusive<ASTLiteral>(url));
+
+    auto table_function = TableFunctionFactory::instance().get(args, context_);
+    if (!table_function)
+        return nullptr;
+
+    /// The cache is keyed on the name alone, so what authorizes a resolution is checked above it. The
+    /// grant is the table function's to check: a filtered grant matches the URI it reports, not the path.
+    table_function->checkSourceAccess(context_, /* is_insert_query */ false);
+
+    checkUrl(url, context_, true);
+
     /// Check if the table exists in the loaded tables map.
     {
         std::lock_guard lock(mutex);
@@ -119,16 +134,6 @@ StoragePtr DatabaseHDFS::getTableImpl(const String & name, ContextPtr context_) 
         if (it != loaded_tables.end())
             return it->second;
     }
-
-    auto url = getTablePath(name);
-
-    checkUrl(url, context_, true);
-
-    auto args = makeASTFunction("hdfs", make_intrusive<ASTLiteral>(url));
-
-    auto table_function = TableFunctionFactory::instance().get(args, context_);
-    if (!table_function)
-        return nullptr;
 
     /// TableFunctionHDFS throws exceptions, if table cannot be created.
     auto table_storage = table_function->execute(args, context_, name);

--- a/tests/integration/test_database_hdfs_read_grant/configs/allowlist.xml
+++ b/tests/integration/test_database_hdfs_read_grant/configs/allowlist.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <remote_url_allow_hosts>
+        <host>allowed.example.com:9000</host>
+    </remote_url_allow_hosts>
+</clickhouse>

--- a/tests/integration/test_database_hdfs_read_grant/test.py
+++ b/tests/integration/test_database_hdfs_read_grant/test.py
@@ -1,0 +1,100 @@
+"""A `HDFS` database must not serve a table from its cache unchecked.
+
+The cache is keyed on the table name alone, so an entry one user resolved is handed to every later
+caller. Both the read source grant and the remote host filter therefore have to be checked above it.
+The same shape was fixed for the `Filesystem` database in
+https://github.com/ClickHouse/ClickHouse/issues/118042.
+"""
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.config_manager import ConfigManager
+
+if is_arm():
+    pytestmark = pytest.mark.skip
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", with_hdfs=True, stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_hdfs_database_cache_is_checked(started_cluster):
+    hdfs_api = started_cluster.hdfs_api
+    for name in ("warm.tsv", "cold.tsv", "cold2.tsv"):
+        hdfs_api.write_data("/" + name, "7\n")
+
+    # The engine rejects a source that carries a path, so table names here are relative, which is the
+    # form the `EXISTS TABLE` arms below need.
+    node.query("CREATE DATABASE hdfs_db ENGINE = HDFS('hdfs://hdfs1:9000')")
+    # The source grant is the variable under test, so the table grant is deliberately broad and cannot
+    # confound the result. It also shows that it does not confer the source grant by itself.
+    node.query("CREATE USER u")
+    node.query("GRANT SELECT ON *.* TO u")
+
+    # A user holding the grant resolves the name, which is what caches the storage for it.
+    assert node.query("SELECT * FROM hdfs_db.`warm.tsv`") == "7\n"
+
+    # `tryGetTable` reports a denied resolution as `UNKNOWN_TABLE` (code 60). What this asserts is that
+    # the cached name is refused exactly like the name that was never resolved.
+    error = node.query_and_get_error("SELECT * FROM hdfs_db.`warm.tsv`", user="u")
+    assert "Code: 60." in error, error
+    error = node.query_and_get_error("SELECT * FROM hdfs_db.`cold.tsv`", user="u")
+    assert "Code: 60." in error, error
+
+    # `EXISTS TABLE` needs only `SHOW TABLES`, so it must answer alike for a cached name and for one
+    # that was never resolved, or it reports which names other users have read.
+    assert node.query("EXISTS TABLE hdfs_db.`warm.tsv`", user="u") == "1\n"
+    assert node.query("EXISTS TABLE hdfs_db.`never.tsv`", user="u") == "1\n"
+    # A name that forms no usable URL still answers 0, and answers it to everyone: the two lines above
+    # are a measurement, and this probe does not depend on the grant.
+    assert node.query("EXISTS TABLE hdfs_db.`hdfs://hdfs1:9000`", user="u") == "0\n"
+    assert node.query("EXISTS TABLE hdfs_db.`hdfs://hdfs1:9000`") == "0\n"
+
+    node.query("GRANT READ ON HDFS TO u")
+
+    # With the grant the cached name is served, while a name that was never resolved is not: only the
+    # latter calls the table function, which also requires `CREATE TEMPORARY TABLE`. That contrast is
+    # what shows the query above was answered from the cache and not by resolving the file again.
+    assert node.query("SELECT * FROM hdfs_db.`warm.tsv`", user="u") == "7\n"
+    error = node.query_and_get_error("SELECT * FROM hdfs_db.`cold2.tsv`", user="u")
+    assert "Code: 60." in error, error
+    node.query("GRANT CREATE TEMPORARY TABLE ON *.* TO u")
+    assert node.query("SELECT * FROM hdfs_db.`cold2.tsv`", user="u") == "7\n"
+
+    # A grant restricted by URL must keep working: the filter is matched against the URI the table
+    # function reports, which for HDFS is the host of the table and not its path.
+    node.query("CREATE USER f")
+    node.query("GRANT SELECT ON *.* TO f")
+    node.query("GRANT READ ON HDFS('hdfs://hdfs1:9000') TO f")
+    assert node.query("SELECT * FROM hdfs_db.`warm.tsv`", user="f") == "7\n"
+
+    # The host filter is re-read on `SYSTEM RELOAD CONFIG`, which keeps the cache, so a cached table
+    # must stop being served once its host is no longer allowed. These run as the fully granted user,
+    # so the grant cannot be the cause.
+    with ConfigManager() as cm:
+        cm.add_main_config(node, "configs/allowlist.xml")
+        error = node.query_and_get_error("SELECT * FROM hdfs_db.`warm.tsv`")
+        assert "Code: 60." in error, error
+        assert node.query("EXISTS TABLE hdfs_db.`warm.tsv`") == "0\n"
+        # A path that reports the refusal instead of masking it names the URL that was rejected.
+        error = node.query_and_get_error("INSERT INTO hdfs_db.`warm.tsv` VALUES (1)")
+        assert "UNACCEPTABLE_URL" in error, error
+        # The name that is not in the cache is refused the same way, as it already was.
+        error = node.query_and_get_error("SELECT * FROM hdfs_db.`cold.tsv`")
+        assert "Code: 60." in error, error
+
+    # Removing the file and reloading again restores the answer, so the refusals above came from the
+    # filter and not from an evicted or poisoned cache entry.
+    assert node.query("SELECT * FROM hdfs_db.`warm.tsv`") == "7\n"
+
+    node.query("DROP DATABASE hdfs_db SYNC")
+    node.query("DROP USER u, f")

--- a/tests/integration/test_database_hdfs_read_grant/test.py
+++ b/tests/integration/test_database_hdfs_read_grant/test.py
@@ -61,14 +61,15 @@ def test_hdfs_database_cache_is_checked(started_cluster):
 
     node.query("GRANT READ ON HDFS TO u")
 
-    # With the grant the cached name is served, while a name that was never resolved is not: only the
-    # latter calls the table function, which also requires `CREATE TEMPORARY TABLE`. That contrast is
-    # what shows the query above was answered from the cache and not by resolving the file again.
+    # With the grant the cached name is served. `TableFunctionExecute` counts calls of the table
+    # function, which serving from the cache does not make, so a counter that does not move is what
+    # shows the read was answered from the cache. The resolve below is the control that moves it.
+    calls = "SELECT sum(value) FROM system.events WHERE event = 'TableFunctionExecute'"
+    before = int(node.query(calls))
     assert node.query("SELECT * FROM hdfs_db.`warm.tsv`", user="u") == "7\n"
-    error = node.query_and_get_error("SELECT * FROM hdfs_db.`cold2.tsv`", user="u")
-    assert "Code: 60." in error, error
-    node.query("GRANT CREATE TEMPORARY TABLE ON *.* TO u")
-    assert node.query("SELECT * FROM hdfs_db.`cold2.tsv`", user="u") == "7\n"
+    assert int(node.query(calls)) == before
+    assert node.query("SELECT * FROM hdfs_db.`cold2.tsv`") == "7\n"
+    assert int(node.query(calls)) > before
 
     # A grant restricted by URL must keep working: the filter is matched against the URI the table
     # function reports, which for HDFS is the host of the table and not its path.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/119029


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `HDFS` database serving a table from its internal cache without the `READ ON HDFS` grant. The grant and the `remote_url_allow_hosts` filter were checked only while a table name was resolved for the first time, so once any user holding the grant had read a name, every user with `SELECT` on the database was served the contents of the file, and that table kept being served after its host was removed from the allowlist. `EXISTS TABLE`, which requires only `SHOW TABLES`, answered from the same cache and so reported which names other users had resolved. Both checks now run before the cache is consulted, and the existence probe no longer consults it.


### Description

`DatabaseHDFS` caches every table it resolves, keyed on the name alone, and read that cache above
every check that authorizes a resolution. A cache hit therefore ran neither the read source grant,
which only `ITableFunction::checkSourceAccess` performs, nor `DatabaseHDFS::checkUrl`, which applies
`remote_url_allow_hosts`. `isTableExist` answered from that same cache, and otherwise asked
`checkUrl` about the bare table name, which fails `checkHDFSURL` for every relative name.

`getTableImpl` now builds the table function, checks the grant and the URL, then reads the cache. The table function checks the grant, because a filtered grant is matched against the URI
it reports, which for HDFS is the host with the path stripped: the table's own URL would deny a
holder of `GRANT READ ON HDFS('hdfs://host:9000')` on the uncached path too. `isTableExist` asks
about the resolved URL and no longer reads the cache; it needs no grant, issuing no HDFS
request, unlike the `Filesystem` probe reaching `fs::exists`, and `DatabaseS3::isTableExist` is
already this shape. That is narrower than what I wrote on #119029, where I expected the parent's
grant gate.

Compatibility: a warm-cache read without `READ ON HDFS` is now refused, which is the defect itself,
and `EXISTS TABLE` answers 1 for any name forming an allowlisted URL, where uncached relative names
answered 0. The module fails on master; each hunk reverted alone reddens a different assertion.

Also noticed, not fixed here: `INSERT` and `TRUNCATE` authorize with `READ ON HDFS`, never
`WRITE ON HDFS`, since `StorageObjectStorage` inherits the no-op `IStorage::checkInsertIsAllowed`,
and a cache hit skips the `CREATE TEMPORARY TABLE` check an uncached resolve applies. Master answers
alike for an uncached name, so neither is widened here. Dropping that check alone would open the
write path, so both need the write-mode re-resolution the `URL` database does through a proxy.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119523&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119523](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119523+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.81` (included in `26.10` and later)
- Backported to: `26.9.1.1605`, `26.8.7.21`, `26.7.12.5`, `26.3.33.113`
<!-- ch-version-info:end -->