### PR TITLE
Do not access ports from `IProcessor::work()`

### DIFF
--- a/src/Processors/Transforms/CreatingSetsTransform.cpp
+++ b/src/Processors/Transforms/CreatingSetsTransform.cpp
@@ -80,8 +80,8 @@ CreatingSetsTransform::CreatingSetsTransform(
 
 IProcessor::Status CreatingSetsTransform::prepare()
 {
-    /// `work` runs without the executor's graph lock, so every port access lives here. The base
-    /// class closes the input only on the path that still expects to generate output.
+    /// work() runs without the executor's graph lock, so it must not change port state; that happens here.
+    /// The base class closes the input only on the path that still expects to generate output.
     if (finished_input)
         input.close();
 

--- a/src/Processors/Transforms/CreatingSetsTransform.cpp
+++ b/src/Processors/Transforms/CreatingSetsTransform.cpp
@@ -78,6 +78,16 @@ CreatingSetsTransform::CreatingSetsTransform(
 {
 }
 
+IProcessor::Status CreatingSetsTransform::prepare()
+{
+    /// `work` runs without the executor's graph lock, so every port access lives here. The base
+    /// class closes the input only on the path that still expects to generate output.
+    if (finished_input)
+        input.close();
+
+    return IAccumulatingTransform::prepare();
+}
+
 void CreatingSetsTransform::work()
 {
     try
@@ -86,10 +96,7 @@ void CreatingSetsTransform::work()
             init();
 
         if (done_with_set && done_with_table)
-        {
             finishConsume();
-            input.close();
-        }
 
         IAccumulatingTransform::work();
     }

--- a/src/Processors/Transforms/CreatingSetsTransform.h
+++ b/src/Processors/Transforms/CreatingSetsTransform.h
@@ -38,6 +38,7 @@ public:
 
     String getName() const override { return "CreatingSetsTransform"; }
 
+    Status prepare() override;
     void work() override;
     void consume(Chunk chunk) override;
     Chunk generate() override;

--- a/src/Processors/Transforms/ScatterByPartitionTransform.cpp
+++ b/src/Processors/Transforms/ScatterByPartitionTransform.cpp
@@ -79,6 +79,7 @@ IProcessor::Status ScatterByPartitionTransform::prepare()
         return Status::NeedData;
 
     chunk = input.pull();
+    was_output_processed.assign(output_size, false);
 
     return Status::Ready;
 }
@@ -86,7 +87,6 @@ IProcessor::Status ScatterByPartitionTransform::prepare()
 void ScatterByPartitionTransform::work()
 {
     generateOutputChunks();
-    was_output_processed.assign(outputs.size(), false);
     has_output_chunks = true;
 }
 

--- a/src/Processors/Transforms/ScatterByPartitionTransform.cpp
+++ b/src/Processors/Transforms/ScatterByPartitionTransform.cpp
@@ -60,7 +60,7 @@ IProcessor::Status ScatterByPartitionTransform::prepare()
         return Status::Finished;
     }
 
-    /// `work` runs without the executor's graph lock, so every port access lives here.
+    /// work() runs without the executor's graph lock, so it must not change port state; that happens here.
     if (has_output_chunks && !pushOutputChunks())
         return Status::PortFull;
 

--- a/src/Processors/Transforms/ScatterByPartitionTransform.cpp
+++ b/src/Processors/Transforms/ScatterByPartitionTransform.cpp
@@ -60,27 +60,10 @@ IProcessor::Status ScatterByPartitionTransform::prepare()
         return Status::Finished;
     }
 
-    if (!all_outputs_processed)
-    {
-        auto output_it = outputs.begin();
-        bool can_push = false;
-        /// A finished output never becomes pushable again, so waiting for one would wedge the
-        /// pipeline forever. `work` already skips them; `prepare` must agree.
-        bool has_pending_output = false;
-        for (size_t i = 0; i < output_size; ++i, ++output_it)
-        {
-            if (was_output_processed[i] || output_it->isFinished())
-                continue;
+    /// `work` runs without the executor's graph lock, so every port access lives here.
+    if (has_output_chunks && !pushOutputChunks())
+        return Status::PortFull;
 
-            if (output_it->canPush())
-                can_push = true;
-            else
-                has_pending_output = true;
-        }
-        if (!can_push && has_pending_output)
-            return Status::PortFull;
-        return Status::Ready;
-    }
     /// Try get chunk from input.
 
     if (input.isFinished())
@@ -96,17 +79,20 @@ IProcessor::Status ScatterByPartitionTransform::prepare()
         return Status::NeedData;
 
     chunk = input.pull();
-    has_data = true;
-    was_output_processed.assign(outputs.size(), false);
 
     return Status::Ready;
 }
 
 void ScatterByPartitionTransform::work()
 {
-    if (all_outputs_processed)
-        generateOutputChunks();
-    all_outputs_processed = true;
+    generateOutputChunks();
+    was_output_processed.assign(outputs.size(), false);
+    has_output_chunks = true;
+}
+
+bool ScatterByPartitionTransform::pushOutputChunks()
+{
+    bool all_outputs_processed = true;
 
     size_t chunk_number = 0;
     for (auto & output : outputs)
@@ -118,6 +104,8 @@ void ScatterByPartitionTransform::work()
         if (was_processed)
             continue;
 
+        /// A finished output never becomes pushable again, so waiting for one would wedge the
+        /// pipeline forever.
         if (output.isFinished())
             continue;
 
@@ -138,11 +126,12 @@ void ScatterByPartitionTransform::work()
         was_processed = true;
     }
 
-    if (all_outputs_processed)
-    {
-        has_data = false;
-        output_chunks.clear();
-    }
+    if (!all_outputs_processed)
+        return false;
+
+    has_output_chunks = false;
+    output_chunks.clear();
+    return true;
 }
 
 void ScatterByPartitionTransform::generateOutputChunks()

--- a/src/Processors/Transforms/ScatterByPartitionTransform.h
+++ b/src/Processors/Transforms/ScatterByPartitionTransform.h
@@ -27,6 +27,8 @@ struct ScatterByPartitionTransform : IProcessor
 private:
 
     void generateOutputChunks();
+    /// Hands the scattered chunks to the outputs. Returns true once all of them are handed over.
+    bool pushOutputChunks();
 
     size_t output_size;
     ColumnNumbers key_columns;
@@ -35,8 +37,7 @@ private:
     /// When set, chunks are routed round-robin starting from this output instead of by key hash.
     std::optional<size_t> round_robin_bucket;
 
-    bool has_data = false;
-    bool all_outputs_processed = true;
+    bool has_output_chunks = false;
     std::vector<char> was_output_processed;
     Chunk chunk;
 

--- a/src/Processors/tests/gtest_scatter_round_robin.cpp
+++ b/src/Processors/tests/gtest_scatter_round_robin.cpp
@@ -6,6 +6,10 @@
 #include <Processors/ISink.h>
 #include <Processors/Sources/SourceFromChunks.h>
 #include <Processors/Transforms/ScatterByPartitionTransform.h>
+#include <Common/assert_cast.h>
+
+#include <algorithm>
+#include <numeric>
 
 using namespace DB;
 
@@ -44,6 +48,62 @@ public:
 protected:
     void consume(Chunk chunk) override { collected.push_back(std::move(chunk)); }
 };
+
+Chunk makeSingleValueChunk(UInt64 value)
+{
+    auto column = ColumnUInt64::create();
+    column->insertValue(value);
+    Columns columns;
+    columns.emplace_back(std::move(column));
+    return Chunk(std::move(columns), 1);
+}
+
+std::vector<UInt64> collectedValues(const Chunks & chunks)
+{
+    std::vector<UInt64> values;
+    values.reserve(chunks.size());
+    for (const auto & chunk : chunks)
+        values.push_back(assert_cast<const ColumnUInt64 &>(*chunk.getColumns().front()).getElement(0));
+    return values;
+}
+
+/// Takes a single chunk and closes its input, like a satisfied LIMIT downstream.
+class OneChunkSink final : public IProcessor
+{
+public:
+    explicit OneChunkSink(SharedHeader header_) : IProcessor({header_}, {}) { }
+
+    String getName() const override { return "OneChunkSink"; }
+
+    Status prepare() override
+    {
+        auto & input = inputs.front();
+
+        if (!collected.empty() || input.isFinished())
+        {
+            input.close();
+            return Status::Finished;
+        }
+
+        input.setNeeded();
+        if (!input.hasData())
+            return Status::NeedData;
+
+        collected.push_back(input.pull());
+        input.close();
+        return Status::Finished;
+    }
+
+    Chunks collected;
+};
+
+void runSingleThreaded(const Processors & processors)
+{
+    auto shared_processors = std::make_shared<Processors>(processors);
+    QueryStatusPtr status;
+    PipelineExecutor executor(shared_processors, status);
+    executor.execute(1, false);
+}
 
 }
 
@@ -94,4 +154,99 @@ TEST(ScatterRoundRobin, SpreadsChunksAndKeepsChunkInfo)
 
     /// The first chunk carried a ChunkInfo; it landed in bucket 2 and must keep it.
     EXPECT_FALSE(sinks[2]->collected[0].getChunkInfos().empty());
+}
+
+/// A finished output never becomes pushable again, so the transform must drop its chunk and keep
+/// serving the others instead of waiting forever.
+TEST(ScatterRoundRobin, FinishedOutputDoesNotWedgeThePipeline)
+{
+    constexpr size_t bucket_count = 3;
+    constexpr size_t total_chunks = 12;
+    auto header = makeHeader();
+
+    Chunks input;
+    for (size_t i = 0; i < total_chunks; ++i)
+        input.push_back(makeSingleValueChunk(i));
+
+    auto source = std::make_shared<SourceFromChunks>(header, std::move(input));
+    auto scatter = ScatterByPartitionTransform::createRoundRobin(header, bucket_count, /*start_bucket=*/0);
+    connect(source->getPort(), scatter->getInputs().front());
+
+    Processors processors{source, scatter};
+
+    auto early_finisher = std::make_shared<OneChunkSink>(header);
+    std::vector<std::shared_ptr<CollectingSink>> sinks;
+    size_t bucket = 0;
+    for (auto & output : scatter->getOutputs())
+    {
+        if (bucket++ == 1)
+        {
+            connect(output, early_finisher->getInputs().front());
+            processors.push_back(early_finisher);
+            continue;
+        }
+
+        auto sink = std::make_shared<CollectingSink>(header);
+        connect(output, sink->getPort());
+        sinks.push_back(sink);
+        processors.push_back(sink);
+    }
+
+    runSingleThreaded(processors);
+
+    EXPECT_EQ(collectedValues(early_finisher->collected), (std::vector<UInt64>{1}));
+    EXPECT_EQ(collectedValues(sinks[0]->collected), (std::vector<UInt64>{0, 3, 6, 9}));
+    EXPECT_EQ(collectedValues(sinks[1]->collected), (std::vector<UInt64>{2, 5, 8, 11}));
+}
+
+/// Hash mode scatters rows into per-output chunks that live until they are handed over, so a chunk
+/// that could not be pushed must hold the transform at `PortFull`: consuming the next input chunk
+/// would scatter on top of the pending one.
+TEST(ScatterByPartition, DoesNotPullAnotherChunkWhileOneIsPending)
+{
+    constexpr size_t bucket_count = 2;
+    constexpr size_t rows = 25;
+    auto header = makeHeader();
+
+    auto scatter = std::make_shared<ScatterByPartitionTransform>(header, bucket_count, ColumnNumbers{0});
+
+    OutputPort upstream(header);
+    connect(upstream, scatter->getInputs().front());
+
+    InputPort accepting(header);
+    InputPort refusing(header);
+    auto output_it = scatter->getOutputs().begin();
+    connect(*output_it++, accepting);
+    connect(*output_it, refusing);
+
+    /// `refusing` never asks for data, so the scatter cannot hand over its bucket.
+    accepting.setNeeded();
+
+    ASSERT_EQ(scatter->prepare(), IProcessor::Status::NeedData);
+    upstream.push(makeChunk(rows));
+    ASSERT_EQ(scatter->prepare(), IProcessor::Status::Ready);
+    scatter->work();
+
+    EXPECT_EQ(scatter->prepare(), IProcessor::Status::PortFull);
+    ASSERT_TRUE(accepting.hasData());
+    ASSERT_FALSE(refusing.hasData());
+
+    /// Once the refusing output accepts, the pending bucket is handed over and input is wanted again.
+    refusing.setNeeded();
+    EXPECT_EQ(scatter->prepare(), IProcessor::Status::NeedData);
+    ASSERT_TRUE(refusing.hasData());
+
+    std::vector<UInt64> routed;
+    for (auto * port : {&accepting, &refusing})
+    {
+        const auto chunk = port->pull();
+        const auto & column = assert_cast<const ColumnUInt64 &>(*chunk.getColumns().front());
+        for (size_t i = 0; i < chunk.getNumRows(); ++i)
+            routed.push_back(column.getElement(i));
+    }
+
+    std::sort(routed.begin(), routed.end());
+    std::vector<UInt64> expected(rows);
+    std::iota(expected.begin(), expected.end(), 0);
+    EXPECT_EQ(routed, expected);
 }

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -6,6 +6,8 @@
 #include <Processors/IProcessor.h>
 #include <Processors/ISource.h>
 #include <Processors/Port.h>
+#include <Processors/Sources/SourceFromChunks.h>
+#include <Processors/Transforms/ScatterByPartitionTransform.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipeline.h>
 #include <Columns/ColumnsNumber.h>
@@ -13,6 +15,7 @@
 #include <DataTypes/DataTypesNumber.h>
 
 #include <functional>
+#include <set>
 #include <utility>
 
 using namespace DB;
@@ -381,6 +384,15 @@ private:
     std::vector<std::weak_ptr<IProcessor>> batch_history;
 };
 
+Chunk makeSingleValueChunk(UInt8 value)
+{
+    auto column = ColumnUInt8::create();
+    column->insertValue(value);
+    Columns columns;
+    columns.emplace_back(std::move(column));
+    return Chunk(std::move(columns), 1);
+}
+
 }
 
 TEST(Processors, PortDisconnect)
@@ -603,4 +615,70 @@ TEST(Processors, UpdatePipelineRemovalIsNotStrandedByCancellation)
     /// A source scheduled for removal must leave the pipeline even when the query is cancelled in
     /// the middle of the update, otherwise it stays around until the whole pipeline is destroyed.
     EXPECT_TRUE(coordinator->getSourceWeak(0).expired());
+}
+
+/// Reclaiming a retired processor sweeps `post_updated_output_ports` of *every* node under the graph
+/// write lock, so a processor that touches its ports outside `prepare` writes to that vector with no
+/// lock held. Scatter next to removal churn, on many threads, is that collision.
+TEST(Processors, UpdatePipelineRemovalWithConcurrentScatter)
+{
+    constexpr size_t total_batches = 400;
+    constexpr size_t scatter_outputs = 8;
+    constexpr size_t scattered_chunks = 4000;
+    constexpr size_t num_threads = 16;
+
+    auto header = makeHeader();
+
+    auto coordinator = std::make_shared<BatchCyclingCoordinator>(header, total_batches);
+
+    Chunks chunks;
+    chunks.reserve(scattered_chunks);
+    for (size_t i = 0; i < scattered_chunks; ++i)
+        chunks.push_back(makeSingleValueChunk(static_cast<UInt8>(i % 256)));
+
+    Pipe scatter_pipe(std::make_shared<SourceFromChunks>(header, std::move(chunks)));
+    scatter_pipe.transform([&](const OutputPortRawPtrs & ports) -> Processors
+    {
+        auto scatter = ScatterByPartitionTransform::createRoundRobin(header, scatter_outputs, /*start_bucket=*/0);
+        connect(*ports.front(), scatter->getInputs().front());
+        return Processors{std::move(scatter)};
+    });
+
+    Pipes pipes;
+    pipes.emplace_back(coordinator);
+    pipes.emplace_back(std::move(scatter_pipe));
+
+    auto united = Pipe::unitePipes(std::move(pipes));
+    united.resize(1, /*strict=*/false, /*min_outstreams_per_resize_after_split=*/0);
+
+    QueryPipeline pipeline(std::move(united));
+    pipeline.setNumThreads(num_threads);
+
+    std::multiset<UInt8> pulled;
+    {
+        PullingAsyncPipelineExecutor executor(pipeline);
+
+        Chunk chunk;
+        while (executor.pull(chunk))
+        {
+            if (!chunk)
+                continue;
+            const auto & col = assert_cast<const ColumnUInt8 &>(*chunk.getColumns().front());
+            for (size_t i = 0; i < chunk.getNumRows(); ++i)
+                pulled.insert(col.getElement(i));
+        }
+
+        /// Removal still runs to completion alongside the scatter.
+        for (const auto & weak : coordinator->batchHistory())
+            EXPECT_TRUE(weak.expired());
+    }
+
+    std::multiset<UInt8> expected;
+    /// The coordinator's first batch is swallowed by its EarlyClosingTransform.
+    for (size_t i = 1; i < total_batches; ++i)
+        expected.insert(static_cast<UInt8>(i));
+    for (size_t i = 0; i < scattered_chunks; ++i)
+        expected.insert(static_cast<UInt8>(i % 256));
+
+    EXPECT_EQ(pulled, expected);
 }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118031
Related: https://github.com/ClickHouse/ClickHouse/pull/118393


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`IProcessor::work()` is documented as unable to access any ports (`IProcessor.h:189-194`),
because it runs with no graph lock held: `PipelineExecutor` calls `executeTask()` at
`PipelineExecutor.cpp:356` and only enters `graph->updateNode` at `:379`. Two processors break
that contract, and one of them was caught by the AST fuzzer:

`ScatterByPartitionTransform::work()` pushed to its output ports. `OutputPort::pushData` ->
`Port::updateVersion` -> `Port::UpdateInfo::update` appends to that node's own
`post_updated_output_ports`, which the executor `erase_if`-scans for every node under the
`nodes_mutex` write lock while reclaiming a retired processor
(`ExecutingGraph::removePendingGroup` -> `removeAffectedEdges`). The result is a concurrent
`push_back` / `erase_if` on one `std::vector<void *>`: reported as a ThreadSanitizer data race,
and able to drop or duplicate an edge id, or leave a freed `Edge *` behind. Reachable from
ordinary SQL, since the scatter is inserted for any window-function sort with a non-empty
`PARTITION BY`, for hash-sharded merge joins and for distributed shuffle.

`CreatingSetsTransform::work()` closed its input port, the same violation on the set-building
path.

I moved the port access of both into `prepare()`, which runs under the graph lock, and left
`ExecutingGraph` alone: with the contract honoured, the only writers of `post_updated_*_ports`
run under `nodes_mutex`, so its write lock is exclusive as designed. The scatter keeps hashing
and `IColumn::scatter` in `work()` and hands the chunks over from `prepare()`, modelled on
`CopyTransform`; it still refuses to pull a new input chunk before the previous one is fully
handed over, and still skips a finished output. No other `work()`, `onCancel()` or
`onAsyncJobReady()` body in `src/` changes port state (a few read a port header, which
never reaches `Port::updateVersion`).

CI provenance: `AST fuzzer (amd_tsan)` on
[`2dc6db1`](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118770&sha=2dc6db181e290d068142b103ea59fd19424162bc&name_0=PR&name_1=AST%20fuzzer%20%28amd_tsan%29).
Not caused by that PR, which changes no executor file.

<details>
<summary>ThreadSanitizer report (reproduced locally, TSAN gtest)</summary>

```
WARNING: ThreadSanitizer: data race
  Read of size 8 by thread T4:                 <- holds nodes_mutex (write)
    std::vector<void*>::size() / std::erase_if<...>   libcxx/__vector/{vector,erase}.h
    DB::ExecutingGraph::removeAffectedEdges(...)      Runtime/ExecutingGraph.cpp:156
    DB::ExecutingGraph::removePendingGroup(...)       Runtime/ExecutingGraph.cpp:265
    DB::ExecutingGraph::removeReadyGroups(...)        Runtime/ExecutingGraph.cpp:275
    DB::ExecutingGraph::updateNode(...)               Runtime/ExecutingGraph.cpp:502
    DB::PipelineExecutor::executeStepImpl(...)        Runtime/PipelineExecutor.cpp:379

  Previous write of size 8 by thread T2:       <- holds no lock
    std::vector<void*>::push_back                     libcxx/__vector/vector.h:1165
    DB::ScatterByPartitionTransform::work()           Transforms/ScatterByPartitionTransform.cpp
    DB::ExecutionThreadContext::executeTask()         Runtime/ExecutionThreadContext.cpp:58
    DB::PipelineExecutor::executeStepImpl(...)        Runtime/PipelineExecutor.cpp:356
```

</details>

Also noticed and deliberately not changed: `executeJob` reads `node->back_edges.empty()`
without the lock (`ExecutionThreadContext.cpp:61`) while `removeAffectedEdges` erases from that
list. It is executor-side rather than a processor-contract violation, has no CIDB occurrence,
and #118393 already replaces that read.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119577&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119577](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119577+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
