### PR TITLE
Avoid copying column TTL descriptions during merge selection

### DIFF
--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -364,7 +364,7 @@ bool StorageInMemoryMetadata::hasOnlyRowsTTL() const
     return hasRowsTTL() && !has_any_other_ttl;
 }
 
-TTLColumnsDescription StorageInMemoryMetadata::getColumnTTLs() const
+const TTLColumnsDescription & StorageInMemoryMetadata::getColumnTTLs() const
 {
     return column_ttls_by_name;
 }

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -181,7 +181,7 @@ struct StorageInMemoryMetadata
     bool hasAnyTableTTL() const;
 
     /// Separate TTLs for columns.
-    TTLColumnsDescription getColumnTTLs() const;
+    const TTLColumnsDescription & getColumnTTLs() const;
     bool hasAnyColumnTTL() const;
 
     /// Just wrapper for table TTLs, return rows part of table TTLs.


### PR DESCRIPTION
`StorageInMemoryMetadata::getColumnTTLs` copies the TTL map and clones its expression trees. Merge selection repeats this work when checking each part.

Return a const reference to the existing map. Callers keep the metadata snapshot alive while reading it.

A paired test on a 26.8-based build ingested 2 million events into 2,000 partitions, producing the same 39,762 inserted parts per version. Merge-selection traces used 100 Hz sampling during ingestion and a further 60 seconds of background merges.

| Metric | Before | After |
|---|---:|---:|
| TTL-check CPU samples | 12,921 | 2,052 (−84%) |
| Merge-selection CPU samples | 38,108 | 33,399 (−12%) |
| Completed merges | 7,591 | 7,938 |

TTL copy/destruction stacks disappear. Merge-selection CPU samples per completed merge fall by 16%.

Two column TTL functional tests passed. Benchmark row checksums and all nine query results matched.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce merge-selection CPU overhead for tables with column TTLs by avoiding copies of TTL descriptions.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119644&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119644](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119644+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
