### PR TITLE
Run only shell-free tests for distroless images in the docker library check (26.3)

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -3,6 +3,7 @@ import atexit
 import json
 import logging
 import os
+import shlex
 import tempfile
 import traceback
 from pathlib import Path
@@ -289,6 +290,62 @@ def build_and_push_image(
     return result
 
 
+def is_distroless_image(docker_image: str) -> bool:
+    _, tag = docker_image.rsplit(":", 1)
+    return "distroless" in tag.split("-")
+
+
+def get_official_images_variant(docker_image: str) -> str:
+    # The official-images test runner derives its lookup variant from the final
+    # tag suffix. For example, head-distroless-amd64 is looked up as repo:amd64.
+    _, tag = docker_image.rsplit(":", 1)
+    return tag.rsplit("-", 1)[-1]
+
+
+def write_distroless_docker_library_config(docker_image: str, config_dir: Path) -> Path:
+    """Map arch-suffixed distroless tags to the distroless-safe config tests."""
+    # Generate a short config fragment for local arch-suffixed distroless CI tags.
+    # The runner derives tags like head-distroless-amd64 as repo:amd64; map that
+    # derived key to the distroless-safe tests because this helper is only used
+    # for images already identified as distroless.
+    repo, _ = docker_image.rsplit(":", 1)
+    variant = get_official_images_variant(docker_image)
+    image_variant = shlex.quote(f"{repo}:{variant}")
+    tests_var = (
+        "keeperDistrolessSafeTests"
+        if "clickhouse-keeper" in repo
+        else "clickhouseDistrolessSafeTests"
+    )
+
+    generated_config = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            prefix="docker-library-distroless-",
+            suffix=".sh",
+            dir=config_dir,
+            delete=False,
+            encoding="utf-8",
+        ) as f:
+            generated_config = Path(f.name)
+            f.write(
+                "#!/usr/bin/env bash\n"
+                "\n"
+                "explicitTests+=(\n"
+                f"\t[{image_variant}]=1\n"
+                ")\n"
+                "\n"
+                "imageTests+=(\n"
+                f'\t[{image_variant}]="${{{tests_var}}}"\n'
+                ")\n"
+            )
+            return generated_config
+    except Exception:
+        if generated_config:
+            generated_config.unlink(missing_ok=True)
+        raise
+
+
 def test_docker_library(test_results) -> None:
     """we test our images vs the official docker library repository to track integrity"""
     arch = "amd64" if Utils.is_amd() else "arm64"
@@ -311,10 +368,24 @@ def test_docker_library(test_results) -> None:
             raise RuntimeError(f"Failed to clone {repo}")
         run_sh = (repo_path / "test/run.sh").absolute()
         for image in check_images:
-            cmd = f"{run_sh} {image} -c {repo_path / 'test/config.sh'} -c {config_override}"
-            test_results.append(
-                Result.from_commands_run(name=f"{test_name} ({image})", command=cmd)
-            )
+            generated_config = None
+            try:
+                configs = [repo_path / "test/config.sh", config_override]
+                if is_distroless_image(image):
+                    generated_config = write_distroless_docker_library_config(
+                        image, config_override.parent
+                    )
+                    configs.append(generated_config)
+                config_args = " ".join(
+                    f"-c {shlex.quote(Path(config).as_posix())}" for config in configs
+                )
+                cmd = f"{shlex.quote(run_sh.as_posix())} {shlex.quote(image)} {config_args}"
+                test_results.append(
+                    Result.from_commands_run(name=f"{test_name} ({image})", command=cmd)
+                )
+            finally:
+                if generated_config:
+                    generated_config.unlink(missing_ok=True)
 
     except Exception as e:
         logging.error("Failed while testing the docker library image: %s", e)

--- a/ci/jobs/scripts/docker_server/config.sh
+++ b/ci/jobs/scripts/docker_server/config.sh
@@ -5,12 +5,27 @@ currentDir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # iterate over all directories in current path
 clickhouseTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-*' -not -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
-clickhouseDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
 keeperTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'keeper-*' -type d -exec basename {} \; )
+
+# Distroless images have no shell or coreutils inside the container, so run
+# only tests known to work with that constraint.
+clickhouseDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
+clickhouseDistrolessSafeTests="clickhouse-basics ${clickhouseDistrolessTests}"
+keeperDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'keeper-distroless-*' -type d -exec basename {} \; )
+keeperDistrolessSafeTests="clickhouse-distroless-no-shell ${keeperDistrolessTests}"
+
+# Distroless images cannot run the official-images global tests that assume a
+# shell/coreutils are available. Mark these image variants as explicit so the
+# runner uses only the imageTests listed below instead of adding global tests.
+# Arch-suffixed local CI tags are handled in docker_server.py.
+explicitTests+=(
+	['clickhouse/clickhouse-server:distroless']=1
+	['clickhouse/clickhouse-keeper:distroless']=1
+)
 
 imageTests+=(
 	['clickhouse/clickhouse-server']="${clickhouseTests}"
-	['clickhouse/clickhouse-server:distroless']="${clickhouseTests} ${clickhouseDistrolessTests}"
+	['clickhouse/clickhouse-server:distroless']="${clickhouseDistrolessSafeTests}"
 	['clickhouse/clickhouse-keeper']="${keeperTests}"
-	['clickhouse/clickhouse-keeper:distroless']="${keeperTests}"
+	['clickhouse/clickhouse-keeper:distroless']="${keeperDistrolessSafeTests}"
 )


### PR DESCRIPTION
Since #119493 swapped the 26.3 distroless base image to `gcr.io/distroless/base-nossl-debian13`, the distroless images have no shell and no coreutils. The `docker library image test` in the `Docker server image` and `Docker keeper image` jobs still ran the `docker-library/official-images` *global* tests against them, so `utc` and `no-hard-coded-passwords` die with

```
docker: Error response from daemon: ... exec: "date": executable file not found in $PATH
docker: Error response from daemon: ... exec: "cut": executable file not found in $PATH
```

and both jobs are red on **every** pull request targeting 26.3 since 2026-09-11 16:22 UTC (for example https://github.com/ClickHouse/ClickHouse/pull/119500, and the 26.3 release-branch CI itself). `master` is unaffected because it already restricts the test set for distroless images; this change ports that fix to 26.3.

What it does:
- `ci/jobs/scripts/docker_server/config.sh` gains distroless-safe test lists and marks the distroless image variants as `explicitTests`, so the runner does not add the global tests. The file is now byte-identical to `master`.
- `test_docker_library` in `ci/jobs/docker_server.py` generates a small config fragment for the arch-suffixed local CI tags: the official-images runner derives `clickhouse/clickhouse-server:head-distroless-amd64` as `clickhouse/clickhouse-server:amd64`, so the plain `:distroless` key alone never matches.

Verified locally against a fresh clone of `docker-library/official-images`, with the test selection printed instead of executed:

| image | before | after |
|---|---|---|
| `clickhouse-server:head-distroless-amd64` | `utc no-hard-coded-passwords override-cmd clickhouse-initdb-skip-user-setup clickhouse-override-tcp-port clickhouse-basics` (exactly the 6 tests of the failing CI run) | `clickhouse-basics clickhouse-distroless-no-shell clickhouse-distroless-initdb` |
| `clickhouse-keeper:head-distroless-amd64` | `utc no-hard-coded-passwords override-cmd` | `clickhouse-distroless-no-shell` |
| `clickhouse-server:head-amd64` (unchanged) | 6 tests incl. globals | same 6 tests |

26.4 has the identical gap (same `config.sh`, same job script) and gets the same fix in https://github.com/ClickHouse/ClickHouse/pull/119533. 25.8 is red the same way, but its docker job still runs from the older `tests/ci/docker_server.py`, which does not use the repository `config.sh` at all, so it needs a separate, differently shaped fix.

Related: https://github.com/ClickHouse/ClickHouse/pull/119493
Related: https://github.com/ClickHouse/ClickHouse/pull/119492
Related: https://github.com/ClickHouse/ClickHouse/pull/119494

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.33.58`
<!-- ch-version-info:end -->