### PR TITLE
Avoid copying whole directory maps in plain-rewritable metadata snapshots

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsDirectoryMap.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsDirectoryMap.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace DB
+{
+
+struct FsNode;
+
+/// Persistent AVL tree: snapshots share unchanged entries. Updating one child copies
+/// O(log n) entries instead of all n children of a directory containing many parts.
+class FsDirectoryMap
+{
+    struct Entry;
+    using EntryPtr = std::shared_ptr<const Entry>;
+    using Value = std::shared_ptr<FsNode>;
+
+    struct Entry
+    {
+        std::string name;
+        Value value;
+        EntryPtr left;
+        EntryPtr right;
+        int height;
+    };
+
+    EntryPtr root;
+
+    static int height(const EntryPtr & entry)
+    {
+        return entry ? entry->height : 0;
+    }
+
+    static EntryPtr make(const std::string & name, const Value & value, EntryPtr left, EntryPtr right)
+    {
+        const int new_height = 1 + std::max(height(left), height(right));
+        return std::make_shared<Entry>(name, value, std::move(left), std::move(right), new_height);
+    }
+
+    static EntryPtr balance(const std::string & name, const Value & value, EntryPtr left, EntryPtr right)
+    {
+        if (height(left) > height(right) + 1)
+        {
+            if (height(left->left) < height(left->right))
+            {
+                const auto & middle = left->right;
+                return make(middle->name, middle->value,
+                    make(left->name, left->value, left->left, middle->left),
+                    make(name, value, middle->right, std::move(right)));
+            }
+            return make(left->name, left->value, left->left, make(name, value, left->right, std::move(right)));
+        }
+        if (height(right) > height(left) + 1)
+        {
+            if (height(right->right) < height(right->left))
+            {
+                const auto & middle = right->left;
+                return make(middle->name, middle->value,
+                    make(name, value, std::move(left), middle->left),
+                    make(right->name, right->value, middle->right, right->right));
+            }
+            return make(right->name, right->value, make(name, value, std::move(left), right->left), right->right);
+        }
+        return make(name, value, std::move(left), std::move(right));
+    }
+
+    /// A null value removes an entry. Build the new root before publishing it so
+    /// allocation failures leave this map and all its snapshots unchanged.
+    static EntryPtr update(const EntryPtr & entry, const std::string & name, const Value & value)
+    {
+        if (!entry)
+            return value ? make(name, value, nullptr, nullptr) : nullptr;
+
+        if (name < entry->name)
+            return balance(entry->name, entry->value, update(entry->left, name, value), entry->right);
+        if (name > entry->name)
+            return balance(entry->name, entry->value, entry->left, update(entry->right, name, value));
+        if (value)
+            return make(name, value, entry->left, entry->right);
+        if (!entry->left)
+            return entry->right;
+        if (!entry->right)
+            return entry->left;
+
+        auto successor = entry->right;
+        while (successor->left)
+            successor = successor->left;
+        return balance(successor->name, successor->value, entry->left, update(entry->right, successor->name, nullptr));
+    }
+
+    template <typename Callback>
+    static void visit(const EntryPtr & entry, const Callback & callback)
+    {
+        if (!entry)
+            return;
+        visit(entry->left, callback);
+        callback(entry->name, entry->value);
+        visit(entry->right, callback);
+    }
+
+public:
+    Value get(const std::string & name) const
+    {
+        const auto * entry = root.get();
+        while (entry)
+        {
+            if (name == entry->name)
+                return entry->value;
+            entry = (name < entry->name ? entry->left : entry->right).get();
+        }
+        return nullptr;
+    }
+
+    void set(const std::string & name, const Value & value)
+    {
+        root = update(root, name, value);
+    }
+    void erase(const std::string & name)
+    {
+        root = update(root, name, nullptr);
+    }
+    bool empty() const
+    {
+        return !root;
+    }
+
+    template <typename Callback>
+    void forEach(const Callback & callback) const
+    {
+        visit(root, callback);
+    }
+};
+
+}

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.cpp
@@ -38,11 +38,9 @@ Ptr walk(Ptr node, const NormalizedPath & path)
 {
     for (const auto & step : path)
     {
-        const auto it = node->subdirectories.find(step);
-        if (it == node->subdirectories.end())
+        node = node->subdirectories.get(step);
+        if (!node)
             return nullptr;
-
-        node = it->second;
     }
 
     return node;
@@ -60,9 +58,10 @@ void traverseNode(const std::string & path, const FsNodePtr & start, const std::
 
         observe(node_path, node);
 
-        unvisited.reserve(unvisited.size() + node->subdirectories.size());
-        for (const auto & [subdir, subnode] : node->subdirectories)
+        node->subdirectories.forEach([&](const auto & subdir, const auto & subnode)
+        {
             unvisited.emplace_back(node_path / subdir, subnode);
+        });
     }
 }
 
@@ -75,11 +74,9 @@ bool hasFileOnPath(const FsNodePtr & root, const NormalizedPath & path)
         if (!isVirtual(node) && node->info->files.contains(step))
             return true;
 
-        const auto it = node->subdirectories.find(step);
-        if (it == node->subdirectories.end())
+        node = node->subdirectories.get(step);
+        if (!node)
             return false;
-
-        node = it->second;
     }
 
     return false;
@@ -93,12 +90,12 @@ std::pair<FsNodePtr, FsNodePtr> clonePath(const FsNodePtr & start, const Normali
     for (const auto & step : path)
     {
         FsNodePtr cloned_child;
-        if (auto it = node->subdirectories.find(step); it != node->subdirectories.end())
-            cloned_child = std::make_shared<FsNode>(*it->second);
+        if (auto child = node->subdirectories.get(step))
+            cloned_child = std::make_shared<FsNode>(*child);
         else
             cloned_child = std::make_shared<FsNode>();
 
-        node->subdirectories[step] = cloned_child;
+        node->subdirectories.set(step, cloned_child);
         node = std::move(cloned_child);
     }
 
@@ -111,12 +108,12 @@ void trimPath(FsNodePtr node, const NormalizedPath & path)
     for (const auto & step : path)
     {
         spine.emplace_back(node, step);
-        node = node->subdirectories.at(step);
+        node = node->subdirectories.get(step);
     }
 
     for (const auto & [parent, name] : spine | std::views::reverse)
     {
-        const FsNodePtr & child = parent->subdirectories.at(name);
+        const FsNodePtr child = parent->subdirectories.get(name);
         if (!isVirtual(child) || !child->subdirectories.empty())
             break;
 
@@ -145,7 +142,7 @@ FsNodePtr moveTree(const FsNodePtr & root, const NormalizedPath & from, const No
     trimPath(without_subtree, from.parent_path());
 
     const auto [cloned_root, cloned_to_parent] = clonePath(without_subtree, to.parent_path());
-    cloned_to_parent->subdirectories[to.filename()] = detached;
+    cloned_to_parent->subdirectories.set(to.filename(), detached);
 
     return cloned_root;
 
@@ -252,7 +249,7 @@ void FsSnapshot::recordFile(const std::string & path, FileRemoteInfo info)
     if (isVirtual(node))
         throw Exception(ErrorCodes::CANNOT_CREATE_FILE, "Creation of a file under the virtual directory is not possible");
 
-    if (node->subdirectories.contains(normalized_path.filename()))
+    if (node->subdirectories.get(normalized_path.filename()))
         throw Exception(ErrorCodes::CANNOT_CREATE_FILE, "There is a subdirectory '{}' under the path '{}'. Can't create file", normalized_path.filename().string(), normalized_path.parent_path().string());
 
     if (node->info->files.contains(normalized_path.filename()))
@@ -294,7 +291,7 @@ std::vector<std::string> FsSnapshot::listDirectory(const std::string & path) con
         return {};
 
     std::vector<std::string> result;
-    result.append_range(node->subdirectories | std::views::keys);
+    node->subdirectories.forEach([&](const auto & name, const auto &) { result.push_back(name); });
 
     if (!isVirtual(node))
         result.append_range(node->info->files | std::views::keys);

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Disks/DiskObjectStorage/MetadataStorages/NormalizedPath.h>
+#include <Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsDirectoryMap.h>
 
 #include <Common/CurrentMetrics.h>
 
@@ -33,7 +34,7 @@ struct DirectoryRemoteInfo
 struct FsNode : public std::enable_shared_from_this<FsNode>
 {
     std::optional<DirectoryRemoteInfo> info = {};
-    std::unordered_map<std::string, std::shared_ptr<FsNode>> subdirectories = {};
+    FsDirectoryMap subdirectories;
 };
 
 /// Mutable snapshot of the virtual file system tree.

--- a/src/Disks/tests/gtest_fs_snapshot.cpp
+++ b/src/Disks/tests/gtest_fs_snapshot.cpp
@@ -1,0 +1,107 @@
+#include <Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.h>
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <random>
+
+using namespace DB;
+
+TEST(FsSnapshot, BranchesRemainIndependent)
+{
+    FsSnapshot original;
+    original.recordDirectoryPath("table/part", {.remote_path = "remote", .etag = "etag", .files = {}});
+    original.recordFile("table/part/data", {123, 456});
+
+    FsSnapshot renamed(original.getRoot());
+    FsSnapshot removed(original.getRoot());
+    renamed.moveDirectory("table/part", "other/part");
+    removed.removeFile("table/part/data");
+    removed.recordFile("table/part/new", {789, 123});
+
+    ASSERT_TRUE(original.existsFile("table/part/data"));
+    EXPECT_FALSE(original.existsFile("table/part/new"));
+    EXPECT_FALSE(original.existsDirectory("other"));
+    EXPECT_EQ(original.getFileRemoteInfo("table/part/data")->bytes_size, 123);
+    EXPECT_TRUE(renamed.existsFile("other/part/data"));
+    EXPECT_FALSE(renamed.existsDirectory("table"));
+    EXPECT_FALSE(removed.existsFile("table/part/data"));
+    EXPECT_TRUE(removed.existsFile("table/part/new"));
+
+    FsSnapshot before_removal(renamed.getRoot());
+    renamed.removeDirectory("other");
+    EXPECT_TRUE(renamed.listDirectory("").empty());
+    EXPECT_TRUE(before_removal.existsFile("other/part/data"));
+    EXPECT_THROW(original.moveDirectory("table", "table/part/child"), std::exception);
+    EXPECT_THROW(original.recordFile("table/part/data", {0, 0}), std::exception);
+    EXPECT_TRUE(original.existsFile("table/part/data"));
+}
+
+TEST(FsSnapshot, WideDirectorySharesUnchangedEntries)
+{
+    FsSnapshot original;
+    for (size_t i = 0; i < 10000; ++i)
+        original.recordDirectoryPath("table/" + std::to_string(i), {.remote_path = std::to_string(i), .etag = "", .files = {}});
+
+    auto children = original.getRoot()->subdirectories.get("table")->subdirectories;
+    FsSnapshot changed(original.getRoot());
+    changed.recordFile("table/5000/data", {123, 456});
+
+    size_t copied_entries = 0;
+    children.forEach([&](const auto &, const auto & child)
+    {
+        if (child.use_count() > 1)
+            ++copied_entries;
+    });
+    /// One update must share siblings, not copy the whole directory map.
+    EXPECT_LT(copied_entries, 32);
+    EXPECT_FALSE(original.existsFile("table/5000/data"));
+    EXPECT_TRUE(changed.existsFile("table/5000/data"));
+    EXPECT_EQ(original.listDirectory("table").size(), 10000);
+    EXPECT_EQ(changed.listDirectory("table").size(), 10000);
+}
+
+TEST(FsSnapshot, DirectoryMapMatchesOrderedMap)
+{
+    FsDirectoryMap actual;
+    std::map<std::string, std::shared_ptr<FsNode>> expected;
+    std::mt19937 random(123);
+
+    auto check = [](const auto & map, const auto & reference)
+    {
+        std::map<std::string, std::shared_ptr<FsNode>> entries;
+        map.forEach([&](const auto & name, const auto & value) { entries.emplace(name, value); });
+        EXPECT_EQ(entries, reference);
+        EXPECT_EQ(map.empty(), reference.empty());
+        for (const auto & [name, value] : reference)
+            EXPECT_EQ(map.get(name), value);
+    };
+
+    for (size_t i = 0; i < 10000; ++i)
+    {
+        const auto snapshot = actual;
+        const auto before = expected;
+        const auto name = std::to_string(random() % 128);
+        if (random() % 2)
+        {
+            auto value = std::make_shared<FsNode>();
+            actual.set(name, value);
+            expected[name] = value;
+        }
+        else
+        {
+            actual.erase(name);
+            expected.erase(name);
+            EXPECT_FALSE(actual.get(name));
+        }
+        check(actual, expected);
+        check(snapshot, before);
+    }
+
+    while (!expected.empty())
+    {
+        actual.erase(expected.begin()->first);
+        expected.erase(expected.begin());
+        check(actual, expected);
+    }
+}

--- a/src/Disks/tests/gtest_fs_snapshot.cpp
+++ b/src/Disks/tests/gtest_fs_snapshot.cpp
@@ -61,11 +61,35 @@ TEST(FsSnapshot, WideDirectorySharesUnchangedEntries)
     EXPECT_EQ(changed.listDirectory("table").size(), 10000);
 }
 
+TEST(FsSnapshot, WideDirectoryRemovalSharesUnchangedEntries)
+{
+    FsSnapshot original;
+    for (size_t i = 0; i < 10000; ++i)
+        original.recordDirectoryPath("table/" + std::to_string(i), {.remote_path = std::to_string(i), .etag = "", .files = {}});
+
+    auto children = original.getRoot()->subdirectories.get("table")->subdirectories;
+    FsSnapshot changed(original.getRoot());
+    changed.removeDirectory("table/5000");
+
+    size_t copied_entries = 0;
+    children.forEach([&](const auto &, const auto & child)
+    {
+        if (child.use_count() > 1)
+            ++copied_entries;
+    });
+    /// Removing one child must share siblings, just like updating one child.
+    EXPECT_LT(copied_entries, 32);
+    EXPECT_TRUE(original.existsDirectory("table/5000"));
+    EXPECT_FALSE(changed.existsDirectory("table/5000"));
+    EXPECT_EQ(original.listDirectory("table").size(), 10000);
+    EXPECT_EQ(changed.listDirectory("table").size(), 9999);
+}
+
 TEST(FsSnapshot, DirectoryMapMatchesOrderedMap)
 {
     FsDirectoryMap actual;
     std::map<std::string, std::shared_ptr<FsNode>> expected;
-    std::mt19937 random(123);
+    std::mt19937 random(123); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
 
     auto check = [](const auto & map, const auto & reference)
     {


### PR DESCRIPTION
With many parts, `FsSnapshot` copies the whole child-directory map for each metadata update. Old-part cleanup does this repeatedly while holding the metadata lock. Inserts wait for that lock while holding the parts lock, which also delays merges.

This change uses a persistent balanced tree for child directories. Snapshots share unchanged entries. Each update copies O(log n) entries instead of all n entries. Existing snapshots remain valid.

We tested a 26.8-based build with 2 million Kafka events, 1,000 teams, and 2,000 team/month partitions. The test used Packed parts, four ClickHouse CPUs, and an S3 proxy backed by local NVMe. Merges stayed enabled.

| Proxy measurement | Before | After |
|---|---:|---:|
| Ingestion time | 22m46s | 13m26s |
| Insert parts-lock hold time | 414s | 48s |
| Merge parts-lock wait time | 209s | 25s |

Ingestion took 41% less time. Native local ingestion stayed near 10 minutes. This was one sequential comparison; natural merge choices differed. Lock times accumulate across operations and are not wall-time components.

Three new snapshot tests and 52 existing metadata tests passed on the 26.8-based build. Both loads passed row, checksum, and query-result checks.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce metadata update cost and lock contention for `s3_plain_rewritable` disks with many parts by sharing unchanged directory entries between snapshots.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119625&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119625](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119625+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
