### PR TITLE
Check a part's own consistency even when one of its projections is broken

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1542,7 +1542,14 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
         if (!(*storage.getSettings())[MergeTreeSetting::columns_and_secondary_indices_sizes_lazy_calculation])
             calculateColumnsAndSecondaryIndicesSizesOnDisk();
 
-        if (check_consistency && !has_broken_projections)
+        /// A broken projection does not break its part on purpose, and this check tolerates one by
+        /// itself: `loadProjections` above marks such a projection broken instead of failing, and the
+        /// file-size loop of `checkConsistencyBase` does the same for the `.proj` entry of the part's
+        /// checksums. Skipping the check entirely instead used to take the part's own crash-corruption
+        /// protection away with it: a marks file left empty by a power loss loads as an empty
+        /// `index_granularity`, `loadRowsCount` then reports zero rows, and the part's acknowledged
+        /// rows disappear from every query - with nothing detached to recover them from.
+        if (check_consistency)
             checkConsistency(require_columns_checksums);
 
         loadDefaultCompressionCodec();

--- a/tests/queries/0_stateless/05214_broken_projection_does_not_skip_part_check.reference
+++ b/tests/queries/0_stateless/05214_broken_projection_does_not_skip_part_check.reference
@@ -1,0 +1,8 @@
+inserted	5000
+both rows	0
+both detached parts	1	broken-on-start
+both broken projections	0
+inserted	5000
+projection only rows	5000
+projection only detached parts	0	\N
+projection only broken projections	1

--- a/tests/queries/0_stateless/05214_broken_projection_does_not_skip_part_check.sh
+++ b/tests/queries/0_stateless/05214_broken_projection_does_not_skip_part_check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# A broken projection does not break its part, on purpose. But the part's own consistency check used to
+# be skipped whenever one of its projections was broken, which took the part's crash-corruption
+# protection away with it: a marks file left empty by a power loss loads as an empty `index_granularity`,
+# the row count becomes zero, and the acknowledged rows disappear from every query with nothing detached
+# to recover them from. The part is detached as broken now, while a broken projection alone still is not.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORKING_DIR="${CLICKHOUSE_TMP}/05214_broken_projection_does_not_skip_part_check"
+
+create_table()
+{
+    ${CLICKHOUSE_LOCAL} --path "${WORKING_DIR}" --multiquery -q "
+        CREATE TABLE t (id UInt64, v UInt64, PROJECTION p (SELECT v, count() GROUP BY v))
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+
+        INSERT INTO t SELECT number, number % 10 FROM numbers(5000);
+        SELECT 'inserted', count() FROM t;
+    " </dev/null
+}
+
+report()
+{
+    ${CLICKHOUSE_LOCAL} --path "${WORKING_DIR}" --multiquery -q "
+        SELECT '$1 rows', count() FROM t;
+        SELECT '$1 detached parts', count(), any(reason) FROM system.detached_parts
+        WHERE database = currentDatabase() AND table = 't';
+        SELECT '$1 broken projections', countIf(is_broken) FROM system.projection_parts
+        WHERE database = currentDatabase() AND table = 't';
+    " </dev/null
+}
+
+# The marks of the part itself are gone as well as the projection's, which is what a single power loss
+# can leave behind.
+rm -rf "${WORKING_DIR}"
+mkdir -p "${WORKING_DIR}"
+create_table
+find "${WORKING_DIR}" -name 'data.cmrk4' -exec truncate -s 0 {} \;
+report 'both'
+
+# Only the projection's marks are gone: the part keeps all of its rows and stays attached.
+rm -rf "${WORKING_DIR}"
+mkdir -p "${WORKING_DIR}"
+create_table
+find "${WORKING_DIR}" -path '*p.proj*' -name 'data.cmrk4' -exec truncate -s 0 {} \;
+report 'projection only'
+
+rm -rf "${WORKING_DIR}"


### PR DESCRIPTION
When a part has a broken projection, the part's own consistency check was skipped entirely on load:

```cpp
if (check_consistency && !has_broken_projections)
    checkConsistency(require_columns_checksums);
```

A broken projection is a tolerated, long-lived state on purpose (#56593), and projection files are not `fsync`ed on insert (#111318), so a part can run for a long time with one. On any later restart where the part's *own* marks file was torn by a crash, the corruption then went completely undetected: a zero-length marks file loads as an empty `index_granularity` without throwing, `loadRowsCount` reports zero rows because of it, and the part's acknowledged rows disappeared from every query - with nothing in `detached/` to recover them from and nothing above INFO in the log. The same corruption on a part *without* a broken projection is detected and the part detached.

The guard is not needed for what it was meant to do, because the check tolerates a broken projection by itself: `loadProjections` marks such a projection broken instead of failing the part, and the file-size loop of `checkConsistencyBase` does the same for the `.proj` entry of the part's checksums (`markProjectionPartAsBroken`). `doCheckConsistency` of every part type looks at the part's own files only. So the check runs unconditionally now.

The test covers both directions: a part whose own marks file is empty is detached as `broken-on-start`, and a part whose *projection's* marks file alone is empty keeps all of its rows, stays attached, and reports the projection as broken.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116589

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a part with a broken projection skipping its own consistency check on load, which let a crash-torn marks file load as an empty part and silently drop the part's rows instead of detaching it as broken.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119586&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119586](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119586+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
