### PR TITLE
Fix silently lost rows for a window function over a multi-shard query whose columns are only filtered or joined

### DIFF
--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2813,6 +2813,18 @@ void Planner::buildPlanForQueryNode()
                   */
                 auto & window_analysis_result = expression_analysis_result.getWindow();
                 if (window_analysis_result.before_window_actions)
+                {
+                    /// When the result is a mergeable state, this is the last step of the stage, so its output
+                    /// is the header sent to the initiator. A block with no columns cannot express how many
+                    /// rows it holds, so keep a placeholder column to carry the row count across the boundary.
+                    auto & before_window_dag = window_analysis_result.before_window_actions->dag;
+                    if (!query_processing_info.isFinalizingStage() && before_window_dag.getOutputs().empty())
+                    {
+                        auto marker_type = std::make_shared<DataTypeUInt8>();
+                        before_window_dag.getOutputs().push_back(&before_window_dag.materializeNode(
+                            before_window_dag.addColumn(marker_type->createColumnConst(0, 0u), marker_type, "__row_count_marker")));
+                    }
+
                     addExpressionStep(
                         planner_context,
                         query_plan,
@@ -2821,6 +2833,7 @@ void Planner::buildPlanForQueryNode()
                         select_query_options,
                         "Before WINDOW",
                         useful_sets);
+                }
             }
             else
             {

--- a/tests/queries/0_stateless/05210_distributed_window_no_input_column.reference
+++ b/tests/queries/0_stateless/05210_distributed_window_no_input_column.reference
@@ -1,0 +1,35 @@
+WHERE only
+2000	2000	2000
+PREWHERE only
+2000	2000	2000
+WHERE only, selective
+1000	1000
+JOIN ON only
+200	200
+table expression projecting an unused constant
+2000	2000
+row_number
+2000	2000
+serialized query plan
+2000	2000
+ORDER BY with LIMIT on the initiator
+3	2000
+QUALIFY
+2000	2000
+control: the filtered column is also selected
+2000	999	2000
+control: single shard
+1000	1000
+control: not distributed
+1000	1000
+control: the result keeps exactly one column
+c
+2000
+control: a user column may be named like the placeholder
+2000	999
+placeholder is in the distributed plan
+1
+placeholder is not in the local plan
+0
+placeholder is not added when a column survives the boundary
+0

--- a/tests/queries/0_stateless/05210_distributed_window_no_input_column.sql
+++ b/tests/queries/0_stateless/05210_distributed_window_no_input_column.sql
@@ -1,0 +1,105 @@
+-- Tags: distributed
+
+-- A window function over a multi-shard query is computed on the initiator, so the shard's plan ends at
+-- the "Before WINDOW" step and that step's output is the header the shard sends. When the window
+-- function needs no column of its input and every table column is consumed before that boundary
+-- (WHERE, PREWHERE or JOIN ON), the header carried no column at all. A block with no columns cannot
+-- express how many rows it holds, so all rows were lost with no error.
+
+SET enable_analyzer = 1;
+SET prefer_localhost_replica = 0;
+
+DROP TABLE IF EXISTS t_window_no_input;
+DROP TABLE IF EXISTS t_window_no_input_keys;
+
+CREATE TABLE t_window_no_input (a UInt64, s String) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_window_no_input SELECT number, toString(number) FROM numbers(1000);
+
+CREATE TABLE t_window_no_input_keys (k UInt64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_window_no_input_keys SELECT number FROM numbers(100);
+
+-- Each route below returned no rows at all. Selecting count() observes the row count, so a result
+-- that went back to being empty cannot satisfy these assertions.
+
+SELECT 'WHERE only';
+SELECT count(), min(c), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0);
+
+SELECT 'PREWHERE only';
+SELECT count(), min(c), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) PREWHERE a >= 0);
+
+SELECT 'WHERE only, selective';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a < 500);
+
+SELECT 'JOIN ON only';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) AS x
+    INNER JOIN t_window_no_input_keys AS y ON x.a = y.k);
+
+SELECT 'table expression projecting an unused constant';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', view(SELECT 1 AS cst, number AS a FROM numbers(1000)))
+    WHERE a >= 0);
+
+SELECT 'row_number';
+SELECT count(), max(c) FROM (SELECT row_number() OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0);
+
+SELECT 'serialized query plan';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0)
+    SETTINGS serialize_query_plan = 1;
+
+SELECT 'ORDER BY with LIMIT on the initiator';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0
+    ORDER BY 1 LIMIT 3);
+
+SELECT 'QUALIFY';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0
+    QUALIFY c > 0);
+
+-- Controls: these were already correct and must stay byte for byte identical.
+
+SELECT 'control: the filtered column is also selected';
+SELECT count(), max(a), max(c) FROM (SELECT a, count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0);
+
+SELECT 'control: single shard';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0);
+
+SELECT 'control: not distributed';
+SELECT count(), max(c) FROM (SELECT count(*) OVER () AS c FROM t_window_no_input WHERE a >= 0);
+
+SELECT 'control: the result keeps exactly one column';
+SELECT * FROM (SELECT count(*) OVER () AS c
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0)
+    ORDER BY c LIMIT 1 FORMAT TSVWithNames;
+
+SELECT 'control: a user column may be named like the placeholder';
+SELECT count(), max(mk) FROM (SELECT count(*) OVER () AS c, `__row_count_marker` AS mk
+    FROM (SELECT a AS `__row_count_marker`
+        FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0));
+
+-- The placeholder is added to the mergeable-stage header, and only there.
+
+SELECT 'placeholder is in the distributed plan';
+SELECT count() > 0 FROM (EXPLAIN header = 1 SELECT count(*) OVER ()
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0)
+WHERE explain ILIKE '%__row_count_marker%';
+
+SELECT 'placeholder is not in the local plan';
+SELECT count() FROM (EXPLAIN header = 1 SELECT count(*) OVER () FROM t_window_no_input WHERE a >= 0)
+WHERE explain ILIKE '%__row_count_marker%';
+
+SELECT 'placeholder is not added when a column survives the boundary';
+SELECT count() FROM (EXPLAIN header = 1 SELECT a, count(*) OVER ()
+    FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_window_no_input) WHERE a >= 0)
+WHERE explain ILIKE '%__row_count_marker%';
+
+DROP TABLE t_window_no_input;
+DROP TABLE t_window_no_input_keys;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119588
Related: https://github.com/ClickHouse/ClickHouse/pull/113469
Related: https://github.com/ClickHouse/ClickHouse/pull/113955
Related: https://github.com/ClickHouse/ClickHouse/pull/108045
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a window function over a multi-shard query silently returning no rows when the table's columns are referenced only in `WHERE`, `PREWHERE` or `JOIN ON` and the window function needs no column, for example `SELECT count(*) OVER () FROM remote('h1,h2', db.t) WHERE a >= 0`. The fix covers the analyzer (`enable_analyzer = 1`). Closes #119588.

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/119588
Related: https://github.com/ClickHouse/ClickHouse/pull/113469 (the sibling no-column route)

A window function over a distributed query runs on the initiator, so the shard's plan ends at the
`Before WINDOW` step, whose output is the header the shard sends. When the window function needs no
column of its input (`count(*) OVER ()`, `row_number() OVER ()`) and every table column is consumed
before that boundary, the header ended up with no column at all. A block with no columns cannot express
how many rows it holds, so all rows were lost with no error; the initiator derived the same empty
header. `WHERE`, `PREWHERE` and `JOIN ON` trigger it by making the column read, so the existing
synthetic row-count column never applies.

The fix gives that step one column when it would otherwise have none: if the plan is not built to the
finalizing stage and its output list is empty, one materialized `UInt8`
`__row_count_marker` output is appended. That list is tested after `ActionsChain::finalize`, when it
already holds every column a later step needs, so empty means nothing survives that boundary. Every
query correct today keeps the header it sends byte for byte, no local plan is touched and no setting
changes, so mixed-version exposure is limited to queries losing rows now.

The test covers nine repaired shapes, each asserting the row count; it passes 50 of 50 randomized runs
with the fix and fails all 50 on master.

Still broken as before: a table expression projecting **only** a constant
(`remote(..., view(SELECT 1 AS a))`), where the shard keeps the constant but the initiator's plan does
not. It now reports `NOT_FOUND_COLUMN_IN_BLOCK` rather than a `LOGICAL_ERROR`; neither returns wrong
results. #113469 covers that route and composes with this one.

The issue is labelled `bug-unreleased`, but it reproduces on the official 26.8.3.98 build.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119678&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119678](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119678+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
