### PR TITLE
Perf(Array): Optimize arrayIntersect for empty seed arrays

### DIFF
--- a/src/Functions/array/arrayIntersect.cpp
+++ b/src/Functions/array/arrayIntersect.cpp
@@ -668,6 +668,7 @@ ColumnPtr FunctionArrayIntersect::execute(const UnpackedArrays & arrays, Mutable
         return arg_index <= map_arg ? arg_index - 1 : arg_index;
     };
 
+    const bool is_intersect = mode == ArraySetMode::Intersect;
     size_t result_offset = 0;
     for (size_t row = 0; row < rows; ++row)
     {
@@ -676,6 +677,25 @@ ColumnPtr FunctionArrayIntersect::execute(const UnpackedArrays & arrays, Mutable
         {
             if (arena->allocatedBytes())
                 arena.emplace();
+        }
+
+        if (is_intersect)
+        {
+            const auto & seed_arg = arrays.args[map_arg];
+            const size_t seed_offset = seed_arg.is_const ? (*seed_arg.offsets)[0] : (*seed_arg.offsets)[row];
+            if (seed_offset == prev_off[map_arg])
+            {
+                for (size_t arg_num = 0; arg_num < args; ++arg_num)
+                {
+                    const auto & arg = arrays.args[arg_num];
+                    if (arg.is_const)
+                        prev_off[arg_num] = 0;
+                    else
+                        prev_off[arg_num] = (*arg.offsets)[row];
+                }
+                result_offsets.getElement(row) = result_offset;
+                continue;
+            }
         }
 
         bool all_has_nullable = arrays.nullable_result;

--- a/tests/performance/array_intersect.xml
+++ b/tests/performance/array_intersect.xml
@@ -1,0 +1,44 @@
+<test>
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <query>
+        SELECT arrayIntersect(
+            range(16 + number % 2),
+            range(256 + number % 2),
+            range(256 + number % 2))
+        FROM numbers(100000)
+        FORMAT Null
+    </query>
+
+    <query>
+        SELECT arrayIntersect(
+            range(256 + number % 2),
+            if(number % 2 = 0, emptyArrayUInt64(), range(16 + number % 2)),
+            range(256 + number % 2))
+        FROM numbers(100000)
+        FORMAT Null
+    </query>
+
+    <query>
+        SELECT arrayIntersect(
+            range(256 + number % 2),
+            if(number % 10 = 0, range(16 + number % 2), emptyArrayUInt64()),
+            range(256 + number % 2))
+        FROM numbers(100000)
+        FORMAT Null
+    </query>
+
+    <query>
+        SELECT arrayIntersect(
+            arrayMap(x -> (x, x + 1), range(128 + number % 2)),
+            if(
+                number % 2 = 0,
+                CAST([], 'Array(Tuple(UInt64, UInt64))'),
+                arrayMap(x -> (x, x + 1), range(16 + number % 2))),
+            arrayMap(x -> (x, x + 1), range(128 + number % 2)))
+        FROM numbers(100000)
+        FORMAT Null
+    </query>
+</test>

--- a/tests/queries/0_stateless/04691_array_intersect_smallest_argument.reference
+++ b/tests/queries/0_stateless/04691_array_intersect_smallest_argument.reference
@@ -42,6 +42,11 @@
 []
 [1,2]
 [1,2]
+-- row-varying empty seed argument
+[]
+[0,1,2]
+[]
+[0,1,2]
 -- the output keeps the order of the first argument
 [3,2,1]
 [3]

--- a/tests/queries/0_stateless/04691_array_intersect_smallest_argument.sql
+++ b/tests/queries/0_stateless/04691_array_intersect_smallest_argument.sql
@@ -35,6 +35,13 @@ SELECT arrayIntersect([], [], []);
 SELECT arraySort(arrayUnion([1, 2], []));
 SELECT arraySort(arraySymmetricDifference([1, 2], []));
 
+SELECT '-- row-varying empty seed argument';
+SELECT arrayIntersect(
+    materialize(range(3)),
+    if(number % 2 = 0, emptyArrayUInt64(), range(3)),
+    materialize(range(3)))
+FROM numbers(4);
+
 SELECT '-- the output keeps the order of the first argument';
 SELECT arrayIntersect([5, 4, 3, 2, 1], [1, 2, 3]);
 SELECT arrayIntersect([5, 4, 3, 2, 1], [3], [3, 2, 1]);


### PR DESCRIPTION
**What changed**

- Check whether the selected smallest array is empty for the current row.
- If it is empty, write the current output offset and skip the rest of the row.
- Update all input offsets before moving to the next row.
- Keep `arrayUnion` and `arraySymmetricDifference` unchanged.

**Why**

- An empty seed means the intersection is empty.
- The old code still scans the other arrays.
- It also hashes values and serializes generic values.
- The new check skips that work.

**Tests and benchmark**

- Add row-varying coverage with the selected seed in the middle argument.
- Add a non-empty control.
- Add 50% and 90% empty-seed cases.
- Add a generic tuple case.
- Use one thread and `FORMAT Null`.

The focused performance comparison from fc7975b07d2f to 93ce8972f9ed shows:

| Case | AMD | ARM |
| --- | ---: | ---: |
| 50% empty UInt64 seed | 156.0 ms -> 110.6 ms (-29.2%) | 172.2 ms -> 116.8 ms (-32.2%) |
| 90% empty UInt64 seed | 135.7 ms -> 53.7 ms (-60.4%) | 160.3 ms -> 52.5 ms (-67.3%) |
| 50% empty Tuple seed | 827.3 ms -> 471.4 ms (-43.1%) | 917.4 ms -> 510.7 ms (-44.4%) |

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid processing the other arrays when the selected seed array is empty in `arrayIntersect`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119661&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119661](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119661+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
