### PR TITLE
Do not treat a join key that cannot be null-extended as null-rejecting in the join order optimizer

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -12,6 +12,7 @@
 #include <Interpreters/HashJoin/HashJoin.h>
 #include <Interpreters/HashTablesStatistics.h>
 #include <Interpreters/JoinExpressionActions.h>
+#include <Interpreters/JoinUtils.h>
 #include <Interpreters/MergeJoin.h>
 #include <Interpreters/TableJoin.h>
 
@@ -860,6 +861,14 @@ static bool isNullPropagatingFunction(const String & name)
     return names.contains(name);
 }
 
+/// An outer join pads an unmatched row with a top-level NULL only for a type its nullability
+/// conversion can wrap. `Array`/`Map` are padded with the type default (`[]`, `map()`) instead, and
+/// `Variant`/`Dynamic` with an internal NULL: both match another such key rather than rejecting it.
+static bool nullExtensionIsNull(const DataTypePtr & type)
+{
+    return isNullableOrLowCardinalityNullable(type) || JoinCommon::canBecomeNullable(type);
+}
+
 /// Relations R such that `node` evaluates to NULL when all of R's columns are NULL ("strict" on R).
 /// Recurses only through null-propagating functions; any other node is opaque and contributes {}.
 static BitSet strictOnRelations(const ActionsDAG::Node * node, const JoinExpressionActions & actions)
@@ -868,6 +877,8 @@ static BitSet strictOnRelations(const ActionsDAG::Node * node, const JoinExpress
     {
         case ActionsDAG::ActionType::INPUT:
         case ActionsDAG::ActionType::PLACEHOLDER:
+            if (!nullExtensionIsNull(node->result_type))
+                return {};
             /// A leaf column reference is null exactly on its own relation.
             return JoinActionRef(node, actions).getSourceRelations();
         case ActionsDAG::ActionType::ALIAS:

--- a/tests/queries/0_stateless/05183_join_order_conflict_detector_direct_key_null_extension.reference
+++ b/tests/queries/0_stateless/05183_join_order_conflict_detector_direct_key_null_extension.reference
@@ -1,0 +1,22 @@
+Array    rows limit=0	1	1	ten
+Array    rows limit=0	2	\N	null_key
+Array    rows cd_a  	1	1	ten
+Array    rows cd_a  	2	\N	null_key
+Array    rows cd_c  	1	1	ten
+Array    rows cd_c  	2	\N	null_key
+Array    plan cd_a	Join conditions: k = k
+Array    plan cd_a	Join conditions: a = a
+Variant  rows limit=0	1	1	ten
+Variant  rows limit=0	2	\N	null_key
+Variant  rows cd_a  	1	1	ten
+Variant  rows cd_a  	2	\N	null_key
+Variant  plan cd_a	Join conditions: k = k
+Variant  plan cd_a	Join conditions: a = a
+Nullable rows limit=0	1	1	ten
+Nullable rows limit=0	2	\N	\N
+Nullable rows cd_a  	1	1	ten
+Nullable rows cd_a  	2	\N	\N
+Nullable plan cd_a	Join conditions: a = a
+Nullable plan cd_a	Join conditions: k = k
+Nullable plan cd_c	Join conditions: a = a
+Nullable plan cd_c	Join conditions: k = k

--- a/tests/queries/0_stateless/05183_join_order_conflict_detector_direct_key_null_extension.sql
+++ b/tests/queries/0_stateless/05183_join_order_conflict_detector_direct_key_null_extension.sql
@@ -1,0 +1,99 @@
+-- The join-order conflict detectors (CD-A / CD-C) relax the assoc/asscom reordering rules when the
+-- ON condition rejects nulls on the null-supplying relation. That premise holds only if an unmatched
+-- outer-join row is padded with a top-level SQL NULL. A key type the nullability conversion cannot
+-- wrap is padded with the type default instead (`[]` for Array), and Variant/Dynamic are padded with
+-- an internal NULL; a join key comparison MATCHES both, so the ON condition rejects nothing and the
+-- reassociation loses rows. The analysis was introduced by
+-- https://github.com/ClickHouse/ClickHouse/pull/119305.
+--
+-- Every arm pins its own SETTINGS on purpose: clickhouse-test randomizes
+-- query_plan_optimize_join_order_algorithm on every run and query_plan_optimize_join_order_limit to 0
+-- in ~5% of runs, either of which would silently make the arm vacuous.
+--
+-- The plan arms print the ON condition of each join step, root first. `k = k` at the root is the
+-- original left-deep association `(t1 LEFT JOIN t2) LEFT JOIN t3`; `a = a` at the root is the
+-- right-deep reassociation the detectors unlock. Asserting the conditions rather than the step
+-- sequence keeps the arm immune to the build/probe side swap, which is randomized.
+
+SET enable_analyzer = 1, single_join_prefer_left_table = 0;
+-- Pinned because the plan arms assert on the association the optimizer chooses.
+SET query_plan_optimize_join_order_randomize = 0, use_hash_table_stats_for_join_reordering = 0;
+-- Make t1 look expensive so the detector prefers to reorder t2/t3 to the front.
+SET param__internal_join_table_stat_hints = '{"t1": {"cardinality": 100000, "distinct_keys": {"a": 2}}, "t2": {"cardinality": 1, "distinct_keys": {"a": 1, "k": 1}}, "t3": {"cardinality": 1, "distinct_keys": {"k": 1}}}';
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+CREATE TABLE t1 (a Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t1 VALUES (1), (2);
+
+-- t1.a = 2 has no t2 match, so t2.k is null-extended. It must not match t3's null-ish key row, i.e.
+-- the `2 \N null_key` row below must survive every reordering.
+
+-- Array cannot be wrapped in Nullable, so the null extension writes `[]`, which matches t3's `[]`.
+CREATE TABLE t2 (a Nullable(Int64), k Array(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t3 (k Array(Int64), tag String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t2 VALUES (1, [10]);
+INSERT INTO t3 VALUES ([10], 'ten'), ([], 'null_key');
+
+SELECT 'Array    rows limit=0', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0;
+SELECT 'Array    rows cd_a  ', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1;
+SELECT 'Array    rows cd_c  ', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_c = 1;
+SELECT 'Array    plan cd_a' AS arm, replaceRegexpOne(explain, '^[^A-Za-z]+', '') AS join_step
+FROM ( EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1 )
+WHERE explain LIKE '%Join conditions:%';
+
+DROP TABLE t2;
+DROP TABLE t3;
+
+-- Variant is padded with a real NULL, but it is an internal (ColumnVariant) NULL that the join key
+-- comparison treats as an ordinary key and matches against t3's NULL key.
+CREATE TABLE t2 (a Nullable(Int64), k Variant(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t3 (k Variant(Int64), tag String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t2 VALUES (1, 10::Int64);
+INSERT INTO t3 VALUES (10::Int64, 'ten'), (NULL, 'null_key');
+
+SELECT 'Variant  rows limit=0', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0;
+SELECT 'Variant  rows cd_a  ', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1;
+SELECT 'Variant  plan cd_a' AS arm, replaceRegexpOne(explain, '^[^A-Za-z]+', '') AS join_step
+FROM ( EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1 )
+WHERE explain LIKE '%Join conditions:%';
+
+DROP TABLE t2;
+DROP TABLE t3;
+
+-- Control: a Nullable key IS padded with a top-level NULL that rejects the join condition, so the
+-- reassociation is sound and must keep happening. This arm reddens if the fix over-restricts and
+-- disables the detector instead of narrowing it.
+CREATE TABLE t2 (a Nullable(Int64), k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t3 (k Nullable(Int64), tag String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t2 VALUES (1, 10);
+INSERT INTO t3 VALUES (10, 'ten'), (NULL, 'null_key');
+
+SELECT 'Nullable rows limit=0', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 0;
+SELECT 'Nullable rows cd_a  ', t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1;
+SELECT 'Nullable plan cd_a' AS arm, replaceRegexpOne(explain, '^[^A-Za-z]+', '') AS join_step
+FROM ( EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1 )
+WHERE explain LIKE '%Join conditions:%';
+
+-- CD-C witness. CD-C must reach the same sound reassociation as CD-A; plain DPsub cannot reassociate
+-- a LeftOuter/LeftOuter pair at all, so `a = a` at the root also proves the detector is engaged and
+-- has not silently fallen back.
+SELECT 'Nullable plan cd_c' AS arm, replaceRegexpOne(explain, '^[^A-Za-z]+', '') AS join_step
+FROM ( EXPLAIN SELECT count() FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k
+    SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10, query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_c = 1 )
+WHERE explain LIKE '%Join conditions:%';
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/119305
Related: https://github.com/ClickHouse/ClickHouse/pull/119512
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/119305 (introduced the analysis)
Related: https://github.com/ClickHouse/ClickHouse/pull/119512 (same premise at the `CAST` node, which
this PR does not touch and that one gates: a `CAST` whose result type cannot hold a top-level NULL,
say `CAST(k AS Variant(Int64))`, is still null-rejecting here, exactly as on master; adjacent hunk,
so whichever merges second needs a trivial rebase)

Found while adjudicating a #119512 review comment; no open issue covers it.

The conflict detectors relax the assoc/asscom rules when the ON condition rejects nulls on the
null-supplying relation. `trust_null_rejection` already checks what that needs, an unmatched row padded
with a real SQL NULL, but only at *setting* granularity (`join_use_nulls`), never per column: the
INPUT/PLACEHOLDER leaf of `strictOnRelations` claimed null-rejection for any key type.

Some keys are padded with a matchable value instead. `Array`, `Map`, `Variant` and `Dynamic` have
`canBeInsideNullable() == false`, so `JoinCommon::convertTypeToNullable` returns them unchanged
and padding writes the type default (`[]`, `map()`). `Variant`/`Dynamic` pad with `Null()`,
but as an internal `ColumnVariant` discriminator that `extractNestedColumnsAndNullMap` never
inspects, so it stays an ordinary hash key. Either way the ON condition rejects
nothing and the reassociation drops rows: with an `Array(Int64)` or `Variant(Int64)` key under
`join_use_nulls = 1` plus `'dpsub'` and either detector, a `LEFT JOIN` chain loses the null-extended
row's match (reproducer below).

The leaf is now gated on `isNullableOrLowCardinalityNullable(t) || JoinCommon::canBecomeNullable(t)`,
i.e. `isNullableOrLowCardinalityNullable(convertTypeToNullable(t))` allocation-free: the executor's
own decision procedure for the padding, so analysis and execution cannot drift.
`canContainNull` would be wrong, it re-admits `Variant`/`Dynamic`.

Both detectors default off and `greedy` is the default solver, so nothing changes by default, and
the change only removes bits from `nr_rels`, so it cannot admit a reordering master
rejects. New test `05183` covers both routes plus a `Nullable(Int64)` control that must keep
reassociating: disabling the guard reddens the route arms, forcing it always-on reddens the control.

<details>
<summary>Reproducer and measurements (click to expand)</summary>

`t1(a Nullable(Int64))={1,2}`, `t2(a,k)={(1,val)}`, `t3(k,tag)={(val,'ten'),(nullish,'null_key')}`,
`k` typed as the key type under test:

```sql
SELECT t1.a, t2.a, t3.tag FROM t1 LEFT JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.k = t3.k ORDER BY ALL
SETTINGS join_use_nulls = 1, query_plan_optimize_join_order_limit = 10,
query_plan_optimize_join_order_algorithm = 'dpsub', query_plan_optimize_join_order_use_conflict_detector_a = 1;
```

Second row only; the reference arm is the same query at `query_plan_optimize_join_order_limit = 0`:

| key type | reference | before | after |
|---|---|---|---|
| `Array(Int64)` | `2 \N null_key` | `2 \N \N` | `2 \N null_key` |
| `Variant(Int64)` | `2 \N null_key` | `2 \N \N` | `2 \N null_key` |
| `Nullable(Int64)` control | `2 \N \N` | `2 \N \N` | unchanged, still reassociated |

`Map(String, Int64)` behaves as `Array(Int64)`. `Int64`, `Tuple(Int64)`, `LowCardinality(String)`,
`JSON`, `QBit` and `Interval` keys are unaffected either way: their ON condition carries a
`toNullable(k) = CAST(k AS Nullable(...))` wrapper, so the `typeChangingSides().empty()` guard in
`addChildQueryGraph` keeps that child join out of the reorderable graph entirely.

Validation: `05183` 50/50 with randomization on, plus 9 join-order neighbours unchanged, including
both pinned TPC-H plan tests.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119584&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119584](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119584+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

