### PR TITLE
Do not lose the rows of a shard that returns no columns

### DIFF
--- a/docs/reference/interfaces/specs/NativeFormat.mdx
+++ b/docs/reference/interfaces/specs/NativeFormat.mdx
@@ -239,6 +239,21 @@ All Data-family packets share the same Block wire format. The variants differ on
 | Header block  | N > 0       | 0        | Announces the result schema (column names + types). |
 | Result block  | N > 0       | M > 0    | Actual result rows. |
 | Empty block   | 0           | 0        | Sentinel — end-of-input on the client side; boundary marker on the server side. |
+| Column-less row block | 0   | M > 0    | Rows that carry no values: only their number is the result. Written at revision `54493` and above (`DBMS_MIN_REVISION_WITH_COLUMN_LESS_BLOCK_ROW_COUNT`). |
+
+`num_rows` is written independently of `num_columns`, so a block can declare rows while carrying no
+columns at all. That is not a contradiction: a query can ask a server for a number of rows and nothing
+else — the part of `SELECT count() OVER () FROM distributed_table` that the shards compute, where the
+window function is evaluated on the initiator and takes no arguments — and then every row of the answer
+holds no values. A reader must take the row count of such a block from `num_rows`: with no columns to
+count, it has no other source, and the count is not recoverable from the (empty) payload. Since the
+row count is all there is, a column-less block with `num_rows > 0` carries no column entries, exactly
+like the other `num_columns = 0` variants.
+
+A reader below revision `54493` rejects this variant (`INCORRECT_DATA`), so a writer only emits it once
+the negotiated revision is at least that; below it the block is written as an empty block, and its rows
+are lost. This also keeps a `Native` file — written at revision `0` — free of the variant, where a
+declared row count with no columns remains a sign of a truncated or corrupted stream.
 
 ### Byte-level examples {#byte-level-examples}
 
@@ -311,6 +326,7 @@ Each feature sits behind a `DBMS_MIN_REVISION_WITH_*` threshold. The writer emit
 | `LowCardinality` on the wire | `DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE` | `54405` | Special case — does **not** follow the simple below-threshold rule. `LowCardinality(T)` is stripped to base type `T` only when the revision is *non-zero* and below `54405`, or when stripping is forced separately. Revision `0` keeps it. See the note below. |
 | V2 `Dynamic` / `JSON` serialization | `DBMS_MIN_REVISION_WITH_V2_DYNAMIC_AND_JSON_SERIALIZATION` | `54473` | `Dynamic` and `JSON`/`Object` use V1 serialization (with the `max_dynamic_*` parameter) instead of V2. |
 | Offsets `String` serialization | `DBMS_MIN_REVISION_WITH_STRING_WITH_SIZE_STREAM_SERIALIZATION` | `54492` | Below the threshold `String` column data uses the per-value layout (`VarUInt` length prefix + raw bytes per row) instead of the [offsets layout](#string-type) (cumulative byte offsets as `UInt64`, then all data concatenated). Gated purely on the revision, with no per-column wire marker. At or above the threshold the offsets layout also applies to `String` nested inside composite types (`Array`, `Nullable`, `Map`, `Tuple`, `Variant`, `Dynamic`, `JSON`), but **not** to the dictionary of a `LowCardinality` column: a `LowCardinality` dictionary is always written with the default nested serialization, so its `String` values keep the per-value layout (this includes `LowCardinality(String)` and `LowCardinality(Nullable(String))`). The `Buffers` format is not part of the protocol and always uses the per-value layout. |
+| Row count of a column-less block | `DBMS_MIN_REVISION_WITH_COLUMN_LESS_BLOCK_ROW_COUNT` | `54493` | A block with no columns always declares `num_rows = 0`, so rows that carry no values cannot be sent (see [block variants](#block-variants)). Below the threshold a reader that is given no header treats `num_columns = 0` with `num_rows > 0` as corruption and raises `INCORRECT_DATA`. |
 | Aggregate-function versioning | `DBMS_MIN_REVISION_WITH_AGGREGATE_FUNCTIONS_VERSIONING` | `54452` | `AggregateFunction` state is written without an embedded version. |
 | `skip_degree` in `quantileDeterministic` state | `DBMS_MIN_REVISION_WITH_QUANTILE_DETERMINISTIC_SKIP_DEGREE` | `54491` | `AggregateFunction(quantileDeterministic, ...)` states (and the `quantiles`/`median` spellings of the same function) are written at state version `0`, without the trailing `UInt8 skip_degree`. See the note under [type aliases](#type-aliases). |
 | `out_of_order_buckets` in `BlockInfo` | `DBMS_MIN_REVISION_WITH_OUT_OF_ORDER_BUCKETS_IN_AGGREGATION` | `54480` | `BlockInfo` field ID `3` is not written (see [BlockInfo](#blockinfo)). |

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -524,7 +524,8 @@ Packet HedgedConnections::receivePacketFromReplica(const ReplicaLocation & repli
         case Protocol::Server::Data:
             /// If we received the first not empty data packet and still can change replica,
             /// disable changing replica with this offset.
-            if (offset_states[replica_location.offset].can_change_replica && packet.block.rows() > 0)
+            if (offset_states[replica_location.offset].can_change_replica
+                && (packet.block.rows() > 0 || packet.block.info.num_rows_without_columns > 0))
                 disableChangingReplica(replica_location);
             replica_with_last_received_packet = replica_location;
             break;

--- a/src/Core/BlockInfo.h
+++ b/src/Core/BlockInfo.h
@@ -45,6 +45,18 @@ struct BlockInfo
 
 #undef DECLARE_FIELD
 
+    /** num_rows_without_columns:
+      * `Block::rows` takes the number of rows from the first column, so a block with no columns always
+      * reports zero rows. Such a block is not always empty - its rows can carry no values at all, which
+      * is what a shard produces for `SELECT count() OVER () FROM distributed_table`, where the initiator
+      * needs the number of rows and nothing else. For those blocks the row count is kept here, so that it
+      * survives the conversion from a `Chunk` and the serialization.
+      *
+      * This is not one of the serialized fields above: on the wire the value is the row count of the
+      * block, which the `Native` format writes independently of the columns.
+      */
+    size_t num_rows_without_columns = 0;
+
     /// Write the values in binary form. NOTE: You could use protobuf, but it would be overkill for this case.
     void write(WriteBuffer & out, UInt64 server_protocol_revision) const;
 

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -252,6 +252,12 @@ static constexpr auto DBMS_MIN_REVISION_WITH_QUANTILE_DETERMINISTIC_SKIP_DEGREE 
 /// Send String columns in the native protocol with a separate stream of cumulative byte offsets.
 static constexpr auto DBMS_MIN_REVISION_WITH_STRING_WITH_SIZE_STREAM_SERIALIZATION = 54492;
 
+/// Send the number of rows of a block that has no columns. Such a block is not empty: its rows carry
+/// no values, which is what a shard produces for a query whose intermediate result needs nothing from
+/// it, e.g. `SELECT count() OVER () FROM distributed_table`. The count cannot be derived from the
+/// columns, and an older receiver rejects a column-less block that declares rows.
+static constexpr auto DBMS_MIN_REVISION_WITH_COLUMN_LESS_BLOCK_ROW_COUNT = 54493;
+
 
 /// Version of ClickHouse TCP protocol.
 ///
@@ -260,5 +266,5 @@ static constexpr auto DBMS_MIN_REVISION_WITH_STRING_WITH_SIZE_STREAM_SERIALIZATI
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54492;
+static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54493;
 }

--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -175,7 +175,15 @@ Block NativeReader::read()
     }
 
     if (columns == 0 && header.empty() && rows != 0)
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Zero columns but {} rows in Native format.", rows);
+    {
+        /// The rows of such a block carry no values at all - it is what a shard sends for a query whose
+        /// intermediate result needs nothing from it. Only a sender that speaks a new enough protocol
+        /// revision can mean it; at a lower revision (a `Native` file, for one) this is malformed data.
+        if (server_revision < DBMS_MIN_REVISION_WITH_COLUMN_LESS_BLOCK_ROW_COUNT)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Zero columns but {} rows in Native format.", rows);
+
+        res.info.num_rows_without_columns = rows;
+    }
 
     /// `rows` comes from the block header, and the limit it is checked against is deliberately
     /// generous, so it must not be used to preallocate the columns: a header declaring a huge row
@@ -353,7 +361,8 @@ Block NativeReader::read()
         res.swap(tmp_res);
     }
 
-    if (res.rows() != rows)
+    /// A block with no columns keeps its row count in the block info, `Block::rows` reports zero for it.
+    if (res.columns() != 0 && res.rows() != rows)
         throw Exception(ErrorCodes::INCORRECT_DATA, "Row count mismatch after deserialization, got: {}, expected: {}", res.rows(), rows);
 
     return res;

--- a/src/Formats/NativeWriter.cpp
+++ b/src/Formats/NativeWriter.cpp
@@ -135,6 +135,11 @@ size_t NativeWriter::write(const Block & block)
     size_t columns = block.columns();
     size_t rows = block.rows();
 
+    /// A block with no columns can still carry rows, and then its count is in the block info.
+    /// A receiver that does not expect it rejects such a block, so keep sending zero rows to those.
+    if (columns == 0 && client_revision >= DBMS_MIN_REVISION_WITH_COLUMN_LESS_BLOCK_ROW_COUNT)
+        rows = block.info.num_rows_without_columns;
+
     writeVarUInt(columns, ostr);
     writeVarUInt(rows, ostr);
 

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -157,7 +157,12 @@ bool PullingAsyncPipelineExecutor::pull(Block & block, uint64_t milliseconds)
         return true;
     }
 
+    const size_t num_rows = chunk.getNumRows();
     block = lazy_format->getPort(IOutputFormat::PortKind::Main).getHeader().cloneWithColumns(chunk.detachColumns());
+
+    /// A block takes its number of rows from its columns, so without them the count has to be kept aside.
+    if (block.columns() == 0)
+        block.info.num_rows_without_columns = num_rows;
 
     if (auto agg_info = chunk.getChunkInfos().get<AggregatedChunkInfo>())
     {

--- a/src/Processors/Executors/PullingPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingPipelineExecutor.cpp
@@ -77,7 +77,13 @@ bool PullingPipelineExecutor::pull(Block & block)
         return true;
     }
 
+    const size_t num_rows = chunk.getNumRows();
     block = pulling_format->getPort(IOutputFormat::PortKind::Main).getHeader().cloneWithColumns(chunk.detachColumns());
+
+    /// A block takes its number of rows from its columns, so without them the count has to be kept aside.
+    if (block.columns() == 0)
+        block.info.num_rows_without_columns = num_rows;
+
     if (auto agg_info = chunk.getChunkInfos().get<AggregatedChunkInfo>())
     {
         block.info.bucket_num = agg_info->bucket_num;

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -211,7 +211,11 @@ std::optional<Chunk> RemoteSource::tryGenerate()
     else
         block = query_executor->readBlock();
 
-    if (block.empty())
+    /// A block with no columns carries its number of rows in the block info; it is the end of the data
+    /// only when it has no rows either.
+    UInt64 num_rows = block.empty() ? block.info.num_rows_without_columns : block.rows();
+
+    if (block.empty() && num_rows == 0)
     {
         if (manually_add_rows_before_limit_counter)
             rows_before_limit->add(rows);
@@ -219,7 +223,6 @@ std::optional<Chunk> RemoteSource::tryGenerate()
         return {};
     }
 
-    UInt64 num_rows = block.rows();
     rows += num_rows;
     Chunk chunk(block.getColumns(), num_rows);
 

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -763,10 +763,11 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
                 connections->dumpAddresses());
             break;
         case Protocol::Server::Data:
-            /// Note: `packet.block.rows() > 0` means it's a header block.
+            /// Note: `packet.block.rows() == 0` means it's a header block.
             /// We can actually return it, and the first call to RemoteQueryExecutor::read
             /// will return earlier. We should consider doing it.
-            if (!packet.block.empty() && (packet.block.rows() > 0))
+            /// A block with no columns carries its number of rows in the block info.
+            if (packet.block.rows() > 0 || packet.block.info.num_rows_without_columns > 0)
             {
                 got_data_from_replica = true;
                 return ReadResult(adaptBlockStructure(packet.block, *header));

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1638,8 +1638,10 @@ void TCPHandler::processOrdinaryQuery(QueryState & state)
                     else
                         sendLogs(state);
 
-                    // Block might be empty in case of timeout, i.e. there is no data to process
-                    if (!block.empty() && !state.io.null_format && !discard_query_data)
+                    // Block might be empty in case of timeout, i.e. there is no data to process.
+                    // A block with no columns is not empty when it carries rows that hold no values.
+                    const bool block_has_data = !block.empty() || block.info.num_rows_without_columns > 0;
+                    if (block_has_data && !state.io.null_format && !discard_query_data)
                         sendData(state, block);
 
                     out->sync();

--- a/tests/queries/0_stateless/05208_window_function_only_over_shards.reference
+++ b/tests/queries/0_stateless/05208_window_function_only_over_shards.reference
@@ -1,0 +1,27 @@
+control	2
+window	2
+window	2
+window with a column	0	2
+window with a column	0	2
+every shard is remote	2
+every shard is remote	2
+three shards	3
+three shards	3
+three shards	3
+several rows per shard	6	21
+rank	2	1
+cluster	2
+cluster	2
+filter above the window	8
+without block marshalling	2
+without block marshalling	2
+without compression	2
+without compression	2
+synchronous socket	2
+synchronous socket	2
+hedged requests	2
+hedged requests	2
+old analyzer	2
+old analyzer	2
+old analyzer, every shard is remote	2
+old analyzer, every shard is remote	2

--- a/tests/queries/0_stateless/05208_window_function_only_over_shards.sql
+++ b/tests/queries/0_stateless/05208_window_function_only_over_shards.sql
@@ -1,0 +1,29 @@
+-- When the SELECT list of a query over several shards consists of window functions only, the shards
+-- have nothing to return: the rows of their part of the result carry no values at all, and a block
+-- takes its number of rows from its columns. The rows of every shard but the local one used to be
+-- lost, so the window step on the initiator saw fewer rows, or none at all.
+--
+-- The labels are added outside the distributed subquery on purpose: a constant in the SELECT list of
+-- the query over the shards is computed by the shards without the old analyzer, which hides the bug.
+
+SET enable_analyzer = 1;
+SET prefer_localhost_replica = 1;
+
+SELECT 'control', count() FROM remote('127.0.0.{1,2}', system.one);
+SELECT 'window', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one));
+SELECT 'window with a column', d, c FROM (SELECT dummy AS d, count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) ORDER BY d, c;
+SELECT 'every shard is remote', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS prefer_localhost_replica = 0;
+SELECT 'three shards', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2,3}', system.one));
+SELECT 'several rows per shard', count(), sum(r) FROM (SELECT row_number() OVER () AS r FROM remote('127.0.0.{1,2}', numbers(3)));
+SELECT 'rank', count(), max(r) FROM (SELECT rank() OVER () AS r FROM remote('127.0.0.{1,2}', system.one));
+SELECT 'cluster', c FROM (SELECT count() OVER () AS c FROM cluster('test_cluster_two_shards', system.one));
+SELECT 'filter above the window', count() FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', numbers(4))) WHERE c = 8;
+
+-- The row count has to survive every shape of the receiving side.
+SELECT 'without block marshalling', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS prefer_localhost_replica = 0, enable_parallel_blocks_marshalling = 0;
+SELECT 'without compression', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS prefer_localhost_replica = 0, network_compression_method = 'NONE';
+SELECT 'synchronous socket', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS prefer_localhost_replica = 0, use_hedged_requests = 0, async_socket_for_remote = 0;
+SELECT 'hedged requests', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS prefer_localhost_replica = 0, use_hedged_requests = 1;
+
+SELECT 'old analyzer', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS enable_analyzer = 0;
+SELECT 'old analyzer, every shard is remote', c FROM (SELECT count() OVER () AS c FROM remote('127.0.0.{1,2}', system.one)) SETTINGS enable_analyzer = 0, prefer_localhost_replica = 0;


### PR DESCRIPTION
When the SELECT list of a query over several shards consists of window functions only, the rows coming from the remote shards were silently dropped:

```sql
SELECT count() FROM remote('127.0.0.{1,2}', system.one);
-- 2  (two shards, one row each)

SELECT count() OVER () FROM remote('127.0.0.{1,2}', system.one);
-- 1          <-- one row with value 1; expected two rows, both 2

SELECT count() OVER () FROM remote('127.0.0.{1,2}', system.one) SETTINGS prefer_localhost_replica = 0;
-- (no rows)  <-- every shard is remote: everything is lost
```

The window function is evaluated on the initiator, and it takes no arguments, so the shards have nothing to return: the rows of their part of the result carry no values at all. A `Block` takes its number of rows from its columns, so a block with no columns always reports zero rows, and the count of such a block was lost twice over - when the shard's `Chunk` was turned into a `Block` for sending, and again when the received block was turned back into a `Chunk`. `NativeWriter` therefore declared zero rows, the initiator dropped the block as empty, and the window step saw only the local shard's rows. Adding any column to the SELECT list restored the full row set, and both analyzers were affected.

The row count of a column-less block now survives that round trip. `BlockInfo` carries it (not as one of its serialized fields: on the wire it is the block's row count, which the `Native` format writes independently of the columns), the two `Chunk`-to-`Block` conversions fill it in, and the receiving side takes the number of rows from it when there are no columns to count. Sending it is gated on a new protocol revision, `DBMS_MIN_REVISION_WITH_COLUMN_LESS_BLOCK_ROW_COUNT`: an older receiver rejects a column-less block that declares rows, so in a mixed-version cluster the block is written as before, and a `Native` file - written at revision `0` - still treats a declared row count with no columns as corrupted data.

The specification of the `Native` format is updated with the new block variant and the revision that gates it.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119373

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a query over a multi-shard `Distributed` table or `remote()` silently losing the remote shards' rows when its SELECT list consists of window functions only, such as `SELECT count() OVER () FROM distributed_table`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119542&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119542](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119542+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
