### PR TITLE
Fix equals behavior with FixedStrings in containers

### DIFF
--- a/src/DataTypes/FixedStringZeroPadding.cpp
+++ b/src/DataTypes/FixedStringZeroPadding.cpp
@@ -2,6 +2,7 @@
 
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnTuple.h>
@@ -39,14 +40,16 @@ bool zeroPaddedStringComparison(const DataTypePtr & left, const DataTypePtr & ri
         return false;
     }
 
-    /// Deliberately not recursed into. `equals` compares an `Array` or a `Map` through a cast to
-    /// their common type, which drops the padding of only the operand it converts, so it does not
-    /// apply the rule to their elements: `[toFixedString('V0', 3)] = ['V0\0']` is 0 while
-    /// `toFixedString('V0', 3) = 'V0\0'` is 1. Recursing here would make these functions disagree
-    /// with `equals` in the opposite direction. `Tuple` above is different: `equals` decomposes it
-    /// element-wise with the element types intact, so the rule does reach a `FixedString` inside it.
-    if (typeid_cast<const DataTypeArray *>(left_decayed.get()) || typeid_cast<const DataTypeMap *>(left_decayed.get()))
-        return false;
+    const auto * left_array = typeid_cast<const DataTypeArray *>(left_decayed.get());
+    const auto * right_array = typeid_cast<const DataTypeArray *>(right_decayed.get());
+    if (left_array && right_array)
+        return zeroPaddedStringComparison(left_array->getNestedType(), right_array->getNestedType());
+
+    const auto * left_map = typeid_cast<const DataTypeMap *>(left_decayed.get());
+    const auto * right_map = typeid_cast<const DataTypeMap *>(right_decayed.get());
+    if (left_map && right_map)
+        return zeroPaddedStringComparison(left_map->getKeyType(), right_map->getKeyType())
+            || zeroPaddedStringComparison(left_map->getValueType(), right_map->getValueType());
 
     return isStringOrFixedString(left_decayed) && isStringOrFixedString(right_decayed)
         && (isFixedString(left_decayed) || isFixedString(right_decayed));
@@ -100,6 +103,15 @@ ColumnPtr stripTrailingZerosInStrings(const ColumnPtr & column, const DataTypePt
         return ColumnConst::create(
             stripTrailingZerosInStrings(column_const->getDataColumnPtr(), type), column_const->size());
 
+    if (const auto * type_low_cardinality = typeid_cast<const DataTypeLowCardinality *>(type.get()))
+    {
+        /// Values differing only in trailing zeros collapse onto one, which a dictionary must not
+        /// hold twice, so the canonical form of a `LowCardinality` column is a full one. Both
+        /// operands of a comparison are canonicalised together, so they stay the same shape.
+        return stripTrailingZerosInStrings(
+            column->convertToFullColumnIfLowCardinality(), type_low_cardinality->getDictionaryType());
+    }
+
     if (const auto * type_nullable = typeid_cast<const DataTypeNullable *>(type.get()))
     {
         const auto & column_nullable = assert_cast<const ColumnNullable &>(*column);
@@ -116,6 +128,21 @@ ColumnPtr stripTrailingZerosInStrings(const ColumnPtr & column, const DataTypePt
         for (size_t i = 0; i < element_types.size(); ++i)
             elements[i] = stripTrailingZerosInStrings(column_tuple.getColumnPtr(i), element_types[i]);
         return ColumnTuple::create(std::move(elements));
+    }
+
+    if (const auto * type_array = typeid_cast<const DataTypeArray *>(type.get()))
+    {
+        const auto & column_array = assert_cast<const ColumnArray &>(*column);
+        return ColumnArray::create(
+            stripTrailingZerosInStrings(column_array.getDataPtr(), type_array->getNestedType()),
+            column_array.getOffsetsPtr());
+    }
+
+    if (const auto * type_map = typeid_cast<const DataTypeMap *>(type.get()))
+    {
+        const auto & column_map = assert_cast<const ColumnMap &>(*column);
+        return ColumnMap::create(
+            stripTrailingZerosInStrings(column_map.getNestedColumnPtr(), type_map->getNestedType()));
     }
 
     if (isString(type))

--- a/src/DataTypes/FixedStringZeroPadding.cpp
+++ b/src/DataTypes/FixedStringZeroPadding.cpp
@@ -163,15 +163,4 @@ ColumnPtr stripTrailingZerosInStrings(const ColumnPtr & column, const DataTypePt
     return column;
 }
 
-ColumnPtr stripTrailingZerosInArrayElements(const ColumnPtr & column, const DataTypePtr & element_type)
-{
-    if (const auto * column_const = typeid_cast<const ColumnConst *>(column.get()))
-        return ColumnConst::create(
-            stripTrailingZerosInArrayElements(column_const->getDataColumnPtr(), element_type), column_const->size());
-
-    const auto & column_array = assert_cast<const ColumnArray &>(*column);
-    return ColumnArray::create(
-        stripTrailingZerosInStrings(column_array.getDataPtr(), element_type), column_array.getOffsetsPtr());
-}
-
 }

--- a/src/DataTypes/FixedStringZeroPadding.h
+++ b/src/DataTypes/FixedStringZeroPadding.h
@@ -20,14 +20,15 @@ namespace DB
   * `CAST(FixedString AS String)` removes the padding from only the operand it converts. The declared
   * types are the only place the rule is visible, which is what these functions expose.
   *
-  * Callers: the `arrayIndex.h` functions (`has`, `indexOf`, `countEqual`, `indexOfAssumeSorted`),
-  * and `MergeTreeIndexBloomFilter`, which must agree with them or it prunes granules holding rows
-  * the function would match.
+  * Callers: `FunctionComparison`, which compares an `Array`, a `Map` or a `Tuple` through a cast to
+  * the common type of its operands; the `arrayIndex.h` functions (`has`, `indexOf`, `countEqual`,
+  * `indexOfAssumeSorted`); and `MergeTreeIndexBloomFilter`, which must agree with them or it prunes
+  * granules holding rows the function would match.
   */
 
 /// Whether comparing values of these two types ignores trailing zero bytes. Recurses into `Tuple`,
-/// which `equals` decomposes element-wise, but not into `Array` or `Map`, which `equals` compares
-/// through a lossy cast and so does not apply the rule to.
+/// `Array` and `Map`, so a `FixedString` nested at any depth is compared the same way as a
+/// top-level one.
 bool zeroPaddedStringComparison(const DataTypePtr & left, const DataTypePtr & right);
 
 /// Whether a search constant of this type is subject to the rule, and so has no single canonical
@@ -55,7 +56,7 @@ inline std::string_view stripTrailingZeros(std::string_view value)
 }
 
 /// Rewrites every `String` value reachable in `column` into its canonical form, recursing through
-/// `Const`, `Nullable` and `Tuple` — matching `zeroPaddedStringComparison`.
+/// `Const`, `Nullable`, `Tuple`, `Array` and `Map` — matching `zeroPaddedStringComparison`.
 /// Apply to both operands after a cast to their common type, which strips all trailing '\0' from
 /// FixedString but leaves String untouched.
 ColumnPtr stripTrailingZerosInStrings(const ColumnPtr & column, const DataTypePtr & type);

--- a/src/DataTypes/FixedStringZeroPadding.h
+++ b/src/DataTypes/FixedStringZeroPadding.h
@@ -22,8 +22,9 @@ namespace DB
   *
   * Callers: `FunctionComparison`, which compares an `Array`, a `Map` or a `Tuple` through a cast to
   * the common type of its operands; the `arrayIndex.h` functions (`has`, `indexOf`, `countEqual`,
-  * `indexOfAssumeSorted`); and `MergeTreeIndexBloomFilter`, which must agree with them or it prunes
-  * granules holding rows the function would match.
+  * `indexOfAssumeSorted`) and `hasAllAny.h`; and `KeyCondition` and the `bloom_filter`, `ngrambf_v1`
+  * and `text` index conditions, which must agree with them or they prune granules holding rows the
+  * function would match.
   */
 
 /// Whether comparing values of these two types ignores trailing zero bytes. Recurses into `Tuple`,
@@ -60,9 +61,5 @@ inline std::string_view stripTrailingZeros(std::string_view value)
 /// Apply to both operands after a cast to their common type, which strips all trailing '\0' from
 /// FixedString but leaves String untouched.
 ColumnPtr stripTrailingZerosInStrings(const ColumnPtr & column, const DataTypePtr & type);
-
-/// As above, for the elements of an array column: `hasAny`/`hasAll` compare elements of their two
-/// array arguments, so the rule applies one level inside each.
-ColumnPtr stripTrailingZerosInArrayElements(const ColumnPtr & column, const DataTypePtr & element_type);
 
 }

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -28,6 +28,7 @@
 #include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/FixedStringZeroPadding.h>
 #include <DataTypes/NumberTraits.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <Functions/ComparisonOrderDomain.h>
@@ -1455,6 +1456,17 @@ private:
         DataTypePtr common_type = getLeastSupertype(DataTypes{c0.type, c1.type});
         ColumnPtr c0_converted = castColumn(c0, common_type);
         ColumnPtr c1_converted = castColumn(c1, common_type);
+
+        /// The common type of a `FixedString` and a `String` is `String`, and the cast to it removes
+        /// the padding from the `FixedString` operand while leaving the `String` operand as it is.
+        /// That is a canonicalisation of one operand only, so without the step below an `Array`, a
+        /// `Map` or a `Tuple` holding a `FixedString` would compare unequal to one holding the same
+        /// value written out with its trailing zeros. See `zeroPaddedStringComparison`.
+        if (zeroPaddedStringComparison(c0.type, c1.type))
+        {
+            c0_converted = stripTrailingZerosInStrings(c0_converted, common_type);
+            c1_converted = stripTrailingZerosInStrings(c1_converted, common_type);
+        }
 
         return executeGenericIdenticalTypes(c0_converted.get(), c1_converted.get());
     }

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -84,8 +84,25 @@ struct CountEqualAction
 namespace Impl
 {
 
-/// Field-level equality honouring the zero-padding rule. Recurses into `Tuple` so a `FixedString`
-/// inside one is compared the same way as a top-level one, matching `equals`.
+/// Field-level equality honouring the zero-padding rule. Recurses into `Tuple`, `Array` and `Map`
+/// so a `FixedString` nested at any depth is compared the same way as a top-level one, matching
+/// `equals`.
+inline bool fieldsEqual(const Field & left, const Field & right, bool zero_padded);
+
+/// Element-wise equality of the two vectors backing a `Tuple`, an `Array` or a `Map` Field.
+template <typename T>
+bool fieldVectorsEqual(const T & left, const T & right)
+{
+    if (left.size() != right.size())
+        return false;
+
+    for (size_t i = 0; i < left.size(); ++i)
+        if (!fieldsEqual(left[i], right[i], true))
+            return false;
+
+    return true;
+}
+
 inline bool fieldsEqual(const Field & left, const Field & right, bool zero_padded)
 {
     if (!zero_padded)
@@ -95,22 +112,15 @@ inline bool fieldsEqual(const Field & left, const Field & right, bool zero_padde
         return stripTrailingZeros(left.safeGet<String>()) == stripTrailingZeros(right.safeGet<String>());
 
     if (left.getType() == Field::Types::Tuple && right.getType() == Field::Types::Tuple)
-    {
-        const auto & left_tuple = left.safeGet<Tuple>();
-        const auto & right_tuple = right.safeGet<Tuple>();
-        if (left_tuple.size() != right_tuple.size())
-            return false;
+        return fieldVectorsEqual(left.safeGet<Tuple>(), right.safeGet<Tuple>());
 
-        for (size_t i = 0; i < left_tuple.size(); ++i)
-            if (!fieldsEqual(left_tuple[i], right_tuple[i], true))
-                return false;
+    if (left.getType() == Field::Types::Array && right.getType() == Field::Types::Array)
+        return fieldVectorsEqual(left.safeGet<Array>(), right.safeGet<Array>());
 
-        return true;
-    }
+    /// A `Map` Field is a vector of two-element `Tuple`s, each handled by the branch above.
+    if (left.getType() == Field::Types::Map && right.getType() == Field::Types::Map)
+        return fieldVectorsEqual(left.safeGet<Map>(), right.safeGet<Map>());
 
-    /// No `Array` or `Map` case: `zeroPaddedStringComparison` does not apply the rule to their
-    /// elements, because `equals` does not either. `accurateEquals` below compares them exactly,
-    /// which is what `equals` does for those types.
     return accurateEquals(left, right);
 }
 

--- a/src/Functions/array/hasAllAny.h
+++ b/src/Functions/array/hasAllAny.h
@@ -72,19 +72,14 @@ public:
         for (size_t i = 0; i < num_args; ++i)
             preprocessed_columns[i] = castColumn(arguments[i], common_type);
 
-        /// These functions compare the elements of their array arguments, so the zero-padding rule is
-        /// decided by the element types. The cast above dropped the `FixedString` padding of the
-        /// operands it converted and left a `String` operand as it was, so canonicalise every one to
-        /// make the search agree with `equals`, and with `has`. See `zeroPaddedStringComparison`.
-        const auto * first_array_type = typeid_cast<const DataTypeArray *>(arguments[0].type.get());
-        const auto * second_array_type = typeid_cast<const DataTypeArray *>(arguments[1].type.get());
-        if (first_array_type && second_array_type
-            && zeroPaddedStringComparison(first_array_type->getNestedType(), second_array_type->getNestedType()))
-        {
-            const auto & element_type = assert_cast<const DataTypeArray &>(*common_type).getNestedType();
+        /// These functions compare the elements of their array arguments, and
+        /// `zeroPaddedStringComparison` recurses into `Array`, so the argument types decide the rule.
+        /// The cast above dropped the `FixedString` padding of the operands it converted and left a
+        /// `String` operand as it was, so canonicalise every one to make the search agree with
+        /// `equals`, and with `has`.
+        if (zeroPaddedStringComparison(arguments[0].type, arguments[1].type))
             for (auto & preprocessed_column : preprocessed_columns)
-                preprocessed_column = stripTrailingZerosInArrayElements(preprocessed_column, element_type);
-        }
+                preprocessed_column = stripTrailingZerosInStrings(preprocessed_column, common_type);
 
         VectorWithMemoryTracking<std::unique_ptr<GatherUtils::IArraySource>> sources;
 

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -10,6 +10,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/FieldToDataType.h>
+#include <DataTypes/FixedStringZeroPadding.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <DataTypes/Utils.h>
 #include <Interpreters/Context.h>
@@ -4427,6 +4428,17 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
 
             if (!cast_not_needed && !key_expr_type_not_null->equals(*const_type))
             {
+                /// A `FixedString` nested in an `Array`, a `Map` or a `Tuple` is compared ignoring
+                /// its trailing zero bytes, so the constant stands for a family of key values rather
+                /// than for one. Unlike a top-level `String`, that family is not a contiguous run of
+                /// the sort order — `['V0', 'a']` lies between `['V0']` and `['V0\0']` and is not a
+                /// member — so no range built from the converted constant covers it, and pruning
+                /// would drop granules holding matching rows. Decline index analysis. A top-level
+                /// `String` or `FixedString` key is handled below and is left untouched.
+                if (!isStringOrFixedString(key_expr_type_not_null)
+                    && zeroPaddedStringComparison(key_expr_type_not_null, const_type))
+                    return false;
+
                 if (const_value.getType() == Field::Types::String)
                 {
                     /// These functions use the constant as a string pattern or prefix.

--- a/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.reference
+++ b/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.reference
@@ -53,3 +53,5 @@ primary key must not prune matching rows
 index path	2
 full scan path	2
 exact string constant still prunes	1
+fixed width rows	1
+fixed width rows unindexed	1

--- a/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.reference
+++ b/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.reference
@@ -1,0 +1,55 @@
+scalar and tuple reference
+fs3 = str_padded	1
+tuple	1
+str = str_padded	0
+containers
+array	1
+array str_short	1
+array of tuple	1
+nested array	1
+map key	1
+map value	1
+array of map	1
+widths
+fs3 vs fs4	1
+fs4 vs str_padded	1
+str element, fs needle	1
+operators
+eq	1
+ne	0
+lt	0
+le	1
+gt	0
+ge	1
+materialized
+array	1
+array both	1
+map	1
+nested array	1
+low cardinality and nullable
+lc element	1
+lc materialized	1
+nullable element	1
+null stays null	0
+negative controls
+str vs str_padded	0
+str prefix	0
+interior zero preserved	1
+interior zero not collapsed	0
+different content	0
+different length arrays	0
+element order	0
+long values
+long match	1
+long no match	0
+agreement with has and arrayExists
+nested has	1	1	1
+nested indexOf	1	1
+map element has	1	1
+short needle nested array	1	1	1
+short needle map	1	1	1
+short needle array of tuple	1	1
+primary key must not prune matching rows
+index path	2
+full scan path	2
+exact string constant still prunes	1

--- a/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.sql
+++ b/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.sql
@@ -1,0 +1,101 @@
+-- `equals` treats the trailing zero bytes of a `FixedString` as padding, so
+-- `toFixedString('V0', 3) = 'V0\0'`. The rule reaches a `FixedString` nested in an `Array`, a
+-- `Map` or a `Tuple`, so a container holding one compares equal to a container holding the same
+-- value written out with its trailing zeros. Plain `String` against plain `String` stays
+-- length-sensitive at every depth.
+
+select 'scalar and tuple reference';
+select 'fs3 = str_padded', toFixedString('V0', 3) = 'V0\0';
+select 'tuple', tuple(toFixedString('V0', 3)) = tuple('V0\0');
+select 'str = str_padded', 'V0' = 'V0\0';
+
+select 'containers';
+select 'array', [toFixedString('V0', 3)] = ['V0\0'];
+select 'array str_short', [toFixedString('V0', 3)] = ['V0'];
+select 'array of tuple', [tuple(toFixedString('V0', 3))] = [tuple('V0\0')];
+select 'nested array', [[toFixedString('V0', 3)]] = [['V0\0']];
+select 'map key', map(toFixedString('V0', 3), 1) = map('V0\0', 1);
+select 'map value', map(1, toFixedString('V0', 3)) = map(1, 'V0\0');
+select 'array of map', [map(toFixedString('V0', 3), 1)] = [map('V0\0', 1)];
+
+-- The width of the `FixedString` is not part of the value.
+select 'widths';
+select 'fs3 vs fs4', [toFixedString('V0', 3)] = [toFixedString('V0', 4)];
+select 'fs4 vs str_padded', [toFixedString('V0', 4)] = ['V0\0'];
+select 'str element, fs needle', ['V0'] = [toFixedString('V0', 3)];
+
+-- Every comparison operator shares one code path and must agree.
+select 'operators';
+select 'eq', [toFixedString('V0', 3)] = ['V0\0'];
+select 'ne', [toFixedString('V0', 3)] != ['V0\0'];
+select 'lt', [toFixedString('V0', 3)] < ['V0\0'];
+select 'le', [toFixedString('V0', 3)] <= ['V0\0'];
+select 'gt', [toFixedString('V0', 3)] > ['V0\0'];
+select 'ge', [toFixedString('V0', 3)] >= ['V0\0'];
+
+-- Constant folding must not disagree with the vector path.
+select 'materialized';
+select 'array', [toFixedString('V0', 3)] = materialize(['V0\0']);
+select 'array both', materialize([toFixedString('V0', 3)]) = materialize(['V0\0']);
+select 'map', map(toFixedString('V0', 3), 1) = materialize(map('V0\0', 1));
+select 'nested array', materialize([[toFixedString('V0', 3)]]) = [['V0\0']];
+
+select 'low cardinality and nullable';
+select 'lc element', [toLowCardinality(toFixedString('V0', 3))] = [toLowCardinality('V0\0')];
+select 'lc materialized', materialize([toLowCardinality(toFixedString('V0', 3))]) = [toLowCardinality('V0\0')];
+select 'nullable element',
+    cast([toFixedString('V0', 3)], 'Array(Nullable(FixedString(3)))') = cast(['V0\0'], 'Array(Nullable(String))');
+select 'null stays null', cast([null], 'Array(Nullable(FixedString(3)))') = cast(['V0\0'], 'Array(Nullable(String))');
+
+-- Only trailing zeros of a `FixedString` are padding.
+select 'negative controls';
+select 'str vs str_padded', ['V0'] = ['V0\0'];
+select 'str prefix', ['ab'] = ['abc'];
+select 'interior zero preserved', [toFixedString('a\0b', 3)] = [toFixedString('a\0b', 4)];
+select 'interior zero not collapsed', [toFixedString('a\0b', 3)] = [toFixedString('ab', 3)];
+select 'different content', [toFixedString('AB', 2)] = [toFixedString('AC', 2)];
+select 'different length arrays', [toFixedString('V0', 3)] = ['V0\0', 'x'];
+select 'element order', [toFixedString('V0', 3), toFixedString('q', 1)] = ['q', 'V0\0'];
+
+-- Values longer than one SIMD register.
+select 'long values';
+select 'long match', [toFixedString(repeat('a', 33), 33)] = [toFixedString(repeat('a', 33), 40)];
+select 'long no match', [toFixedString(repeat('a', 33), 33)] = [toFixedString(repeat('b', 33), 40)];
+
+-- `has` searches for an element with the same comparison, so the two must agree.
+select 'agreement with has and arrayExists';
+select 'nested has',
+    has([[toFixedString('V0', 3)]], ['V0\0']),
+    has(materialize([[toFixedString('V0', 3)]]), ['V0\0']),
+    arrayExists(x -> x = ['V0\0'], [[toFixedString('V0', 3)]]);
+select 'nested indexOf',
+    indexOf([[toFixedString('V0', 3)]], ['V0\0']),
+    indexOf(materialize([[toFixedString('V0', 3)]]), ['V0\0']);
+select 'map element has',
+    has([map(toFixedString('V0', 3), 1)], map('V0\0', 1)),
+    has(materialize([map(toFixedString('V0', 3), 1)]), map('V0\0', 1));
+-- `toFixedString('V0', 3)` is stored as the three bytes `V0\0`, which are byte-identical to the
+-- `String` `'V0\0'`. Comparing against `'V0'` instead is the case a byte-wise comparison gets
+-- wrong, so it is the one that distinguishes a working search from a coincidence.
+select 'short needle nested array',
+    has([[toFixedString('V0', 3)]], ['V0']),
+    has(materialize([[toFixedString('V0', 3)]]), ['V0']),
+    arrayExists(x -> x = ['V0'], [[toFixedString('V0', 3)]]);
+select 'short needle map',
+    has([map(toFixedString('V0', 3), 1)], map('V0', 1)),
+    has(materialize([map(toFixedString('V0', 3), 1)]), map('V0', 1)),
+    arrayExists(x -> x = map('V0', 1), [map(toFixedString('V0', 3), 1)]);
+select 'short needle array of tuple',
+    has([[tuple(toFixedString('V0', 3))]], [tuple('V0')]),
+    has(materialize([[tuple(toFixedString('V0', 3))]]), [tuple('V0')]);
+
+-- The matching values are not a contiguous run of the sort order: `['V0', 'a']` lies between
+-- `['V0']` and `['V0\0']` and does not match. A range built from the constant would prune a
+-- granule holding a matching row, so index analysis is declined for these comparisons.
+select 'primary key must not prune matching rows';
+create table t_zero_pad_key (a Array(String)) engine = MergeTree order by a settings index_granularity = 1;
+insert into t_zero_pad_key values (['V0']), (['V0', 'a']), (['V0\0']), (['ZZ']);
+select 'index path', count() from t_zero_pad_key where a = cast(['V0'] as Array(FixedString(3)));
+select 'full scan path', count() from t_zero_pad_key where a = materialize(cast(['V0'] as Array(FixedString(3))));
+select 'exact string constant still prunes', count() from t_zero_pad_key where a = ['V0\0'];
+drop table t_zero_pad_key;

--- a/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.sql
+++ b/tests/queries/0_stateless/05031_equals_fixed_string_padding_in_containers.sql
@@ -99,3 +99,11 @@ select 'index path', count() from t_zero_pad_key where a = cast(['V0'] as Array(
 select 'full scan path', count() from t_zero_pad_key where a = materialize(cast(['V0'] as Array(FixedString(3))));
 select 'exact string constant still prunes', count() from t_zero_pad_key where a = ['V0\0'];
 drop table t_zero_pad_key;
+
+-- A fixed-width element stores exactly one spelling per value, so the constant still identifies a
+-- single key value. Pin the rows either way.
+create table t_zero_pad_key_fs (a Array(FixedString(3))) engine = MergeTree order by a settings index_granularity = 1;
+insert into t_zero_pad_key_fs values ([toFixedString('V0', 3)]), ([toFixedString('AA', 3)]), ([toFixedString('ZZ', 3)]);
+select 'fixed width rows', count() from t_zero_pad_key_fs where a = ['V0\0'];
+select 'fixed width rows unindexed', count() from t_zero_pad_key_fs where a = materialize(['V0\0']);
+drop table t_zero_pad_key_fs;


### PR DESCRIPTION
WIP, not ready for review.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Equals will now correctly compare Strings and FixedStrings within containers.
