### PR TITLE
Fix restored access entities not being enforced until the next access change

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -19,7 +19,6 @@
 #include <Access/AccessBackup.h>
 #include <Access/resolveSetting.h>
 #include <Backups/BackupEntriesCollector.h>
-#include <Backups/RestorerFromBackup.h>
 #include <Core/Settings.h>
 #include <base/range.h>
 #include <IO/Operators.h>
@@ -664,12 +663,6 @@ See also /etc/clickhouse-server/users.xml on the server where ClickHouse is inst
             "{}: Authentication failed: password is incorrect, or there is no user with such name",
             std::vector<std::string>{credentials.getUserName()}}, error_code);
     }
-}
-
-void AccessControl::restoreFromBackup(RestorerFromBackup & restorer, const String & data_path_in_backup)
-{
-    MultipleAccessStorage::restoreFromBackup(restorer, data_path_in_backup);
-    changes_notifier->sendNotifications();
 }
 
 void AccessControl::setExternalAuthenticatorsConfig(const Poco::Util::AbstractConfiguration & config)

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -128,9 +128,6 @@ public:
 
     AuthResult authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ClientInfo & client_info) const;
 
-    /// Makes a backup of access entities.
-    void restoreFromBackup(RestorerFromBackup & restorer, const String & data_path_in_backup) override;
-
     void setExternalAuthenticatorsConfig(const Poco::Util::AbstractConfiguration & config);
 
     /// Sets the default profile's name.

--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -4,6 +4,7 @@
 #include <Access/Credentials.h>
 #include <Access/User.h>
 #include <Access/AccessBackup.h>
+#include <Access/AccessControl.h>
 #include <Backups/BackupEntriesCollector.h>
 #include <Backups/IBackupCoordination.h>
 #include <Backups/IRestoreCoordination.h>
@@ -909,8 +910,14 @@ void IAccessStorage::restoreFromBackup(RestorerFromBackup & restorer, const Stri
         [this, &restorer, data_path_in_backup]
         {
             auto entities_to_restore = restorer.getAccessEntitiesToRestore(data_path_in_backup);
+            if (entities_to_restore.new_entities.empty())
+                return; /// Only one data path of a restore carries its access entities.
+
             const auto & restore_settings = restorer.getRestoreSettings();
             restoreAccessEntitiesFromBackup(*this, entities_to_restore, restore_settings);
+
+            /// The entities went straight into this storage, so no subscriber knows about them yet.
+            restorer.getContext()->getAccessControl().getChangesNotifier().sendNotifications();
         });
 }
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2540,6 +2540,9 @@ def test_structure_only_restores_access_entities_and_udfs():
     )
 
     assert instance.query("EXISTS test.table") == "1\n"
+    # The restored row policy is for u1 and applies at once, and this config enables
+    # throw_on_unmatched_row_policies, so drop it before reading as `default`.
+    instance.query("DROP ROW POLICY rowpol1 ON test.table")
     assert instance.query("SELECT count() FROM test.table") == "0\n"
     assert (
         instance.query("SHOW CREATE USER u1")
@@ -2548,7 +2551,6 @@ def test_structure_only_restores_access_entities_and_udfs():
     assert instance.query("SELECT linear_equation(2, 3, 1)") == "7\n"
 
     instance.query("DROP FUNCTION linear_equation")
-    instance.query("DROP ROW POLICY rowpol1 ON test.table")
     instance.query("DROP DATABASE test")
     instance.query("DROP USER u1")
     instance.query("DROP ROLE r1")
@@ -2605,9 +2607,8 @@ def test_structure_only_restores_access_entities_and_udfs():
         f" SETTINGS structure_only=true, restore_access_entities='true', restore_functions='1'"
     )
 
-    # Table exists but has no data
+    # Table exists; emptiness is asserted below, after the row policy is dropped.
     assert instance.query("EXISTS test.table") == "1\n"
-    assert instance.query("SELECT count() FROM test.table") == "0\n"
 
     # All access entity types were restored
     assert (
@@ -2631,7 +2632,10 @@ def test_structure_only_restores_access_entities_and_udfs():
 
     instance.query("DROP FUNCTION linear_equation")
 
+    # As in phase 4, drop the restored policy before reading the table as `default`.
     instance.query("DROP ROW POLICY rowpol1 ON test.table")
+    assert instance.query("SELECT count() FROM test.table") == "0\n"
+
     instance.query("DROP DATABASE test")
     instance.query("DROP USER u1")
     instance.query("DROP ROLE r1")

--- a/tests/queries/0_stateless/05182_restore_access_entities_are_enforced.reference
+++ b/tests/queries/0_stateless/05182_restore_access_entities_are_enforced.reference
@@ -1,0 +1,6 @@
+-- enforced when created by DDL
+3	2
+-- restored
+1
+-- enforced right after RESTORE, without SYSTEM RELOAD USERS
+3	2

--- a/tests/queries/0_stateless/05182_restore_access_entities_are_enforced.sh
+++ b/tests/queries/0_stateless/05182_restore_access_entities_are_enforced.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+
+# Disabled parallel for two reasons. RESTORE can only restore either all access entities or none
+# (it can't restore only the entities added by the current test run), so a RESTORE from a parallel
+# test run could recreate our entities before we expect that. And this test asserts that a RESTORE
+# refreshes the access caches by itself, which any concurrent access DDL would also do, hiding a
+# regression.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+user="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+policy="policy_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+backup_name="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}')"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP USER IF EXISTS ${user};
+CREATE TABLE ${CLICKHOUSE_DATABASE}.t (id Int64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ${CLICKHOUSE_DATABASE}.t SELECT number FROM numbers(10);
+CREATE USER ${user} IDENTIFIED WITH no_password;
+GRANT SELECT ON ${CLICKHOUSE_DATABASE}.* TO ${user};
+CREATE ROW POLICY ${policy} ON ${CLICKHOUSE_DATABASE}.t USING id < 3 TO ${user};
+"
+
+echo "-- enforced when created by DDL"
+${CLICKHOUSE_CLIENT} --user "${user}" --query "SELECT count(), max(id) FROM ${CLICKHOUSE_DATABASE}.t"
+
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE system.users, TABLE system.row_policies TO ${backup_name} FORMAT Null"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP ROW POLICY ${policy} ON ${CLICKHOUSE_DATABASE}.t;
+DROP USER ${user};
+"
+
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE system.users, TABLE system.row_policies FROM ${backup_name} FORMAT Null"
+
+echo "-- restored"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.row_policies WHERE short_name = '${policy}' AND database = '${CLICKHOUSE_DATABASE}' AND table = 't'"
+
+echo "-- enforced right after RESTORE, without SYSTEM RELOAD USERS"
+${CLICKHOUSE_CLIENT} --user "${user}" --query "SELECT count(), max(id) FROM ${CLICKHOUSE_DATABASE}.t"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP ROW POLICY IF EXISTS ${policy} ON ${CLICKHOUSE_DATABASE}.t;
+DROP USER IF EXISTS ${user};
+"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `RESTORE` of access entities (`system.users`, `system.roles`, `system.row_policies`, `system.settings_profiles`, `system.quotas`) not taking effect until the next access change or `SYSTEM RELOAD USERS`. For example, a restored row policy was listed in `system.row_policies` but was not enforced, so the users it targets kept reading every row.


### Description

`RESTORE` of the ACL system tables reports success, but no restored entity is enforced: a restored row policy appears in `system.row_policies` and does not apply until an unrelated access DDL, `SYSTEM RELOAD USERS`, or a restart, so on an idle server it can stay unenforced indefinitely. Reproduced on the official 26.9.1.1224 binary (below): 10 rows served where the policy permits 3.

Root cause: `AccessControl::restoreFromBackup` drained the access-change notifier immediately after `MultipleAccessStorage::restoreFromBackup`, which at that point has only registered a deferred data-restore task, so the queue was empty. The inserts happen later, from `runDataRestoreTasks()` via `restoreAccessEntitiesFromBackup`, straight into the destination storage, bypassing `AccessControl::insertImpl`'s own drain. `AccessChangesNotifier` only queues changes, so the batch waited for an unrelated caller while every cache subscriber kept its pre-restore state.

Fix: drain inside the deferred task instead, after the entities are inserted and their dependencies fixed up, and only in the task that restored something (exactly one data path carries the access entities). The now-purposeless `AccessControl::restoreFromBackup` override is removed.

Validation: new stateless test `05182_restore_access_entities_are_enforced` asserts the same policy is enforced when created by DDL with no reload (control) and after a `RESTORE`. It fails deterministically without this change, passes 50/50 with it, and four mutation arms redden it.

`test_structure_only_restores_access_entities_and_udfs` asserted the unenforced behaviour: it read a restored table as `default` while a restored policy for `u1` applied. Its two reads now drop that policy first; `test_backup_restore_new` and `test_backup_restore_on_cluster` pass.

A `RESTORE` that fails part-way still leaves already-inserted entities unpublished; `RESTORE` has no rollback for access entities and that is not addressed here.

Reported by the sibling agent fleet (OranjeAI).

<details>
<summary>Reproduction on the official 26.9.1.1224 binary</summary>

Single server, default settings, a `local` disk named `backups`.

```sql
CREATE TABLE dt (id Int64) ENGINE = MergeTree ORDER BY id;
INSERT INTO dt SELECT number FROM numbers(10);
CREATE USER ud IDENTIFIED WITH no_password;
GRANT SELECT ON default.dt TO ud;
CREATE ROW POLICY rpd ON default.dt USING id < 3 TO ud;

-- as ud, baseline:                     SELECT count() FROM default.dt  -> 3   (enforced)
BACKUP TABLE system.users, TABLE system.row_policies TO Disk('backups','d2');
DROP ROW POLICY rpd ON default.dt; DROP USER ud;
RESTORE TABLE system.users, TABLE system.row_policies FROM Disk('backups','d2');

SELECT count() FROM system.row_policies WHERE name LIKE '%rpd%';  -- 1  (restored)
-- as ud, right after the RESTORE:      SELECT count() FROM default.dt  -> 10  <-- bug
-- as ud, +5 s:                                                        -> 10  (not time-based)
SYSTEM RELOAD USERS;
-- as ud:                               SELECT count() FROM default.dt  -> 3
```

The baseline line is the control: the notifier, the policy and the setup all work, so the 10 can
only mean "restored but never published to the caches".

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119615&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119615](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119615+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

