### PR TITLE
Let a wait in 02932 outlive a slow refresh

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -7729,6 +7729,12 @@ if __name__ == "__main__":
     if args.secure and os.getenv("CLICKHOUSE_PORT_HTTP_PROTO") is None:
         os.environ["CLICKHOUSE_PORT_HTTP_PROTO"] = "https"
 
+    # A `.sh` test is killed after this many seconds, counted from the start of its own process. A
+    # test that bounds its own waits so that a hang stays reportable needs that number: the cap
+    # differs per job (60s in Fast test, the 600s default in the stateless ones), and a bound past
+    # it is never reached, because the kill truncates the very report it exists to produce.
+    os.environ["CLICKHOUSE_TEST_TIMEOUT"] = str(args.timeout)
+
     client_database = os.getenv("CLICKHOUSE_DATABASE")
     if client_database is not None:
         args.client += f" --database={client_database}"

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_1.sh
@@ -10,12 +10,25 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT="`echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g'`"
 CLICKHOUSE_CLIENT="`echo "$CLICKHOUSE_CLIENT --session_timezone Etc/UTC"`"
 
-# Whole budget for one wait, both SIGKILL graces and the diagnostic dump included: `timeout -k`
-# waits its grace in addition to the primary duration, so the graces come out of the budget.
-WAIT_TOTAL_S=30
+# Both SIGKILL graces and the diagnostic dump come out of every budget below: `timeout -k` waits
+# its grace in addition to the primary duration, so the graces are subtracted, not added on top.
 WAIT_DUMP_S=8
 WAIT_KILL_S=2
-WAIT_POLL_S=$((WAIT_TOTAL_S - WAIT_DUMP_S - WAIT_KILL_S))
+
+# Cap for a single wait. It has to cover a whole refresh rather than only scheduling latency: a
+# refresh writes a part to the default disk, and in the object-storage configurations under load
+# that takes tens of seconds. One `rmv_b` refresh in `arm_asan_ubsan, azure` spent 15.5s inside a
+# single-row part write and completed 0.2s after the 20s of polling this used to allow, which
+# reported a view that was refreshing normally as a failure.
+WAIT_MAX_S=120
+
+# `clickhouse-test` kills the test after CLICKHOUSE_TEST_TIMEOUT seconds, counted from the start of
+# this script, so a wait that expires later than that reports nothing: the kill truncates the very
+# diagnostic the bounded waits exist to produce. That cap is not the same everywhere - 60s in Fast
+# test, 600s in the stateless jobs - hence one deadline for the whole script, derived from it, that
+# no single wait may poll past. Hold back the dump's own budget and a margin for the harness.
+HARNESS_TIMEOUT_S=${CLICKHOUSE_TEST_TIMEOUT:-600}
+SCRIPT_DEADLINE=$((EPOCHSECONDS + HARNESS_TIMEOUT_S - WAIT_DUMP_S - 5))
 
 wait_failed() {
     echo "Wait failed for: $1"
@@ -34,7 +47,12 @@ wait_failed() {
 # transitions), leaving the last output in $wait_result. Expiry reports and exits non-zero.
 wait_for() {
     local query="$1" op="$2" value="$3" rc remaining out
-    local poll_end=$((EPOCHSECONDS + WAIT_POLL_S + WAIT_KILL_S))
+    local poll_end=$((EPOCHSECONDS + WAIT_MAX_S)) bound="the ${WAIT_MAX_S}s cap on one wait"
+    if ((poll_end > SCRIPT_DEADLINE))
+    then
+        poll_end=$SCRIPT_DEADLINE
+        bound="the harness cap of ${HARNESS_TIMEOUT_S}s on the whole test"
+    fi
     wait_result='(no poll returned)'
     while :
     do
@@ -42,7 +60,7 @@ wait_for() {
         if ((remaining <= 0))
         then
             wait_failed "$query" "$op $value" "$wait_result" \
-                "budget exhausted, last poll returned normally"
+                "budget exhausted ($bound), last poll returned normally"
         fi
         # -k because a client ignoring SIGTERM would keep a bare `timeout` waiting forever.
         out=$(timeout -k "$WAIT_KILL_S" "$remaining" $CLICKHOUSE_CLIENT -q "$query")


### PR DESCRIPTION
`Stateless tests (arm_asan_ubsan, azure, parallel)` on master failed `02932_refreshable_materialized_views_1` at the wait for `rmv_b`'s `next_refresh_time` to advance to `2062-01-01 00:00:00`:

https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=bdbd87dd4e6bb5e5a9960a1d69d8a558f3ea8eb7&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29

The diagnostic the wait prints on expiry says why. The refresh it was waiting for took 18825 ms, of which `MergedBlockOutputStream` spent 15.5s writing a one-row part to the Azure disk, and it completed 0.2s after the wait's 20s of polling had run out — the dump taken right after the expiry already reported the awaited `next_refresh_time`. The server was globally slow in that window (several unrelated queries in the same run took 18-20s), with no OOM in `dmesg`. Nothing was stuck; the budget was simply shorter than a refresh in that configuration.

That budget was a single 30s constant, sized for the 60s per-test cap of Fast test so a stuck wait still reports inside it. One constant cannot also cover a slow but progressing refresh, because the cap is not the same everywhere: 60s in Fast test, the 600s default in the stateless jobs.

So separate the two roles:

- `clickhouse-test` exports its `--timeout` as `CLICKHOUSE_TEST_TIMEOUT`, so a test that bounds its own waits can place them inside the cap it is actually killed at — which it cannot otherwise know.
- The test derives one deadline for the whole script from that cap and polls no wait past it, and caps a single wait at 120s so a hang still reports promptly instead of spending the whole script budget. The expiry message names which of the two bounds ran out.

The report now lands inside the cap wherever the hang happens, not only when it happens early, which a per-wait constant cannot guarantee. Verified end to end against a wait that can never be satisfied: it reports with the full `system.view_refreshes` dump at 44.9s of 60s under `--timeout 60`, naming the harness cap, and at 128.3s under the 600s default, naming the 120s per-wait cap. The passing path is untouched — the `.reference` is unchanged and the test passes 5/5 locally, 3 runs at the default cap and 2 at 60s — and a throwaway probe test confirms `CLICKHOUSE_TEST_TIMEOUT` reaches a `.sh` test with the value `--timeout` was given.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119642&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119642](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119642+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1335` (included in `26.9` and later)
<!-- ch-version-info:end -->