### PR TITLE
Cover the GCS header translation wiring end to end

### DIFF
--- a/src/IO/S3/tests/gtest_gcs_header_translation.cpp
+++ b/src/IO/S3/tests/gtest_gcs_header_translation.cpp
@@ -5,7 +5,18 @@
 #if USE_AWS_S3
 
 #include <IO/HTTPHeaderEntries.h>
+#include <IO/S3/Client.h>
+#include <IO/S3/Credentials.h>
+#include <IO/S3/PocoHTTPClient.h>
 #include <IO/S3/Requests.h>
+#include <IO/S3/tests/TestPocoHTTPServer.h>
+
+#include <Common/ProxyConfiguration.h>
+#include <Common/RemoteHostFilter.h>
+
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+
+#include <mutex>
 
 namespace
 {
@@ -128,6 +139,186 @@ TEST(GCSHeaderTranslation, NormalizesHeaderNames)
     EXPECT_EQ(headers[2].name, "custom-auth-token");
     /// Values are untouched.
     EXPECT_EQ(headers[2].value, "KeepTheValue");
+}
+
+
+namespace
+{
+
+/// A stand-in for GCS on localhost: it records the headers of the last request and answers in the
+/// `x-goog-` spelling, the way GCS does. Metadata is echoed back as `x-goog-meta-*`; `x-goog-hash`
+/// and `x-goog-generation` are GCS-only names we do not translate, so they must not confuse the SDK.
+class MockGCSHandler : public Poco::Net::HTTPRequestHandler
+{
+public:
+    MockGCSHandler(std::mutex & mutex_, Poco::Net::MessageHeader & last_request_header_)
+        : mutex(mutex_), last_request_header(last_request_header_)
+    {
+    }
+
+    void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override
+    {
+        {
+            std::lock_guard lock(mutex);
+            last_request_header = request;
+        }
+
+        response.set("ETag", "\"d41d8cd98f00b204e9800998ecf8427e\"");
+        response.set("x-goog-meta-owner", "analytics");
+        response.set("x-goog-generation", "1700000000000000");
+        response.set("x-goog-hash", "crc32c=AAAAAA==");
+        response.setContentType("binary/octet-stream");
+        response.setContentLength(0);
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+        response.send().flush();
+    }
+
+private:
+    std::mutex & mutex;
+    Poco::Net::MessageHeader & last_request_header;
+};
+
+class MockGCSHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory
+{
+public:
+    MockGCSHandlerFactory(std::mutex & mutex_, Poco::Net::MessageHeader & last_request_header_)
+        : mutex(mutex_), last_request_header(last_request_header_)
+    {
+    }
+
+    Poco::Net::HTTPRequestHandler * createRequestHandler(const Poco::Net::HTTPServerRequest &) override
+    {
+        return new MockGCSHandler(mutex, last_request_header);
+    }
+
+private:
+    std::mutex & mutex;
+    Poco::Net::MessageHeader & last_request_header;
+};
+
+class MockGCSServer
+{
+public:
+    MockGCSServer()
+        : server_socket(std::make_unique<Poco::Net::ServerSocket>(0))
+        , server(std::make_unique<Poco::Net::HTTPServer>(
+              new MockGCSHandlerFactory(mutex, last_request_header), *server_socket, makeMockServerParams()))
+    {
+        server->start();
+    }
+
+    ~MockGCSServer() { server->stop(); }
+
+    UInt16 getPort() const { return server_socket->address().port(); }
+
+    Poco::Net::MessageHeader getLastRequestHeader()
+    {
+        std::lock_guard lock(mutex);
+        return last_request_header;
+    }
+
+private:
+    std::mutex mutex;
+    Poco::Net::MessageHeader last_request_header;
+    std::unique_ptr<Poco::Net::ServerSocket> server_socket;
+    std::unique_ptr<Poco::Net::HTTPServer> server;
+};
+
+/// The API mode is GCS only when the endpoint is Google's and the credentials are empty, so the
+/// endpoint has to carry the real name. It is never resolved: the request is routed to the mock
+/// through a proxy, and `HTTPConnectionPool` connects to the proxy without consulting the resolver.
+std::unique_ptr<DB::S3::Client> makeClientTalkingToMockGCS(UInt16 mock_port, const DB::RemoteHostFilter & remote_host_filter)
+{
+    auto client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+        "us-east-1",
+        remote_host_filter,
+        /* s3_max_redirects = */ 10,
+        DB::S3::PocoHTTPClientConfiguration::RetryStrategy{.max_retries = 0},
+        /* s3_slow_all_threads_after_network_error = */ false,
+        /* s3_slow_all_threads_after_retryable_error = */ false,
+        /* enable_s3_requests_logging = */ false,
+        /* for_disk_s3 = */ false,
+        /* opt_disk_name = */ {},
+        /* request_throttler = */ {},
+        "http");
+
+    client_configuration.endpointOverride = "http://storage.googleapis.com";
+    client_configuration.per_request_configuration = [mock_port]
+    {
+        return DB::ProxyConfiguration{
+            .host = "127.0.0.1",
+            .protocol = DB::ProxyConfiguration::Protocol::HTTP,
+            .port = mock_port,
+        };
+    };
+
+    DB::S3::ClientSettings client_settings{
+        .use_virtual_addressing = false,
+        .gcs_issue_compose_request = false,
+        .is_s3express_bucket = false,
+    };
+
+    return DB::S3::ClientFactory::instance().create(
+        client_configuration,
+        client_settings,
+        /* access_key_id = */ "",
+        /* secret_access_key = */ "",
+        /* server_side_encryption_customer_key_base64 = */ "",
+        /* sse_kms_config = */ {},
+        /* headers = */ {},
+        DB::S3::CredentialsConfiguration{
+            .no_sign_request = true,
+            .forbid_implicit_credentials = true,
+        });
+}
+
+}
+
+/// The boundary the helpers exist for: a request built by the real client and sent over the real
+/// HTTP path has to leave in the `x-goog-` spelling. Dropping the `translateHeadersToGCS` call in
+/// `Client::BuildHttpRequest` fails here while every helper test above still passes.
+TEST(GCSHeaderTranslation, RequestLeavesInTheGoogleSpelling)
+{
+    MockGCSServer mock_gcs;
+    DB::RemoteHostFilter remote_host_filter;
+    auto client = makeClientTalkingToMockGCS(mock_gcs.getPort(), remote_host_filter);
+    ASSERT_TRUE(client);
+
+    DB::S3::PutObjectRequest request;
+    request.SetBucket("test-bucket");
+    request.SetKey("test.txt");
+    request.SetMetadata({{"owner", "analytics"}});
+    request.SetBody(std::make_shared<Aws::StringStream>("content"));
+
+    const auto outcome = client->PutObject(request);
+    ASSERT_TRUE(outcome.IsSuccess()) << outcome.GetError().GetMessage();
+
+    const auto headers = mock_gcs.getLastRequestHeader();
+    EXPECT_EQ(headers.get("x-goog-meta-owner", ""), "analytics");
+    EXPECT_FALSE(headers.has("x-amz-meta-owner"));
+    EXPECT_FALSE(headers.has("x-amz-api-version"));
+}
+
+/// The other half of the boundary: GCS answers in its own spelling, and the SDK parses only the
+/// `x-amz-` one. Dropping the response shim in `PocoHTTPClient` loses the metadata here.
+TEST(GCSHeaderTranslation, ResponseMetadataReachesTheSDK)
+{
+    MockGCSServer mock_gcs;
+    DB::RemoteHostFilter remote_host_filter;
+    auto client = makeClientTalkingToMockGCS(mock_gcs.getPort(), remote_host_filter);
+    ASSERT_TRUE(client);
+
+    DB::S3::HeadObjectRequest request;
+    request.SetBucket("test-bucket");
+    request.SetKey("test.txt");
+
+    const auto outcome = client->HeadObject(request);
+    ASSERT_TRUE(outcome.IsSuccess()) << outcome.GetError().GetMessage();
+
+    const auto & metadata = outcome.GetResult().GetMetadata();
+    const auto it = metadata.find("owner");
+    ASSERT_NE(it, metadata.end());
+    EXPECT_EQ(it->second, "analytics");
 }
 
 #endif


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/119042

Follow-up to #119042, addressing the remaining review comment there.

The tests added in that pull request stop at the helper layer: `translateHeadersToGCS`, `translateHeaderNameFromGCS` and `normalizeHeaderNames` are each checked in isolation, but the two places the change actually depends on — the `translateHeadersToGCS` call in `Client::BuildHttpRequest` and the response shim in `PocoHTTPClient` — were unproven, so removing either left the file green while the end-to-end "GCS metadata works" behavior regressed.

This adds two boundary tests that go through the real `S3::Client` and the real HTTP path against a mock GCS on localhost:

- `RequestLeavesInTheGoogleSpelling` — a `PutObject` with object metadata must arrive as `x-goog-meta-*`, with no `x-amz-meta-*` and no `x-amz-api-version`.
- `ResponseMetadataReachesTheSDK` — a `HeadObject` answered in the `x-goog-` spelling must surface through `GetMetadata`.

The API mode is GCS only for a `storage.googleapis.com` endpoint with empty credentials, so the endpoint keeps the real name and the request is routed to the mock through a proxy; `HTTPConnectionPool` connects to the proxy without consulting the resolver, so nothing is resolved over DNS.

Verified with a control binary: with the `translateHeadersToGCS` call and the response shim removed, the six helper tests still pass while both new tests fail. With the wiring in place all 8 `GCSHeaderTranslation` tests and all 21 `IOTestAwsS3Client` tests pass.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119628&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119628](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119628+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
