### PR TITLE
Add platform support parameters to CloudOnlyBadge

### DIFF
--- a/docs/snippets/ar/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/ar/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'حصريًا في ClickHouse Cloud'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ar/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/ar/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'متاح فقط في ClickHouse Cloud'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/components/Badges/CloudOnlyBadge.jsx
@@ -10,10 +10,20 @@ const Icon = () => {
     )
 }
 
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'ClickHouse Cloud only'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'ClickHouse Cloud only'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/es/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/es/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'Solo para ClickHouse Cloud'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/es/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/es/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'Solo para ClickHouse Cloud'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/fr/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/fr/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'ClickHouse Cloud uniquement'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/fr/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/fr/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'Uniquement sur ClickHouse Cloud'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ja/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/ja/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'ClickHouse Cloud 限定'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ja/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/ja/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'ClickHouse Cloud 専用'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ko/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/ko/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'ClickHouse Cloud 전용'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ko/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/ko/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'ClickHouse Cloud 전용'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/pt-BR/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/pt-BR/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'Somente no ClickHouse Cloud'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/pt-BR/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/pt-BR/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'Somente no ClickHouse Cloud'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ru/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/ru/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'Только в ClickHouse Cloud'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/ru/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/ru/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'Только в ClickHouse Cloud'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/zh/components/Badges/CloudOnlyBadge.jsx
+++ b/docs/snippets/zh/components/Badges/CloudOnlyBadge.jsx
@@ -8,10 +8,20 @@ const Icon = () => {
         </div>
     )
 }
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
-            <Icon />{'仅 ClickHouse Cloud 可用'}
+            <Icon />{'Available in ' + label}
         </div>
     )
 }

--- a/docs/snippets/zh/components/CloudOnlyBadge/CloudOnlyBadge.jsx
+++ b/docs/snippets/zh/components/CloudOnlyBadge/CloudOnlyBadge.jsx
@@ -1,4 +1,14 @@
-export const CloudOnlyBadge = () => {
+export const CloudOnlyBadge = ({ supported = ['cloud', 'private', 'BYOC'] }) => {
+    const platforms = supported.map((platform) => ({
+        cloud: 'ClickHouse Cloud',
+        private: 'ClickHouse Private',
+        BYOC: 'BYOC',
+    })[platform] || platform)
+    const label = platforms.length === 1
+        ? platforms[0]
+        : platforms.length === 2
+            ? platforms.join(' and ')
+            : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1]
     return (
         <div className="cloudBadge">
             <div className="cloudIcon">
@@ -7,7 +17,7 @@ export const CloudOnlyBadge = () => {
                       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
-            {'仅限 ClickHouse Cloud'}
+            {'Available in ' + label}
         </div>
     )
 }

--- a/programs/server/docs.html
+++ b/programs/server/docs.html
@@ -674,13 +674,31 @@
     /// surfaces convey the same status. Known badges get a descriptive label; any other `*Badge` (the
     /// website adds new ones over time) falls back to its name with the camel case split (e.g.
     /// `CommunityMaintainedBadge` -> `Community Maintained`).
-    function badgeLabel(name) {
+    function cloudOnlyBadgeLabel(attributes) {
+        const match = /(?:^|\s)supported\s*=\s*\{?\s*\[([^\]]*)\]/.exec(attributes || '');
+        const supported = match
+            ? Array.from(match[1].matchAll(/"([^"]*)"/g), (item) => item[1])
+            : ['cloud', 'private', 'BYOC'];
+        const platforms = supported.map((platform) => ({
+            cloud: 'ClickHouse Cloud',
+            private: 'ClickHouse Private',
+            BYOC: 'BYOC',
+        })[platform] || platform);
+        const names = platforms.length === 1
+            ? platforms[0]
+            : platforms.length === 2
+                ? platforms.join(' and ')
+                : platforms.slice(0, -1).join(', ') + ', and ' + platforms[platforms.length - 1];
+        return 'Available in ' + names;
+    }
+
+    function badgeLabel(name, attributes) {
         switch (name) {
             case 'ExperimentalBadge': return 'Experimental';
             case 'BetaBadge': return 'Beta';
             case 'CloudNotSupportedBadge': return 'Not supported in ClickHouse Cloud';
             case 'CloudAvailableBadge': return 'Available in ClickHouse Cloud';
-            case 'CloudOnlyBadge': return 'ClickHouse Cloud only';
+            case 'CloudOnlyBadge': return cloudOnlyBadgeLabel(attributes);
             case 'PrivatePreviewBadge': return 'Private Preview';
             case 'ScalePlanFeatureBadge': return 'Scale plan feature';
             case 'EnterprisePlanFeatureBadge': return 'Enterprise plan feature';
@@ -801,7 +819,7 @@
                 if (closing)
                     return '';
                 const payload = badgePayload(name, attributes);
-                return '**[' + badgeLabel(name) + ']**' + (payload ? ' ' + payload : '');
+                return '**[' + badgeLabel(name, attributes) + ']**' + (payload ? ' ' + payload : '');
             });
 
         /// Likewise strip any remaining *self-closing* PascalCase component that was neither imported

--- a/src/Client/TerminalMarkdownRenderer.cpp
+++ b/src/Client/TerminalMarkdownRenderer.cpp
@@ -401,9 +401,79 @@ bool isMdxLayoutComponent(std::string_view name)
         || name == "VerticalStepper" || name == "Image";
 }
 
+std::optional<std::vector<String>> mdxStringArrayAttribute(std::string_view attrs, std::string_view name)
+{
+    size_t pos = 0;
+    while (pos < attrs.size())
+    {
+        const size_t found = attrs.find(name, pos);
+        if (found == std::string_view::npos)
+            return std::nullopt;
+        pos = found + name.size();
+        const bool at_word_start = found == 0 || isInlineSpace(attrs[found - 1]);
+        std::string_view rest = attrs.substr(found + name.size());
+        while (!rest.empty() && isInlineSpace(rest.front()))
+            rest.remove_prefix(1);
+        if (!at_word_start || rest.empty() || rest.front() != '=')
+            continue;
+        rest.remove_prefix(1);
+        while (!rest.empty() && isInlineSpace(rest.front()))
+            rest.remove_prefix(1);
+        if (!rest.empty() && rest.front() == '{')
+            rest.remove_prefix(1);
+        while (!rest.empty() && isInlineSpace(rest.front()))
+            rest.remove_prefix(1);
+        if (rest.empty() || rest.front() != '[')
+            return std::nullopt;
+        rest.remove_prefix(1);
+
+        std::vector<String> result;
+        while (true)
+        {
+            while (!rest.empty() && (isInlineSpace(rest.front()) || rest.front() == ','))
+                rest.remove_prefix(1);
+            if (rest.empty() || rest.front() == ']')
+                return result;
+            if (rest.front() != '"')
+                return std::nullopt;
+            rest.remove_prefix(1);
+            const size_t close = rest.find('"');
+            if (close == std::string_view::npos)
+                return std::nullopt;
+            result.emplace_back(rest.substr(0, close));
+            rest.remove_prefix(close + 1);
+        }
+    }
+    return std::nullopt;
+}
+
+String cloudOnlyBadgeLabel(std::string_view attributes)
+{
+    std::vector<String> supported = {"cloud", "private", "BYOC"};
+    if (auto attribute = mdxStringArrayAttribute(attributes, "supported"))
+        supported = std::move(*attribute);
+
+    for (auto & platform : supported)
+    {
+        if (platform == "cloud")
+            platform = "ClickHouse Cloud";
+        else if (platform == "private")
+            platform = "ClickHouse Private";
+    }
+
+    String result = "Available in ";
+    for (size_t i = 0; i < supported.size(); ++i)
+    {
+        if (i > 0)
+            result += i + 1 == supported.size() ? (supported.size() == 2 ? " and " : ", and ") : ", ";
+        result += supported[i];
+    }
+    return result;
+}
+
 /// Human-readable text for an MDX badge component such as `<ExperimentalBadge/>`. Known badges get a
 /// descriptive label; any other `*Badge` component falls back to its name with the camel case split.
-String badgeLabel(std::string_view name)
+String badgeLabel(std::string_view name, std::string_view attributes = {})
 {
     if (name == "ExperimentalBadge")
         return "Experimental";
@@ -414,7 +484,7 @@ String badgeLabel(std::string_view name)
     if (name == "CloudAvailableBadge")
         return "Available in ClickHouse Cloud";
     if (name == "CloudOnlyBadge")
-        return "ClickHouse Cloud only";
+        return cloudOnlyBadgeLabel(attributes);
     if (name == "PrivatePreviewBadge")
         return "Private Preview";
     if (name == "ScalePlanFeatureBadge")
@@ -805,7 +875,7 @@ private:
                         const std::string_view name = s.substr(name_begin, p - name_begin);
                         if (name.size() > 5 && name[0] >= 'A' && name[0] <= 'Z' && name.ends_with("Badge"))
                         {
-                            append("[" + badgeLabel(name) + "]", Style{.bold = true});
+                            append("[" + badgeLabel(name, s.substr(p, close - 1 - p)) + "]", Style{.bold = true});
                             /// A plan-gating badge also carries a substantive message built from its
                             /// attributes; render it after the label (see `badgePayload`).
                             if (const String payload = badgePayload(name, s.substr(p, close - 1 - p)); !payload.empty())

--- a/src/Client/tests/gtest_terminal_markdown_renderer.cpp
+++ b/src/Client/tests/gtest_terminal_markdown_renderer.cpp
@@ -161,6 +161,12 @@ TEST(TerminalMarkdownRenderer, BadgeComponentRendered)
 {
     EXPECT_EQ(plainRenderer().render("<ExperimentalBadge/>"), "[Experimental]\n");
     EXPECT_EQ(plainRenderer().render("<CloudNotSupportedBadge/>"), "[Not supported in ClickHouse Cloud]\n");
+    EXPECT_EQ(
+        plainRenderer(200).render("<CloudOnlyBadge/>"),
+        "[Available in ClickHouse Cloud, ClickHouse Private, and BYOC]\n");
+    EXPECT_EQ(
+        plainRenderer(200).render("<CloudOnlyBadge supported={[\"cloud\", \"BYOC\"]}/>"),
+        "[Available in ClickHouse Cloud and BYOC]\n");
 }
 
 TEST(TerminalMarkdownRenderer, PlanFeatureBadgeRendersItsMessage)

--- a/tests/queries/0_stateless/04418_docs_web_ui_importless_mdx_badge.reference
+++ b/tests/queries/0_stateless/04418_docs_web_ui_importless_mdx_badge.reference
@@ -1,4 +1,4 @@
 ClickHouse <span class="accent">Reference</span>
-function badgeLabel(name) {
+function badgeLabel(name, attributes) {
 [A-Z][A-Za-z0-9]*Badge
 1

--- a/tests/queries/0_stateless/04418_docs_web_ui_importless_mdx_badge.sh
+++ b/tests/queries/0_stateless/04418_docs_web_ui_importless_mdx_badge.sh
@@ -22,7 +22,7 @@ PAGE="$(${CLICKHOUSE_CURL} -sS "${URL}/docs")"
 echo "$PAGE" | grep -oF 'ClickHouse <span class="accent">Reference</span>' | head -n1
 
 # `preprocessMarkdown` renders each `*Badge` as a readable label via `badgeLabel` ...
-echo "$PAGE" | grep -oF 'function badgeLabel(name) {' | head -n1
+echo "$PAGE" | grep -oF 'function badgeLabel(name, attributes) {' | head -n1
 # ... matching the `*Badge` name directly, so an importless badge is handled the same as an imported one.
 echo "$PAGE" | grep -oF '[A-Z][A-Za-z0-9]*Badge' | head -n1
 

--- a/tests/queries/0_stateless/04493_docs_web_ui_badge_label.reference
+++ b/tests/queries/0_stateless/04493_docs_web_ui_badge_label.reference
@@ -1,5 +1,7 @@
 ClickHouse <span class="accent">Reference</span>
-function badgeLabel(name) {
-'**[' + badgeLabel(name) + ']**'
+function cloudOnlyBadgeLabel(attributes) {
+function badgeLabel(name, attributes) {
+'**[' + badgeLabel(name, attributes) + ']**'
+case 'CloudOnlyBadge': return cloudOnlyBadgeLabel(attributes);
 case 'CloudNotSupportedBadge': return 'Not supported in ClickHouse Cloud';
 1

--- a/tests/queries/0_stateless/04493_docs_web_ui_badge_label.sh
+++ b/tests/queries/0_stateless/04493_docs_web_ui_badge_label.sh
@@ -23,8 +23,10 @@ PAGE="$(${CLICKHOUSE_CURL} -sS "${URL}/docs")"
 echo "$PAGE" | grep -oF 'ClickHouse <span class="accent">Reference</span>' | head -n1
 
 # `preprocessMarkdown` renders each `*Badge` as a readable label via `badgeLabel` ...
-echo "$PAGE" | grep -oF 'function badgeLabel(name) {' | head -n1
-echo "$PAGE" | grep -oF "'**[' + badgeLabel(name) + ']**'" | head -n1
+echo "$PAGE" | grep -oF 'function cloudOnlyBadgeLabel(attributes) {' | head -n1
+echo "$PAGE" | grep -oF 'function badgeLabel(name, attributes) {' | head -n1
+echo "$PAGE" | grep -oF "'**[' + badgeLabel(name, attributes) + ']**'" | head -n1
+echo "$PAGE" | grep -oF "case 'CloudOnlyBadge': return cloudOnlyBadgeLabel(attributes);" | head -n1
 # ... using the same labels as the terminal `help` renderer.
 echo "$PAGE" | grep -oF "case 'CloudNotSupportedBadge': return 'Not supported in ClickHouse Cloud';" | head -n1
 


### PR DESCRIPTION
Cloud-only badges now accept a supported platform list, while their default continues to cover ClickHouse Cloud, ClickHouse Private, and BYOC. The website, terminal help, and server documentation renderer now display the selected platforms consistently.

### Changelog category (leave one):
- Documentation

### Changelog entry:

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119589&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119589](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119589+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1516` (included in `26.9` and later)
<!-- ch-version-info:end -->