### PR TITLE
Validate a Map key subcolumn by its substream path in skip-index analysis

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -254,13 +254,17 @@ std::optional<MapIndexInfo> tryResolveMapIndexInfo(const String & map_column_nam
 /// Try to parse a Map subcolumn reference like `map.key_<serialized_key>` and resolve it
 /// against the bloom filter index header. The subcolumn name format is produced by
 /// `FunctionToSubcolumnsPass`.
-std::optional<MapIndexInfo> tryParseMapSubcolumn(const String & column_name, const Block & header)
+std::optional<MapIndexInfo> tryParseMapSubcolumn(
+    const String & column_name, const Block & header, const StorageMetadataPtr & metadata_snapshot)
 {
     auto parsed = tryParseMapSubcolumnName(column_name);
     if (!parsed)
         return std::nullopt;
 
     auto & [map_column_name, serialized_key] = *parsed;
+
+    if (!metadata_snapshot || !isKeySubcolumnOfMap(metadata_snapshot->getColumns(), column_name, map_column_name))
+        return std::nullopt;
 
     auto map_keys_index_column_name = fmt::format("mapKeys({})", map_column_name);
     if (!header.has(map_keys_index_column_name))
@@ -284,7 +288,8 @@ std::optional<MapIndexInfo> tryParseMapSubcolumn(const String & column_name, con
 
 /// Try to resolve a `MapIndexInfo` from a key node that is either an `arrayElement(map, key)`
 /// function call or a `map.key_<serialized_key>` subcolumn reference.
-std::optional<MapIndexInfo> tryResolveMapInfoFromNode(const RPNBuilderTreeNode & key_node, const Block & header)
+std::optional<MapIndexInfo> tryResolveMapInfoFromNode(
+    const RPNBuilderTreeNode & key_node, const Block & header, const StorageMetadataPtr & metadata_snapshot)
 {
     if (key_node.isFunction())
     {
@@ -303,14 +308,21 @@ std::optional<MapIndexInfo> tryResolveMapInfoFromNode(const RPNBuilderTreeNode &
         }
     }
 
-    return tryParseMapSubcolumn(key_node.getColumnName(), header);
+    return tryParseMapSubcolumn(key_node.getColumnName(), header, metadata_snapshot);
 }
 
 }
 
 MergeTreeIndexConditionBloomFilter::MergeTreeIndexConditionBloomFilter(
-    const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_)
-    : WithContext(context_), header(header_), hash_functions(hash_functions_)
+    const ActionsDAG::Node * predicate,
+    ContextPtr context_,
+    const Block & header_,
+    size_t hash_functions_,
+    StorageMetadataPtr metadata_snapshot_)
+    : WithContext(context_)
+    , header(header_)
+    , hash_functions(hash_functions_)
+    , metadata_snapshot(std::move(metadata_snapshot_))
 {
     if (!predicate)
     {
@@ -683,7 +695,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeIn(
     }
 
     /// Handle both `arrayElement(map, 'key') IN (set)` and `map.key_<serialized_key> IN (set)`.
-    if (auto map_info = tryResolveMapInfoFromNode(key_node, header))
+    if (auto map_info = tryResolveMapInfoFromNode(key_node, header, metadata_snapshot))
     {
         /** It is important to ignore keys like column_map['Key'] IN ('') because if the key does not exist in the map
           * we return the default value for arrayElement.
@@ -1188,7 +1200,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
     /// Handle both `arrayElement(map, 'key') = value` and `map.key_<serialized_key> = value`.
     if (function_name == "equals")
     {
-        if (auto map_info = tryResolveMapInfoFromNode(key_node, header))
+        if (auto map_info = tryResolveMapInfoFromNode(key_node, header, metadata_snapshot))
         {
             /** It is important to ignore keys like column_map['Key'] = '' because if the key does not exist in the map
               * we return the default value for arrayElement.
@@ -1304,7 +1316,8 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilter::createIndexAggregator() c
 
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilter::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionBloomFilter>(predicate, context, index.sample_block, hash_functions);
+    return std::make_shared<MergeTreeIndexConditionBloomFilter>(
+        predicate, context, index.sample_block, hash_functions, metadata_snapshot);
 }
 
 static void assertIndexColumnsType(const Block & header)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.h
@@ -72,7 +72,12 @@ public:
         std::vector<std::pair<size_t, ColumnPtr>> predicate;
     };
 
-    MergeTreeIndexConditionBloomFilter(const ActionsDAG::Node * predicate, ContextPtr context_, const Block & header_, size_t hash_functions_);
+    MergeTreeIndexConditionBloomFilter(
+        const ActionsDAG::Node * predicate,
+        ContextPtr context_,
+        const Block & header_,
+        size_t hash_functions_,
+        StorageMetadataPtr metadata_snapshot_);
 
     bool alwaysUnknownOrTrue() const override;
 
@@ -89,6 +94,7 @@ public:
 private:
     const Block & header;
     const size_t hash_functions;
+    const StorageMetadataPtr metadata_snapshot;
     std::vector<RPNElement> rpn;
 
     bool mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -157,12 +157,14 @@ MergeTreeConditionBloomFilterText::MergeTreeConditionBloomFilterText(
     ContextPtr context,
     const Block & index_sample_block,
     const BloomFilterParameters & params_,
-    TokenizerPtr token_extactor_)
+    TokenizerPtr token_extactor_,
+    StorageMetadataPtr metadata_snapshot_)
     : index_columns(index_sample_block.getNames())
     , index_data_types(index_sample_block.getNamesAndTypesList().getTypes())
     , params(params_)
     , owned_tokenizer(token_extactor_ && token_extactor_->isStateful() ? token_extactor_->clone() : nullptr)
     , tokenizer(owned_tokenizer ? owned_tokenizer.get() : token_extactor_)
+    , metadata_snapshot(std::move(metadata_snapshot_))
 {
     if (!predicate)
     {
@@ -634,6 +636,9 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
         {
             auto & [map_column_name, serialized_key] = *parsed;
 
+            if (!metadata_snapshot || !isKeySubcolumnOfMap(metadata_snapshot->getColumns(), column_name, map_column_name))
+                return false;
+
             /// Same as arrayElement: skip when comparing with default value because
             /// the subcolumn returns default for keys that don't exist in the map.
             /// Unwrapped default: LC(Nullable(String)) default is NULL, but the subcolumn returns '' for a missing key.
@@ -977,7 +982,8 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexBloomFilterText::createIndexAggregator
 MergeTreeIndexConditionPtr MergeTreeIndexBloomFilterText::createIndexCondition(
         const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeConditionBloomFilterText>(predicate, context, index.sample_block, params, tokenizer.get());
+    return std::make_shared<MergeTreeConditionBloomFilterText>(
+        predicate, context, index.sample_block, params, tokenizer.get(), metadata_snapshot);
 }
 
 MergeTreeIndexPtr bloomFilterIndexTextCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & /*settings*/)

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
@@ -70,7 +70,8 @@ public:
             ContextPtr context,
             const Block & index_sample_block,
             const BloomFilterParameters & params_,
-            TokenizerPtr token_extactor_);
+            TokenizerPtr token_extactor_,
+            StorageMetadataPtr metadata_snapshot_);
 
     ~MergeTreeConditionBloomFilterText() override = default;
 
@@ -152,6 +153,8 @@ private:
 
     std::unique_ptr<ITokenizer> owned_tokenizer;
     TokenizerPtr tokenizer;
+
+    StorageMetadataPtr metadata_snapshot;
 
     RPN rpn;
 };

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -141,9 +141,11 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     TokenizerPtr tokenizer_,
     MergeTreeIndexTextPreprocessorPtr preprocessor_,
     MergeTreeIndexTextPostprocessorPtr postprocessor_,
-    bool has_positions_)
+    bool has_positions_,
+    StorageMetadataPtr metadata_snapshot_)
     : WithContext(context_)
     , header(index_sample_block)
+    , metadata_snapshot(std::move(metadata_snapshot_))
     , normalized_index_column_name(normalized_index_column_name_)
     , owned_tokenizer(tokenizer_ && tokenizer_->isStateful() ? std::shared_ptr<const ITokenizer>(tokenizer_->clone()) : nullptr)
     , tokenizer(owned_tokenizer ? owned_tokenizer.get() : tokenizer_)
@@ -1122,7 +1124,9 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         if (auto parsed = tryParseMapSubcolumnName(index_column_name))
         {
             auto & [map_column_name, _] = *parsed;
-            if (header.has(fmt::format("mapValues({})", map_column_name))
+            if (metadata_snapshot
+                && isKeySubcolumnOfMap(metadata_snapshot->getColumns(), index_column_name, map_column_name)
+                && header.has(fmt::format("mapValues({})", map_column_name))
                 && value_field.getType() == Field::Types::String
                 && !value_field.safeGet<String>().empty())
             {
@@ -1821,6 +1825,10 @@ bool MergeTreeIndexConditionText::traverseMapElementKeyNode(const RPNBuilderFunc
         if (!header.has(fmt::format("mapKeys({})", map_column_name)))
             return false;
 
+        if (!metadata_snapshot
+            || !isKeySubcolumnOfMap(metadata_snapshot->getColumns(), required_column.name, map_column_name))
+            return false;
+
         key_const_value = std::move(serialized_key);
     }
 
@@ -1861,10 +1869,13 @@ bool MergeTreeIndexConditionText::hasIndexForMapElementValue(const RPNBuilderTre
     }
 
     /// Handle `map.key_<serialized_key>` subcolumn form.
-    auto parsed = tryParseMapSubcolumnName(node.getColumnName());
+    auto column_name = node.getColumnName();
+    auto parsed = tryParseMapSubcolumnName(column_name);
     if (!parsed)
         return false;
     auto & [map_column_name, serialized_key] = *parsed;
+    if (!metadata_snapshot || !isKeySubcolumnOfMap(metadata_snapshot->getColumns(), column_name, map_column_name))
+        return false;
     return header.has(fmt::format("mapValues({})", map_column_name));
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -97,7 +97,8 @@ public:
         TokenizerPtr tokenizer_,
         MergeTreeIndexTextPreprocessorPtr preprocessor_,
         MergeTreeIndexTextPostprocessorPtr postprocessor_,
-        bool has_positions_);
+        bool has_positions_,
+        StorageMetadataPtr metadata_snapshot_);
 
     ~MergeTreeIndexConditionText() override = default;
     static bool isSupportedFunction(const String & function_name);
@@ -206,6 +207,7 @@ private:
     static bool requiresReadingAllTokens(const RPNElement & element);
 
     Block header;
+    StorageMetadataPtr metadata_snapshot;
     std::optional<String> normalized_index_column_name;
     /// A private clone of the index tokenizer when it is stateful, so concurrent conditions do not
     /// share mutable parsing state; null otherwise.

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -2053,7 +2053,16 @@ MergeTreeIndexAggregatorPtr MergeTreeIndexText::createIndexAggregator() const
 
 MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
-    return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, normalized_index_column_name, tokenizer.get(), preprocessor, postprocessor, params.positions);
+    return std::make_shared<MergeTreeIndexConditionText>(
+        predicate,
+        context,
+        index.sample_block,
+        normalized_index_column_name,
+        tokenizer.get(),
+        preprocessor,
+        postprocessor,
+        params.positions,
+        metadata_snapshot);
 }
 
 DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -11,6 +11,8 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/NestedUtils.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <DataTypes/Serializations/SerializationMap.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
@@ -70,6 +72,51 @@ String getIndexFileName(const String & index_name, bool escape_filename)
             "Skip index name ({}) cannot contain '/' with `escape_index_filenames` disabled", index_name);
 
     return String(SKIP_INDEX_FILE_PREFIX) + index_name;
+}
+
+bool isKeySubcolumnOfMap(
+    const ColumnsDescription & columns, const String & column_name, const String & map_column_name)
+{
+    auto options = GetColumnsOptions(GetColumnsOptions::All).withSubcolumns();
+    auto resolved_key = columns.tryGetColumn(options, column_name);
+    auto resolved_map = columns.tryGetColumn(options, map_column_name);
+
+    if (!resolved_key || !resolved_map || !resolved_key->isSubcolumn())
+        return false;
+
+    if (resolved_key->getNameInStorage() != resolved_map->getNameInStorage())
+        return false;
+
+    auto key_info = resolved_key->getTypeInStorage()->tryGetSubcolumnInfo(resolved_key->getSubcolumnName());
+    if (!key_info || !SerializationMap::isKeyValueSubcolumn(key_info->substreams_path))
+        return false;
+
+    /// The key's parent must be this index's map; an empty path means the map is the storage column
+    /// itself. Distinct paths can render to the same subcolumn name under one storage column, so
+    /// only the paths decide. `bucket` carries no identity: it is a Map-with-buckets read detail.
+    ISerialization::SubstreamPath map_path;
+    if (resolved_map->isSubcolumn())
+    {
+        auto map_info = resolved_map->getTypeInStorage()->tryGetSubcolumnInfo(resolved_map->getSubcolumnName());
+        if (!map_info)
+            return false;
+        map_path = map_info->substreams_path;
+    }
+
+    const auto & key_path = key_info->substreams_path;
+    if (key_path.size() != map_path.size() + 1)
+        return false;
+
+    for (size_t i = 0; i < map_path.size(); ++i)
+    {
+        if (key_path[i].type != map_path[i].type
+            || key_path[i].name_of_substream != map_path[i].name_of_substream
+            || key_path[i].variant_element_name != map_path[i].variant_element_name
+            || key_path[i].object_path_name != map_path[i].object_path_name)
+            return false;
+    }
+
+    return true;
 }
 
 String IMergeTreeIndex::getFileName() const

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -445,4 +445,12 @@ bool indexFileExistsInChecksums(
     const std::string & path_prefix,
     const std::string & extension,
     const IDataPartStorage * storage = nullptr);
+
+/// Whether @column_name really is the key subcolumn of the Map named @map_column_name, which the
+/// `<map>.key_<key>` spelling alone cannot tell: subcolumn names are flat, and identifier
+/// resolution takes the shortest matching column prefix, so a physical column, a Tuple element or a
+/// JSON path can claim the name. Only the resolved subcolumn's substream path tells a map's key
+/// from such a claimant, and only its parent tells one map's key from another map's.
+bool isKeySubcolumnOfMap(
+    const ColumnsDescription & columns, const String & column_name, const String & map_column_name);
 }

--- a/tests/queries/0_stateless/03990_map_subcolumn_skip_index.reference
+++ b/tests/queries/0_stateless/03990_map_subcolumn_skip_index.reference
@@ -57,3 +57,22 @@ Granules: 1/1
 -- Correctness without optimization
 3	3
 6	6
+-- Section 8
+-- dynamic JSON path shadowing a Map column: indexed count, oracle
+1	1
+-- same, with optimize_functions_to_subcolumns = 0
+1	1
+-- bloom_filter condition: indexed count, oracle
+1	1
+-- text index on mapValues: indexed count, oracle
+1	1
+-- physical column named m.key_nokey: indexed count, oracle
+1	1
+-- key of a different map under the same name space: indexed count, oracle
+1	1
+-- parents rendering to the same name: indexed count, oracle
+1	1
+-- JSON typed path key subcolumn: index still prunes the missing key
+Granules: 0/1
+-- JSON typed path key subcolumn: missing key, present key
+0	1

--- a/tests/queries/0_stateless/03990_map_subcolumn_skip_index.reference
+++ b/tests/queries/0_stateless/03990_map_subcolumn_skip_index.reference
@@ -68,6 +68,8 @@ Granules: 1/1
 1	1
 -- physical column named m.key_nokey: indexed count, oracle
 1	1
+-- physical column named m.key_nokey, text index on mapKeys: indexed count, oracle
+1	1
 -- key of a different map under the same name space: indexed count, oracle
 1	1
 -- parents rendering to the same name: indexed count, oracle

--- a/tests/queries/0_stateless/03990_map_subcolumn_skip_index.sql
+++ b/tests/queries/0_stateless/03990_map_subcolumn_skip_index.sql
@@ -421,6 +421,25 @@ FROM t_shadow_physical WHERE `m.key_nokey` = 'hello' SETTINGS use_skip_indexes =
 
 DROP TABLE t_shadow_physical;
 
+DROP TABLE IF EXISTS t_shadow_physical_text;
+
+-- Same name collision reaching the `text` index's mapKeys path, which validates the name separately.
+CREATE TABLE t_shadow_physical_text
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapKeys(m) TYPE text(tokenizer = splitByNonAlpha) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_physical_text VALUES ({'abc':'x'}, 'hello');
+
+SELECT '-- physical column named m.key_nokey, text index on mapKeys: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_physical_text WHERE hasToken(`m.key_nokey`, 'hello') SETTINGS use_skip_indexes = 0)
+FROM t_shadow_physical_text WHERE hasToken(`m.key_nokey`, 'hello') SETTINGS use_skip_indexes = 1;
+
+DROP TABLE t_shadow_physical_text;
+
 DROP TABLE IF EXISTS t_shadow_other_map;
 
 -- Two maps in one name space: the key belongs to the JSON's map, the index covers the physical one.

--- a/tests/queries/0_stateless/03990_map_subcolumn_skip_index.sql
+++ b/tests/queries/0_stateless/03990_map_subcolumn_skip_index.sql
@@ -329,3 +329,161 @@ SELECT id, m['key0'] FROM t_map_idx_correct WHERE m['key0'] > 0 ORDER BY id
 SETTINGS optimize_functions_to_subcolumns = 0;
 
 DROP TABLE t_map_idx_correct;
+
+-- ==========================================
+-- Section 8: `<map>.key_<key>` names that belong to something else must not select the index
+-- ==========================================
+-- Index analysis used to split such a name at `.key_` and probe the map's index, while identifier
+-- resolution binds the name to the shortest matching column prefix. When those disagree the index
+-- prunes the granule the predicate actually matches, so each arm prints the indexed count next to
+-- the `use_skip_indexes = 0` oracle: they must be equal, and equal to 1.
+
+SELECT '-- Section 8';
+
+DROP TABLE IF EXISTS t_shadow_dynamic;
+
+-- A `JSON` column `j` captures `j.m.key_nokey` as a dynamic path, so the physical map `j.m` is
+-- never read by this predicate.
+CREATE TABLE t_shadow_dynamic
+(
+    j JSON,
+    `j.m` Map(String, String),
+    INDEX idx mapKeys(`j.m`) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_dynamic VALUES ('{"m.key_nokey":"hello"}', {'abc':'x'});
+
+SELECT '-- dynamic JSON path shadowing a Map column: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_dynamic WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 0)
+FROM t_shadow_dynamic WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 1;
+
+SELECT '-- same, with optimize_functions_to_subcolumns = 0';
+SELECT count(), (SELECT count() FROM t_shadow_dynamic WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 0)
+FROM t_shadow_dynamic WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 1, optimize_functions_to_subcolumns = 0;
+
+DROP TABLE t_shadow_dynamic;
+
+DROP TABLE IF EXISTS t_shadow_dynamic_bf;
+
+-- The same shape reaching the `bloom_filter` condition instead of the text bloom filter.
+CREATE TABLE t_shadow_dynamic_bf
+(
+    j JSON,
+    `j.m` Map(String, String),
+    INDEX idx mapKeys(`j.m`) TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_dynamic_bf VALUES ('{"m.key_nokey":"hello"}', {'abc':'x'});
+
+SELECT '-- bloom_filter condition: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_dynamic_bf WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 0)
+FROM t_shadow_dynamic_bf WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 1;
+
+DROP TABLE t_shadow_dynamic_bf;
+
+DROP TABLE IF EXISTS t_shadow_dynamic_text;
+
+-- And the `text` index on `mapValues`.
+CREATE TABLE t_shadow_dynamic_text
+(
+    j JSON,
+    `j.m` Map(String, String),
+    INDEX idx mapValues(`j.m`) TYPE text(tokenizer = splitByNonAlpha) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_dynamic_text VALUES ('{"m.key_nokey":"hello"}', {'abc':'zzz'});
+
+SELECT '-- text index on mapValues: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_dynamic_text WHERE hasToken(j.m.key_nokey, 'hello') SETTINGS use_skip_indexes = 0)
+FROM t_shadow_dynamic_text WHERE hasToken(j.m.key_nokey, 'hello') SETTINGS use_skip_indexes = 1;
+
+DROP TABLE t_shadow_dynamic_text;
+
+DROP TABLE IF EXISTS t_shadow_physical;
+
+-- A physical column can carry the name too.
+CREATE TABLE t_shadow_physical
+(
+    m Map(String, String),
+    `m.key_nokey` String,
+    INDEX idx mapKeys(m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_physical VALUES ({'abc':'x'}, 'hello');
+
+SELECT '-- physical column named m.key_nokey: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_physical WHERE `m.key_nokey` = 'hello' SETTINGS use_skip_indexes = 0)
+FROM t_shadow_physical WHERE `m.key_nokey` = 'hello' SETTINGS use_skip_indexes = 1;
+
+DROP TABLE t_shadow_physical;
+
+DROP TABLE IF EXISTS t_shadow_other_map;
+
+-- Two maps in one name space: the key belongs to the JSON's map, the index covers the physical one.
+CREATE TABLE t_shadow_other_map
+(
+    j JSON(m Map(String, String)),
+    `j.m` Map(String, String),
+    INDEX idx mapKeys(`j.m`) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_other_map VALUES ('{"m":{"nokey":"hello"}}', {'abc':'x'});
+
+SELECT '-- key of a different map under the same name space: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_other_map WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 0)
+FROM t_shadow_other_map WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 1;
+
+DROP TABLE t_shadow_other_map;
+
+DROP TABLE IF EXISTS t_shadow_same_rendered_name;
+
+-- Two maps whose parents render to the same subcolumn name under the same storage column: the
+-- direct Tuple element `x.Map(String, String)` and the `Map(String, String)` variant of element `x`.
+-- Only the substream paths differ, so a name comparison cannot separate them.
+SET enable_variant_type = 1;
+
+CREATE TABLE t_shadow_same_rendered_name
+(
+    c Tuple(`x.Map(String, String)` Map(String, String), x Variant(Map(String, String), UInt64)),
+    INDEX idx mapKeys(c.`x.Map(String, String)`) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_shadow_same_rendered_name VALUES ((map('abc', 'x'), map('nokey', 'hello')));
+
+SELECT '-- parents rendering to the same name: indexed count, oracle';
+SELECT count(), (SELECT count() FROM t_shadow_same_rendered_name WHERE c.`x.Map(String, String)`.key_nokey = 'hello' SETTINGS use_skip_indexes = 0)
+FROM t_shadow_same_rendered_name WHERE c.`x.Map(String, String)`.key_nokey = 'hello' SETTINGS use_skip_indexes = 1;
+
+DROP TABLE t_shadow_same_rendered_name;
+
+DROP TABLE IF EXISTS t_json_typed_map;
+
+-- In-range control: a genuine key subcolumn reached through a JSON typed path must stay indexable,
+-- so the missing key still prunes and the present key is still found.
+CREATE TABLE t_json_typed_map
+(
+    j JSON(m Map(String, String)),
+    INDEX idx mapKeys(j.m) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_json_typed_map VALUES ('{"m":{"abc":"x"}}');
+
+SELECT '-- JSON typed path key subcolumn: index still prunes the missing key';
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM t_json_typed_map WHERE j.m.key_zzz = 'x'
+) WHERE explain LIKE '%Granules:%';
+
+SELECT '-- JSON typed path key subcolumn: missing key, present key';
+SELECT
+    (SELECT count() FROM t_json_typed_map WHERE j.m.key_zzz = 'x'),
+    (SELECT count() FROM t_json_typed_map WHERE j.m.key_abc = 'x');
+
+DROP TABLE t_json_typed_map;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/119457


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results when a skip index over a `Map` column was consulted for a `<map>.key_<key>` predicate whose name does not belong to that map. Because dots are legal in column names, a `JSON` column `j` beside a `Map` column named `` `j.m` `` made `j.m.key_<key>` resolve to a dynamic path of `j`, while index analysis read it as a key of `` `j.m` `` and skipped the granule holding the matching row. A physical column, a `Tuple` element or another map sharing the name space had the same effect.


### Description

A `<map>.key_<key>` name was split lexically at the first `.key_`, with no check
that it belongs to the map the index covers. Identifier resolution answers differently: it binds a
dotted name through the **shortest** matching column prefix. Where the two disagree, the index prunes
the granule the predicate matches and the query silently returns fewer rows. Reachable at defaults:

```sql
CREATE TABLE tdj (j JSON, `j.m` Map(String, String),
    INDEX idx mapKeys(`j.m`) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1)
ENGINE = MergeTree ORDER BY tuple();
INSERT INTO tdj VALUES ('{"m.key_nokey":"hello"}', {'abc':'x'});

SELECT count() FROM tdj WHERE j.m.key_nokey = 'hello';                     -- 0, wrong
SELECT count() FROM tdj WHERE j.m.key_nokey = 'hello' SETTINGS use_skip_indexes = 0;  -- 1
```

Here `j.m.key_nokey` reads dynamic JSON path `m.key_nokey` of `j` (`toTypeName` is `Dynamic`), not
the physical map the index covers. The name is spelled by the query, so this does not depend on
`optimize_functions_to_subcolumns`.

The rewrite side gates on `canOptimizeToExpectedSubcolumn`: the resolved subcolumn's substream path
must end in the expected marker, since subcolumn names are flat. It never asks whose column that
subcolumn is; the consuming side asked nothing.
`isKeySubcolumnOfMap` asks both at the five skip-index call sites: resolve the name as the analyzer
does, require a substream path ending in `Substream::MapKeyValue`, and require its parent path to be
this index's map, compared structurally: two maps under one storage column can flatten to one
name. Refusal is fail-safe: fewer granules are pruned.

Extended `03990_map_subcolumn_skip_index` fails on the parent commit and passes here, with an
in-range control (a genuine key subcolumn under a JSON typed path) that keeps pruning; 20/20
randomized reruns green.

#119457 (mine) refuses the same parse for an enumerated set of names. This subsumes it (key
subcolumns are never enumerated) and also covers the dynamic path, which no set can reach.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119591&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119591](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119591+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
