### PR TITLE
Report the stack trace of a large charge to the global memory tracker

### DIFF
--- a/docs/reference/system-tables/stack_trace.mdx
+++ b/docs/reference/system-tables/stack_trace.mdx
@@ -100,6 +100,6 @@ res:       /lib/x86_64-linux-gnu/libc-2.27.so
 ## See Also {#see-also}
 
 - [Introspection Functions](/reference/functions/regular-functions/introspection) — Which introspection functions are available and how to use them.
-- [system.trace_log](/reference/system-tables/trace_log) — Contains stack traces collected by the sampling query profiler.
+- [system.trace_log](/reference/system-tables/trace_log) — Contains stack traces collected by the sampling query profiler and by the other sources named in the `trace_type` column.
 - [arrayMap](/reference/functions/regular-functions/array-functions#arrayMap)) — Description and usage example of the `arrayMap` function.
 - [arrayFilter](/reference/functions/regular-functions/array-functions#arrayFilter) — Description and usage example of the `arrayFilter` function.

--- a/docs/reference/system-tables/trace_log.mdx
+++ b/docs/reference/system-tables/trace_log.mdx
@@ -1,6 +1,6 @@
 ---
 description: 'System table containing stack traces collected by the sampling query
-  profiler.'
+  profiler and by the other sources named in the trace_type column.'
 keywords: ['system table', 'trace_log']
 slug: /operations/system-tables/trace_log
 title: 'system.trace_log'
@@ -13,7 +13,7 @@ import SystemTableCloud from '/snippets/_system_table_cloud.mdx';
 
 ## Description {#description}
 
-Contains stack traces collected by the [sampling query profiler](/concepts/features/performance/troubleshoot/sampling-query-profiler).
+Contains stack traces collected by the [sampling query profiler](/concepts/features/performance/troubleshoot/sampling-query-profiler) and by the other sources named in the `trace_type` column.
 
 ClickHouse creates this table when the [trace_log](/reference/settings/server-settings/settings/other#trace_log) server configuration section is set. Also see settings: [query_profiler_real_time_period_ns](/reference/settings/session-settings/query-profiler#query_profiler_real_time_period_ns), [query_profiler_cpu_time_period_ns](/reference/settings/session-settings/query-profiler#query_profiler_cpu_time_period_ns), [memory_profiler_step](/reference/settings/session-settings/memory-profiler#memory_profiler_step),
 [memory_profiler_sample_probability](/reference/settings/session-settings/memory-profiler#memory_profiler_sample_probability), [trace_profile_events](/reference/settings/session-settings/trace-profile-events#trace_profile_events).

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -202,6 +202,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 max_unexpected_parts_loading_thread_pool_size;
     extern const ServerSettingsUInt64 max_per_cpu_untracked_memory;
     extern const ServerSettingsUInt64 per_cpu_untracked_memory_thread_buffer;
+    extern const ServerSettingsUInt64 min_allocation_size_to_log_stack_trace;
     extern const ServerSettingsUInt64 min_allocation_size_to_throw_on_memory_limit;
     extern const ServerSettingsUInt64 mmap_cache_size;
     extern const ServerSettingsBool show_addresses_in_stack_traces;
@@ -1488,6 +1489,10 @@ void LocalServer::processConfig()
 
     CurrentMemoryTracker::setMinAllocationSizeBytesToThrow(
         server_settings[ServerSetting::min_allocation_size_to_throw_on_memory_limit]);
+
+    /// clickhouse-local never creates a trace collector, so the setter reports the refusal here.
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(
+        server_settings[ServerSetting::min_allocation_size_to_log_stack_trace]);
 
     per_cpu_memory.setBudgetCapacity(server_settings[ServerSetting::max_per_cpu_untracked_memory]);
     per_cpu_memory.setThreadBuffer(server_settings[ServerSetting::per_cpu_untracked_memory_thread_buffer]);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -377,6 +377,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 merges_mutations_memory_usage_soft_limit;
     extern const ServerSettingsDouble merges_mutations_memory_usage_to_ram_ratio;
     extern const ServerSettingsString merge_workload;
+    extern const ServerSettingsUInt64 min_allocation_size_to_log_stack_trace;
     extern const ServerSettingsUInt64 min_allocation_size_to_throw_on_memory_limit;
     extern const ServerSettingsUInt64 mmap_cache_size;
     extern const ServerSettingsString mutation_workload;
@@ -2576,6 +2577,9 @@ try
 
             CurrentMemoryTracker::setMinAllocationSizeBytesToThrow(
                 new_server_settings[ServerSetting::min_allocation_size_to_throw_on_memory_limit]);
+
+            MemoryTracker::setMinAllocationSizeToLogStackTrace(
+                new_server_settings[ServerSetting::min_allocation_size_to_log_stack_trace]);
 
             per_cpu_memory.setBudgetCapacity(new_server_settings[ServerSetting::max_per_cpu_untracked_memory]);
             per_cpu_memory.setThreadBuffer(new_server_settings[ServerSetting::per_cpu_untracked_memory_thread_buffer]);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1389,6 +1389,10 @@ try
     {
         global_context->createTraceCollector();
 
+        /// The config reloader applies this too; the seed here covers startup, which runs before its first callback.
+        MemoryTracker::setMinAllocationSizeToLogStackTrace(
+            server_settings[ServerSetting::min_allocation_size_to_log_stack_trace]);
+
         /// Set up server-wide memory profiler (for total memory tracker).
         if (server_settings[ServerSetting::total_memory_profiler_step])
             total_memory_tracker.setProfilerStep(server_settings[ServerSetting::total_memory_profiler_step]);

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -350,8 +350,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
             if (metric_loaded != CurrentMetrics::end())
                 CurrentMetrics::add(metric_loaded, size);
 
-            /// This branch returns below without reaching commitAllocation, so it is the only place
-            /// that can report an allocation charged here.
+            /// This branch returns below without reaching commitAllocation, so an allocation charged here would otherwise go unreported.
             const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_acquire);
             if (unlikely(trace_threshold && static_cast<UInt64>(size) >= trace_threshold))
                 traceLargeAllocation(size);

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -291,12 +291,11 @@ void MemoryTracker::setMinAllocationSizeToLogStackTrace(UInt64 value)
         value = 0;
     }
 
-    /// Switching the diagnostic on refills the trace budget, so re-enabling it to investigate a live
-    /// incident is not starved by traces spent earlier. A config reload that leaves the value
-    /// unchanged is not a transition and refills nothing.
-    const UInt64 previous = min_allocation_size_to_log_stack_trace.exchange(value, std::memory_order_relaxed);
-    if (value && !previous)
+    /// Reset the budget while the threshold is still 0, so no thread can be spending it, then
+    /// publish. A reload that leaves the value unchanged is not a transition and refills nothing.
+    if (value && !min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed))
         large_allocations_traced.store(0, std::memory_order_relaxed);
+    min_allocation_size_to_log_stack_trace.store(value, std::memory_order_relaxed);
 }
 
 UInt64 MemoryTracker::getMinAllocationSizeToLogStackTrace()

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -20,6 +20,7 @@
 #include <Common/VariableContext.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
+#include <Common/setThreadName.h>
 #include <Common/thread_local_rng.h>
 #include <base/defines.h>
 
@@ -33,6 +34,7 @@
 #include <atomic>
 #include <random>
 #include <cstdlib>
+#include <mutex>
 #include <string>
 
 
@@ -138,12 +140,17 @@ namespace ProfileEvents
     extern const Event PageCacheOvercommitResize;
     extern const Event MemoryAllocatedWithoutCheck;
     extern const Event MemoryAllocatedWithoutCheckBytes;
+    extern const Event MemoryLargeAllocationTraced;
 }
 
 using namespace std::chrono_literals;
 
 static constexpr size_t log_peak_memory_usage_every = 1ULL << 30;
 static std::atomic_bool total_memory_tracker_initialized{false};
+static std::atomic<UInt64> min_allocation_size_to_log_stack_trace{0};
+/// Symbolizing in TraceCollector is expensive and the trigger repeats, so traces are budgeted.
+static constexpr UInt64 max_large_allocations_traced = 10;
+static std::atomic<UInt64> large_allocations_traced{0};
 
 MemoryTracker total_memory_tracker(nullptr, VariableContext::Global);
 MemoryTracker background_memory_tracker(&total_memory_tracker, VariableContext::User, false);
@@ -267,6 +274,58 @@ static void incrementAllocationWithoutCheck(Int64 size) noexcept
     }
 }
 
+void MemoryTracker::setMinAllocationSizeToLogStackTrace(UInt64 value)
+{
+    /// Capturing a stack costs an unwind and the trace is delivered through the TraceCollector
+    /// pipe, so without a collector the setting could only throw work away.
+    if (value && !DB::TraceSender::isCollecting())
+    {
+        static std::once_flag warned;
+        std::call_once(warned, []
+        {
+            LOG_WARNING(
+                getLogger("MemoryTracker"),
+                "min_allocation_size_to_log_stack_trace is ignored because the trace collector is not "
+                "running (it requires `trace_log` to be configured).");
+        });
+        value = 0;
+    }
+
+    /// Switching the diagnostic on refills the trace budget, so re-enabling it to investigate a live
+    /// incident is not starved by traces spent earlier. A config reload that leaves the value
+    /// unchanged is not a transition and refills nothing.
+    const UInt64 previous = min_allocation_size_to_log_stack_trace.exchange(value, std::memory_order_relaxed);
+    if (value && !previous)
+        large_allocations_traced.store(0, std::memory_order_relaxed);
+}
+
+UInt64 MemoryTracker::getMinAllocationSizeToLogStackTrace()
+{
+    return min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed);
+}
+
+void MemoryTracker::traceLargeAllocation(Int64 size) noexcept
+{
+    /// Tracing the collector's own allocations would feed the diagnostic with itself. Deliberately
+    /// narrower than MemoryTrackerUntrackedAllocationsBlockerInThread, which also covers system-log
+    /// enqueues and whole ZooKeeper thread loops - the background paths this exists to catch.
+    if (DB::getThreadName() == DB::ThreadName::TRACE_COLLECTOR)
+        return;
+
+    if (large_allocations_traced.fetch_add(1, std::memory_order_relaxed) >= max_large_allocations_traced)
+        return;
+
+    ProfileEvents::increment(ProfileEvents::MemoryLargeAllocationTraced);
+
+    /// Unsymbolized: StackTrace::toString takes the symbolizer cache mutex and allocates, neither of
+    /// which may happen inside an allocation. TraceCollector symbolizes instead.
+    DB::TraceSender::send(DB::TraceType::MemoryLargeAllocation, StackTrace(), DB::TraceSender::Extras{
+        .size = size,
+        .memory_context = level,
+        .memory_blocked_context = MemoryTrackerBlockerInThread::getLevel(),
+    });
+}
+
 AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, MemoryTracker * query_tracker, double _sample_probability)
 {
     if (size < 0)
@@ -290,6 +349,12 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
             auto metric_loaded = metric.load(std::memory_order_relaxed);
             if (metric_loaded != CurrentMetrics::end())
                 CurrentMetrics::add(metric_loaded, size);
+
+            /// This branch returns below without reaching commitAllocation, so it is the only place
+            /// that can report an allocation charged here.
+            const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed);
+            if (unlikely(trace_threshold && static_cast<UInt64>(size) >= trace_threshold))
+                traceLargeAllocation(size);
         }
 
         /// Since the MemoryTrackerBlockerInThread should respect the level, we should go to the next parent.
@@ -530,6 +595,15 @@ Int64 MemoryTracker::decrementLocalUsage(Int64 size) noexcept
 
 void MemoryTracker::commitAllocation(Int64 size, Int64 will_be, bool memory_limit_exceeded_ignored, bool enforce_memory_limit) noexcept
 {
+    /// Only reached once the allocation survived every limit check, so a refused or reverted add is
+    /// never reported here.
+    if (level == VariableContext::Global)
+    {
+        const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed);
+        if (unlikely(trace_threshold && static_cast<UInt64>(size) >= trace_threshold))
+            traceLargeAllocation(size);
+    }
+
     const auto current_profiler_limit = profiler_limit.load(std::memory_order_relaxed);
     bool allocation_traced = false;
     if (unlikely(current_profiler_limit && will_be > current_profiler_limit))

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -295,7 +295,8 @@ void MemoryTracker::setMinAllocationSizeToLogStackTrace(UInt64 value)
     /// publish. A reload that leaves the value unchanged is not a transition and refills nothing.
     if (value && !min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed))
         large_allocations_traced.store(0, std::memory_order_relaxed);
-    min_allocation_size_to_log_stack_trace.store(value, std::memory_order_relaxed);
+    /// Release pairs with the acquire at the detect sites, so a thread that sees the threshold also sees the reset budget.
+    min_allocation_size_to_log_stack_trace.store(value, std::memory_order_release);
 }
 
 UInt64 MemoryTracker::getMinAllocationSizeToLogStackTrace()
@@ -351,7 +352,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
 
             /// This branch returns below without reaching commitAllocation, so it is the only place
             /// that can report an allocation charged here.
-            const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed);
+            const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_acquire);
             if (unlikely(trace_threshold && static_cast<UInt64>(size) >= trace_threshold))
                 traceLargeAllocation(size);
         }
@@ -598,7 +599,7 @@ void MemoryTracker::commitAllocation(Int64 size, Int64 will_be, bool memory_limi
     /// never reported here.
     if (level == VariableContext::Global)
     {
-        const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed);
+        const UInt64 trace_threshold = min_allocation_size_to_log_stack_trace.load(std::memory_order_acquire);
         if (unlikely(trace_threshold && static_cast<UInt64>(size) >= trace_threshold))
             traceLargeAllocation(size);
     }

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -291,12 +291,13 @@ void MemoryTracker::setMinAllocationSizeToLogStackTrace(UInt64 value)
         value = 0;
     }
 
-    /// Reset the budget while the threshold is still 0, so no thread can be spending it, then
-    /// publish. A reload that leaves the value unchanged is not a transition and refills nothing.
-    if (value && !min_allocation_size_to_log_stack_trace.load(std::memory_order_relaxed))
-        large_allocations_traced.store(0, std::memory_order_relaxed);
-    /// Release pairs with the acquire at the detect sites, so a thread that sees the threshold also sees the reset budget.
+    /// Release pairs with the acquire at the detect sites, so a thread that sees the threshold also sees the collector's budget reset.
     min_allocation_size_to_log_stack_trace.store(value, std::memory_order_release);
+}
+
+void MemoryTracker::resetLargeAllocationTraceBudget()
+{
+    large_allocations_traced.store(0, std::memory_order_relaxed);
 }
 
 UInt64 MemoryTracker::getMinAllocationSizeToLogStackTrace()

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -352,7 +352,7 @@ public:
     static void setMinAllocationSizeToLogStackTrace(UInt64 value);
     static UInt64 getMinAllocationSizeToLogStackTrace();
 
-    /// Refills the budget for the traces above. Called once per TraceCollector, see its constructor.
+    /// Resets the budget for the traces above. Called once per TraceCollector, see its constructor.
     static void resetLargeAllocationTraceBudget();
 
     /// Prints info about peak memory consumption into log.

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -352,6 +352,9 @@ public:
     static void setMinAllocationSizeToLogStackTrace(UInt64 value);
     static UInt64 getMinAllocationSizeToLogStackTrace();
 
+    /// Refills the budget for the traces above. Called once per TraceCollector, see its constructor.
+    static void resetLargeAllocationTraceBudget();
+
     /// Prints info about peak memory consumption into log.
     void logPeakMemoryUsage();
 };

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -347,8 +347,9 @@ public:
     static void updateRSS(Int64 rss_);
     static void updateAllocated(Int64 allocated_, bool log_change);
 
-    /// Report a stack trace for any single allocation of at least `value` bytes charged to the
-    /// global tracker; 0 disables. Coerced to 0 when no TraceCollector is running.
+    /// Report a stack trace for any single charge of at least `value` bytes to the global tracker.
+    /// A charge is one tracker call and may batch a thread's deferred allocations, so it is not
+    /// necessarily one allocation. 0 disables; coerced to 0 when no TraceCollector is running.
     static void setMinAllocationSizeToLogStackTrace(UInt64 value);
     static UInt64 getMinAllocationSizeToLogStackTrace();
 

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -141,6 +141,7 @@ private:
     void logMemoryUsage(Int64 current) const;
     Int64 decrementLocalUsage(Int64 size) noexcept;
     void commitAllocation(Int64 size, Int64 will_be, bool memory_limit_exceeded_ignored, bool enforce_memory_limit) noexcept;
+    void traceLargeAllocation(Int64 size) noexcept;
 
     void setOrRaiseProfilerLimit(Int64 value);
 
@@ -345,6 +346,11 @@ public:
     /// update values based on external information (e.g. jemalloc's stat)
     static void updateRSS(Int64 rss_);
     static void updateAllocated(Int64 allocated_, bool log_change);
+
+    /// Report a stack trace for any single allocation of at least `value` bytes charged to the
+    /// global tracker; 0 disables. Coerced to 0 when no TraceCollector is running.
+    static void setMinAllocationSizeToLogStackTrace(UInt64 value);
+    static UInt64 getMinAllocationSizeToLogStackTrace();
 
     /// Prints info about peak memory consumption into log.
     void logPeakMemoryUsage();

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -849,6 +849,7 @@ The server successfully detected this situation and will download merged part fr
     M(GlobalMemoryLimitExceeded, "Number of times the global memory limit was exceeded.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheck, "Number of times memory has been allocated without checking for memory constraints.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheckBytes, "Amount of bytes that has been allocated without checking for memory constraints.", ValueType::Number) \
+    M(MemoryLargeAllocationTraced, "Number of times a stack trace was captured for a single allocation at or above `min_allocation_size_to_log_stack_trace`.", ValueType::Number) \
     \
     M(AzureGetObject, "Number of Azure API GetObject calls.", ValueType::Number) \
     M(AzureUpload, "Number of Azure blob storage API Upload calls", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -849,7 +849,7 @@ The server successfully detected this situation and will download merged part fr
     M(GlobalMemoryLimitExceeded, "Number of times the global memory limit was exceeded.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheck, "Number of times memory has been allocated without checking for memory constraints.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheckBytes, "Amount of bytes that has been allocated without checking for memory constraints.", ValueType::Number) \
-    M(MemoryLargeAllocationTraced, "Number of times a stack trace was captured for a single allocation at or above `min_allocation_size_to_log_stack_trace`.", ValueType::Number) \
+    M(MemoryLargeAllocationTraced, "Number of times a stack trace was captured for a single charge to the global memory tracker at or above `min_allocation_size_to_log_stack_trace`.", ValueType::Number) \
     \
     M(AzureGetObject, "Number of Azure API GetObject calls.", ValueType::Number) \
     M(AzureUpload, "Number of Azure blob storage API Upload calls", ValueType::Number) \

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -77,6 +77,11 @@ void StackTrace::setShowAddresses(bool show)
     show_addresses.store(show, std::memory_order_relaxed);
 }
 
+bool StackTrace::showAddresses()
+{
+    return show_addresses.load(std::memory_order_relaxed);
+}
+
 std::string signalToErrorMessage(int sig, const siginfo_t & info, [[maybe_unused]] const ucontext_t & context)
 {
     std::string message = getSignalCodeDescription(sig, info.si_code);

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -128,6 +128,7 @@ public:
     /// If you turn off addresses, it will be more secure, but we will be unable to help you with debugging.
     /// Please note: addresses are also available in the system.stack_trace and system.trace_log tables.
     static void setShowAddresses(bool show);
+    static bool showAddresses();
 
     /// Renders the demangled name of a frame for display: shortens well-known libc++ spellings, and returns
     /// "?" for frames whose name carries no information. @param file is the source location of the frame.

--- a/src/Common/TraceSender.h
+++ b/src/Common/TraceSender.h
@@ -24,7 +24,8 @@ enum class TraceType : uint8_t
     ProfileEvent,
     JemallocSample,
     MemoryAllocatedWithoutCheck,
-    Instrumentation
+    Instrumentation,
+    MemoryLargeAllocation
 };
 
 /// This is the second part of TraceCollector, that sends stacktrace to the pipe.
@@ -49,6 +50,9 @@ public:
     /// Collect a stack trace. This method is signal safe.
     /// Precondition: the TraceCollector object must be created.
     static void send(TraceType trace_type, const StackTrace & stack_trace, Extras extras) noexcept;
+
+    /// True when a TraceCollector is running, i.e. when `send()` can deliver rather than discard.
+    static bool isCollecting() { return pipe.fds_rw[1] >= 0 && !shutdown.load(); }
 
 private:
     friend class TraceCollector;

--- a/src/Common/tests/gtest_memory_tracker.cpp
+++ b/src/Common/tests/gtest_memory_tracker.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <functional>
 #include <future>
+#include <memory>
 #include <thread>
 
 #include <Common/CurrentMemoryTracker.h>
@@ -11,9 +12,14 @@
 #include <Common/Exception.h>
 #include <Common/LockMemoryExceptionInThread.h>
 #include <Common/MemoryTracker.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/MemoryTrackerUntrackedAllocationsBlockerInThread.h>
 #include <Common/OvercommitTracker.h>
+#include <Common/ProfileEvents.h>
 #include <Common/ThreadStatus.h>
+#include <Common/TraceSender.h>
 #include <Interpreters/ProcessList.h>
+#include <Interpreters/TraceCollector.h>
 #include <base/scope_guard.h>
 
 namespace DB::ErrorCodes
@@ -24,6 +30,11 @@ namespace DB::ErrorCodes
 namespace CurrentMetrics
 {
     extern const Metric MergesMutationsMemoryTracking;
+}
+
+namespace ProfileEvents
+{
+    extern const Event MemoryLargeAllocationTraced;
 }
 
 namespace
@@ -326,6 +337,171 @@ TEST(MemoryTracker, LimitEnforcementCanBeDisabled)
         std::ignore = CurrentMemoryTracker::free(OVER_LIMIT);
         expectUsage(hierarchy, 0);
     });
+}
+
+
+/// min_allocation_size_to_log_stack_trace: a stack trace for one large allocation charged to the
+/// global tracker. These cases charge the tracker directly, so no real memory is ever allocated and
+/// the sizes can be large enough that one unmatched add dwarfs the accounting noise.
+
+constexpr Int64 TRACE_THRESHOLD = 64 * MB;
+constexpr Int64 QUALIFYING_ALLOCATION = 128 * MB;
+/// Mirrors max_large_allocations_traced in MemoryTracker.cpp.
+constexpr ProfileEvents::Count TRACE_BUDGET = 10;
+
+ProfileEvents::Count tracedLargeAllocations()
+{
+    return ProfileEvents::global_counters[ProfileEvents::MemoryLargeAllocationTraced];
+}
+
+/// Charges the *global* tracker with exactly `size`: this thread has no ThreadStatus, so
+/// CurrentMemoryTracker skips untracked-memory batching and calls total_memory_tracker directly.
+void chargeAndRelease(Int64 size, size_t times = 1)
+{
+    for (size_t i = 0; i < times; ++i)
+    {
+        std::ignore = CurrentMemoryTracker::alloc(size);
+        std::ignore = CurrentMemoryTracker::free(size);
+    }
+}
+
+/// A live collector is required twice over: the setter refuses a threshold without one, and its
+/// thread is what runs the symbolize-and-log path, which the destructor drains before returning.
+/// Switching the threshold off in TearDown and on again in SetUp also refills the trace budget, so
+/// every case below starts from a full one and can assert exact counts.
+class MemoryTrackerLargeAllocationTrace : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        collector = std::make_unique<DB::TraceCollector>();
+        MemoryTracker::setMinAllocationSizeToLogStackTrace(TRACE_THRESHOLD);
+        ASSERT_EQ(MemoryTracker::getMinAllocationSizeToLogStackTrace(), static_cast<UInt64>(TRACE_THRESHOLD));
+    }
+
+    void TearDown() override
+    {
+        MemoryTracker::setMinAllocationSizeToLogStackTrace(0);
+        collector.reset();
+    }
+
+private:
+    std::unique_ptr<DB::TraceCollector> collector;
+};
+
+TEST_F(MemoryTrackerLargeAllocationTrace, FiresOnTheUnblockedPath)
+{
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(QUALIFYING_ALLOCATION);
+
+    EXPECT_EQ(tracedLargeAllocations(), before + 1);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, FiresOnTheBlockedGlobalPath)
+{
+    const auto before = tracedLargeAllocations();
+    {
+        /// This path updates the global amount and returns before commitAllocation, so it needs its
+        /// own detection: unmodified master reports nothing at all for an allocation charged here.
+        MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+        chargeAndRelease(QUALIFYING_ALLOCATION);
+    }
+
+    EXPECT_EQ(tracedLargeAllocations(), before + 1);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, SilentBelowTheThreshold)
+{
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(TRACE_THRESHOLD - 1);
+
+    EXPECT_EQ(tracedLargeAllocations(), before);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, TracedUnderTheUntrackedAllocationsBlocker)
+{
+    const auto before = tracedLargeAllocations();
+    {
+        /// Pins that this diagnostic is deliberately not gated on this blocker, unlike the sibling
+        /// MemoryAllocatedWithoutCheck telemetry: it is held across system-log enqueues and whole
+        /// ZooKeeper thread loops, which are candidate origins for the allocation being hunted.
+        MemoryTrackerUntrackedAllocationsBlockerInThread blocker;
+        chargeAndRelease(QUALIFYING_ALLOCATION);
+    }
+
+    EXPECT_EQ(tracedLargeAllocations(), before + 1);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, StopsFiringOnceTheBudgetIsSpent)
+{
+    const size_t batch = TRACE_BUDGET + 10;
+
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(QUALIFYING_ALLOCATION, batch);
+    const auto first = tracedLargeAllocations() - before;
+
+    chargeAndRelease(QUALIFYING_ALLOCATION, batch);
+    const auto second = tracedLargeAllocations() - before - first;
+
+    /// A batch larger than the budget spends exactly the budget, and the next one is silent: without
+    /// the bound each batch would trace `batch` times.
+    EXPECT_EQ(first, TRACE_BUDGET);
+    EXPECT_EQ(second, 0u);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, BudgetRefillsOnlyWhenSwitchedOn)
+{
+    chargeAndRelease(QUALIFYING_ALLOCATION, TRACE_BUDGET + 1);
+    const auto spent = tracedLargeAllocations();
+
+    /// Re-applying the same value is what a configuration reload does, and it must not refill the
+    /// budget: a server that reloads periodically would otherwise have no bound at all.
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(TRACE_THRESHOLD);
+    chargeAndRelease(QUALIFYING_ALLOCATION);
+    EXPECT_EQ(tracedLargeAllocations(), spent);
+
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(0);
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(TRACE_THRESHOLD);
+    chargeAndRelease(QUALIFYING_ALLOCATION);
+    EXPECT_EQ(tracedLargeAllocations(), spent + 1);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, DoesNotDisturbAccounting)
+{
+    const Int64 before = total_memory_tracker.get();
+    chargeAndRelease(QUALIFYING_ALLOCATION, TRACE_BUDGET + 10);
+
+    /// The collector thread symbolizes under a Global blocker, and those allocations are charged
+    /// here too, so this is a tolerance rather than an equality. A single leaked or double-counted
+    /// add would be QUALIFYING_ALLOCATION, well above it.
+    EXPECT_LT(std::abs(total_memory_tracker.get() - before), QUALIFYING_ALLOCATION / 2);
+}
+
+TEST(MemoryTrackerLargeAllocationTraceDefaults, IsInertByDefault)
+{
+    ASSERT_EQ(MemoryTracker::getMinAllocationSizeToLogStackTrace(), 0u);
+
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(QUALIFYING_ALLOCATION);
+
+    EXPECT_EQ(tracedLargeAllocations(), before);
+}
+
+TEST(MemoryTrackerLargeAllocationTraceDefaults, RefusedWithoutTraceCollector)
+{
+    ASSERT_FALSE(DB::TraceSender::isCollecting());
+
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(TRACE_THRESHOLD);
+    SCOPE_EXIT(MemoryTracker::setMinAllocationSizeToLogStackTrace(0));
+
+    /// Without a collector the trace could only be captured and discarded, so the setter stores 0
+    /// and system.server_settings reports that rather than the configured value.
+    EXPECT_EQ(MemoryTracker::getMinAllocationSizeToLogStackTrace(), 0u);
+
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(QUALIFYING_ALLOCATION);
+
+    EXPECT_EQ(tracedLargeAllocations(), before);
 }
 
 }

--- a/src/Common/tests/gtest_memory_tracker.cpp
+++ b/src/Common/tests/gtest_memory_tracker.cpp
@@ -354,15 +354,19 @@ ProfileEvents::Count tracedLargeAllocations()
     return ProfileEvents::global_counters[ProfileEvents::MemoryLargeAllocationTraced];
 }
 
-/// Charges the *global* tracker with exactly `size`: this thread has no ThreadStatus, so
-/// CurrentMemoryTracker skips untracked-memory batching and calls total_memory_tracker directly.
+/// Charges the *global* tracker with exactly `size`, which the threshold cases depend on. A
+/// ThreadStatus (this thread has one or not depending on the other tests in the binary) batches
+/// charges and flushes a whole batch as one add, so no remainder may be pending around a charge.
 void chargeAndRelease(Int64 size, size_t times = 1)
 {
     for (size_t i = 0; i < times; ++i)
     {
+        DB::CurrentThread::flushUntrackedMemory();
         std::ignore = CurrentMemoryTracker::alloc(size);
         std::ignore = CurrentMemoryTracker::free(size);
     }
+
+    DB::CurrentThread::flushUntrackedMemory();
 }
 
 /// A live collector is required twice over: the setter refuses a threshold without one, and its

--- a/src/Common/tests/gtest_memory_tracker.cpp
+++ b/src/Common/tests/gtest_memory_tracker.cpp
@@ -367,8 +367,8 @@ void chargeAndRelease(Int64 size, size_t times = 1)
 
 /// A live collector is required twice over: the setter refuses a threshold without one, and its
 /// thread is what runs the symbolize-and-log path, which the destructor drains before returning.
-/// Switching the threshold off in TearDown and on again in SetUp also refills the trace budget, so
-/// every case below starts from a full one and can assert exact counts.
+/// Constructing one in SetUp also refills the trace budget, so every case below starts from a full
+/// one and can assert exact counts.
 class MemoryTrackerLargeAllocationTrace : public ::testing::Test
 {
 protected:
@@ -449,13 +449,13 @@ TEST_F(MemoryTrackerLargeAllocationTrace, StopsFiringOnceTheBudgetIsSpent)
     EXPECT_EQ(second, 0u);
 }
 
-TEST_F(MemoryTrackerLargeAllocationTrace, BudgetRefillsOnlyWhenSwitchedOn)
+TEST_F(MemoryTrackerLargeAllocationTrace, BudgetIsNotRaisedByReconfiguration)
 {
     chargeAndRelease(QUALIFYING_ALLOCATION, TRACE_BUDGET + 1);
     const auto spent = tracedLargeAllocations();
 
-    /// Re-applying the same value is what a configuration reload does, and it must not refill the
-    /// budget: a server that reloads periodically would otherwise have no bound at all.
+    /// Re-applying the value is what a configuration reload does, and switching it off and on again
+    /// is the obvious way to ask for more. Neither raises the bound: only a new collector does.
     MemoryTracker::setMinAllocationSizeToLogStackTrace(TRACE_THRESHOLD);
     chargeAndRelease(QUALIFYING_ALLOCATION);
     EXPECT_EQ(tracedLargeAllocations(), spent);
@@ -463,7 +463,7 @@ TEST_F(MemoryTrackerLargeAllocationTrace, BudgetRefillsOnlyWhenSwitchedOn)
     MemoryTracker::setMinAllocationSizeToLogStackTrace(0);
     MemoryTracker::setMinAllocationSizeToLogStackTrace(TRACE_THRESHOLD);
     chargeAndRelease(QUALIFYING_ALLOCATION);
-    EXPECT_EQ(tracedLargeAllocations(), spent + 1);
+    EXPECT_EQ(tracedLargeAllocations(), spent);
 }
 
 TEST_F(MemoryTrackerLargeAllocationTrace, DoesNotDisturbAccounting)

--- a/src/Common/tests/gtest_memory_tracker.cpp
+++ b/src/Common/tests/gtest_memory_tracker.cpp
@@ -418,6 +418,28 @@ TEST_F(MemoryTrackerLargeAllocationTrace, SilentBelowTheThreshold)
     EXPECT_EQ(tracedLargeAllocations(), before);
 }
 
+TEST_F(MemoryTrackerLargeAllocationTrace, FiresAtExactlyTheThreshold)
+{
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(TRACE_THRESHOLD);
+
+    /// The setting is documented as a minimum, so the comparison is inclusive: this is the case
+    /// that distinguishes it from a strict one.
+    EXPECT_EQ(tracedLargeAllocations(), before + 1);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, FiresAtExactlyTheThresholdOnTheBlockedGlobalPath)
+{
+    const auto before = tracedLargeAllocations();
+    {
+        MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+        chargeAndRelease(TRACE_THRESHOLD);
+    }
+
+    /// The second detect site carries its own copy of the comparison, so it needs its own case.
+    EXPECT_EQ(tracedLargeAllocations(), before + 1);
+}
+
 TEST_F(MemoryTrackerLargeAllocationTrace, TracedUnderTheUntrackedAllocationsBlocker)
 {
     const auto before = tracedLargeAllocations();

--- a/src/Common/tests/gtest_memory_tracker.cpp
+++ b/src/Common/tests/gtest_memory_tracker.cpp
@@ -340,8 +340,8 @@ TEST(MemoryTracker, LimitEnforcementCanBeDisabled)
 }
 
 
-/// min_allocation_size_to_log_stack_trace: a stack trace for one large allocation charged to the
-/// global tracker. These cases charge the tracker directly, so no real memory is ever allocated and
+/// min_allocation_size_to_log_stack_trace: a stack trace for one large charge to the global
+/// tracker. These cases charge the tracker directly, so no real memory is ever allocated and
 /// the sizes can be large enough that one unmatched add dwarfs the accounting noise.
 
 constexpr Int64 TRACE_THRESHOLD = 64 * MB;

--- a/src/Common/tests/gtest_memory_tracker.cpp
+++ b/src/Common/tests/gtest_memory_tracker.cpp
@@ -444,6 +444,45 @@ TEST_F(MemoryTrackerLargeAllocationTrace, FiresAtExactlyTheThresholdOnTheBlocked
     EXPECT_EQ(tracedLargeAllocations(), before + 1);
 }
 
+TEST_F(MemoryTrackerLargeAllocationTrace, SilentBelowTheThresholdOnTheBlockedGlobalPath)
+{
+    const auto before = tracedLargeAllocations();
+    {
+        MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+        chargeAndRelease(TRACE_THRESHOLD - 1);
+    }
+
+    /// That copy needs its own negative too: the unblocked one leaves it unconstrained.
+    EXPECT_EQ(tracedLargeAllocations(), before);
+}
+
+/// The two cases below turn the threshold off inside the fixture rather than relying on the default,
+/// because the budget is what a spent one hides: nothing traces once it is gone, so a disabled-path
+/// assertion is only alive while the fixture's collector has just refilled it.
+
+TEST_F(MemoryTrackerLargeAllocationTrace, SilentWhenDisabled)
+{
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(0);
+
+    const auto before = tracedLargeAllocations();
+    chargeAndRelease(QUALIFYING_ALLOCATION);
+
+    EXPECT_EQ(tracedLargeAllocations(), before);
+}
+
+TEST_F(MemoryTrackerLargeAllocationTrace, SilentWhenDisabledOnTheBlockedGlobalPath)
+{
+    MemoryTracker::setMinAllocationSizeToLogStackTrace(0);
+
+    const auto before = tracedLargeAllocations();
+    {
+        MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+        chargeAndRelease(QUALIFYING_ALLOCATION);
+    }
+
+    EXPECT_EQ(tracedLargeAllocations(), before);
+}
+
 TEST_F(MemoryTrackerLargeAllocationTrace, TracedUnderTheUntrackedAllocationsBlocker)
 {
     const auto before = tracedLargeAllocations();

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -443,7 +443,7 @@ Minimum size, in bytes, of a single allocation charged to the global (server-wid
 
 This is a diagnostic for a global tracked total that has grown far beyond the process's real memory usage. In that state the server refuses every allocation, down to zero-byte ones, while using a fraction of its limit, and ordinary telemetry cannot attribute the step: allocations charged under a `MemoryTrackerBlockerInThread` are neither limit-checked nor traced, and the `system.trace_log` inserts that would carry the rest fail once the server is wedged. The server log keeps being written, so the stack trace reaches it.
 
-At most 10 traces are captured each time the diagnostic is switched on, because capturing and symbolizing a stack is expensive and the trigger tends to repeat. Setting the value back to `0` and then to a nonzero value again refills that budget; a configuration reload that leaves the value unchanged does not.
+At most 10 traces are captured per server run, because capturing and symbolizing a stack is expensive and the trigger tends to repeat. Changing this setting at runtime, in either direction, does not raise that bound.
 
 Requires `trace_log` to be configured. Without a running trace collector the value is ignored and reported as `0` in [`system.server_settings`](/operations/system-tables/server_settings), since the trace could only be captured and discarded.
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -445,9 +445,9 @@ This is a diagnostic for a global tracked total that has grown far beyond the pr
 
 At most 10 traces are captured per server run, because capturing and symbolizing a stack is expensive and the trigger tends to repeat. Changing this setting at runtime, in either direction, does not raise that bound.
 
-Requires `trace_log` to be configured. Without a running trace collector the value is ignored and reported as `0` in [`system.server_settings`](/operations/system-tables/server_settings), since the trace could only be captured and discarded.
+Requires `trace_log` to be configured. Without a running trace collector the value is ignored and reported as `0` in [`system.server_settings`](/operations/system-tables/server_settings), since the trace could only be captured and discarded. A trace the collector processes before that table is attached, which happens late in startup, reaches the server log only.
 
-A value of `0` (default) disables the diagnostic. Set it well above the largest allocation the server legitimately makes, otherwise ordinary large allocations are logged too.
+A value of `0` (default) disables the diagnostic. Set it well above the largest allocation the server legitimately makes, otherwise ordinary large allocations are logged too and startup can spend the whole budget.
 )", 0) \
     DECLARE(Double, max_server_memory_usage_to_ram_ratio, 0.9, R"(
 The maximum amount of memory the server is allowed to use, expressed as a ratio to all available memory.

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -438,6 +438,17 @@ A value of `0` (default) preserves the legacy behaviour: implicit `operator new`
 
 Note, to avoid side effects it is recommended to set value greater then `max_untracked_memory`.
 )", 0) \
+    DECLARE(UInt64, min_allocation_size_to_log_stack_trace, 0, R"(
+Minimum size, in bytes, of a single allocation charged to the global (server-wide) memory tracker for which a stack trace is captured, written to the server log at `Error` level and inserted into [`system.trace_log`](/operations/system-tables/trace_log) with trace type `MemoryLargeAllocation`.
+
+This is a diagnostic for a global tracked total that has grown far beyond the process's real memory usage. In that state the server refuses every allocation, down to zero-byte ones, while using a fraction of its limit, and ordinary telemetry cannot attribute the step: allocations charged under a `MemoryTrackerBlockerInThread` are neither limit-checked nor traced, and the `system.trace_log` inserts that would carry the rest fail once the server is wedged. The server log keeps being written, so the stack trace reaches it.
+
+At most 10 traces are captured each time the diagnostic is switched on, because capturing and symbolizing a stack is expensive and the trigger tends to repeat. Setting the value back to `0` and then to a nonzero value again refills that budget; a configuration reload that leaves the value unchanged does not.
+
+Requires `trace_log` to be configured. Without a running trace collector the value is ignored and reported as `0` in [`system.server_settings`](/operations/system-tables/server_settings), since the trace could only be captured and discarded.
+
+A value of `0` (default) disables the diagnostic. Set it well above the largest allocation the server legitimately makes, otherwise ordinary large allocations are logged too.
+)", 0) \
     DECLARE(Double, max_server_memory_usage_to_ram_ratio, 0.9, R"(
 The maximum amount of memory the server is allowed to use, expressed as a ratio to all available memory.
 
@@ -3565,6 +3576,7 @@ ChangeableSettingsMap collectChangeableServerSettings(ContextPtr context)
         = {
             {"max_server_memory_usage", {std::to_string(total_memory_tracker.getHardLimit()), ChangeableWithoutRestart::Yes}},
             {"min_allocation_size_to_throw_on_memory_limit", {std::to_string(CurrentMemoryTracker::getMinAllocationSizeBytesToThrow()), ChangeableWithoutRestart::Yes}},
+            {"min_allocation_size_to_log_stack_trace", {std::to_string(MemoryTracker::getMinAllocationSizeToLogStackTrace()), ChangeableWithoutRestart::Yes}},
             {"max_per_cpu_untracked_memory", {std::to_string(per_cpu_memory.budgetCapacity()), ChangeableWithoutRestart::Yes}},
             {"per_cpu_untracked_memory_thread_buffer", {std::to_string(per_cpu_memory.threadBuffer()), ChangeableWithoutRestart::Yes}},
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -439,9 +439,11 @@ A value of `0` (default) preserves the legacy behaviour: implicit `operator new`
 Note, to avoid side effects it is recommended to set value greater then `max_untracked_memory`.
 )", 0) \
     DECLARE(UInt64, min_allocation_size_to_log_stack_trace, 0, R"(
-Minimum size, in bytes, of a single allocation charged to the global (server-wide) memory tracker for which a stack trace is captured, written to the server log at `Warning` level and inserted into [`system.trace_log`](/operations/system-tables/trace_log) with trace type `MemoryLargeAllocation`.
+Minimum size, in bytes, of a single charge to the global (server-wide) memory tracker for which a stack trace is captured, written to the server log at `Warning` level and inserted into [`system.trace_log`](/operations/system-tables/trace_log) with trace type `MemoryLargeAllocation`.
 
-This is a diagnostic for a global tracked total that has grown far beyond the process's real memory usage. In that state the server refuses every allocation, down to zero-byte ones, while using a fraction of its limit, and ordinary telemetry cannot attribute the step: allocations charged under a `MemoryTrackerBlockerInThread` are neither limit-checked nor traced, and the `system.trace_log` inserts that would carry the rest fail once the server is wedged. The server log keeps being written, so the stack trace reaches it.
+The size compared against the threshold, and reported, is what one tracker call charges, which is not necessarily one allocation: a thread defers its small allocations and flushes them as a single charge, so the reported size can exceed the allocation at the top of the reported stack by up to `max_untracked_memory`. Keeping the threshold well above `max_untracked_memory` keeps that difference immaterial.
+
+This is a diagnostic for a global tracked total that has grown far beyond the process's real memory usage. In that state the server refuses every allocation, down to zero-byte ones, while using a fraction of its limit, and ordinary telemetry cannot attribute the step: allocations charged under a `MemoryTrackerBlockerInThread` skip the limit check and the traces that accompany it, and the `system.trace_log` inserts that would carry the rest fail once the server is wedged. The server log keeps being written, so the stack trace reaches it.
 
 At most 10 traces are captured per server run, because capturing and symbolizing a stack is expensive and the trigger tends to repeat. Changing this setting at runtime, in either direction, does not raise that bound.
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -439,7 +439,7 @@ A value of `0` (default) preserves the legacy behaviour: implicit `operator new`
 Note, to avoid side effects it is recommended to set value greater then `max_untracked_memory`.
 )", 0) \
     DECLARE(UInt64, min_allocation_size_to_log_stack_trace, 0, R"(
-Minimum size, in bytes, of a single allocation charged to the global (server-wide) memory tracker for which a stack trace is captured, written to the server log at `Error` level and inserted into [`system.trace_log`](/operations/system-tables/trace_log) with trace type `MemoryLargeAllocation`.
+Minimum size, in bytes, of a single allocation charged to the global (server-wide) memory tracker for which a stack trace is captured, written to the server log at `Warning` level and inserted into [`system.trace_log`](/operations/system-tables/trace_log) with trace type `MemoryLargeAllocation`.
 
 This is a diagnostic for a global tracked total that has grown far beyond the process's real memory usage. In that state the server refuses every allocation, down to zero-byte ones, while using a fraction of its limit, and ordinary telemetry cannot attribute the step: allocations charged under a `MemoryTrackerBlockerInThread` are neither limit-checked nor traced, and the `system.trace_log` inserts that would carry the rest fail once the server is wedged. The server log keeps being written, so the stack trace reaches it.
 

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -18,7 +18,7 @@
     M(QueryThreadLog,        query_thread_log,     "Contains information about threads that execute queries, for example, thread name, thread start time, duration of query processing.") \
     M(PartLog,               part_log,             "This table contains information about events that occurred with data parts in the MergeTree family tables, such as adding or merging data.") \
     M(BackgroundSchedulePoolLog, background_schedule_pool_log, "Contains history of background schedule pool task executions.") \
-    M(TraceLog,              trace_log,            "Contains stack traces collected by the sampling query profiler.") \
+    M(TraceLog,              trace_log,            "Contains stack traces collected by the sampling query profiler and by the other sources named in the trace_type column.") \
     M(CrashLog,              crash_log,            "Contains information about stack traces for fatal errors. The table does not exist in the database by default, it is created only when fatal errors occur.") \
     M(TextLog,               text_log,             "Contains logging entries which are normally written to a log file or to stdout.") \
     M(MetricLog,             metric_log,           "Contains history of metrics values from tables system.metrics and system.events, periodically flushed to disk.") \

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -35,8 +35,8 @@ namespace ErrorCodes
 namespace
 {
 
-/// `trace` holds addresses already normalized to physical file offsets, which is what
-/// SymbolIndex::findSymbol expects; StackTrace::toString would need raw runtime frame pointers.
+/// Frames in the main object arrive here already reduced to physical file offsets (see run()), which
+/// StackTrace::toString cannot resolve; SymbolIndex::findSymbol accepts either representation.
 std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
 {
     std::string result;

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -72,6 +72,10 @@ std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
 
 TraceCollector::TraceCollector()
 {
+    /// The budget belongs to this collector's lifetime: a trace can only be delivered while one
+    /// exists, and the server constructs exactly one, before any threshold can be published.
+    MemoryTracker::resetLargeAllocationTraceBudget();
+
     TraceSender::pipe.open();
 
     /** Turn write end of pipe to non-blocking mode to avoid deadlocks

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -35,8 +35,8 @@ namespace ErrorCodes
 namespace
 {
 
-/// Frames in the main object may arrive here already reduced to physical file offsets (see run()), which
-/// StackTrace::toString cannot resolve; SymbolIndex::findSymbol accepts either representation.
+/// Frames in the main object may arrive here already reduced to physical file offsets (see run()),
+/// and SymbolIndex::findSymbol accepts either representation.
 std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
 {
     std::string result;

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -20,6 +20,7 @@
 #include <base/demangle.h>
 #include <base/errnoToString.h>
 #include <Common/logger_useful.h>
+#include <Common/StackTrace.h>
 #include <Common/SymbolIndex.h>
 
 
@@ -39,8 +40,9 @@ namespace
 std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
 {
     std::string result;
+    const bool show_addresses = StackTrace::showAddresses();
 
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
     const SymbolIndex & symbol_index = SymbolIndex::instance();
 #endif
 
@@ -48,7 +50,7 @@ std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
     {
         std::string_view name = "?";
 
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
         DemangleResult demangled;
         if (const auto * symbol = symbol_index.findSymbol(reinterpret_cast<const void *>(trace[frame])))
         {
@@ -57,7 +59,10 @@ std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
         }
 #endif
 
-        result += fmt::format("{}{}. 0x{:x} {}", frame ? "\n" : "", frame, trace[frame], name);
+        if (show_addresses)
+            result += fmt::format("{}{}. 0x{:x} {}", frame ? "\n" : "", frame, trace[frame], name);
+        else
+            result += fmt::format("{}{}. {}", frame ? "\n" : "", frame, name);
     }
 
     return result;
@@ -254,8 +259,8 @@ void TraceCollector::run()
                     "(blocked context: {}). Global tracked total when logged: {}. Stack trace:\n{}",
                     ReadableSize(size),
                     thread_id,
-                    memory_blocked_context == TraceSender::MEMORY_CONTEXT_UNKNOWN
-                        ? std::string_view("Unknown")
+                    static_cast<VariableContext>(memory_blocked_context) == VariableContext::Max
+                        ? std::string_view("none")
                         : magic_enum::enum_name(static_cast<VariableContext>(memory_blocked_context)),
                     ReadableSize(total_memory_tracker.get()),
                     symbolizeNormalizedTrace(trace));

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -7,13 +7,17 @@
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/TraceLog.h>
+#include <Common/MemoryTracker.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/Exception.h>
 #include <Common/MemoryTrackerUntrackedAllocationsBlockerInThread.h>
 #include <Common/TraceSender.h>
 #include <Common/ProfileEvents.h>
 #include <Common/VariableContext.h>
+#include <Common/formatReadable.h>
 #include <Common/setThreadName.h>
+#include <base/EnumReflection.h>
+#include <base/demangle.h>
 #include <base/errnoToString.h>
 #include <Common/logger_useful.h>
 #include <Common/SymbolIndex.h>
@@ -25,6 +29,40 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+/// `trace` holds addresses already normalized to physical file offsets, which is what
+/// SymbolIndex::findSymbol expects; StackTrace::toString would need raw runtime frame pointers.
+std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
+{
+    std::string result;
+
+#if defined(__ELF__) && !defined(OS_FREEBSD)
+    const SymbolIndex & symbol_index = SymbolIndex::instance();
+#endif
+
+    for (size_t frame = 0; frame < trace.size(); ++frame)
+    {
+        std::string_view name = "?";
+
+#if defined(__ELF__) && !defined(OS_FREEBSD)
+        DemangleResult demangled;
+        if (const auto * symbol = symbol_index.findSymbol(reinterpret_cast<const void *>(trace[frame])))
+        {
+            demangled = tryDemangle(symbol->name);
+            name = demangled ? std::string_view(demangled.get()) : std::string_view(symbol->name);
+        }
+#endif
+
+        result += fmt::format("{}{}. 0x{:x} {}", frame ? "\n" : "", frame, trace[frame], name);
+    }
+
+    return result;
+}
+
 }
 
 TraceCollector::TraceCollector()
@@ -204,6 +242,24 @@ void TraceCollector::run()
 
             ProfileEvents::Count increment = 0;
             readPODBinary(increment, in);
+
+            /// Mirrored to the log before the trace_log insert below, because a server whose global
+            /// tracker has run away fails every system-log flush while still writing its log file,
+            /// and that is exactly the state this trace type exists to diagnose.
+            if (trace_type == TraceType::MemoryLargeAllocation)
+            {
+                LOG_ERROR(
+                    getLogger("MemoryTracker"),
+                    "Single allocation of {} charged to the global memory tracker on thread {} "
+                    "(blocked context: {}). Global tracked total when logged: {}. Stack trace:\n{}",
+                    ReadableSize(size),
+                    thread_id,
+                    memory_blocked_context == TraceSender::MEMORY_CONTEXT_UNKNOWN
+                        ? std::string_view("Unknown")
+                        : magic_enum::enum_name(static_cast<VariableContext>(memory_blocked_context)),
+                    ReadableSize(total_memory_tracker.get()),
+                    symbolizeNormalizedTrace(trace));
+            }
 
             if (auto trace_log = getTraceLog())
             {

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -257,7 +257,7 @@ void TraceCollector::run()
             /// and that is exactly the state this trace type exists to diagnose.
             if (trace_type == TraceType::MemoryLargeAllocation)
             {
-                LOG_ERROR(
+                LOG_WARNING(
                     getLogger("MemoryTracker"),
                     "Single allocation of {} charged to the global memory tracker on thread {} "
                     "(blocked context: {}). Global tracked total when logged: {}. Stack trace:\n{}",

--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -35,7 +35,7 @@ namespace ErrorCodes
 namespace
 {
 
-/// Frames in the main object arrive here already reduced to physical file offsets (see run()), which
+/// Frames in the main object may arrive here already reduced to physical file offsets (see run()), which
 /// StackTrace::toString cannot resolve; SymbolIndex::findSymbol accepts either representation.
 std::string symbolizeNormalizedTrace(const std::vector<UInt64> & trace)
 {
@@ -259,7 +259,7 @@ void TraceCollector::run()
             {
                 LOG_WARNING(
                     getLogger("MemoryTracker"),
-                    "Single allocation of {} charged to the global memory tracker on thread {} "
+                    "Single charge of {} to the global memory tracker on thread {} "
                     "(blocked context: {}). Global tracked total when logged: {}. Stack trace:\n{}",
                     ReadableSize(size),
                     thread_id,

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -107,7 +107,9 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "For profiler-collected trace types, on ELF platforms except FreeBSD, addresses inside the main ClickHouse binary are stored as physical file offsets, "
             "and other addresses are virtual memory addresses inside the ClickHouse server process. "
             "Instrumentation trace rows are an exception: they store raw virtual memory addresses."},
-        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck or MemoryPeak is the amount of memory allocated, for MemoryLargeAllocation is the size of the charge to the global memory tracker, for other trace types is 0."},
+        {"size", std::make_shared<DataTypeInt64>(), "For the memory trace types is a size in bytes: the allocated size for Memory and MemoryAllocatedWithoutCheck; "
+            "the allocated size, negated on a deallocation, for MemorySample and JemallocSample; the new peak of the tracker for MemoryPeak; "
+            "the size of the charge to the global memory tracker for MemoryLargeAllocation. For other trace types is 0."},
         {"ptr", std::make_shared<DataTypeUInt64>(), "The address of the allocated chunk."},
         {"memory_context", std::make_shared<ContextDataType>(context_values), fmt::format("Memory Tracker context (only for Memory, MemoryPeak and MemoryLargeAllocation): {}", context_description)},
         {"memory_blocked_context", std::make_shared<ContextDataType>(context_values), fmt::format("Context for which memory tracker is blocked (for ClickHouse developers only): {}", context_description)},

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -42,6 +42,7 @@ const TraceDataType::Values TraceLogElement::trace_values =
     {"JemallocSample", static_cast<UInt8>(TraceType::JemallocSample)},
     {"MemoryAllocatedWithoutCheck", static_cast<UInt8>(TraceType::MemoryAllocatedWithoutCheck)},
     {"Instrumentation", static_cast<UInt8>(TraceType::Instrumentation)},
+    {"MemoryLargeAllocation", static_cast<UInt8>(TraceType::MemoryLargeAllocation)},
 };
 
 static_assert(TraceSender::MEMORY_CONTEXT_UNKNOWN == -1);
@@ -96,6 +97,7 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "`JemallocSample` represents collecting of jemalloc samples. "
             "`MemoryAllocatedWithoutCheck` represents collection of significant allocations (>16MiB) that is done with ignoring any memory limits (for ClickHouse developers only)."
             "`Instrumentation` represents traces collected by the instrumentation performed through XRay."
+            "`MemoryLargeAllocation` represents a single allocation charged to the global memory tracker whose size reached `min_allocation_size_to_log_stack_trace`; such a trace is also written to the server log (for ClickHouse developers only)."
         },
         {"cpu_id", std::make_shared<DataTypeUInt64>(), "CPU identifier."},
         {"thread_id", std::make_shared<DataTypeUInt64>(), "Thread identifier."},
@@ -105,7 +107,7 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "For profiler-collected trace types, on ELF platforms except FreeBSD, addresses inside the main ClickHouse binary are stored as physical file offsets, "
             "and other addresses are virtual memory addresses inside the ClickHouse server process. "
             "Instrumentation trace rows are an exception: they store raw virtual memory addresses."},
-        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
+        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck, MemoryLargeAllocation or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
         {"ptr", std::make_shared<DataTypeUInt64>(), "The address of the allocated chunk."},
         {"memory_context", std::make_shared<ContextDataType>(context_values), fmt::format("Memory Tracker context (only for Memory/MemoryPeak): {}", context_description)},
         {"memory_blocked_context", std::make_shared<ContextDataType>(context_values), fmt::format("Context for which memory tracker is blocked (for ClickHouse developers only): {}", context_description)},

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -97,7 +97,7 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "`JemallocSample` represents collecting of jemalloc samples. "
             "`MemoryAllocatedWithoutCheck` represents collection of significant allocations (>16MiB) that is done with ignoring any memory limits (for ClickHouse developers only)."
             "`Instrumentation` represents traces collected by the instrumentation performed through XRay."
-            "`MemoryLargeAllocation` represents a single allocation charged to the global memory tracker whose size reached `min_allocation_size_to_log_stack_trace`; such a trace is also written to the server log (for ClickHouse developers only)."
+            " `MemoryLargeAllocation` represents a single allocation charged to the global memory tracker whose size reached `min_allocation_size_to_log_stack_trace`; such a trace is also written to the server log (for ClickHouse developers only)."
         },
         {"cpu_id", std::make_shared<DataTypeUInt64>(), "CPU identifier."},
         {"thread_id", std::make_shared<DataTypeUInt64>(), "Thread identifier."},
@@ -109,7 +109,7 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "Instrumentation trace rows are an exception: they store raw virtual memory addresses."},
         {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck, MemoryLargeAllocation or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
         {"ptr", std::make_shared<DataTypeUInt64>(), "The address of the allocated chunk."},
-        {"memory_context", std::make_shared<ContextDataType>(context_values), fmt::format("Memory Tracker context (only for Memory/MemoryPeak): {}", context_description)},
+        {"memory_context", std::make_shared<ContextDataType>(context_values), fmt::format("Memory Tracker context (only for Memory, MemoryPeak and MemoryLargeAllocation): {}", context_description)},
         {"memory_blocked_context", std::make_shared<ContextDataType>(context_values), fmt::format("Context for which memory tracker is blocked (for ClickHouse developers only): {}", context_description)},
         {"event", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "For trace type ProfileEvent is the name of updated profile event, for other trace types is an empty string."},
         {"increment", std::make_shared<DataTypeInt64>(), "For trace type ProfileEvent is the amount of increment of profile event, for other trace types is 0."},

--- a/src/Interpreters/TraceLog.cpp
+++ b/src/Interpreters/TraceLog.cpp
@@ -97,7 +97,7 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "`JemallocSample` represents collecting of jemalloc samples. "
             "`MemoryAllocatedWithoutCheck` represents collection of significant allocations (>16MiB) that is done with ignoring any memory limits (for ClickHouse developers only)."
             "`Instrumentation` represents traces collected by the instrumentation performed through XRay."
-            " `MemoryLargeAllocation` represents a single allocation charged to the global memory tracker whose size reached `min_allocation_size_to_log_stack_trace`; such a trace is also written to the server log (for ClickHouse developers only)."
+            " `MemoryLargeAllocation` represents a single charge to the global memory tracker whose size reached `min_allocation_size_to_log_stack_trace`; such a trace is also written to the server log (for ClickHouse developers only)."
         },
         {"cpu_id", std::make_shared<DataTypeUInt64>(), "CPU identifier."},
         {"thread_id", std::make_shared<DataTypeUInt64>(), "Thread identifier."},
@@ -107,7 +107,7 @@ ColumnsDescription TraceLogElement::getColumnsDescription()
             "For profiler-collected trace types, on ELF platforms except FreeBSD, addresses inside the main ClickHouse binary are stored as physical file offsets, "
             "and other addresses are virtual memory addresses inside the ClickHouse server process. "
             "Instrumentation trace rows are an exception: they store raw virtual memory addresses."},
-        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck, MemoryLargeAllocation or MemoryPeak is the amount of memory allocated, for other trace types is 0."},
+        {"size", std::make_shared<DataTypeInt64>(), "For trace types Memory, MemorySample, MemoryAllocatedWithoutCheck or MemoryPeak is the amount of memory allocated, for MemoryLargeAllocation is the size of the charge to the global memory tracker, for other trace types is 0."},
         {"ptr", std::make_shared<DataTypeUInt64>(), "The address of the allocated chunk."},
         {"memory_context", std::make_shared<ContextDataType>(context_values), fmt::format("Memory Tracker context (only for Memory, MemoryPeak and MemoryLargeAllocation): {}", context_description)},
         {"memory_blocked_context", std::make_shared<ContextDataType>(context_values), fmt::format("Context for which memory tracker is blocked (for ClickHouse developers only): {}", context_description)},

--- a/src/Interpreters/TraceLog.h
+++ b/src/Interpreters/TraceLog.h
@@ -35,7 +35,7 @@ struct TraceLogElement
     ThreadName thread_name = ThreadName::UNKNOWN;
     String query_id{};
     std::vector<UInt64> trace{};
-    /// Allocation size in bytes for TraceType::Memory and TraceType::MemorySample.
+    /// Size in bytes for the memory trace types, zero for the others.
     Int64 size{};
     /// Allocation ptr for TraceType::MemorySample.
     UInt64 ptr{};

--- a/tests/config/config.d/memory_profiler.yaml
+++ b/tests/config/config.d/memory_profiler.yaml
@@ -1,5 +1,5 @@
 ---
 total_memory_profiler_step: 100Mi
-# 16x the largest single allocation ever seen traced in a stress run, and below the smallest
+# 16x the largest single charge ever seen traced in a stress run, and below the smallest
 # observed global-tracker drift step, so only a runaway global allocation reaches the log.
 min_allocation_size_to_log_stack_trace: 8Gi

--- a/tests/config/config.d/memory_profiler.yaml
+++ b/tests/config/config.d/memory_profiler.yaml
@@ -1,2 +1,5 @@
 ---
 total_memory_profiler_step: 100Mi
+# 16x the largest single allocation ever seen traced in a stress run, and below the smallest
+# observed global-tracker drift step, so only a runaway global allocation reaches the log.
+min_allocation_size_to_log_stack_trace: 8Gi

--- a/tests/integration/test_memory_tracker_large_allocation_trace/configs/with_addresses.yaml
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/configs/with_addresses.yaml
@@ -1,0 +1,2 @@
+---
+min_allocation_size_to_log_stack_trace: 64Mi

--- a/tests/integration/test_memory_tracker_large_allocation_trace/configs/without_addresses.yaml
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/configs/without_addresses.yaml
@@ -1,0 +1,3 @@
+---
+min_allocation_size_to_log_stack_trace: 64Mi
+show_addresses_in_stack_traces: false

--- a/tests/integration/test_memory_tracker_large_allocation_trace/test.py
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/test.py
@@ -1,0 +1,93 @@
+import re
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+THRESHOLD = 64 * 1024 * 1024
+LOG_MARKER = "Single allocation of"
+# One PODArray doubling past the threshold: reallocs of 64, 128 and 256 MiB, no limit in the way.
+TRIGGER = "SELECT length(groupArray(number)) FROM numbers(30000000) SETTINGS max_memory_usage = 0"
+
+# A new log record ends the multi-line message that carries the stack.
+LOG_LINE = re.compile(r"^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.")
+# "<index>. 0x<address> <symbol>" / "<index>. <symbol>", symbol resolved to something but "?".
+FRAME_WITH_ADDRESS = re.compile(r"^\d+\. 0x[0-9a-f]+ (?!\?$)\S")
+FRAME_WITHOUT_ADDRESS = re.compile(r"^\d+\. (?!\?$)\S")
+
+node = cluster.add_instance("node", main_configs=["configs/with_addresses.yaml"])
+# show_addresses_in_stack_traces is applied at startup only, so it needs its own instance rather
+# than a config reload.
+node_no_addresses = cluster.add_instance(
+    "node_no_addresses", main_configs=["configs/without_addresses.yaml"]
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def stack_of_first_record(instance):
+    """The frame lines of the first logged trace, and only those: the lines after the marker up to
+    the next log record. Slicing to one record keeps unrelated log content out of the assertions."""
+    lines = instance.grep_in_log(LOG_MARKER, after=40).splitlines()
+    assert any(LOG_MARKER in line for line in lines), lines
+    start = next(i for i, line in enumerate(lines) if LOG_MARKER in line)
+
+    frames = []
+    for line in lines[start + 1 :]:
+        if LOG_LINE.match(line) or line == "--":
+            break
+        frames.append(line)
+    assert frames, lines
+    return frames
+
+
+def test_setting_is_reported_as_changeable():
+    assert (
+        node.query(
+            "SELECT value, changeable_without_restart FROM system.server_settings "
+            "WHERE name = 'min_allocation_size_to_log_stack_trace'"
+        ).strip()
+        == f"{THRESHOLD}\tYes"
+    )
+
+
+def test_large_allocation_reaches_the_server_log_and_trace_log():
+    assert not node.contains_in_log(LOG_MARKER)
+
+    node.query(TRIGGER)
+
+    frames = stack_of_first_record(node)
+    # A resolved frame, rather than a specific function name: inlining makes a named frame brittle.
+    assert any(FRAME_WITH_ADDRESS.match(frame) for frame in frames), frames
+
+    node.query("SYSTEM FLUSH LOGS trace_log")
+    count, memory_context, max_size = (
+        node.query(
+            "SELECT count(), any(memory_context), max(size) FROM system.trace_log "
+            "WHERE trace_type = 'MemoryLargeAllocation'"
+        )
+        .strip()
+        .split("\t")
+    )
+    assert int(count) > 0
+    assert memory_context == "Global"
+    assert int(max_size) >= THRESHOLD
+
+
+def test_addresses_are_hidden_when_disabled():
+    assert not node_no_addresses.contains_in_log(LOG_MARKER)
+
+    node_no_addresses.query(TRIGGER)
+
+    frames = stack_of_first_record(node_no_addresses)
+    assert any(FRAME_WITHOUT_ADDRESS.match(frame) for frame in frames), frames
+    assert not any("0x" in frame for frame in frames), frames

--- a/tests/integration/test_memory_tracker_large_allocation_trace/test.py
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/test.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 import pytest
 
@@ -39,7 +40,13 @@ def started_cluster():
 def stack_of_first_record(instance):
     """The frame lines of the first logged trace, and only those: the lines after the marker up to
     the next log record. Slicing to one record keeps unrelated log content out of the assertions."""
-    lines = instance.grep_in_log(LOG_MARKER, after=40).splitlines()
+    # The record is produced by the collector thread, not by the query, so wait for it rather
+    # than racing it. One log record is written in a single call, so the marker being visible
+    # means the frame lines below it are too.
+    instance.wait_for_log_line(LOG_MARKER, timeout=60)
+    # only_latest: the wait tees into a sibling log file, and a multi-file zgrep prefixes every
+    # line with its filename, which the frame patterns below would then not match.
+    lines = instance.grep_in_log(LOG_MARKER, after=40, only_latest=True).splitlines()
     assert any(LOG_MARKER in line for line in lines), lines
     start = next(i for i, line in enumerate(lines) if LOG_MARKER in line)
 
@@ -75,15 +82,21 @@ def test_large_allocation_reaches_the_server_log_and_trace_log():
         FRAME_WITH_ADDRESS.match(frame) and not TRACER_FRAME.search(frame) for frame in frames
     ), frames
 
-    node.query("SYSTEM FLUSH LOGS trace_log")
-    count, memory_context, max_size, without_stack = (
-        node.query(
-            "SELECT count(), any(memory_context), max(size), countIf(length(trace) = 0) "
-            "FROM system.trace_log WHERE trace_type = 'MemoryLargeAllocation'"
+    deadline = time.monotonic() + 60
+    while True:
+        node.query("SYSTEM FLUSH LOGS trace_log")
+        count, memory_context, max_size, without_stack = (
+            node.query(
+                "SELECT count(), any(memory_context), max(size), countIf(length(trace) = 0) "
+                "FROM system.trace_log WHERE trace_type = 'MemoryLargeAllocation'"
+            )
+            .strip()
+            .split("\t")
         )
-        .strip()
-        .split("\t")
-    )
+        if int(count) > 0 or time.monotonic() > deadline:
+            break
+        time.sleep(1)
+
     assert int(count) > 0
     assert memory_context == "Global"
     assert int(max_size) >= THRESHOLD

--- a/tests/integration/test_memory_tracker_large_allocation_trace/test.py
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/test.py
@@ -9,6 +9,8 @@ cluster = ClickHouseCluster(__file__)
 
 THRESHOLD = 64 * 1024 * 1024
 LOG_MARKER = "Single allocation of"
+# The Upgrade check fails a job on any <Error> record it does not excuse, so the level is contract.
+LOG_RECORD_PREFIX = "<Warning> MemoryTracker: "
 # One PODArray doubling past the threshold: reallocs of 64, 128 and 256 MiB, no limit in the way.
 TRIGGER = "SELECT length(groupArray(number)) FROM numbers(30000000) SETTINGS max_memory_usage = 0"
 
@@ -49,6 +51,7 @@ def stack_of_first_record(instance):
     lines = instance.grep_in_log(LOG_MARKER, after=40, only_latest=True).splitlines()
     assert any(LOG_MARKER in line for line in lines), lines
     start = next(i for i, line in enumerate(lines) if LOG_MARKER in line)
+    assert LOG_RECORD_PREFIX + LOG_MARKER in lines[start], lines[start]
 
     frames = []
     for line in lines[start + 1 :]:

--- a/tests/integration/test_memory_tracker_large_allocation_trace/test.py
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/test.py
@@ -62,6 +62,15 @@ def stack_of_first_record(instance):
     return frames
 
 
+def effective_threshold(instance):
+    return int(
+        instance.query(
+            "SELECT value FROM system.server_settings "
+            "WHERE name = 'min_allocation_size_to_log_stack_trace'"
+        ).strip()
+    )
+
+
 def test_setting_is_reported_as_changeable():
     assert (
         node.query(
@@ -117,3 +126,17 @@ def test_addresses_are_hidden_when_disabled():
         FRAME_WITHOUT_ADDRESS.match(frame) and not TRACER_FRAME.search(frame) for frame in frames
     ), frames
     assert not any("0x" in frame for frame in frames), frames
+
+
+def test_threshold_is_applied_by_a_runtime_reload():
+    # Startup and the config reloader apply the threshold at separate places, and only a reload
+    # exercises the second one. Both directions, since the setting is lowered as well as raised.
+    config = "/etc/clickhouse-server/config.d/with_addresses.yaml"
+    try:
+        node.replace_in_config(config, "64Mi", "128Mi")
+        node.query("SYSTEM RELOAD CONFIG")
+        assert effective_threshold(node) == 2 * THRESHOLD
+    finally:
+        node.replace_in_config(config, "128Mi", "64Mi")
+        node.query("SYSTEM RELOAD CONFIG")
+    assert effective_threshold(node) == THRESHOLD

--- a/tests/integration/test_memory_tracker_large_allocation_trace/test.py
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/test.py
@@ -16,6 +16,8 @@ LOG_LINE = re.compile(r"^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.")
 # "<index>. 0x<address> <symbol>" / "<index>. <symbol>", symbol resolved to something but "?".
 FRAME_WITH_ADDRESS = re.compile(r"^\d+\. 0x[0-9a-f]+ (?!\?$)\S")
 FRAME_WITHOUT_ADDRESS = re.compile(r"^\d+\. (?!\?$)\S")
+# The tracer's own frames. A stack made only of these names no allocation site.
+TRACER_FRAME = re.compile(r"\b(StackTrace|TraceSender|MemoryTracker|CurrentMemoryTracker)\b")
 
 node = cluster.add_instance("node", main_configs=["configs/with_addresses.yaml"])
 # show_addresses_in_stack_traces is applied at startup only, so it needs its own instance rather
@@ -68,12 +70,16 @@ def test_large_allocation_reaches_the_server_log_and_trace_log():
     frames = stack_of_first_record(node)
     # A resolved frame, rather than a specific function name: inlining makes a named frame brittle.
     assert any(FRAME_WITH_ADDRESS.match(frame) for frame in frames), frames
+    # One of them resolves outside the tracer, so the stack reaches the allocation site.
+    assert any(
+        FRAME_WITH_ADDRESS.match(frame) and not TRACER_FRAME.search(frame) for frame in frames
+    ), frames
 
     node.query("SYSTEM FLUSH LOGS trace_log")
-    count, memory_context, max_size = (
+    count, memory_context, max_size, without_stack = (
         node.query(
-            "SELECT count(), any(memory_context), max(size) FROM system.trace_log "
-            "WHERE trace_type = 'MemoryLargeAllocation'"
+            "SELECT count(), any(memory_context), max(size), countIf(length(trace) = 0) "
+            "FROM system.trace_log WHERE trace_type = 'MemoryLargeAllocation'"
         )
         .strip()
         .split("\t")
@@ -81,6 +87,7 @@ def test_large_allocation_reaches_the_server_log_and_trace_log():
     assert int(count) > 0
     assert memory_context == "Global"
     assert int(max_size) >= THRESHOLD
+    assert int(without_stack) == 0
 
 
 def test_addresses_are_hidden_when_disabled():
@@ -90,4 +97,7 @@ def test_addresses_are_hidden_when_disabled():
 
     frames = stack_of_first_record(node_no_addresses)
     assert any(FRAME_WITHOUT_ADDRESS.match(frame) for frame in frames), frames
+    assert any(
+        FRAME_WITHOUT_ADDRESS.match(frame) and not TRACER_FRAME.search(frame) for frame in frames
+    ), frames
     assert not any("0x" in frame for frame in frames), frames

--- a/tests/integration/test_memory_tracker_large_allocation_trace/test.py
+++ b/tests/integration/test_memory_tracker_large_allocation_trace/test.py
@@ -8,7 +8,7 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 THRESHOLD = 64 * 1024 * 1024
-LOG_MARKER = "Single allocation of"
+LOG_MARKER = "Single charge of"
 # The Upgrade check fails a job on any <Error> record it does not excuse, so the level is contract.
 LOG_RECORD_PREFIX = "<Warning> MemoryTracker: "
 # One PODArray doubling past the threshold: reallocs of 64, 128 and 256 MiB, no limit in the way.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/117681
Related: https://github.com/ClickHouse/ClickHouse/pull/118434#issuecomment-5631672326
Related: https://github.com/ClickHouse/ClickHouse/pull/118094
Related: https://github.com/ClickHouse/ClickHouse/pull/117738
Related: https://github.com/ClickHouse/ClickHouse/pull/117995

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added a server setting `min_allocation_size_to_log_stack_trace`. When a single charge to the global memory tracker reaches it, the stack trace is written to the server log and to `system.trace_log` with trace type `MemoryLargeAllocation`. This attributes a global tracked total that has grown far beyond real memory usage, a state in which the server refuses every allocation while far below its limit. Default `0` keeps it off.


### Description

Requested by @ alexey-milovidov on #118434: the hung check never gets a usable server, every connection being answered with a bogus `(total) memory limit exceeded: would use 160.98 GiB (attempt to allocate chunk of 0.00 B), current RSS: 1.71 GiB`.

**This does not fix the drift.** #118094 and #117738 correct the counter, #117995 stops the harness calling it a deadlock, and #118094 states the remaining gap itself: where the phantom bytes come from is still unknown. This change makes the next occurrence say where.

On one such run, no artifact can name the site, for two structural reasons:

- the blocked-`Global` branch of `MemoryTracker::allocImpl` adds to `amount` and `rss`, updates the peak and the metric, then returns **without reaching `commitAllocation`** - so no limit check, no trace, no `ProfileEvent`;
- everything that does reach `commitAllocation` reports into `system.trace_log`, the sink the wedge breaks (`Failed to flush system log system.trace_log` x109 in that run).

The log file is the one channel that survives; it carried all 31,310 refusals. So both global write paths now send a `TraceType::MemoryLargeAllocation` through `TraceSender`, and `TraceCollector` symbolizes it and writes one `LOG_WARNING` before the `trace_log` insert. Unsymbolized at the send site: `e7a58e703cb81` removed direct logging from `MemoryTracker` because it can deadlock. The pipe record is unchanged.

Only the global tracker is instrumented; per-query drift is already in `query_log.memory_usage`. `adjustOnBackgroundTaskEnd` and `updateAllocated` are excluded by measurement: both write `amount`, never `rss`. Best-effort: a full pipe drops the trace, and an allocation on the collector thread is not traced.

Validated by the new `test_memory_tracker_large_allocation_trace` (both deliveries, the setting, and a stack resolving past the tracker) and 14 gtest cases; removing either detect site, or either half of either site's threshold guard, reddens a different one.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119527&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119527](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119527+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.229` (included in `26.10` and later)
<!-- ch-version-info:end -->