### PR TITLE
Stop a stored timeSeriesSelector() or prometheusQuery() definition from making the server unstartable

### DIFF
--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -13,6 +13,7 @@
 #include <Core/ConstantValue.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageTimeSeries.h>
@@ -54,9 +55,23 @@ String getStringConstArgument(const ASTPtr & arg, const ContextPtr & context, st
     return String(value.getDataAt());
 }
 
+/// Rewrites the argument(s) naming the TimeSeries table to its resolved `database.table`, keeping the
+/// argument count. A single argument becomes a compound identifier, the node the parser itself produces
+/// for `database.table`; a table identifier there would be resolved as an expression and rejected.
+void setResolvedTableArgument(ASTs & args, size_t num_table_args, const StorageID & storage_id)
+{
+    if (num_table_args == 1)
+        args[0] = make_intrusive<ASTIdentifier>(std::vector<String>{storage_id.database_name, storage_id.table_name});
+    else
+    {
+        args[0] = make_intrusive<ASTLiteral>(storage_id.database_name);
+        args[1] = make_intrusive<ASTLiteral>(storage_id.table_name);
+    }
 }
 
-StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(ASTs & args, const ContextPtr & context, bool over_range)
+}
+
+StoragePrometheusQuery::Arguments StoragePrometheusQuery::parseArgumentsOnly(ASTs & args, const ContextPtr & context, bool over_range)
 {
     std::string_view function_name = over_range ? "prometheusQueryRange" : "prometheusQuery";
     size_t min_num_args = 3 + over_range * 2;
@@ -103,8 +118,52 @@ StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(A
         }
     }
 
-    time_series_storage_id = context->resolveStorageID(time_series_storage_id);
+    size_t num_table_args = argument_index;
 
+    /// Fill in the database name while the creating context is still available and write it back into
+    /// the argument: a stored definition is replayed against the loader's current database. Resolving
+    /// the table itself here would wait for its startup job, which a load job cannot do.
+    if (auto temporary_table_id = context->tryResolveStorageID(time_series_storage_id, Context::ResolveExternal))
+    {
+        /// A temporary table carries its own UUID and cannot appear in a stored definition.
+        time_series_storage_id = std::move(temporary_table_id);
+    }
+    else
+    {
+        if (time_series_storage_id.database_name.empty())
+            time_series_storage_id.database_name = context->getCurrentDatabase();
+        if (!time_series_storage_id.database_name.empty())
+            setResolvedTableArgument(args, num_table_args, time_series_storage_id);
+    }
+
+    Arguments parsed_args;
+    parsed_args.time_series_storage_id = std::move(time_series_storage_id);
+    parsed_args.promql_query = getStringConstArgument(args[argument_index++], context, "promql_query");
+
+    if (over_range)
+    {
+        parsed_args.mode = PrometheusQueryEvaluationMode::QUERY_RANGE;
+        std::tie(parsed_args.start_time, parsed_args.start_time_type) = evaluateConstantExpression(args[argument_index++], context);
+        std::tie(parsed_args.end_time, parsed_args.end_time_type) = evaluateConstantExpression(args[argument_index++], context);
+        std::tie(parsed_args.step, parsed_args.step_type) = evaluateConstantExpression(args[argument_index++], context);
+    }
+    else
+    {
+        parsed_args.mode = PrometheusQueryEvaluationMode::QUERY;
+        std::tie(parsed_args.start_time, parsed_args.start_time_type) = evaluateConstantExpression(args[argument_index++], context);
+        parsed_args.end_time = parsed_args.start_time;
+        parsed_args.end_time_type = parsed_args.start_time_type;
+    }
+
+    chassert(argument_index == args.size());
+    return parsed_args;
+}
+
+StoragePrometheusQuery::Configuration
+StoragePrometheusQuery::resolveConfiguration(const Arguments & parsed_args, const ContextPtr & context)
+{
+    /// The parsed identifier carries a database name but no UUID: `parseArgumentsOnly` may not read the catalog.
+    auto time_series_storage_id = context->tryResolveStorageID(parsed_args.time_series_storage_id);
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(time_series_storage_id, context));
     checkTimeSeriesVersionSupportedByPromQL(*time_series_storage);
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(context, false);
@@ -113,46 +172,18 @@ StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(A
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
-    PrometheusQueryTree promql_query{getStringConstArgument(args[argument_index++], context, "promql_query"), timestamp_scale};
-
-    PrometheusQueryEvaluationMode mode = {};
-    DateTime64 start_time;
-    DateTime64 end_time;
-    Decimal64 step;
-
-    if (over_range)
-    {
-        auto [start_time_field, start_time_type] = evaluateConstantExpression(args[argument_index++], context);
-        auto [end_time_field, end_time_type] = evaluateConstantExpression(args[argument_index++], context);
-        auto [step_field, step_type] = evaluateConstantExpression(args[argument_index++], context);
-
-        mode = PrometheusQueryEvaluationMode::QUERY_RANGE;
-        start_time = parseTimeSeriesTimestamp(start_time_field, start_time_type, timestamp_scale);
-        end_time = parseTimeSeriesTimestamp(end_time_field, end_time_type, timestamp_scale);
-        step = parseTimeSeriesDuration(step_field, step_type, timestamp_scale);
-    }
-    else
-    {
-        auto [time_field, time_type] = evaluateConstantExpression(args[argument_index++], context);
-
-        mode = PrometheusQueryEvaluationMode::QUERY;
-        start_time = parseTimeSeriesTimestamp(time_field, time_type, timestamp_scale);
-        end_time = start_time;
-        step = 0;
-    }
-
-    chassert(argument_index == args.size());
-
     Configuration config;
-    config.promql_query = std::make_shared<PrometheusQueryTree>(std::move(promql_query));
+    config.promql_query = std::make_shared<PrometheusQueryTree>(parsed_args.promql_query, timestamp_scale);
     auto & evaluation_settings = config.evaluation_settings;
     evaluation_settings.time_series_storage_id = std::move(time_series_storage_id);
     evaluation_settings.timestamp_data_type = std::move(timestamp_data_type);
     evaluation_settings.scalar_data_type = std::move(scalar_data_type);
-    evaluation_settings.mode = mode;
-    evaluation_settings.start_time = start_time;
-    evaluation_settings.end_time = end_time;
-    evaluation_settings.step = step;
+    evaluation_settings.mode = parsed_args.mode;
+    evaluation_settings.start_time = parseTimeSeriesTimestamp(parsed_args.start_time, parsed_args.start_time_type, timestamp_scale);
+    evaluation_settings.end_time = parseTimeSeriesTimestamp(parsed_args.end_time, parsed_args.end_time_type, timestamp_scale);
+    evaluation_settings.step = parsed_args.step_type
+        ? parseTimeSeriesDuration(parsed_args.step, parsed_args.step_type, timestamp_scale)
+        : Decimal64{0};
     return config;
 }
 

--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -128,7 +128,9 @@ StoragePrometheusQuery::Arguments StoragePrometheusQuery::parseArgumentsOnly(AST
         /// A temporary table carries its own UUID and cannot appear in a stored definition.
         time_series_storage_id = std::move(temporary_table_id);
     }
-    else
+    /// An empty table name names nothing: qualifying it would form the database-without-table pair
+    /// `StorageID::assertNotEmpty()` rejects, and a compound identifier cannot hold an empty part.
+    else if (!time_series_storage_id.empty())
     {
         if (time_series_storage_id.database_name.empty())
             time_series_storage_id.database_name = context->getCurrentDatabase();

--- a/src/Storages/StoragePrometheusQuery.h
+++ b/src/Storages/StoragePrometheusQuery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Field.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 #include <Storages/StorageWithCommonVirtualColumns.h>
 #include <Storages/TimeSeries/PrometheusQueryEvaluationSettings.h>
@@ -18,7 +19,28 @@ public:
         PrometheusQueryEvaluationSettings evaluation_settings;
     };
 
-    static Configuration getConfiguration(ASTs & args, const ContextPtr & context, bool over_range);
+    /// Everything the arguments of prometheusQuery() / prometheusQueryRange() determine without reading
+    /// the catalog. The query is kept as text and the times as written, because parsing the query and
+    /// converting the times both need the scale of the TimeSeries table's timestamps.
+    struct Arguments
+    {
+        StorageID time_series_storage_id = StorageID::createEmpty();
+        String promql_query;
+        PrometheusQueryEvaluationMode mode = {};
+        Field start_time;
+        DataTypePtr start_time_type;
+        Field end_time;
+        DataTypePtr end_time_type;
+        /// Only prometheusQueryRange() has a step; prometheusQuery() evaluates at a single instant.
+        Field step;
+        DataTypePtr step_type;
+    };
+
+    /// `parseArgumentsOnly()` must not read the catalog: a stored `AS prometheusQuery(...)` definition
+    /// is replayed through it while metadata is loaded, so it has to succeed even when the objects it
+    /// names are gone. Reading them is `resolveConfiguration()`'s job.
+    static Arguments parseArgumentsOnly(ASTs & args, const ContextPtr & context, bool over_range);
+    static Configuration resolveConfiguration(const Arguments & parsed_args, const ContextPtr & context);
 
     StoragePrometheusQuery(const StorageID & table_id_, const ColumnsDescription & columns_, const Configuration & config_);
 

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -67,6 +67,20 @@ String getStringConstArgument(const ASTPtr & arg, const ContextPtr & context, st
     return String(value.getDataAt());
 }
 
+/// Rewrites the argument(s) naming the TimeSeries table to its resolved `database.table`, keeping the
+/// argument count. A single argument becomes a compound identifier, the node the parser itself produces
+/// for `database.table`; a table identifier there would be resolved as an expression and rejected.
+void setResolvedTableArgument(ASTs & args, size_t num_table_args, const StorageID & storage_id)
+{
+    if (num_table_args == 1)
+        args[0] = make_intrusive<ASTIdentifier>(std::vector<String>{storage_id.database_name, storage_id.table_name});
+    else
+    {
+        args[0] = make_intrusive<ASTLiteral>(storage_id.database_name);
+        args[1] = make_intrusive<ASTLiteral>(storage_id.table_name);
+    }
+}
+
 }
 
 namespace TimeSeriesSetting
@@ -83,7 +97,7 @@ namespace Setting
     extern const SettingsBool time_series_prefer_recent_samples_table;
 }
 
-StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfiguration(ASTs & args, const ContextPtr & context)
+StorageTimeSeriesSelector::Arguments StorageTimeSeriesSelector::parseArgumentsOnly(ASTs & args, const ContextPtr & context)
 {
     std::string_view function_name = "timeSeriesSelector";
 
@@ -130,8 +144,39 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
         }
     }
 
-    time_series_storage_id = context->resolveStorageID(time_series_storage_id);
+    size_t num_table_args = argument_index;
 
+    /// Fill in the database name while the creating context is still available and write it back into
+    /// the argument: a stored definition is replayed against the loader's current database. Resolving
+    /// the table itself here would wait for its startup job, which a load job cannot do.
+    if (auto temporary_table_id = context->tryResolveStorageID(time_series_storage_id, Context::ResolveExternal))
+    {
+        /// A temporary table carries its own UUID and cannot appear in a stored definition.
+        time_series_storage_id = std::move(temporary_table_id);
+    }
+    else
+    {
+        if (time_series_storage_id.database_name.empty())
+            time_series_storage_id.database_name = context->getCurrentDatabase();
+        if (!time_series_storage_id.database_name.empty())
+            setResolvedTableArgument(args, num_table_args, time_series_storage_id);
+    }
+
+    Arguments parsed_args;
+    parsed_args.time_series_storage_id = std::move(time_series_storage_id);
+    parsed_args.selector = PrometheusQueryTree{getStringConstArgument(args[argument_index++], context, "selector")};
+    std::tie(parsed_args.min_time, parsed_args.min_time_type) = evaluateConstantExpression(args[argument_index++], context);
+    std::tie(parsed_args.max_time, parsed_args.max_time_type) = evaluateConstantExpression(args[argument_index++], context);
+
+    chassert(argument_index == args.size());
+    return parsed_args;
+}
+
+StorageTimeSeriesSelector::Configuration
+StorageTimeSeriesSelector::resolveConfiguration(const Arguments & parsed_args, const ContextPtr & context)
+{
+    /// The parsed identifier carries a database name but no UUID: `parseArgumentsOnly` may not read the catalog.
+    auto time_series_storage_id = context->tryResolveStorageID(parsed_args.time_series_storage_id);
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(time_series_storage_id, context));
     checkTimeSeriesVersionSupportedByPromQL(*time_series_storage);
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(context, false);
@@ -143,24 +188,14 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
-    PrometheusQueryTree selector{getStringConstArgument(args[argument_index++], context, "selector")};
-
-    auto [min_time_field, min_time_type] = evaluateConstantExpression(args[argument_index++], context);
-    auto [max_time_field, max_time_type] = evaluateConstantExpression(args[argument_index++], context);
-
-    auto min_time = parseTimeSeriesTimestamp(min_time_field, min_time_type, timestamp_scale);
-    auto max_time = parseTimeSeriesTimestamp(max_time_field, max_time_type, timestamp_scale);
-
-    chassert(argument_index == args.size());
-
     Configuration config;
     config.time_series_storage_id = std::move(time_series_storage_id);
     config.id_data_type = std::move(id_data_type);
     config.timestamp_data_type = std::move(timestamp_data_type);
     config.scalar_data_type = std::move(scalar_data_type);
-    config.selector = std::move(selector);
-    config.min_time = min_time;
-    config.max_time = max_time;
+    config.selector = parsed_args.selector;
+    config.min_time = parseTimeSeriesTimestamp(parsed_args.min_time, parsed_args.min_time_type, timestamp_scale);
+    config.max_time = parseTimeSeriesTimestamp(parsed_args.max_time, parsed_args.max_time_type, timestamp_scale);
     return config;
 }
 

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -154,7 +154,9 @@ StorageTimeSeriesSelector::Arguments StorageTimeSeriesSelector::parseArgumentsOn
         /// A temporary table carries its own UUID and cannot appear in a stored definition.
         time_series_storage_id = std::move(temporary_table_id);
     }
-    else
+    /// An empty table name names nothing: qualifying it would form the database-without-table pair
+    /// `StorageID::assertNotEmpty()` rejects, and a compound identifier cannot hold an empty part.
+    else if (!time_series_storage_id.empty())
     {
         if (time_series_storage_id.database_name.empty())
             time_series_storage_id.database_name = context->getCurrentDatabase();

--- a/src/Storages/StorageTimeSeriesSelector.h
+++ b/src/Storages/StorageTimeSeriesSelector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/Logger.h>
+#include <Core/Field.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 #include <Storages/StorageWithCommonVirtualColumns.h>
 
@@ -31,7 +32,25 @@ public:
         DateTime64 max_time{};
     };
 
-    static Configuration getConfiguration(ASTs & args, const ContextPtr & context);
+    /// Everything the arguments of timeSeriesSelector() determine without reading the catalog.
+    struct Arguments
+    {
+        StorageID time_series_storage_id = StorageID::createEmpty();
+        PrometheusQueryTree selector;
+
+        /// The time bounds as written: converting them needs the scale of the TimeSeries table's
+        /// timestamps, which only `resolveConfiguration()` reads.
+        Field min_time;
+        DataTypePtr min_time_type;
+        Field max_time;
+        DataTypePtr max_time_type;
+    };
+
+    /// `parseArgumentsOnly()` must not read the catalog: a stored `AS timeSeriesSelector(...)` definition
+    /// is replayed through it while metadata is loaded, so it has to succeed even when the objects it
+    /// names are gone. Reading them is `resolveConfiguration()`'s job.
+    static Arguments parseArgumentsOnly(ASTs & args, const ContextPtr & context);
+    static Configuration resolveConfiguration(const Arguments & parsed_args, const ContextPtr & context);
 
     StorageTimeSeriesSelector(const StorageID & table_id_, const ColumnsDescription & columns_, const Configuration & config_);
 

--- a/src/TableFunctions/TableFunctionPrometheusQuery.cpp
+++ b/src/TableFunctions/TableFunctionPrometheusQuery.cpp
@@ -14,6 +14,16 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+namespace
+{
+
+ColumnsDescription getColumnsDescription(const StoragePrometheusQuery::Configuration & config)
+{
+    PrometheusQueryToSQL::Converter converter{config.promql_query, config.evaluation_settings};
+    return converter.getResultColumns();
+}
+
+}
 
 template <bool over_range>
 void TableFunctionPrometheusQuery<over_range>::parseArguments(const ASTPtr & ast_function, ContextPtr context)
@@ -24,16 +34,15 @@ void TableFunctionPrometheusQuery<over_range>::parseArguments(const ASTPtr & ast
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Table function '{}' must have arguments.", name);
 
     auto & args = args_func.arguments->children;
-    config = StoragePrometheusQuery::getConfiguration(args, context, over_range);
+    parsed_args = StoragePrometheusQuery::parseArgumentsOnly(args, context, over_range);
 }
 
 
 template <bool over_range>
 ColumnsDescription
-TableFunctionPrometheusQuery<over_range>::getActualTableStructure(ContextPtr /* context */, bool /* is_insert_query */) const
+TableFunctionPrometheusQuery<over_range>::getActualTableStructure(ContextPtr context, bool /* is_insert_query */) const
 {
-    PrometheusQueryToSQL::Converter converter{config.promql_query, config.evaluation_settings};
-    return converter.getResultColumns();
+    return getColumnsDescription(StoragePrometheusQuery::resolveConfiguration(parsed_args, context));
 }
 
 
@@ -43,10 +52,11 @@ StoragePtr TableFunctionPrometheusQuery<over_range>::executeImpl(
     ContextPtr context,
     const String & table_name,
     ColumnsDescription /* cached_columns */,
-    bool is_insert_query) const
+    bool /* is_insert_query */) const
 {
-    auto columns = getActualTableStructure(context, is_insert_query);
-    auto res = std::make_shared<StoragePrometheusQuery>(StorageID(getDatabaseName(), table_name), columns, config);
+    auto config = StoragePrometheusQuery::resolveConfiguration(parsed_args, context);
+    auto res = std::make_shared<StoragePrometheusQuery>(
+        StorageID(getDatabaseName(), table_name), getColumnsDescription(config), config);
     res->startup();
     return res;
 }

--- a/src/TableFunctions/TableFunctionPrometheusQuery.h
+++ b/src/TableFunctions/TableFunctionPrometheusQuery.h
@@ -40,7 +40,7 @@ private:
         return "";
     }
 
-    StoragePrometheusQuery::Configuration config;
+    StoragePrometheusQuery::Arguments parsed_args;
 };
 
 }

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
@@ -13,6 +13,19 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+namespace
+{
+
+ColumnsDescription getColumnsDescription(const StorageTimeSeriesSelector::Configuration & config)
+{
+    return ColumnsDescription({
+        {TimeSeriesColumnNames::ID, config.id_data_type},
+        {TimeSeriesColumnNames::Timestamp, config.timestamp_data_type},
+        {TimeSeriesColumnNames::Value, config.scalar_data_type}
+    });
+}
+
+}
 
 void TableFunctionTimeSeriesSelector::parseArguments(const ASTPtr & ast_function, ContextPtr context)
 {
@@ -22,16 +35,12 @@ void TableFunctionTimeSeriesSelector::parseArguments(const ASTPtr & ast_function
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Table function '{}' must have arguments.", name);
 
     auto & args = args_func.arguments->children;
-    config = StorageTimeSeriesSelector::getConfiguration(args, context);
+    parsed_args = StorageTimeSeriesSelector::parseArgumentsOnly(args, context);
 }
 
-ColumnsDescription TableFunctionTimeSeriesSelector::getActualTableStructure(ContextPtr /* context */, bool /* is_insert_query */) const
+ColumnsDescription TableFunctionTimeSeriesSelector::getActualTableStructure(ContextPtr context, bool /* is_insert_query */) const
 {
-    return ColumnsDescription({
-        {TimeSeriesColumnNames::ID, config.id_data_type},
-        {TimeSeriesColumnNames::Timestamp, config.timestamp_data_type},
-        {TimeSeriesColumnNames::Value, config.scalar_data_type}
-    });
+    return getColumnsDescription(StorageTimeSeriesSelector::resolveConfiguration(parsed_args, context));
 }
 
 StoragePtr TableFunctionTimeSeriesSelector::executeImpl(
@@ -39,10 +48,11 @@ StoragePtr TableFunctionTimeSeriesSelector::executeImpl(
         ContextPtr context,
         const String & table_name,
         ColumnsDescription /* cached_columns */,
-        bool is_insert_query) const
+        bool /* is_insert_query */) const
 {
-    auto columns = getActualTableStructure(context, is_insert_query);
-    auto res = std::make_shared<StorageTimeSeriesSelector>(StorageID(getDatabaseName(), table_name), columns, config);
+    auto config = StorageTimeSeriesSelector::resolveConfiguration(parsed_args, context);
+    auto res = std::make_shared<StorageTimeSeriesSelector>(
+        StorageID(getDatabaseName(), table_name), getColumnsDescription(config), config);
     res->startup();
     return res;
 }

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.h
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.h
@@ -36,7 +36,7 @@ private:
         return "";
     }
 
-    StorageTimeSeriesSelector::Configuration config;
+    StorageTimeSeriesSelector::Arguments parsed_args;
 };
 
 }

--- a/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.reference
+++ b/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.reference
@@ -1,0 +1,52 @@
+--- (a) control: with its source intact a replayed definition still reads its row ---
+attached sel
+attached pq
+attached pqr
+1
+1
+5
+--- (b) after the source is dropped all three definitions still attach ---
+attached sel
+attached pq
+attached pqr
+--- (c) and reading them reports the missing source ---
+UNKNOWN_TABLE
+UNKNOWN_TABLE
+UNKNOWN_TABLE
+--- (d) a full definition naming a table that never existed attaches ---
+attached never_existed
+--- (e) after the source is renamed the definition still attaches, and the read reports it ---
+attached sel_renamed
+UNKNOWN_TABLE
+--- (g) a fresh CREATE whose structure is inferred from the function still requires the source ---
+UNKNOWN_TABLE
+UNKNOWN_TABLE
+--- (g2) with an explicit column list nothing is resolved at CREATE ---
+created explicit_columns
+--- (c2) so its missing source is reported on the first read, not hidden ---
+UNKNOWN_TABLE
+--- (h) the tags target is dropped while the TimeSeries table survives ---
+attached sel_no_tags
+UNKNOWN_TABLE
+--- (i) the whole database of the source is dropped ---
+attached sel_no_database
+--- (l) the time bounds are still converted, so the checks that read them still fire ---
+BAD_ARGUMENTS
+BAD_ARGUMENTS
+--- (m) a stored definition binds to the database it was created in, not the replaying session ---
+attached sel_qual
+attached pq_qual
+sel_qual	1
+pq_qual	1
+--- (n) a definition naming the table being created attaches, and the read reports the engine ---
+created selfref
+attached selfref
+UNEXPECTED_TABLE_ENGINE
+--- (o) a real load replays every definition of a database at once ---
+created bad_promql
+attached database
+sel_load	1
+pq_load	1
+UNKNOWN_TABLE
+UNEXPECTED_TABLE_ENGINE
+CANNOT_PARSE_PROMQL_QUERY

--- a/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.reference
+++ b/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.reference
@@ -33,6 +33,10 @@ attached sel_no_database
 --- (l) the time bounds are still converted, so the checks that read them still fire ---
 BAD_ARGUMENTS
 BAD_ARGUMENTS
+--- (l2) a table name that names nothing is reported, not written back into the argument ---
+UNKNOWN_TABLE
+UNKNOWN_TABLE
+UNKNOWN_TABLE
 --- (m) a stored definition binds to the database it was created in, not the replaying session ---
 attached sel_qual
 attached pq_qual

--- a/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.sh
+++ b/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+# Tag no-replicated-database: this test replays stored definitions with `DETACH TABLE` + `ATTACH TABLE`,
+#                             and `DatabaseReplicated::checkQueryValid` rejects a non-permanent
+#                             `DETACH TABLE`; one arm also uses `ATTACH TABLE ... UUID`.
+#
+# `CREATE TABLE ... AS timeSeriesSelector(...)` / `AS prometheusQuery(...)` stores the table-function call
+# as the table's definition. Replaying that definition must not require the objects it names to exist -
+# otherwise a dropped source table makes the definition unloadable, and with async_load_databases = 0 one
+# failed load job takes the whole server down. Only reading such a table may fail.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_time_series_table=1"
+OTHER_DB="${CLICKHOUSE_DATABASE}_source"
+LOADER_DB="${CLICKHOUSE_DATABASE}_loader"
+# Every insert below is INSERT ... SELECT: the client keeps reading stdin for further rows of an inline
+# VALUES payload, and stdin here is an inherited pipe that never ends, so the test would hang.
+
+# Prints the error name of a failing query, or 'no error' when it unexpectedly succeeds.
+error_of() {
+    local err name
+    err=$("$@" 2>&1 >/dev/null) && { echo 'no error'; return; }
+    name=$(grep -oE '\([A-Z_]+\)$' <<<"$err" | head -1 | tr -d '()')
+    echo "${name:-unexpected error: $(head -c 120 <<<"$err")}"
+}
+
+# Replays the stored definition of a table the way a server restart does.
+reattach() { $CLIENT -q "DETACH TABLE $1" && $CLIENT -q "ATTACH TABLE $1" && echo "attached $1"; }
+
+echo '--- (a) control: with its source intact a replayed definition still reads its row ---'
+$CLIENT -mn -q "
+    CREATE TABLE ts ENGINE = TimeSeries;
+    INSERT INTO ts (metric_name, tags, time_series) SELECT 'up', map('job', 'prometheus'), [(1000, 42)];
+    CREATE TABLE sel AS timeSeriesSelector(ts, 'up', 0, 9999999999);
+    CREATE TABLE pq  AS prometheusQuery(ts, 'up', 1000);
+    CREATE TABLE pqr AS prometheusQueryRange(ts, 'up', 1000, 1300, 60);
+"
+reattach sel
+reattach pq
+reattach pqr
+$CLIENT -q "SELECT count() FROM sel"
+$CLIENT -q "SELECT count() FROM pq"
+# One row per series, so count() cannot see the step. The number of evaluation timestamps can: over
+# 1000..1300 this is 5 at step 60, 10 at step 30 and 3 at step 120.
+$CLIENT -q "SELECT sum(length(time_series)) FROM pqr"
+
+echo '--- (b) after the source is dropped all three definitions still attach ---'
+$CLIENT -q "DROP TABLE ts SYNC"
+reattach sel
+reattach pq
+reattach pqr
+
+echo '--- (c) and reading them reports the missing source ---'
+error_of $CLIENT -q "SELECT count() FROM sel"
+error_of $CLIENT -q "SELECT count() FROM pq"
+error_of $CLIENT -q "SELECT sum(length(time_series)) FROM pqr"
+
+echo '--- (d) a full definition naming a table that never existed attaches ---'
+uuid=$($CLIENT -q "SELECT generateUUIDv4()")
+# A full `ATTACH TABLE` warns about the explicit definition, which would pollute stderr.
+$CLIENT --send_logs_level=fatal -q "
+    ATTACH TABLE never_existed UUID '$uuid' (\`id\` Tuple(UInt64, LowCardinality(UUID)), \`timestamp\` DateTime64(3), \`value\` Float64)
+    AS timeSeriesSelector(no_such_time_series_table, 'up', 0, 9999999999)" && echo 'attached never_existed'
+
+echo '--- (e) after the source is renamed the definition still attaches, and the read reports it ---'
+$CLIENT -mn -q "
+    CREATE TABLE ts_renamed ENGINE = TimeSeries;
+    CREATE TABLE sel_renamed AS timeSeriesSelector(ts_renamed, 'up', 0, 9999999999);
+    RENAME TABLE ts_renamed TO ts_new_name;
+"
+reattach sel_renamed
+error_of $CLIENT -q "SELECT count() FROM sel_renamed"
+
+echo '--- (g) a fresh CREATE whose structure is inferred from the function still requires the source ---'
+error_of $CLIENT -q "CREATE TABLE inferred_missing AS timeSeriesSelector(no_such_time_series_table, 'up', 0, 9999999999)"
+error_of $CLIENT -q "CREATE TABLE inferred_missing_pq AS prometheusQuery(no_such_time_series_table, 'up', 1000)"
+
+echo '--- (g2) with an explicit column list nothing is resolved at CREATE ---'
+$CLIENT -q "
+    CREATE TABLE explicit_columns (\`id\` Tuple(UInt64, LowCardinality(UUID)), \`timestamp\` DateTime64(3), \`value\` Float64)
+    AS timeSeriesSelector(no_such_time_series_table, 'up', 0, 9999999999)" && echo 'created explicit_columns'
+
+echo '--- (c2) so its missing source is reported on the first read, not hidden ---'
+error_of $CLIENT -q "SELECT count() FROM explicit_columns"
+
+echo '--- (h) the tags target is dropped while the TimeSeries table survives ---'
+$CLIENT -mn -q "
+    CREATE TABLE ts_tags_target (id UInt64, metric_name LowCardinality(String), tags Map(LowCardinality(String), String),
+                                 min_time DateTime64(3), max_time DateTime64(3)) ENGINE = MergeTree() ORDER BY id;
+    CREATE TABLE ts_samples_target (id UInt64, timestamp DateTime64(3), value Float64) ENGINE = MergeTree() ORDER BY (id, timestamp);
+    CREATE TABLE ts_split ENGINE = TimeSeries SAMPLES ts_samples_target TAGS ts_tags_target;
+    CREATE TABLE sel_no_tags AS timeSeriesSelector(ts_split, 'up', 0, 9999999999);
+    DROP TABLE ts_tags_target SYNC;
+"
+reattach sel_no_tags
+error_of $CLIENT -q "SELECT count() FROM sel_no_tags"
+
+echo '--- (i) the whole database of the source is dropped ---'
+$CLIENT -mn -q "
+    CREATE DATABASE ${OTHER_DB};
+    CREATE TABLE ${OTHER_DB}.ts ENGINE = TimeSeries;
+    CREATE TABLE sel_no_database AS timeSeriesSelector(${OTHER_DB}.ts, 'up', 0, 9999999999);
+    DROP DATABASE ${OTHER_DB} SYNC;
+"
+reattach sel_no_database
+
+echo '--- (l) the time bounds are still converted, so the checks that read them still fire ---'
+$CLIENT -q "CREATE TABLE ts_checks ENGINE = TimeSeries"
+error_of $CLIENT -q "SELECT * FROM timeSeriesSelector(ts_checks, 'up', 9999999999, 0)"
+error_of $CLIENT -q "SELECT * FROM timeSeriesSelector(ts_checks, 'rate(up[5m])', 0, 9999999999)"
+
+echo '--- (m) a stored definition binds to the database it was created in, not the replaying session ---'
+$CLIENT -mn -q "
+    CREATE DATABASE ${OTHER_DB}_replay;
+    CREATE TABLE ts_qual ENGINE = TimeSeries;
+    INSERT INTO ts_qual (metric_name, tags, time_series) SELECT 'up', map('job', 'prometheus'), [(1000, 42)];
+    CREATE TABLE ${OTHER_DB}_replay.ts_qual ENGINE = TimeSeries;
+    CREATE TABLE sel_qual AS timeSeriesSelector(ts_qual, 'up', 0, 9999999999);
+    CREATE TABLE pq_qual AS prometheusQuery(ts_qual, 'up', 1000);
+    DETACH TABLE sel_qual;
+    DETACH TABLE pq_qual;
+"
+# Replay while a different database is current: an unqualified stored name would resolve against it and
+# bind to the decoy above, which returns rows from the wrong table rather than an error. Both table
+# functions carry their own copy of the qualification, so both are replayed here.
+$CLIENT -mn -q "USE ${OTHER_DB}_replay; ATTACH TABLE ${CLICKHOUSE_DATABASE}.sel_qual;" && echo 'attached sel_qual'
+$CLIENT -mn -q "USE ${OTHER_DB}_replay; ATTACH TABLE ${CLICKHOUSE_DATABASE}.pq_qual;" && echo 'attached pq_qual'
+# Labelled: two bare counts are identical lines, so a diff could not name which one lost its binding.
+$CLIENT -q "SELECT 'sel_qual', count() FROM sel_qual"
+$CLIENT -q "SELECT 'pq_qual', count() FROM pq_qual"
+$CLIENT -q "DROP DATABASE ${OTHER_DB}_replay SYNC"
+
+echo '--- (n) a definition naming the table being created attaches, and the read reports the engine ---'
+# An ATTACH runs under the query context, where the table's startup task has already finished, so this
+# arm pins the post-fix behaviour only; arm (o) replays the same shape through the table loader.
+$CLIENT -q "
+    CREATE TABLE selfref (\`id\` Tuple(UInt64, LowCardinality(UUID)), \`timestamp\` DateTime64(3), \`value\` Float64)
+    AS timeSeriesSelector(selfref, 'up', 0, 9999999999)" && echo 'created selfref'
+reattach selfref
+error_of $CLIENT -q "SELECT count() FROM selfref"
+
+echo '--- (o) a real load replays every definition of a database at once ---'
+# `ATTACH DATABASE` goes through the same `TablesLoader` as server startup, so unlike the arms above it
+# replays under the loader's context, whose current database is the global one, and it wires each load
+# job to the table's own startup job.
+$CLIENT -mn -q "
+    CREATE DATABASE ${LOADER_DB};
+    USE ${LOADER_DB};
+    CREATE TABLE ts_load ENGINE = TimeSeries;
+    INSERT INTO ts_load (metric_name, tags, time_series) SELECT 'up', map('job', 'prometheus'), [(1000, 42)];
+    CREATE TABLE ts_load_gone ENGINE = TimeSeries;
+    CREATE TABLE sel_load AS timeSeriesSelector(ts_load, 'up', 0, 9999999999);
+    CREATE TABLE pq_load AS prometheusQuery(ts_load, 'up', 1000);
+    CREATE TABLE sel_load_gone AS timeSeriesSelector(ts_load_gone, 'up', 0, 9999999999);
+    DROP TABLE ts_load_gone SYNC;
+    CREATE TABLE selfref_load (\`id\` Tuple(UInt64, LowCardinality(UUID)), \`timestamp\` DateTime64(3), \`value\` Float64)
+    AS timeSeriesSelector(selfref_load, 'up', 0, 9999999999);
+"
+# The source is named in full here: this definition isolates the stored *query*, which is not parsed
+# until the read either, so a text this grammar rejects cannot make the definition unloadable.
+$CLIENT -q "
+    CREATE TABLE ${LOADER_DB}.bad_promql (\`tags\` Array(Tuple(String, String)), \`timestamp\` DateTime64(3), \`value\` Float64)
+    AS prometheusQuery(${LOADER_DB}.ts_load, 'up{', 1000)" && echo 'created bad_promql'
+$CLIENT -mn -q "DETACH DATABASE ${LOADER_DB}; ATTACH DATABASE ${LOADER_DB};" && echo 'attached database'
+# The names the loader resolves are the ones written back at CREATE: unqualified, they would be looked
+# up in the global current database, where this test has nothing.
+$CLIENT -q "SELECT 'sel_load', count() FROM ${LOADER_DB}.sel_load"
+$CLIENT -q "SELECT 'pq_load', count() FROM ${LOADER_DB}.pq_load"
+error_of $CLIENT -q "SELECT count() FROM ${LOADER_DB}.sel_load_gone"
+error_of $CLIENT -q "SELECT count() FROM ${LOADER_DB}.selfref_load"
+error_of $CLIENT -q "SELECT count() FROM ${LOADER_DB}.bad_promql"
+$CLIENT -q "DROP DATABASE ${LOADER_DB} SYNC"
+
+# A stored table-function definition whose source is missing is exactly what this test creates, so it
+# must not leave one behind for whatever runs next. No SYNC: a proxy whose materialization always
+# throws still holds its table function, which a synchronous drop waits for.
+$CLIENT -mn -q "
+    DROP TABLE IF EXISTS sel, pq, pqr, never_existed, sel_renamed, explicit_columns, sel_no_tags,
+                         sel_no_database, selfref, sel_qual, pq_qual;
+    DROP TABLE IF EXISTS ts_new_name, ts_split, ts_checks, ts_qual;
+    DROP TABLE IF EXISTS ts_samples_target;
+"

--- a/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.sh
+++ b/tests/queries/0_stateless/05190_timeseries_table_function_attach_stored_definition.sh
@@ -113,6 +113,13 @@ $CLIENT -q "CREATE TABLE ts_checks ENGINE = TimeSeries"
 error_of $CLIENT -q "SELECT * FROM timeSeriesSelector(ts_checks, 'up', 9999999999, 0)"
 error_of $CLIENT -q "SELECT * FROM timeSeriesSelector(ts_checks, 'rate(up[5m])', 0, 9999999999)"
 
+echo '--- (l2) a table name that names nothing is reported, not written back into the argument ---'
+# The write-back replaces a single table argument with a `database.table` identifier, whose parts cannot
+# be empty, so an empty name has to stay as written and be reported by the read.
+error_of $CLIENT -q "SELECT * FROM timeSeriesSelector('', 'up', 0, 9999999999)"
+error_of $CLIENT -q "SELECT * FROM prometheusQuery('', 'up', 1000)"
+error_of $CLIENT -q "SELECT * FROM prometheusQueryRange('', 'up', 1000, 1300, 60)"
+
 echo '--- (m) a stored definition binds to the database it was created in, not the replaying session ---'
 $CLIENT -mn -q "
     CREATE DATABASE ${OTHER_DB}_replay;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/116629


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a table created as `AS timeSeriesSelector(...)`, `AS prometheusQuery(...)` or `AS prometheusQueryRange(...)` making the server refuse to start once its source `TimeSeries` table was dropped or renamed. These table functions no longer look the source up while parsing their arguments, the step metadata loading replays, so such a table now attaches and reports the missing source only when read.

### Description

`CREATE TABLE sel AS timeSeriesSelector(ts, 'up', 0, 9999999999); DROP TABLE ts;` and a restart is enough: with `async_load_databases = 0` the server never starts again; at the default it comes up, but that table and `DROP TABLE` on it raise `Code: 722` for good. An unqualified source name in a non-default database does the same with nothing dropped.

This is the [requested investigation](https://github.com/ClickHouse/ClickHouse/pull/116629#issuecomment-5621663399): the eager lookup below is what #116629 was reverted over, when its test left such definitions behind for a stress restart to replay. The lookup predates that PR and is on 26.3-26.8.

Both storages resolve the source at the end of `getConfiguration()`, which their table function calls from `parseArguments()`, so the lookup runs before `execute()` can hand back the lazy `StorageTableFunctionProxy` that carries the structure `ITableFunction.h` caches in metadata "to avoid failures on server startup". So `getConfiguration()` splits into `parseArgumentsOnly()` (no catalog) and `resolveConfiguration()`, called from `getActualTableStructure()` and `executeImpl()`, as `loop()` and `mergeTreeIndex()` already do. Both `Configuration` structs, both constructors and both `readImpl()` are untouched. The source name is canonicalized to `database.table` in the stored argument.

One deliberate consequence: an *inferred*-structure `CREATE` still requires the source, while an explicit column list defers it, and `prometheusQuery()`'s PromQL text, to the first read. `canBeUsedToCreateTable() { return false; }` would be cheaper but only blocks new definitions.

No access-rights code is touched, and two residuals stay. `timeSeriesSamples()`, `timeSeriesTags()` and `timeSeriesMetrics()` resolve in `parseArguments()` too and are creatable-as-table again after the revert; measured, they brick a restart before and after this fix, which does not touch them. A definition already on disk whose source is unqualified still binds against the loader's current database, because replay shares one loader context across databases.

<details>
<summary>Base vs fixed on the same data directory</summary>

Validated by this A/B, a mutation ladder per arm, and 50x50 randomized runs of the new test.

```
# base binary, async_load_databases = 0
<Error> Application: Caught exception while loading metadata: Code: 722. DB::Exception:
  Waited job failed: Code: 695. DB::Exception: Load job 'load table d1.sel' failed: Code: 60.
  DB::Exception: Table d1.ts does not exist: Cannot attach table `d1`.`sel` from metadata file
  store/9ff/.../sel.sql from query ATTACH TABLE d1.sel UUID '...' (...)
  AS timeSeriesSelector(d1.ts, 'up', 0, 9999999999). (UNKNOWN_TABLE) ... (ASYNC_LOAD_WAIT_FAILED)
-> exit 210, server never ready

# base binary, default async_load_databases
SELECT count() FROM d1.sel                         -> Code: 722 ...
SELECT name FROM system.tables WHERE database='d1' -> Code: 722 ...
DROP TABLE d1.sel / DETACH TABLE ... PERMANENTLY   -> Code: 722 ...
DROP DATABASE d1                                   -> Code: 722 ...

# fixed binary, same directory, async_load_databases = 0
SERVER_READY
SELECT name FROM system.tables WHERE database='d1' -> pq, sel
SELECT count() FROM d1.sel                         -> Code: 60. Table d1.ts does not exist. (UNKNOWN_TABLE)
DROP TABLE d1.sel; DROP TABLE d1.pq                -> ok
```

The unqualified-name case, with a decoy `default.ts` of a different engine present, on the fixed
binary: `SHOW CREATE` reads `AS timeSeriesSelector(mydb.ts, 'up', 0, 9999999999)` and after a restart
the read binds to `mydb.ts`, not to the decoy. Dropping the canonicalization makes it bind to the decoy.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119662&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119662](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119662+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
