### PR TITLE
Fix wrong Iceberg truncate partition values for negative numbers

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.cpp
@@ -6,6 +6,8 @@
 #include <Functions/FunctionFactory.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnConst.h>
+#include <DataTypes/FieldToDataType.h>
+#include <Interpreters/castColumn.h>
 #include <Interpreters/Context.h>
 #include <Core/Settings.h>
 #include <Interpreters/Context_fwd.h>
@@ -59,13 +61,23 @@ ChunkPartitioner::ChunkPartitioner(
         auto function = factory.get(transform_and_argument->transform_name, context);
 
         ColumnsWithTypeAndName columns_for_function;
+        DataTypePtr param_type;
         if (transform_and_argument->argument)
+        {
+            /// `icebergTruncate`'s value depends on the width argument's TYPE: an unsigned divisor at
+            /// least as wide as the source converts a negative source to unsigned first. Every Iceberg
+            /// read path derives that type from an `ASTLiteral`, so derive it identically here.
+            param_type = applyVisitor(FieldToDataType(), Field(static_cast<UInt64>(*transform_and_argument->argument)));
+            /// Type resolution stays on `UInt64`: `result_data_types` is published as the manifest's
+            /// Avro partition type, so it must not move. `partitionChunk` converts into it.
             columns_for_function.push_back(ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeUInt64>(), ""));
+        }
         columns_for_function.push_back(sample_block_->getByName(column_name));
 
         result_data_types.push_back(function->getReturnType(columns_for_function));
         functions.push_back(function);
         function_params.push_back(transform_and_argument->argument);
+        function_param_types.push_back(param_type);
         columns_to_apply.push_back(column_name);
     }
 }
@@ -102,15 +114,17 @@ ChunkPartitioner::partitionChunk(const Chunk & chunk)
         ColumnsWithTypeAndName arguments;
         if (function_params[transform_ind].has_value())
         {
-            auto type = std::make_shared<DataTypeUInt64>();
-            auto column_value = ColumnUInt64::create();
+            const auto & type = function_param_types[transform_ind];
+            auto column_value = type->createColumn();
             column_value->insert(*function_params[transform_ind]);
             auto const_column = ColumnConst::create(std::move(column_value), chunk.getNumRows());
             arguments.push_back(ColumnWithTypeAndName(const_column->clone(), type, "#"));
         }
         arguments.push_back(name_to_column[columns_to_apply[transform_ind]]);
-        auto result
-            = functions[transform_ind]->build(arguments)->execute(arguments, result_data_types[transform_ind], chunk.getNumRows(), false);
+        auto transform = functions[transform_ind]->build(arguments);
+        auto result = transform->execute(arguments, transform->getResultType(), chunk.getNumRows(), false);
+        if (!transform->getResultType()->equals(*result_data_types[transform_ind]))
+            result = castColumn({result, transform->getResultType(), ""}, result_data_types[transform_ind]);
         functions_columns.push_back(result);
         raw_columns.push_back(result.get());
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
@@ -44,6 +44,8 @@ private:
 
     std::vector<FunctionOverloadResolverPtr> functions;
     std::vector<std::optional<size_t>> function_params;
+    /// Parallel to `function_params`; null where a transform takes no argument.
+    DataTypes function_param_types;
     std::vector<String> columns_to_apply;
     DataTypes result_data_types;
 

--- a/tests/queries/0_stateless/05182_iceberg_truncate_negative_partition.reference
+++ b/tests/queries/0_stateless/05182_iceberg_truncate_negative_partition.reference
@@ -1,0 +1,41 @@
+=== Int32 / icebergTruncate(10, k) ===
+total	8
+pred_negative	1
+pred_positive	1
+all_rows	[-4,-3,-2,-1,0,1,2,3]
+stored	Int64	(-10)
+stored	Int64	(0)
+=== Int32 / icebergTruncate(1000, k) ===
+total	8
+pred_negative	1
+pred_positive	1
+all_rows	[-4,-3,-2,-1,0,1,2,3]
+stored	Int64	(-1000)
+stored	Int64	(0)
+=== Int32 / icebergTruncate(100000, k) ===
+total	8
+pred_negative	1
+pred_positive	1
+all_rows	[-4,-3,-2,-1,0,1,2,3]
+agrees	Int64	1
+agrees	Int64	1
+=== Int64 / icebergTruncate(10, k) ===
+total	8
+pred_negative	1
+pred_positive	1
+all_rows	[-4,-3,-2,-1,0,1,2,3]
+stored	Int64	(-10)
+stored	Int64	(0)
+=== Int32 / icebergBucket(10, k) ===
+total	8
+pred_negative	1
+pred_positive	1
+all_rows	[-4,-3,-2,-1,0,1,2,3]
+stored	Int32	(1)
+stored	Int32	(2)
+stored	Int32	(5)
+stored	Int32	(6)
+=== mutation control: DELETE on Int32 / icebergTruncate(10, k) ===
+after_delete_total	7
+after_delete_rows	[-4,-3,-1,0,1,2,3]
+delete_files	1	partition_matches_a_data_file	1	orphaned	0

--- a/tests/queries/0_stateless/05182_iceberg_truncate_negative_partition.sh
+++ b/tests/queries/0_stateless/05182_iceberg_truncate_negative_partition.sh
@@ -75,7 +75,9 @@ run_case() {
                 ;;
             *) echo "run_case: unknown stored-partition mode '$4'" >&2; exit 1 ;;
         esac
-    done | sort
+    # LC_ALL=C: a negative partition value carries a `-`, which glibc's non-C collations ignore at
+    # the primary level, so `(-10)` and `(0)` would order differently per locale.
+    done | LC_ALL=C sort
 
     ${CLICKHOUSE_CLIENT} --query "DROP TABLE ${TABLE}"
     rm -rf "${TABLE_PATH}"

--- a/tests/queries/0_stateless/05182_iceberg_truncate_negative_partition.sh
+++ b/tests/queries/0_stateless/05182_iceberg_truncate_negative_partition.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# `icebergTruncate` computes a different value depending on its width argument's TYPE, and the
+# Iceberg read paths derive that type from a literal. A writer that builds the width at a wider
+# unsigned type therefore stores a partition value the reader never computes, and a predicate that
+# matches a stored row is pruned away: for `truncate[10]` over `-4..-1` the writer stored -6 where
+# the Iceberg spec (and the reader) say -10.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+TABLE=
+TABLE_PATH=
+
+cleanup()
+{
+    if [ -n "${TABLE}" ]; then
+        ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
+        rm -rf "${TABLE_PATH}"
+    fi
+}
+trap cleanup EXIT
+
+# $1 = table name suffix, $2 = source column type, $3 = PARTITION BY expression,
+# $4 = stored-partition check: value | agree, $5 = transform width (only for `agree`)
+run_case() {
+    TABLE="t_${CLICKHOUSE_DATABASE}_$1"
+    TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
+    rm -rf "${TABLE_PATH}"
+
+    ${CLICKHOUSE_CLIENT} --query "
+        CREATE TABLE ${TABLE} (k $2, v Int32)
+        ENGINE = IcebergLocal('${TABLE_PATH}')
+        PARTITION BY $3
+    "
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "
+        INSERT INTO ${TABLE} SELECT number - 5, number FROM numbers(1, 8)
+    "
+
+    echo "=== $2 / $3 ==="
+
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT 'total', count() FROM ${TABLE};
+        SELECT 'pred_negative', count() FROM ${TABLE} WHERE k = -1;
+        SELECT 'pred_positive', count() FROM ${TABLE} WHERE k = 2;
+        SELECT 'all_rows', groupArray(k) FROM (SELECT k FROM ${TABLE} ORDER BY k);
+    "
+
+    # The persisted partition value is the half a predicate cannot show, and its declared type is
+    # what external Iceberg readers bind to.
+    for manifest in $(find "${TABLE_PATH}/metadata" -maxdepth 1 -name '*.avro' -not -name 'snap-*.avro' -type f); do
+        case "$4" in
+            value)
+                ${CLICKHOUSE_CLIENT} --query "
+                    SELECT 'stored',
+                           toTypeName(tupleElement(tupleElement(data_file, 'partition'), 1)),
+                           tupleElement(data_file, 'partition')
+                    FROM file('${manifest}', Avro)
+                "
+                ;;
+            # `truncate[100000]` of a negative value is not yet the value the Iceberg spec names, so
+            # pinning it would bless a wrong constant. Assert the writer/reader AGREEMENT instead:
+            # every row of a data file shares its partition value, so truncating the file's own
+            # recorded minimum (field id 1 = `k`) reproduces it. Independent of partition pruning.
+            agree)
+                ${CLICKHOUSE_CLIENT} --query "
+                    SELECT 'agrees',
+                           toTypeName(tupleElement(tupleElement(data_file, 'partition'), 1)),
+                           tupleElement(tupleElement(data_file, 'partition'), 1)
+                             = icebergTruncate($5, reinterpretAsInt32(arrayFilter(x -> x.1 = 1, tupleElement(data_file, 'lower_bounds'))[1].2))
+                    FROM file('${manifest}', Avro)
+                "
+                ;;
+            *) echo "run_case: unknown stored-partition mode '$4'" >&2; exit 1 ;;
+        esac
+    done | sort
+
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE ${TABLE}"
+    rm -rf "${TABLE_PATH}"
+    TABLE=
+}
+
+# A position-delete file is paired with its data file by exact partition value, so the mutation path
+# and the insert path must agree on that value. This arm is a NON-REGRESSION CONTROL, not a fix
+# witness: it is green on both binaries (before the fix both sides say -6, after it both say -10).
+# It exists so that a later change moving one of the two seams and not the other reddens here
+# instead of silently dropping deletes.
+run_mutation_case() {
+    TABLE="t_${CLICKHOUSE_DATABASE}_mut"
+    TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
+    rm -rf "${TABLE_PATH}"
+
+    ${CLICKHOUSE_CLIENT} --query "
+        CREATE TABLE ${TABLE} (k Int32, v Int32)
+        ENGINE = IcebergLocal('${TABLE_PATH}')
+        PARTITION BY icebergTruncate(10, k)
+    "
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "
+        INSERT INTO ${TABLE} SELECT number - 5, number FROM numbers(1, 8)
+    "
+
+    echo "=== mutation control: DELETE on Int32 / icebergTruncate(10, k) ==="
+
+    # `v = 3` is the row k = -2, a negative source. The predicate deliberately avoids `k`: a
+    # predicate on the partition column is answered by pruning, which is the read half this PR
+    # already fixes, and would mask whether the delete itself was applied.
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --mutations_sync=2 --query "
+        ALTER TABLE ${TABLE} DELETE WHERE v = 3
+    "
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT 'after_delete_total', count() FROM ${TABLE};
+        SELECT 'after_delete_rows', groupArray(k) FROM (SELECT k FROM ${TABLE} ORDER BY k);
+    "
+
+    # The invariant is an EQUALITY between the two writers, so assert it as a comparison rather than
+    # as two pinned constants: every position-delete entry must carry the partition value of a data
+    # file. Degrades fail-closed -- no delete file at all gives 0 instead of 1.
+    local entries=
+    for manifest in $(find "${TABLE_PATH}/metadata" -maxdepth 1 -name '*.avro' -not -name 'snap-*.avro' -type f); do
+        entries="${entries}${entries:+ UNION ALL }SELECT tupleElement(data_file, 'content') AS content, toString(tupleElement(data_file, 'partition')) AS part FROM file('${manifest}', Avro)"
+    done
+    ${CLICKHOUSE_CLIENT} --query "
+        WITH entries AS (${entries})
+        SELECT 'delete_files', countIf(content = 1),
+               'partition_matches_a_data_file', countIf(content = 1 AND part IN (SELECT part FROM entries WHERE content = 0)),
+               'orphaned', countIf(content = 1 AND part NOT IN (SELECT part FROM entries WHERE content = 0))
+        FROM entries
+    "
+
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE ${TABLE}"
+    rm -rf "${TABLE_PATH}"
+    TABLE=
+}
+
+# One arm per width-literal type `FieldToDataType` produces, because that type is what the defect
+# turns on: UInt8 (W <= 255), UInt16, then UInt32.
+run_case trunc_10 Int32 'icebergTruncate(10, k)' value
+run_case trunc_1000 Int32 'icebergTruncate(1000, k)' value
+run_case trunc_100000 Int32 'icebergTruncate(100000, k)' agree 100000
+# The second source type Iceberg accepts for this transform carries the same defect.
+run_case trunc_10_int64 Int64 'icebergTruncate(10, k)' value
+# Control: the other transform taking a width shares the same seam and must not move.
+run_case bucket_10 Int32 'icebergBucket(10, k)' value
+run_mutation_case


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/118905

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed an `INSERT` into an Iceberg table partitioned by the `truncate` transform storing a wrong partition value for negative values: `icebergTruncate(10, x)` over `-4..-1` recorded `-6` where the Iceberg spec says `-10`. ClickHouse's reader computed the correct value and therefore pruned away the data file holding a matching row, so `SELECT count() FROM t WHERE x = -1` returned 0 while the row was present, and the persisted metadata was wrong for external readers too.

### Description

`icebergTruncate(W, x)` evaluates `x - positiveModulo(x, W)`, and `positiveModulo` computes with C++ `%` on the declared types: an unsigned divisor at least as wide as the dividend converts it to unsigned first, so the sign correction never runs. Every Iceberg read path builds the transform from an `ASTLiteral`, where `FieldToDataType` narrows the width to `UInt8`/`UInt16`/`UInt32`; only the write path, `ChunkPartitioner`, hardcoded `DataTypeUInt64`. Both `10` and `100000` reproduce it without a `CAST`.

`ChunkPartitioner` now derives the width type with the same visitor, so writer and readers match by construction. Return-type resolution stays on `DataTypeUInt64`: that type is published as the manifest's Avro partition type, so moving it would make new manifests disagree with old ones in the same table; the computed column is converted into it. Mutations and compaction build the same partitioner.

`icebergTruncate` itself is untouched, so SQL results and MergeTree partition IDs do not move: a table `PARTITION BY icebergTruncate(CAST(10,'UInt64'), i32)` keeps its `-6` partition and its rows, which correcting the function would strand behind `PartitionPruner`.

The new stateless test fails before and passes after (predicate, stored value, declared type, plus an `icebergBucket` control); 50/50 passes.

Residuals. Position-delete files are paired with data files by exact recorded partition value, so a mismatch silently drops the delete, in either direction. Measured over all four version combinations (below): master today drops mutations on any table whose data files carry the spec value, which is what Spark, Trino and pyiceberg write; this change repairs those and narrows the mismatch to tables an older ClickHouse wrote with `allow_insert_into_iceberg = 1`, whose partition-column reads are already wrong. Should a position-delete file inherit the referenced data file's recorded tuple instead of recomputing it from row values? That is a mutation-layer change and your call; I have not built it.

<details>
<summary>Measured: which tables lose a mutation, and the two residuals this PR leaves</summary>

`ALTER TABLE t DELETE WHERE v = 3` on 8 rows, `PARTITION BY icebergTruncate(10, i32)`:

| writes the table | mutates and reads it | rows after DELETE | data file | delete file |
|---|---|---|---|---|
| pre-fix | pre-fix | 7 (applied) | `(-6)` | `(-6)` |
| pre-fix | this PR | 8 (silently dropped) | `(-6)` | `(-10)` |
| this PR | this PR | 7 (applied) | `(-10)` | `(-10)` |
| this PR, i.e. any spec-conformant writer | pre-fix, i.e. master | 8 (silently dropped) | `(-10)` | `(-6)` |

`ALTER TABLE ... UPDATE` in row two leaves the original beside its replacement (9 rows), and `OPTIMIZE` is not a migration path: compaction rewrites the data files and keeps their recorded value.

Residuals left: for an `Int32` column a width above 65535 still computes a non-spec value (`icebergTruncate(100000, -1)` = `-67296`, spec `-100000`), because the function stays type-sensitive; correcting it needs a `moduloLegacy`-style compatibility path. And the partition field is still declared Avro `long` for a 4-byte `int`, the other half of #118905, deliberately not in this PR.

My #119514 changes the `bucket` partition field type in the same file; the two are complementary, and I will rebase whichever lands second.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119534&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119534](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119534+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
