### PR TITLE
Docs: show region codes and names for all cloud providers

### DIFF
--- a/docs/products/cloud/reference/supported-regions.mdx
+++ b/docs/products/cloud/reference/supported-regions.mdx
@@ -16,59 +16,59 @@ The following tables list supported regions by cloud provider. Badges indicate a
 <Tabs>
 <Tab title="AWS" id="aws-regions" icon="aws">
 
-| Region | Availability |
-| --- | --- |
-| `af-south-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-east-1` | <Badge color="purple">Private</Badge> |
-| `ap-east-2` | <Badge color="purple">Private</Badge> |
-| `ap-northeast-1` | <Badge color="yellow">Public</Badge> |
-| `ap-northeast-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-south-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-southeast-1` | <Badge color="yellow">Public</Badge> |
-| `ap-southeast-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-southeast-3` | <Badge color="purple">Private</Badge> |
-| `ap-southeast-5` | <Badge color="purple">Private</Badge> |
-| `ca-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-north-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `il-central-1` | <Badge color="yellow">Public</Badge> |
-| `me-central-1` | <Badge color="yellow">Public</Badge> |
-| `mx-central-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `sa-east-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| Region code | Region name | Availability |
+| --- | --- | --- |
+| `af-south-1` | Africa (Cape Town) | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-east-1` | Asia Pacific (Hong Kong) | <Badge color="purple">Private</Badge> |
+| `ap-east-2` | Asia Pacific (Taipei) | <Badge color="purple">Private</Badge> |
+| `ap-northeast-1` | Asia Pacific (Tokyo) | <Badge color="yellow">Public</Badge> |
+| `ap-northeast-2` | Asia Pacific (Seoul) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-south-1` | Asia Pacific (Mumbai) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-southeast-1` | Asia Pacific (Singapore) | <Badge color="yellow">Public</Badge> |
+| `ap-southeast-2` | Asia Pacific (Sydney) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-southeast-3` | Asia Pacific (Jakarta) | <Badge color="purple">Private</Badge> |
+| `ap-southeast-5` | Asia Pacific (Malaysia) | <Badge color="purple">Private</Badge> |
+| `ca-central-1` | Canada (Central) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-central-1` | Europe (Frankfurt) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-north-1` | Europe (Stockholm) | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-1` | Europe (Ireland) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-2` | Europe (London) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `il-central-1` | Israel (Tel Aviv) | <Badge color="yellow">Public</Badge> |
+| `me-central-1` | Middle East (UAE) | <Badge color="yellow">Public</Badge> |
+| `mx-central-1` | Mexico (Central) | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `sa-east-1` | South America (São Paulo) | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-1` | US East (N. Virginia) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-2` | US East (Ohio) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west-2` | US West (Oregon) | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 
 </Tab>
 <Tab title="Google Cloud" id="google-cloud-regions" icon="/images/icons/cloud-providers/google-cloud-color.svg">
 
-| Region | Availability |
-| --- | --- |
-| `asia-northeast1` | <Badge color="yellow">Public</Badge> |
-| `asia-southeast1` | <Badge color="yellow">Public</Badge> |
-| `australia-southeast1` | <Badge color="purple">Private</Badge> |
-| `europe-west2` | <Badge color="yellow">Public</Badge> |
-| `europe-west3` | <Badge color="purple">Private</Badge> |
-| `europe-west4` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `europe-west6` | <Badge color="purple">Private</Badge> |
-| `northamerica-northeast1` | <Badge color="purple">Private</Badge> |
-| `us-central1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west1` | <Badge color="purple">Private</Badge> |
+| Region code | Region name | Availability |
+| --- | --- | --- |
+| `asia-northeast1` | Tokyo, Japan | <Badge color="yellow">Public</Badge> |
+| `asia-southeast1` | Jurong West, Singapore | <Badge color="yellow">Public</Badge> |
+| `australia-southeast1` | Sydney, Australia | <Badge color="purple">Private</Badge> |
+| `europe-west2` | London, United Kingdom | <Badge color="yellow">Public</Badge> |
+| `europe-west3` | Frankfurt, Germany | <Badge color="purple">Private</Badge> |
+| `europe-west4` | Eemshaven, Netherlands | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `europe-west6` | Zurich, Switzerland | <Badge color="purple">Private</Badge> |
+| `northamerica-northeast1` | Montréal, Québec | <Badge color="purple">Private</Badge> |
+| `us-central1` | Council Bluffs, Iowa | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east1` | Moncks Corner, South Carolina | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west1` | The Dalles, Oregon | <Badge color="purple">Private</Badge> |
 
 </Tab>
 <Tab title="Azure" id="azure-regions" icon="/images/icons/cloud-providers/azure.svg">
 
-| Region | Availability |
-| --- | --- |
-| `Australia East` | <Badge color="purple">Private</Badge> |
-| `East US 2` | <Badge color="yellow">Public</Badge> |
-| `Germany West Central` | <Badge color="yellow">Public</Badge> |
-| `Japan East` | <Badge color="purple">Private</Badge> |
-| `UAE North` | <Badge color="purple">Private</Badge> |
-| `West US 3` | <Badge color="yellow">Public</Badge> |
+| Region code | Region name | Availability |
+| --- | --- | --- |
+| `australiaeast` | Australia East | <Badge color="purple">Private</Badge> |
+| `eastus2` | East US 2 | <Badge color="yellow">Public</Badge> |
+| `germanywestcentral` | Germany West Central | <Badge color="yellow">Public</Badge> |
+| `japaneast` | Japan East | <Badge color="purple">Private</Badge> |
+| `uaenorth` | UAE North | <Badge color="purple">Private</Badge> |
+| `westus3` | West US 3 | <Badge color="yellow">Public</Badge> |
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Show region codes alongside readable names in the supported cloud regions tables so users can identify deployment locations without looking up provider codes. Use the same Region code, Region name, and Availability columns for AWS, Google Cloud, and Azure, preserving the existing supported regions and availability badges.

Verified all 39 mappings against the official [AWS](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html), [Google Cloud](https://docs.cloud.google.com/workstations/docs/locations), and [Azure](https://learn.microsoft.com/en-us/azure/reliability/regions-list) lists. Checked the tables in a local Mintlify preview and ran `git diff --check`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add region names and codes consistently across the supported cloud regions tables.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119524&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119524](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119524+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1217` (included in `26.9` and later)
<!-- ch-version-info:end -->