### PR TITLE
Keep an `IS NOT NULL` JOIN ON guard when the join key is `Variant` or `Dynamic`

### DIFF
--- a/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
+++ b/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
@@ -11,6 +11,7 @@
 #include <Core/AccurateComparison.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -71,6 +72,14 @@ static QueryTreeNodePtr findEqualsFunction(const QueryTreeNodes & nodes)
         }
     }
     return nullptr;
+}
+
+/// Whether the join's null-key map excludes every value of `type` that `isNotNull` reports as NULL.
+/// `extractNestedColumnsAndNullMap` reads a top-level `ColumnNullable` only, so a `Variant`/`Dynamic`
+/// NULL stays an ordinary key value and matches another such NULL, while `isNotNull` sees it as NULL.
+static bool joinExcludesNullKeysOf(const DataTypePtr & type)
+{
+    return !canContainNull(*type) || isNullableOrLowCardinalityNullable(type);
 }
 
 /// Checks if the node is combination of isNull and notEquals functions of two the same arguments:
@@ -1605,10 +1614,15 @@ private:
                 if (const auto & equals_function = findEqualsFunction(and_arguments))
                 {
                     const auto & equals_arguments = equals_function->as<FunctionNode>()->getArguments().getNodes();
-                    /// Expected isNotNull arguments
+                    /// Expected isNotNull arguments. Left empty when the join's null-key map does not
+                    /// exclude a key's NULLs, which keeps such a guard while still dropping true constants.
                     QueryTreeNodePtrWithHashSet allowed_arguments;
-                    allowed_arguments.insert(QueryTreeNodePtrWithHash(std::make_shared<ListNode>(QueryTreeNodes{equals_arguments[0]})));
-                    allowed_arguments.insert(QueryTreeNodePtrWithHash(std::make_shared<ListNode>(QueryTreeNodes{equals_arguments[1]})));
+                    if (joinExcludesNullKeysOf(equals_arguments[0]->getResultType())
+                        && joinExcludesNullKeysOf(equals_arguments[1]->getResultType()))
+                    {
+                        allowed_arguments.insert(QueryTreeNodePtrWithHash(std::make_shared<ListNode>(QueryTreeNodes{equals_arguments[0]})));
+                        allowed_arguments.insert(QueryTreeNodePtrWithHash(std::make_shared<ListNode>(QueryTreeNodes{equals_arguments[1]})));
+                    }
 
                     bool can_be_optimized = true;
                     for (const auto & and_argument : and_arguments)

--- a/tests/queries/0_stateless/05184_join_on_isnotnull_variant_key.reference
+++ b/tests/queries/0_stateless/05184_join_on_isnotnull_variant_key.reference
@@ -1,0 +1,14 @@
+variant inner	1
+variant left		
+variant left	10	ten
+variant guard kept	2
+variant true collapsed	0
+variant true merge join	2
+nullable inner	1
+nullable guard dropped	0
+lc nullable inner	1
+lc nullable guard dropped	0
+plain inner	1
+plain guard dropped	0
+dynamic inner	1
+dynamic guard kept	2

--- a/tests/queries/0_stateless/05184_join_on_isnotnull_variant_key.sql
+++ b/tests/queries/0_stateless/05184_join_on_isnotnull_variant_key.sql
@@ -1,0 +1,121 @@
+SET enable_analyzer = 1;
+-- The retained guard is a one-sided ON condition, which the merge-family algorithms do not
+-- implement; the stress test randomizes join_algorithm.
+SET join_algorithm = 'hash';
+SET join_use_nulls = 0;
+
+DROP TABLE IF EXISTS t_variant_left;
+DROP TABLE IF EXISTS t_variant_right;
+DROP TABLE IF EXISTS t_nullable_left;
+DROP TABLE IF EXISTS t_nullable_right;
+DROP TABLE IF EXISTS t_lc_left;
+DROP TABLE IF EXISTS t_lc_right;
+DROP TABLE IF EXISTS t_plain_left;
+DROP TABLE IF EXISTS t_plain_right;
+DROP TABLE IF EXISTS t_dynamic_left;
+DROP TABLE IF EXISTS t_dynamic_right;
+
+CREATE TABLE t_variant_left (k Variant(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_variant_right (k Variant(Int64), tag String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_variant_left VALUES (10::Int64), (NULL);
+INSERT INTO t_variant_right VALUES (10::Int64, 'ten'), (NULL, 'nul');
+
+-- A Variant NULL is a discriminator value, so the join keys on it like any other value and the
+-- IS NOT NULL conjuncts are the only thing excluding the NULL/NULL pair.
+SELECT 'variant inner', count()
+FROM t_variant_left AS l INNER JOIN t_variant_right AS r
+    ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL;
+
+SELECT 'variant left', toString(l.k) AS lk, r.tag AS tag
+FROM t_variant_left AS l LEFT JOIN t_variant_right AS r
+    ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL
+ORDER BY lk, tag;
+
+SELECT 'variant guard kept', count() FROM ( EXPLAIN QUERY TREE
+    SELECT count() FROM t_variant_left AS l INNER JOIN t_variant_right AS r
+        ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL
+) WHERE explain ILIKE '%function_name: isNotNull%';
+
+-- A true constant is redundant for every key type, so the collapse must still happen here; only the
+-- isNotNull guard is type-dependent.
+SELECT 'variant true collapsed', count() FROM ( EXPLAIN QUERY TREE
+    SELECT count() FROM t_variant_left AS l INNER JOIN t_variant_right AS r
+        ON l.k = r.k AND true
+) WHERE explain LIKE '%CONSTANT%';
+
+SELECT 'variant true merge join', count()
+FROM t_variant_left AS l INNER JOIN t_variant_right AS r ON l.k = r.k AND true
+SETTINGS join_algorithm = 'full_sorting_merge';
+
+CREATE TABLE t_nullable_left (k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_nullable_right (k Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nullable_left VALUES (10), (NULL);
+INSERT INTO t_nullable_right VALUES (10), (NULL);
+
+CREATE TABLE t_lc_left (k LowCardinality(Nullable(String))) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_lc_right (k LowCardinality(Nullable(String))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_lc_left VALUES ('a'), (NULL);
+INSERT INTO t_lc_right VALUES ('a'), (NULL);
+
+CREATE TABLE t_plain_left (k Int64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_plain_right (k Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_plain_left VALUES (10), (20);
+INSERT INTO t_plain_right VALUES (10), (30);
+
+-- The rewrite must still fire for the key types whose NULL the join already excludes: a Nullable
+-- NULL, also inside LowCardinality, is dropped by the null-key map, and IS NOT NULL over a
+-- non-nullable key folds to a constant.
+SELECT 'nullable inner', count()
+FROM t_nullable_left AS l INNER JOIN t_nullable_right AS r
+    ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL;
+
+SELECT 'nullable guard dropped', count() FROM ( EXPLAIN QUERY TREE
+    SELECT count() FROM t_nullable_left AS l INNER JOIN t_nullable_right AS r
+        ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL
+) WHERE explain ILIKE '%function_name: isNotNull%';
+
+SELECT 'lc nullable inner', count()
+FROM t_lc_left AS l INNER JOIN t_lc_right AS r
+    ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL;
+
+SELECT 'lc nullable guard dropped', count() FROM ( EXPLAIN QUERY TREE
+    SELECT count() FROM t_lc_left AS l INNER JOIN t_lc_right AS r
+        ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL
+) WHERE explain ILIKE '%function_name: isNotNull%';
+
+SELECT 'plain inner', count()
+FROM t_plain_left AS l INNER JOIN t_plain_right AS r
+    ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL;
+
+SELECT 'plain guard dropped', count() FROM ( EXPLAIN QUERY TREE
+    SELECT count() FROM t_plain_left AS l INNER JOIN t_plain_right AS r
+        ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL
+) WHERE explain ILIKE '%function_name: isNotNull%' OR explain LIKE '%CONSTANT%';
+
+SET allow_dynamic_type_in_join_keys = 1;
+
+CREATE TABLE t_dynamic_left (k Dynamic) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_dynamic_right (k Dynamic) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_dynamic_left SELECT CAST(if(number = 0, NULL, 10), 'Dynamic') FROM numbers(2);
+INSERT INTO t_dynamic_right SELECT CAST(if(number = 0, NULL, 10), 'Dynamic') FROM numbers(2);
+
+-- A Dynamic NULL is the same discriminator value, so the same guard has to survive here.
+SELECT 'dynamic inner', count()
+FROM t_dynamic_left AS l INNER JOIN t_dynamic_right AS r
+    ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL;
+
+SELECT 'dynamic guard kept', count() FROM ( EXPLAIN QUERY TREE
+    SELECT count() FROM t_dynamic_left AS l INNER JOIN t_dynamic_right AS r
+        ON l.k = r.k AND l.k IS NOT NULL AND r.k IS NOT NULL
+) WHERE explain ILIKE '%function_name: isNotNull%';
+
+DROP TABLE t_variant_left;
+DROP TABLE t_variant_right;
+DROP TABLE t_nullable_left;
+DROP TABLE t_nullable_right;
+DROP TABLE t_lc_left;
+DROP TABLE t_lc_right;
+DROP TABLE t_plain_left;
+DROP TABLE t_plain_right;
+DROP TABLE t_dynamic_left;
+DROP TABLE t_dynamic_right;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/98712

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a wrong result when a `JOIN ON` clause guards a `Variant` or `Dynamic` join key with `IS NOT NULL`. The analyzer dropped the guard on the grounds that a NULL key cannot match anyway, which holds for a `Nullable` key but not for `Variant`/`Dynamic`, whose NULL is a discriminator value the join keys on like any other; the NULL/NULL pair therefore matched and a row the query's own predicate excludes was returned. The guard is now kept for those key types.


### Description

At default settings, since `f95434f4c001c` (`v24.7.1.2915-stable`), an explicit `IS NOT NULL` guard in `JOIN ON` is silently discarded for a `Variant` join key:

```sql
CREATE TABLE a (k Variant(Int64)) ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE b (k Variant(Int64)) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO a VALUES (10::Int64), (NULL);
INSERT INTO b VALUES (10::Int64), (NULL);
SELECT count() FROM a INNER JOIN b ON a.k = b.k AND a.k IS NOT NULL AND b.k IS NOT NULL;
-- returns 2, must return 1
```

`tryOptimizeJoinOnNulls` reduces `a = b AND a IS NOT NULL AND b IS NOT NULL` to `a = b`, justified in-code by "for JOIN ON condition NULL is treated as FALSE". That claim is about the null-key map, which `extractNestedColumnsAndNullMap` builds from a top-level `ColumnNullable` only: a `Variant`/`Dynamic` NULL lives in a discriminator, so it stays an ordinary key and matches another such NULL, while `isNotNull` reports it as NULL; the admissibility check tested AST shape only.

The guard is now kept when either `equals` argument can carry a NULL that map misses (`canContainNull` and not `Nullable`/`LowCardinality(Nullable)`), the established in-tree predicate for this hazard (`RewriteAggregateFunctionWithIfPass`, `UniqToCountPass`).

The unguarded `ON a.k = b.k` still matches the internal-NULL pair: documented behaviour of that null-key map, identical under all five algorithms. A retained guard is a join side condition, which the engine does not implement everywhere: with only `full_sorting_merge`/`parallel_full_sorting_merge` enabled, or against a prebuilt `Join` table, such a `LEFT JOIN` now raises rather than running. Neither limit is new - a guard the optimizer cannot pattern-match reaches them today - and the defaults are unaffected.

New `05184_join_on_isnotnull_variant_key` asserts the corrected results and, via `EXPLAIN QUERY TREE`, that the guard is kept for `Variant`/`Dynamic` and still dropped for `Nullable`, `LowCardinality(Nullable)` and non-nullable keys. No open issue reports this.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119590&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119590](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119590+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
