### PR TITLE
Fix an `ALIAS` column read as a default through `Merge` over `Distributed`

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -70,6 +70,7 @@
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/narrowPipe.h>
 #include <Storages/AlterCommands.h>
+#include <Storages/buildQueryTreeForShard.h>
 #include <Storages/ColumnDefault.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/ReadInOrderOptimizer.h>
@@ -1390,7 +1391,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
             {
                 /// Source tables could have different but convertible types, like numeric types of different width.
                 /// We must return streams with structure equals to structure of Merge table.
-                convertAndFilterSourceStream(*common_header, modified_query_info, nested_storage_snapshot, aliases, row_policy_data_opt, context, child, is_smallest_column_requested);
+                convertAndFilterSourceStream(*common_header, query_info, modified_query_info, nested_storage_snapshot, aliases, row_policy_data_opt, context, child, is_smallest_column_requested);
 
                 for (const auto & filter_info : pushed_down_filters)
                 {
@@ -2164,6 +2165,7 @@ void StorageMerge::alter(
 
 void ReadFromMerge::convertAndFilterSourceStream(
     const Block & header,
+    const SelectQueryInfo & outer_query_info,
     SelectQueryInfo & modified_query_info,
     const StorageSnapshotPtr & snapshot,
     const Aliases & aliases,
@@ -2228,6 +2230,29 @@ void ReadFromMerge::convertAndFilterSourceStream(
       * execution names in the output header may be different.
       * The same happens with StorageDistributed, even in the case of FetchColumns.
       */
+
+    /** A child that computes the whole query can return fewer columns than expected: its `ActionsDAG`
+      * deduplicates projection items that expand to the same expression, and `Distributed` inlines the
+      * `ALIAS` columns of the child table before sending the query, so `b UInt64 ALIAS a` selected next
+      * to `a` becomes one column. The names of the collapsed columns are gone from the child's header,
+      * and the reconciliation below matches by name or by position, neither of which can rebuild them -
+      * `addMissingDefaults` would then fill them with the default value of the type.
+      * Fan the collapsed columns back out first, the same way a direct read of such a child does
+      * (see `buildShardCollapseFanOut`, used by the planner for a `Distributed` table read).
+      */
+    if (child.plan.getCurrentHeader()->columns() < header.columns())
+    {
+        /// The translation between an `ALIAS` column's own name and its inlined expression is read from
+        /// the outer query tree and its planner context: those are what the expected `header` is named
+        /// after, and the child's derived planner context holds no column identifiers of its own.
+        if (auto fan_out_actions_dag = buildShardCollapseFanOut(
+                outer_query_info.query_tree, outer_query_info.planner_context, *child.plan.getCurrentHeader(), header))
+        {
+            auto fan_out_step = std::make_unique<ExpressionStep>(child.plan.getCurrentHeader(), std::move(*fan_out_actions_dag));
+            fan_out_step->setStepDescription("Reconstruct deduplicated duplicate-ALIAS columns");
+            child.plan.addStep(std::move(fan_out_step));
+        }
+    }
 
     /** Convert types of columns according to the resulting Merge table.
       * And convert column names to the expected ones.

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -327,6 +327,7 @@ private:
 
     static void convertAndFilterSourceStream(
         const Block & header,
+        const SelectQueryInfo & outer_query_info,
         SelectQueryInfo & modified_query_info,
         const StorageSnapshotPtr & snapshot,
         const Aliases & aliases,

--- a/tests/queries/0_stateless/05209_merge_over_distributed_alias_column.reference
+++ b/tests/queries/0_stateless/05209_merge_over_distributed_alias_column.reference
@@ -1,0 +1,23 @@
+distributed	1	1	1	1
+distributed	1	1	1	1
+merge	1	1	1	1
+merge	1	1	1	1
+table function	1	1
+table function	1	1
+filter on the alias	1	1
+filter on the alias	1	1
+sums	20	20	20	8
+the alias alone	1
+the alias alone	1
+group by the alias	1	2
+group by the alias	2	2
+group by the alias	3	2
+group by the alias	4	2
+order by the alias	4	4
+order by the alias	4	4
+the function alias alone	1	1
+the function alias alone	1	1
+merge over the local table	1	1	1	1
+merge over the local table	2	2	2	1
+old analyzer	1	1	1	1
+old analyzer	1	1	1	1

--- a/tests/queries/0_stateless/05209_merge_over_distributed_alias_column.sql
+++ b/tests/queries/0_stateless/05209_merge_over_distributed_alias_column.sql
@@ -1,0 +1,29 @@
+-- An `ALIAS` column whose expression is a bare reference to another column read back as the default
+-- value of its type through a `Merge` table over a `Distributed` table with a remote shard. The whole
+-- query is delegated to the shards there, and `Distributed` inlines the `ALIAS` column into its
+-- expression before sending it, so `b UInt64 ALIAS a` selected next to `a` came back as one column,
+-- and `Merge` filled the column it was still expecting with the default value instead.
+
+DROP TABLE IF EXISTS t_05209;
+DROP TABLE IF EXISTS t_05209_dist;
+DROP TABLE IF EXISTS t_05209_merge;
+
+CREATE TABLE t_05209 (a UInt64, b UInt64 ALIAS a, c UInt64 ALIAS b, d UInt8 ALIAS a > 0) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_05209 SELECT number + 1 FROM numbers(4);
+
+CREATE TABLE t_05209_dist AS t_05209 ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), t_05209);
+CREATE TABLE t_05209_merge AS t_05209 ENGINE = Merge(currentDatabase(), '^t_05209_dist$');
+
+SET enable_analyzer = 1;
+
+SELECT 'distributed', a, b, c, d FROM t_05209_dist ORDER BY a LIMIT 2;
+SELECT 'merge', a, b, c, d FROM t_05209_merge ORDER BY a LIMIT 2;
+SELECT 'table function', a, b FROM merge(currentDatabase(), '^t_05209_dist$') ORDER BY a LIMIT 2;
+SELECT 'filter on the alias', a, b FROM t_05209_merge WHERE b = 1 ORDER BY a LIMIT 2;
+SELECT 'sums', sum(a), sum(b), sum(c), sum(d) FROM t_05209_merge;
+SELECT 'the alias alone', b FROM t_05209_merge ORDER BY b LIMIT 2;
+SELECT 'group by the alias', b, count() FROM t_05209_merge GROUP BY b ORDER BY b;
+SELECT 'order by the alias', a, b FROM t_05209_merge ORDER BY b DESC, a LIMIT 2;
+SELECT 'the function alias alone', a, d FROM t_05209_merge ORDER BY a LIMIT 2;
+SELECT 'merge over the local table', a, b, c, d FROM merge(currentDatabase(), '^t_05209$') ORDER BY a LIMIT 2;
+SELECT 'old analyzer', a, b, c, d FROM t_05209_merge ORDER BY a LIMIT 2 SETTINGS enable_analyzer = 0;

--- a/tests/queries/0_stateless/05209_merge_over_distributed_alias_column.sql
+++ b/tests/queries/0_stateless/05209_merge_over_distributed_alias_column.sql
@@ -26,4 +26,7 @@ SELECT 'group by the alias', b, count() FROM t_05209_merge GROUP BY b ORDER BY b
 SELECT 'order by the alias', a, b FROM t_05209_merge ORDER BY b DESC, a LIMIT 2;
 SELECT 'the function alias alone', a, d FROM t_05209_merge ORDER BY a LIMIT 2;
 SELECT 'merge over the local table', a, b, c, d FROM merge(currentDatabase(), '^t_05209$') ORDER BY a LIMIT 2;
-SELECT 'old analyzer', a, b, c, d FROM t_05209_merge ORDER BY a LIMIT 2 SETTINGS enable_analyzer = 0;
+-- `optimize_respect_aliases = 0` is pinned because the old analyzer then refuses this shape outright
+-- with `Missing columns: 'b' 'c' 'd'`, on master as well as here: it asks the `Merge` table for the
+-- source column alone and still references the alias columns.
+SELECT 'old analyzer', a, b, c, d FROM t_05209_merge ORDER BY a LIMIT 2 SETTINGS enable_analyzer = 0, optimize_respect_aliases = 1;


### PR DESCRIPTION
An `ALIAS` column whose expression is a bare reference to another column read back as the default value of its type through a `Merge` table over a `Distributed` table with a remote shard:

```sql
CREATE TABLE t (a UInt64, b UInt64 ALIAS a, c UInt64 ALIAS b, d UInt8 ALIAS a > 0) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t SELECT number + 1 FROM numbers(4);
CREATE TABLE t_dist AS t ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), t);
CREATE TABLE t_merge AS t ENGINE = Merge(currentDatabase(), '^t_dist$');

SELECT a, b, c, d FROM t_dist ORDER BY a LIMIT 1;   -- 1 1 1 1
SELECT a, b, c, d FROM t_merge ORDER BY a LIMIT 1;  -- 1 0 0 0  <-- b, c and d are defaults
```

The whole query is delegated to the shards there, and `Distributed` inlines the `ALIAS` columns of the child table into their expressions before sending it, so `b UInt64 ALIAS a` selected next to `a` becomes the same expression as `a` and the child's `ActionsDAG` deduplicates the two into one column. The name of the collapsed column is gone from the child's header, and neither the name nor the position matching in `convertAndFilterSourceStream` can rebuild it, so `addMissingDefaults` filled the column `Merge` was still expecting with the default value of its type. An `ALIAS` column with a function in it (`d UInt8 ALIAS a > 0`) survived, because its expression has an action name of its own and nothing to collapse onto — until a bare alias was selected next to it and the whole reconciliation fell back to defaults.

The fix fans the collapsed columns back out before the reconciliation, with `buildShardCollapseFanOut` — the same helper the planner already uses for a direct read of a `Distributed` table, which is why reading `t_dist` itself was correct all along.

One divergence in this area is older than this change and not addressed by it: when a child table defines the alias differently from the `Merge` table (`b ALIAS a * 100` in the child, `b ALIAS a` in the `Merge` table), a delegated stage evaluates the `Merge` table's definition, while reading the same tables through `Merge` at the `FetchColumns` stage evaluates each child's own. Before this change that shape returned the default value as well.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119374

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix an `ALIAS` column that references another column (`b UInt64 ALIAS a`) reading back as the default value of its type when the table is read through a `Merge` table over a `Distributed` table with a remote shard.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119561&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119561](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119561+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1276` (included in `26.9` and later)
<!-- ch-version-info:end -->