### PR TITLE
Do not leave a `Filesystem` database pointing at a removed directory, which makes the server refuse to start

### DIFF
--- a/tests/queries/0_stateless/05153_database_filesystem_cache_read_on_file_grant.sh
+++ b/tests/queries/0_stateless/05153_database_filesystem_cache_read_on_file_grant.sh
@@ -55,4 +55,13 @@ ${CLICKHOUSE_CLIENT} <<EOF
 DROP DATABASE $fs_db;
 DROP USER $user;
 EOF
-rm -rd "$dir"
+
+# The directory outlives the shell only as the target of the database, but the database's metadata
+# outlives it too, and a `Filesystem` database whose path is gone makes the server refuse to start
+# with `Path does not exist` at metadata loading. Remove the directory only once the database that
+# points at it is really gone, so a run whose `DROP` did not land -- the stress test kills the server
+# under the tests -- leaves a server that still starts.
+if [[ "$(${CLICKHOUSE_CLIENT} --query "EXISTS DATABASE $fs_db" 2>/dev/null)" == "0" ]]
+then
+    rm -rd "$dir"
+fi


### PR DESCRIPTION
`05153_database_filesystem_cache_read_on_file_grant` creates a `Filesystem` database over a directory under `user_files` and removes both at the end. The two cleanups are not atomic and they fail independently: `DROP DATABASE` is a call into the server and fails whenever the server is gone — routine under a stress run, where the server is killed and restarted while the tests run — while `rm -rd` is local and always succeeds.

The database's metadata then outlives the directory it points at, and every later server start aborts while loading metadata:

```
Code: 36. DB::Exception: Path does not exist: /var/lib/clickhouse/user_files/d_05153_test_..._21520:
while loading database `db_05153_test_..._23401` from file metadata/db_05153_test_..._23401.sql. (BAD_ARGUMENTS)
```

so the server never comes back and the job fails with `Cannot start clickhouse-server`. Seen on `Stress test (arm_asan_ubsan, s3)`: https://github.com/ClickHouse/ClickHouse/actions/runs/34678356221/job/103529922983 (report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=116647&sha=fca3eb858cfcfc30c835375b45f976add5188544&name_0=PR&name_1=Stress%20test%20(arm_asan_ubsan,%20s3) , PR https://github.com/ClickHouse/ClickHouse/pull/116647 — the failure is unrelated to that pull request's changes).

The fix removes the directory only once the database that points at it is really gone. A dead server makes `EXISTS DATABASE` produce nothing, the directory is kept, and the leftover is a harmless empty directory instead of a server that cannot start. This mirrors what `05057_file_rename_after_processing_write_grant` already does for the same hazard.

The other `Filesystem` database tests were checked and are not affected: `02722_database_filesystem` and `04653_database_filesystem_concurrent_resolve` create the database over the `user_files` root, which no test removes.

Verified on a local server: the test passes and leaves no directory behind, and `EXISTS DATABASE` answers `1` for a live database, `0` for a dropped one and nothing at all when the server is down.

Related: https://github.com/ClickHouse/ClickHouse/pull/116647

### Documentation entry for user-facing changes

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119618&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119618](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119618+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1380` (included in `26.9` and later)
- Backported to: `26.8.3.106`, `26.7.7.94`, `26.6.5.121`, `26.3.33.70`
<!-- ch-version-info:end -->