### PR TITLE
Fix system.server_settings reporting the reading session's bandwidth limits for the *_for_server rows

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -3664,7 +3664,8 @@ ChangeableSettingsMap collectChangeableServerSettings(ContextPtr context)
             {"enable_write_through_distributed_cache", {std::to_string(context->getWriteThroughDistributedCache()), ChangeableWithoutRestart::Yes}},
 
             /// The server-wide throttlers, not `getRemoteReadThrottler()` and friends: those compose the
-            /// reading request's own per-user and per-query limits on top of the server-wide one.
+            /// reading request's own per-query limit, and for the remote pair its per-user limit, on top of
+            /// the server-wide one.
             {"max_remote_read_network_bandwidth_for_server",
              {context->getServerWideRemoteReadThrottler() ? std::to_string(context->getServerWideRemoteReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
             {"max_remote_write_network_bandwidth_for_server",

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -3663,14 +3663,16 @@ ChangeableSettingsMap collectChangeableServerSettings(ContextPtr context)
             {"enable_read_through_distributed_cache", {std::to_string(context->getReadThroughDistributedCache()), ChangeableWithoutRestart::Yes}},
             {"enable_write_through_distributed_cache", {std::to_string(context->getWriteThroughDistributedCache()), ChangeableWithoutRestart::Yes}},
 
+            /// The server-wide throttlers, not `getRemoteReadThrottler()` and friends: those compose the
+            /// reading request's own per-user and per-query limits on top of the server-wide one.
             {"max_remote_read_network_bandwidth_for_server",
-             {context->getRemoteReadThrottler() ? std::to_string(context->getRemoteReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
+             {context->getServerWideRemoteReadThrottler() ? std::to_string(context->getServerWideRemoteReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
             {"max_remote_write_network_bandwidth_for_server",
-             {context->getRemoteWriteThrottler() ? std::to_string(context->getRemoteWriteThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
+             {context->getServerWideRemoteWriteThrottler() ? std::to_string(context->getServerWideRemoteWriteThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
             {"max_local_read_bandwidth_for_server",
-             {context->getLocalReadThrottler() ? std::to_string(context->getLocalReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
+             {context->getServerWideLocalReadThrottler() ? std::to_string(context->getServerWideLocalReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
             {"max_local_write_bandwidth_for_server",
-             {context->getLocalWriteThrottler() ? std::to_string(context->getLocalWriteThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
+             {context->getServerWideLocalWriteThrottler() ? std::to_string(context->getServerWideLocalWriteThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
             {"max_distributed_cache_read_bandwidth_for_server",
              {context->getDistributedCacheReadThrottler() ? std::to_string(context->getDistributedCacheReadThrottler()->getMaxSpeed()) : "0", ChangeableWithoutRestart::Yes}},
             {"max_distributed_cache_write_bandwidth_for_server",

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5820,13 +5820,33 @@ ThrottlerPtr Context::getReplicatedSendsThrottler() const
     return shared->replicated_sends_throttler;
 }
 
+ThrottlerPtr Context::getServerWideRemoteReadThrottler() const
+{
+    SharedLockGuard lock(shared->mutex);
+    return shared->remote_read_throttler;
+}
+
+ThrottlerPtr Context::getServerWideRemoteWriteThrottler() const
+{
+    SharedLockGuard lock(shared->mutex);
+    return shared->remote_write_throttler;
+}
+
+ThrottlerPtr Context::getServerWideLocalReadThrottler() const
+{
+    SharedLockGuard lock(shared->mutex);
+    return shared->local_read_throttler;
+}
+
+ThrottlerPtr Context::getServerWideLocalWriteThrottler() const
+{
+    SharedLockGuard lock(shared->mutex);
+    return shared->local_write_throttler;
+}
+
 ThrottlerPtr Context::getRemoteReadThrottler() const
 {
-    ThrottlerPtr throttler;
-    {
-        SharedLockGuard lock(shared->mutex);
-        throttler = shared->remote_read_throttler;
-    }
+    ThrottlerPtr throttler = getServerWideRemoteReadThrottler();
 
     /// User-level throttler (`max_network_bandwidth_for_user` / `max_network_bandwidth_for_all_users`).
     if (auto process_list_element = getProcessListElementSafe())
@@ -5844,11 +5864,7 @@ ThrottlerPtr Context::getRemoteReadThrottler() const
 
 ThrottlerPtr Context::getRemoteWriteThrottler() const
 {
-    ThrottlerPtr throttler;
-    {
-        SharedLockGuard lock(shared->mutex);
-        throttler = shared->remote_write_throttler;
-    }
+    ThrottlerPtr throttler = getServerWideRemoteWriteThrottler();
 
     /// User-level throttler (`max_network_bandwidth_for_user` / `max_network_bandwidth_for_all_users`).
     if (auto process_list_element = getProcessListElementSafe())
@@ -5866,11 +5882,7 @@ ThrottlerPtr Context::getRemoteWriteThrottler() const
 
 ThrottlerPtr Context::getLocalReadThrottler() const
 {
-    ThrottlerPtr throttler;
-    {
-        SharedLockGuard lock(shared->mutex);
-        throttler = shared->local_read_throttler;
-    }
+    ThrottlerPtr throttler = getServerWideLocalReadThrottler();
 
     if (auto bandwidth = getSettingsRef()[Setting::max_local_read_bandwidth])
     {
@@ -5884,11 +5896,7 @@ ThrottlerPtr Context::getLocalReadThrottler() const
 
 ThrottlerPtr Context::getLocalWriteThrottler() const
 {
-    ThrottlerPtr throttler;
-    {
-        SharedLockGuard lock(shared->mutex);
-        throttler = shared->local_write_throttler;
-    }
+    ThrottlerPtr throttler = getServerWideLocalWriteThrottler();
 
     if (auto bandwidth = getSettingsRef()[Setting::max_local_write_bandwidth])
     {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -2168,6 +2168,13 @@ public:
     ThrottlerPtr getLocalReadThrottler() const;
     ThrottlerPtr getLocalWriteThrottler() const;
 
+    /// The server-wide throttlers, without the per-user and per-query limits that the getters above
+    /// compose on top of them. Use these to report a server-wide limit, not to throttle a request.
+    ThrottlerPtr getServerWideRemoteReadThrottler() const;
+    ThrottlerPtr getServerWideRemoteWriteThrottler() const;
+    ThrottlerPtr getServerWideLocalReadThrottler() const;
+    ThrottlerPtr getServerWideLocalWriteThrottler() const;
+
     ThrottlerPtr getBackupsThrottler() const;
 
     ThrottlerPtr getMutationsThrottler() const;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -2168,8 +2168,9 @@ public:
     ThrottlerPtr getLocalReadThrottler() const;
     ThrottlerPtr getLocalWriteThrottler() const;
 
-    /// The server-wide throttlers, without the per-user and per-query limits that the getters above
-    /// compose on top of them. Use these to report a server-wide limit, not to throttle a request.
+    /// The server-wide throttlers, without the per-query limit (and, for the remote pair, the per-user
+    /// limit) that the getters above compose on top of them. Use these to report a server-wide limit, not
+    /// to throttle a request.
     ThrottlerPtr getServerWideRemoteReadThrottler() const;
     ThrottlerPtr getServerWideRemoteWriteThrottler() const;
     ThrottlerPtr getServerWideLocalReadThrottler() const;

--- a/tests/integration/test_throttling/test.py
+++ b/tests/integration/test_throttling/test.py
@@ -422,6 +422,22 @@ def test_remote_read_throttling_reload():
     _, took = elapsed(node, "select * from data")
     assert_took(took, 3)
 
+    # The configured server-wide limit is reported, not the reading session's own limit.
+    assert (
+        node.query(
+            "SELECT value FROM system.server_settings"
+            " WHERE name = 'max_remote_read_network_bandwidth_for_server'"
+            " SETTINGS max_remote_read_network_bandwidth = 1000001"
+        ).strip()
+        == "2000000"
+    )
+    assert (
+        node.query(
+            "SELECT getServerSetting('max_remote_read_network_bandwidth_for_server')"
+        ).strip()
+        == "2000000"
+    )
+
     # update bandwidth back to 0
     node_update_config(
         "server", "max_remote_read_network_bandwidth_for_server", "0", False
@@ -453,6 +469,22 @@ def test_local_read_throttling_reload():
     # reading 1e6*8 bytes with 2M default bandwidth should take (8-2)/2=3 seconds
     _, took = elapsed(node, "select * from data")
     assert_took(took, 3)
+
+    # The configured server-wide limit is reported, not the reading session's own limit.
+    assert (
+        node.query(
+            "SELECT value FROM system.server_settings"
+            " WHERE name = 'max_local_read_bandwidth_for_server'"
+            " SETTINGS max_local_read_bandwidth = 1000001"
+        ).strip()
+        == "2000000"
+    )
+    assert (
+        node.query(
+            "SELECT getServerSetting('max_local_read_bandwidth_for_server')"
+        ).strip()
+        == "2000000"
+    )
 
     # update bandwidth back to 0
     node_update_config(
@@ -548,6 +580,22 @@ def test_remote_write_throttling_reload():
     _, took = elapsed(node, "insert into data select * from numbers(1e6)")
     assert_took(took, 3)
 
+    # The configured server-wide limit is reported, not the reading session's own limit.
+    assert (
+        node.query(
+            "SELECT value FROM system.server_settings"
+            " WHERE name = 'max_remote_write_network_bandwidth_for_server'"
+            " SETTINGS max_remote_write_network_bandwidth = 1000001"
+        ).strip()
+        == "2000000"
+    )
+    assert (
+        node.query(
+            "SELECT getServerSetting('max_remote_write_network_bandwidth_for_server')"
+        ).strip()
+        == "2000000"
+    )
+
     # update bandwidth back to 0
     node_update_config(
         "server", "max_remote_write_network_bandwidth_for_server", "0", False
@@ -579,6 +627,22 @@ def test_local_write_throttling_reload():
     # writing 1e6*8 bytes with 2M default bandwidth should take (8-2)/2=3 seconds
     _, took = elapsed(node, "insert into data select * from numbers(1e6)")
     assert_took(took, 3)
+
+    # The configured server-wide limit is reported, not the reading session's own limit.
+    assert (
+        node.query(
+            "SELECT value FROM system.server_settings"
+            " WHERE name = 'max_local_write_bandwidth_for_server'"
+            " SETTINGS max_local_write_bandwidth = 1000001"
+        ).strip()
+        == "2000000"
+    )
+    assert (
+        node.query(
+            "SELECT getServerSetting('max_local_write_bandwidth_for_server')"
+        ).strip()
+        == "2000000"
+    )
 
     # update bandwidth back to 0
     node_update_config(

--- a/tests/queries/0_stateless/05182_system_server_settings_bandwidth_is_server_wide.reference
+++ b/tests/queries/0_stateless/05182_system_server_settings_bandwidth_is_server_wide.reference
@@ -1,0 +1,3 @@
+per_query_limits_excluded 1
+per_user_limit_excluded 1
+readers_agree 1

--- a/tests/queries/0_stateless/05182_system_server_settings_bandwidth_is_server_wide.sh
+++ b/tests/queries/0_stateless/05182_system_server_settings_bandwidth_is_server_wide.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A `*_bandwidth_for_server` limit is server-wide, so the value reported for it must not depend on the
+# session or the user that reads it.
+rows="SELECT name, value FROM system.server_settings WHERE endsWith(name, 'bandwidth_for_server') ORDER BY name"
+
+# The per-query limits are zeroed for the reference reading and for the dedicated user below: a non-zero
+# per-query limit takes precedence over the per-user one, so leaving the profile's value in place would
+# hide the per-user comparison.
+no_limits="max_local_read_bandwidth = 0, max_local_write_bandwidth = 0,
+    max_remote_read_network_bandwidth = 0, max_remote_write_network_bandwidth = 0"
+
+server_wide=$($CLICKHOUSE_CLIENT -q "$rows SETTINGS $no_limits")
+
+with_query_limits=$($CLICKHOUSE_CLIENT -q "$rows SETTINGS
+    max_local_read_bandwidth = 1000001, max_local_write_bandwidth = 1000002,
+    max_remote_read_network_bandwidth = 1000003, max_remote_write_network_bandwidth = 1000004,
+    max_backup_bandwidth = 1000005")
+
+if [ "$server_wide" = "$with_query_limits" ]; then
+    echo "per_query_limits_excluded 1"
+else
+    echo "per_query_limits_excluded 0"
+    diff <(echo "$server_wide") <(echo "$with_query_limits")
+fi
+
+user="user_${CLICKHOUSE_DATABASE}"
+trap '$CLICKHOUSE_CLIENT -q "DROP USER IF EXISTS $user"' EXIT
+
+$CLICKHOUSE_CLIENT -q "
+DROP USER IF EXISTS $user;
+CREATE USER $user IDENTIFIED WITH plaintext_password BY 'password' SETTINGS max_network_bandwidth_for_user = 1234567;
+GRANT SELECT ON system.server_settings TO $user;"
+
+as_user=$($CLICKHOUSE_CLIENT --user "$user" --password "password" -q "$rows SETTINGS $no_limits")
+
+if [ "$server_wide" = "$as_user" ]; then
+    echo "per_user_limit_excluded 1"
+else
+    echo "per_user_limit_excluded 0"
+    diff <(echo "$server_wide") <(echo "$as_user")
+fi
+
+# `getServerSetting` documents that it returns what this table returns.
+agree=$($CLICKHOUSE_CLIENT -q "SELECT getServerSetting('max_local_read_bandwidth_for_server')
+    = toUInt64((SELECT value FROM system.server_settings WHERE name = 'max_local_read_bandwidth_for_server'))
+    SETTINGS max_local_read_bandwidth = 1000006")
+echo "readers_agree $agree"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `max_local_read_bandwidth_for_server`, `max_local_write_bandwidth_for_server`, `max_remote_read_network_bandwidth_for_server` and `max_remote_write_network_bandwidth_for_server` rows of `system.server_settings` reporting the reading session's own bandwidth limit instead of the server-wide one. `getServerSetting()` on those names is fixed the same way.


### Description

`StorageSystemServerSettings::fillData` collects live values with the query context, so these four
rows are read through `Context::get{Remote,Local}{Read,Write}Throttler()`. Those getters compose
request-scoped limits on top of the server-wide throttler: the per-query limit
(`max_local_read_bandwidth` and friends) in all four, and the per-user limit
(`max_network_bandwidth_for_user` / `..._for_all_users`) in the remote pair. That is correct for
throttling, but wrong as the source for a row named `_for_server`.

Reproduction on master, no server configuration needed:

```sql
SELECT name, value, default, changed FROM system.server_settings
WHERE name = 'max_local_read_bandwidth_for_server'
SETTINGS max_local_read_bandwidth = 12345678;

-- got:      12345678  0  0
-- expected:        0  0  0
```

`default` and `changed` stay `0`, so nothing on the row signals that the value is not server-wide;
two concurrent sessions see different values for it; and `getServerSetting()`, documented to mirror
this table, disagrees inside a single statement. No session action is required to hit it: a per-user
network quota in users.xml is enough for the remote rows, and a profile-level per-query limit reaches
all four, which is why ClickHouse's own stateless test config (`tests/config/users.d/limits.yaml`)
makes every one of them report `1T` instead of `0` on each CI run.

Fix: four `Context::getServerWide*Throttler()` accessors return the bare server-wide throttler, and
the four map entries use them. The composing getters keep composing and still feed
`getReadSettings()`/`getWriteSettings()`, so throttling behaviour is unchanged. Both readers share
the map, so the table and `getServerSetting()` are fixed together.

No `SettingsChangesHistory.cpp` entry is needed: no setting is added and no default changes, only a
wrong reported value is corrected.

Also noticed while auditing the map: the `parquet_metadata_cache_size` entry's null guard is dead,
because `context->getParquetMetadataCache()` throws instead of returning null (`tryGetParquetMetadataCache()`
is the non-throwing API); the cache is always set at startup, so there is no user-reachable
consequence and I left it alone.

The two `max_distributed_cache_{read,write}_bandwidth_for_server` rows are routed through matching
`getServerWideDistributedCache{Read,Write}Throttler()` accessors for the same reason. Their getters
here already return the bare server-wide throttler, so the reported values are unchanged in this
repository; routing them through the server-wide accessors keeps every `*_bandwidth_for_server` row
reporting the server-wide limit even where a getter composes a request-scoped throttler on top.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119556&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119556](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119556+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

