### PR TITLE
Document native support for replica-aware routing

### DIFF
--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -2,37 +2,43 @@
 title: 'Replica-aware routing'
 slug: /manage/replica-aware-routing
 description: 'Route related requests to the same ClickHouse Cloud replica for temporary tables, sessions, cache reuse, and read-after-write consistency'
-keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'X-ClickHouse-Replica-Tag', 'session affinity', 'temporary tables', 'read-after-write consistency']
+keywords: ['cloud', 'sticky endpoints', 'sticky', 'endpoints', 'sticky routing', 'routing', 'replica aware routing', 'X-ClickHouse-Replica-Tag', 'session affinity', 'temporary tables', 'read-after-write consistency', 'sni', 'tls-sni-override']
 doc_type: 'guide'
 ---
 
-import { PrivatePreviewBadge } from "/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx";
+import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanFeatureBadge/EnterprisePlanFeatureBadge.jsx";
 
-<PrivatePreviewBadge/>
-<EnterprisePlanFeatureBadge feature="Replica-aware routing" support="true"/>
+<BetaBadge/>
+<EnterprisePlanFeatureBadge feature="Replica-aware routing"/>
 
 Replica-aware routing (also known as sticky sessions, sticky routing, or session affinity) routes related requests to the same ClickHouse replica. Use it when you need [temporary tables](/reference/statements/create/table/temporary-table) or [named session state](/concepts/features/interfaces/http#using-clickhouse-sessions-in-the-http-protocol) to stay reachable across queries, when you want related queries to reuse the same replica's local caches, or when you need [read-after-write consistency](#read-after-write-consistency) across a write and its follow-up reads.
 
 It's best-effort and doesn't guarantee isolation. The proxy maps each routing value to one replica. The mapping remains stable while the number of replicas remains unchanged; scaling the service can map the value to a different replica.
 
-<Warning>
-**Requires the HTTP interface**
+Replica-aware routing is available over both interfaces:
 
-Replica-aware routing is applied at the proxy layer over the [HTTP/HTTPS interface](/concepts/features/interfaces/http) using the `X-ClickHouse-Replica-Tag` header.
+- Over [HTTP/HTTPS](#http-based-routing), using the `X-ClickHouse-Replica-Tag` header.
+- Over the [native protocol](#native-protocol-routing), using a TLS Server Name Indication (SNI) override.
 
-Replica-aware routing is **currently unavailable over the native protocol** (native port, e.g. the [clickhouse-go](/integrations/language-clients/go/index) driver in its default native mode). Native-protocol clients must switch to HTTP and send the routing value on every request.
-</Warning>
+Both are enabled separately and use the same consistent hashing behind the proxy.
 
 ## Prerequisites {#prerequisites}
 
 - Your service needs **2 or more replicas**. On a single-replica service, there's nothing to pin to.
-- Available on **Enterprise** by default when the feature is GA.
+- An **Enterprise** tier service.
 - Supported on standard ClickHouse Cloud services. [BYOC](/products/cloud/guides/infrastructure/deployment-options/byoc/overview) isn't supported yet.
 
 ## Configuring replica-aware routing {#configuring-replica-aware-routing}
 
-Open a [support](https://clickhouse.com/support/program) ticket and ask to enable HTTP-based sticky replica routing. Include your service ID and why you need it (temporary tables, session state, cache reuse, or read-after-write consistency). No restart is required.
+Enterprise customers enable replica-aware routing from the service settings page in the ClickHouse Cloud console. Open your service, go to **Settings**, and turn on the toggle for the interface you want:
+
+- One toggle enables HTTP-based routing on the `X-ClickHouse-Replica-Tag` header.
+- A separate toggle enables native-protocol routing on the SNI override.
+
+Enable either or both. No restart is required, and it can take under a minute to take effect.
+
+The toggles are rolling out across Enterprise tier plans. If they aren't on your service yet, open a [support](https://clickhouse.com/support/program) ticket with your service ID to have the feature turned on earlier.
 
 ## HTTP-based routing {#http-based-routing}
 
@@ -56,21 +62,118 @@ For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass the header with
 `X-ClickHouse-Replica-Tag` provides replica affinity without creating a ClickHouse HTTP session. Concurrent requests can reuse the same tag without encountering `SESSION_IS_LOCKED`.
 </Info>
 
-### Read-after-write consistency {#read-after-write-consistency}
+## Native-protocol routing {#native-protocol-routing}
 
-On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with an `X-ClickHouse-Replica-Tag` header, then reuse the same header value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind. This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.
+Over the [native protocol](/interfaces/tcp) there's no HTTP header to carry the routing value, so the proxy hashes the TLS SNI value instead. You connect to your regular service hostname and validate the regular certificate, but send an SNI of the form `<routing-value>.sticky.<host>`. The proxy extracts the routing value from the SNI and selects a replica with the same consistent hashing used for HTTP.
+
+Because only the SNI changes, no extra certificate or DNS entry is needed for each routing value.
+
+[ClickHouse Client](/interfaces/client) exposes this through `--tls-sni-override`:
+
+```bash
+clickhouse client \
+  --host <host> \
+  --secure \
+  --tls-sni-override my-workload-1.sticky.<host> \
+  --query 'SELECT hostName()'
+```
+
+`--host` is the hostname validated against the certificate, `--secure` turns on TLS, and `--tls-sni-override` supplies the value that's routed on. TLS is required, since without it there's no SNI for the proxy to read.
+
+### Overriding the SNI in your own client {#overriding-sni-in-your-own-client}
+
+A client that builds its own TLS configuration has to separate the two hostnames itself: set the SNI to the sticky hostname, but verify the server certificate against the service hostname. The regular certificate doesn't cover the sticky hostname, so the default hostname check has to be replaced rather than skipped. In Go:
+
+```go
+tlsConfig.ServerName = sniOverride
+
+// Disable the built-in hostname check, which would match the certificate
+// against the sticky hostname in ServerName. The custom callback below
+// still performs full verification.
+tlsConfig.InsecureSkipVerify = true
+
+tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	certs := make([]*x509.Certificate, 0, len(rawCerts))
+	for _, raw := range rawCerts {
+		cert, err := x509.ParseCertificate(raw)
+		if err != nil {
+			return err
+		}
+		certs = append(certs, cert)
+	}
+
+	if len(certs) == 0 {
+		return fmt.Errorf("no certificate presented by %s", dialHost)
+	}
+
+	// Verify the chain against the service hostname, not the SNI value.
+	opts := x509.VerifyOptions{DNSName: dialHost, Intermediates: x509.NewCertPool()}
+	for _, cert := range certs[1:] {
+		opts.Intermediates.AddCert(cert)
+	}
+
+	_, err := certs[0].Verify(opts)
+	return err
+}
+```
+
+<Warning>
+Set `InsecureSkipVerify` only alongside a `VerifyPeerCertificate` callback that performs the chain and hostname verification, as above. On its own it disables certificate verification entirely.
+</Warning>
+
+## Read-after-write consistency {#read-after-write-consistency}
+
+On a multi-replica service, a write on one replica may not be visible on the others until replication catches up. Send your write with a routing value, then reuse that same value on follow-up reads. The proxy routes both to the same replica, so you read your own write even while other replicas are still behind. This pattern works for workloads that write and then immediately read back the same data, such as interactive applications or ETL jobs that validate inserts before moving on.
+
+It also helps after a schema change that hasn't yet replicated, since reusing the routing value keeps inserts on a replica that already has the new schema.
+
+Over HTTP, reuse the header value:
+
+```bash
+# Write, tagged with a routing value
+echo "INSERT INTO events VALUES (now(), 'signup')" | curl \
+  -H 'X-ClickHouse-Replica-Tag: my-workload-1' \
+  -H 'X-ClickHouse-User: default' \
+  -H 'X-ClickHouse-Key: <password>' \
+  'https://<host>:8443/' -d @-
+
+# Read it back on the same replica, using the same value
+echo 'SELECT count() FROM events' | curl \
+  -H 'X-ClickHouse-Replica-Tag: my-workload-1' \
+  -H 'X-ClickHouse-User: default' \
+  -H 'X-ClickHouse-Key: <password>' \
+  'https://<host>:8443/' -d @-
+```
+
+Over the native protocol, reuse the SNI override:
+
+```bash
+# Write with a routing value
+clickhouse client \
+  --host <host> \
+  --secure \
+  --tls-sni-override my-workload-1.sticky.<host> \
+  --query "INSERT INTO events VALUES (now(), 'signup')"
+
+# Read it back on the same replica, using the same value
+clickhouse client \
+  --host <host> \
+  --secure \
+  --tls-sni-override my-workload-1.sticky.<host> \
+  --query 'SELECT count() FROM events'
+```
 
 For broader guarantees across all replicas, you can also set [`select_sequential_consistency`](/reference/settings/session-settings#select_sequential_consistency) to `1` on ClickHouse Cloud.
 
-### Check which replica you hit {#check-which-replica}
+## Check which replica you hit {#check-which-replica}
 
-Run the `SELECT hostName()` example again with the same `X-ClickHouse-Replica-Tag` value. You should get the same hostname while the number of replicas remains unchanged. A different header value may map to a different replica.
+Run one of the `SELECT hostName()` examples again with the same routing value. You should get the same hostname while the number of replicas remains unchanged. A different routing value may map to a different replica.
 
 ## Limitations of replica-aware routing {#limitations-of-replica-aware-routing}
 
 ### Stickiness changes when the replica count changes {#replica-aware-routing-does-not-guarantee-isolation}
 
-Scaling out or in changes the routing hash ring. Requests sharing the same routing value may then land on a different replica. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap.
+Scaling out or in changes the routing hash ring. Requests sharing the same routing value may then land on a different replica. If you rely on temporary tables or session-level settings, be ready to recreate them after a remap. `SELECT hostName()` always tells you which replica you're on.
 
 ### Replica-aware routing isn't workload isolation {#not-workload-isolation}
 
@@ -78,17 +181,23 @@ Sticky routing only controls *which* replica handles a request. That replica may
 
 ### Private networking {#private-networking}
 
-HTTP-based routing works with [private networking](/products/cloud/guides/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
+Both HTTP-based and native-protocol routing work with [private networking](/products/cloud/guides/security/connectivity/private-networking) on your normal service hostname. No extra DNS entries are required.
 
-### Replica-aware routing requires the HTTP protocol {#replica-aware-routing-requires-http}
+### Native-protocol routing requires TLS {#native-protocol-routing-requires-tls}
 
-Sticky routing is keyed on the `X-ClickHouse-Replica-Tag` HTTP header. The native binary protocol doesn't carry this value for the HTTP proxy to hash on, so replica-aware routing isn't available over the native protocol. Native-protocol clients must move the relevant workload to the HTTP interface to use this feature.
+The routing value travels in the TLS SNI, so a native connection has to use TLS. An unencrypted native connection sends no SNI and keeps normal load balancing.
 
 ## Troubleshooting {#troubleshooting}
 
 **Queries still land on different replicas with the same routing value**
 
-- Confirm that every request includes the `X-ClickHouse-Replica-Tag` header.
-- Confirm that every request uses exactly the same routing value.
+- Confirm the toggle for the interface you're using is enabled on the service settings page. The HTTP and native methods are enabled separately.
+- Over HTTP, confirm that every request includes the `X-ClickHouse-Replica-Tag` header, and that every request uses exactly the same value.
+- Over the native protocol, confirm that `--secure` is set and that the SNI value has the form `<routing-value>.sticky.<host>`.
 - Wait briefly after enablement. It can take under a minute to take effect.
 - Check whether the number of replicas recently changed; remapping is expected after scaling. Use `SELECT hostName()` to discover the new mapping.
+
+**Certificate errors over the native protocol**
+
+- Confirm `--host` is your regular service hostname rather than the sticky SNI value. The certificate covers the former.
+- In a client that sets the SNI itself, verify the certificate against the service hostname rather than the SNI value, as shown [above](#overriding-sni-in-your-own-client).

--- a/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
+++ b/docs/products/cloud/features/infrastructure/replica-aware-routing.mdx
@@ -64,11 +64,7 @@ For clickhouse-go (v2), set `Protocol: clickhouse.HTTP` and pass the header with
 
 ## Native-protocol routing {#native-protocol-routing}
 
-Over the [native protocol](/interfaces/tcp) there's no HTTP header to carry the routing value, so the proxy hashes the TLS SNI value instead. You connect to your regular service hostname and validate the regular certificate, but send an SNI of the form `<routing-value>.sticky.<host>`. The proxy extracts the routing value from the SNI and selects a replica with the same consistent hashing used for HTTP.
-
-Because only the SNI changes, no extra certificate or DNS entry is needed for each routing value.
-
-[ClickHouse Client](/interfaces/client) exposes this through `--tls-sni-override`:
+Over the [native protocol](/interfaces/tcp), pass the routing value as a TLS server name of the form `<routing-value>.sticky.<host>`. Connect to your regular service hostname as usual. [ClickHouse Client](/interfaces/client) takes the routing value through `--tls-sni-override`:
 
 ```bash
 clickhouse client \
@@ -78,48 +74,7 @@ clickhouse client \
   --query 'SELECT hostName()'
 ```
 
-`--host` is the hostname validated against the certificate, `--secure` turns on TLS, and `--tls-sni-override` supplies the value that's routed on. TLS is required, since without it there's no SNI for the proxy to read.
-
-### Overriding the SNI in your own client {#overriding-sni-in-your-own-client}
-
-A client that builds its own TLS configuration has to separate the two hostnames itself: set the SNI to the sticky hostname, but verify the server certificate against the service hostname. The regular certificate doesn't cover the sticky hostname, so the default hostname check has to be replaced rather than skipped. In Go:
-
-```go
-tlsConfig.ServerName = sniOverride
-
-// Disable the built-in hostname check, which would match the certificate
-// against the sticky hostname in ServerName. The custom callback below
-// still performs full verification.
-tlsConfig.InsecureSkipVerify = true
-
-tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-	certs := make([]*x509.Certificate, 0, len(rawCerts))
-	for _, raw := range rawCerts {
-		cert, err := x509.ParseCertificate(raw)
-		if err != nil {
-			return err
-		}
-		certs = append(certs, cert)
-	}
-
-	if len(certs) == 0 {
-		return fmt.Errorf("no certificate presented by %s", dialHost)
-	}
-
-	// Verify the chain against the service hostname, not the SNI value.
-	opts := x509.VerifyOptions{DNSName: dialHost, Intermediates: x509.NewCertPool()}
-	for _, cert := range certs[1:] {
-		opts.Intermediates.AddCert(cert)
-	}
-
-	_, err := certs[0].Verify(opts)
-	return err
-}
-```
-
-<Warning>
-Set `InsecureSkipVerify` only alongside a `VerifyPeerCertificate` callback that performs the chain and hostname verification, as above. On its own it disables certificate verification entirely.
-</Warning>
+`--host` is your regular service hostname, `--secure` turns on TLS, and `--tls-sni-override` carries the routing value. TLS is required. No extra certificate or DNS entry is needed.
 
 ## Read-after-write consistency {#read-after-write-consistency}
 
@@ -185,7 +140,7 @@ Both HTTP-based and native-protocol routing work with [private networking](/prod
 
 ### Native-protocol routing requires TLS {#native-protocol-routing-requires-tls}
 
-The routing value travels in the TLS SNI, so a native connection has to use TLS. An unencrypted native connection sends no SNI and keeps normal load balancing.
+Native-protocol routing needs TLS, so pass `--secure`. An unencrypted native connection keeps normal load balancing.
 
 ## Troubleshooting {#troubleshooting}
 
@@ -193,11 +148,10 @@ The routing value travels in the TLS SNI, so a native connection has to use TLS.
 
 - Confirm the toggle for the interface you're using is enabled on the service settings page. The HTTP and native methods are enabled separately.
 - Over HTTP, confirm that every request includes the `X-ClickHouse-Replica-Tag` header, and that every request uses exactly the same value.
-- Over the native protocol, confirm that `--secure` is set and that the SNI value has the form `<routing-value>.sticky.<host>`.
+- Over the native protocol, confirm that `--secure` is set and that `--tls-sni-override` has the form `<routing-value>.sticky.<host>`.
 - Wait briefly after enablement. It can take under a minute to take effect.
 - Check whether the number of replicas recently changed; remapping is expected after scaling. Use `SELECT hostName()` to discover the new mapping.
 
 **Certificate errors over the native protocol**
 
-- Confirm `--host` is your regular service hostname rather than the sticky SNI value. The certificate covers the former.
-- In a client that sets the SNI itself, verify the certificate against the service hostname rather than the SNI value, as shown [above](#overriding-sni-in-your-own-client).
+- Confirm `--host` is your regular service hostname, and that the routing value is passed through `--tls-sni-override` rather than `--host`.


### PR DESCRIPTION
Updates the [replica-aware routing](https://clickhouse.com/docs/manage/replica-aware-routing) page now that the feature works over the native protocol and Enterprise customers can enable it themselves.

The page previously said replica-aware routing was "currently unavailable over the native protocol" and that native-protocol clients had to switch to HTTP, and it told customers to open a support ticket to get the feature turned on. Both are out of date.

Changes:

- **Native support.** New section covering `--tls-sni-override` and the `<routing-value>.sticky.<host>` routing value, kept to what a reader needs in order to open a native connection. Removed the warning callout and the "requires the HTTP protocol" limitation; the real constraint is simply that native-protocol routing needs TLS.
- **Self-serve enablement.** Enterprise customers turn replica-aware routing on from the toggles on the service settings page. The HTTP and native methods are enabled separately. Support is now the fallback for services the rollout hasn't reached.
- **Read-after-write consistency** is shown over both interfaces, and promoted to a top-level section along with the replica check, since neither is HTTP-specific any more. Also notes that reusing a routing value helps when a schema change hasn't yet replicated.
- **Badges:** private preview to beta, and dropped the contact-support wording from the Enterprise plan badge.

Source: [Replica-aware Routing blog](https://app.notion.com/p/Replica-aware-Routing-Blog-3bf2bd19f29081d1844de06f5a1deee8) (internal; not linked from the page).

Two things worth a maintainer's eye:

- The blog says the feature is in public beta, so I switched the badge to beta. Confirm that's the status you want published.
- The [July 13, 2026 cloud changelog entry](https://github.com/ClickHouse/ClickHouse/blob/master/docs/resources/changelogs/cloud/2026.mdx) still describes the older `?session_id=` mechanism and calls the feature private preview. I left it alone as a dated historical record, but if `session_id` no longer routes, that entry is pointing customers at something that doesn't work.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119544&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119544](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119544+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1238` (included in `26.9` and later)
<!-- ch-version-info:end -->