### PR TITLE
Fix flaky 04511_reader_executor_disk_cache: pin Full part storage

### DIFF
--- a/tests/queries/0_stateless/04511_reader_executor_disk_cache.sql
+++ b/tests/queries/0_stateless/04511_reader_executor_disk_cache.sql
@@ -8,9 +8,17 @@
 
 DROP TABLE IF EXISTS t_re_disk_cache;
 
+-- Full (not Packed) part storage, so every stream of the part is its own object and therefore its own
+-- cache key. With Packed storage the whole part is ONE object: the marks streams and the data stream
+-- resolve to the SAME cache segment and race for its single downloader role, and only the role winner
+-- writes. Each stream is bounded to its own slice of the archive (see `ReadBufferFromFileView`), so
+-- the winner fills only that slice and the cold read leaves the segment with holes, which the warm
+-- read then goes back to the source for. `min_bytes_for_full_part_storage` is randomized by the test
+-- harness, so leaving it unpinned made the assertion below fail in about a third of the runs.
 CREATE TABLE t_re_disk_cache (k UInt64, v String)
 ENGINE = MergeTree ORDER BY k
-SETTINGS storage_policy = 's3_cache_04511', min_bytes_for_wide_part = 0;
+SETTINGS storage_policy = 's3_cache_04511', min_bytes_for_wide_part = 0,
+    min_bytes_for_full_part_storage = 0;
 
 -- No cache-on-write, so the first SELECT below is a genuine cold read that must populate the cache.
 INSERT INTO t_re_disk_cache SELECT number, toString(number) FROM numbers(200000)


### PR DESCRIPTION
`04511_reader_executor_disk_cache` asserts that the warm reread of a cold-populated table touches the source not at all. It started failing on master the day after https://github.com/ClickHouse/ClickHouse/pull/118483 merged:

```
-warm_served_from_cache	1
+warm_served_from_cache	0
```

`min_bytes_for_full_part_storage` is randomized by the test harness, so about two thirds of the runs store the part with the Packed storage: every file of the part lives in ONE object, hence ONE filesystem-cache segment. Inside a single query the marks streams and the data stream each build their own `ReaderExecutor` over that object (`max_threads = 1` does not serialize them — the marks load on their own pool threads) and race for the segment's single downloader role. Only the role winner writes; the losers read through from source and discard.

Before #118483 this was invisible: a whole-file read inside `data.packed` was an open-ended range request, so the role winner's fetch ran to the end of the archive and populated the whole segment. #118483 bounds each read to the file's slice, so the winner now fills only that slice and the cold read leaves the segment with holes. The warm read then re-fetches such a segment from its start (`claimLeadRole`'s `available` prefix is deliberately unused — see the "Coarse by design" note in `ReaderExecutor::readThroughCaches`), so `warm` is the whole extent rather than 0.

The fix pins `min_bytes_for_full_part_storage = 0`. With the Full storage every stream is its own object and therefore its own cache key, so each segment has exactly one writer and the cold read populates all of them. That is also what the test means to cover — the executor's read-through contract — rather than whether concurrent streams over one shared segment converge.

Verified against a local minio with the failing run's randomized settings, on `26.9.1.1234` (the SHA from the report below): the test as it stands fails 97/200, the patched test passes 350/350. Cross-checked on `26.9.1.1193` (just before #118483), where the unpatched test passes 100/100 and the cold read pulls 4064344 bytes from source for a 1630734-byte archive — the over-read that #118483 removed is what used to fill the segment.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=1d0999bf07898241e1229af5b6c1717aec5d275c&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20sequential%2C%202%2F2%29

No tracking issue was filed for this failure (searched open and closed issues).

Caused by: https://github.com/ClickHouse/ClickHouse/pull/118483
Related: https://github.com/ClickHouse/ClickHouse/pull/115664

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119645&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119645](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119645+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
