### PR TITLE
Test the read-in-order prefix guard from SQL

### DIFF
--- a/tests/queries/0_stateless/05210_merge_read_in_order_prefix_wider_than_key.reference
+++ b/tests/queries/0_stateless/05210_merge_read_in_order_prefix_wider_than_key.reference
@@ -1,0 +1,8 @@
+select status: 0
+0	0
+0	0
+0	0
+0	0
+0	0
+planned: a_alias
+planned: z_plain

--- a/tests/queries/0_stateless/05210_merge_read_in_order_prefix_wider_than_key.sh
+++ b/tests/queries/0_stateless/05210_merge_read_in_order_prefix_wider_than_key.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: this test WAITS on a process-global PAUSEABLE failpoint, so a concurrent
+# instance pausing or resuming the same channel would break the synchronisation.
+
+# A `Merge` read computes one read-in-order prefix from the metadata of the tables it selected and
+# then hands it to every `ReadFromMergeTree` in its child plans. An `Alias` child resolves its
+# target by name twice - once when its child plan is built, once when the prefix is computed - so
+# swapping the target in between makes the prefix longer than the sorting key of the read that has
+# to honor it. `spreadMarkRangesAmongStreamsWithOrder` then grew the sorting-key expression list
+# instead of cutting it, padding it with null `ASTPtr`s, and the server crashed while compiling it.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+FP="storage_merge_create_children_plans_pause"
+QID="merge_prefix_${CLICKHOUSE_DATABASE}_$$"
+
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT ${FP}" 2>/dev/null ||:
+    wait 2>/dev/null ||:
+}
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS target;
+    DROP TABLE IF EXISTS target_wider_key;
+    DROP TABLE IF EXISTS a_alias;
+    DROP TABLE IF EXISTS z_plain;
+    DROP TABLE IF EXISTS m;
+
+    -- The read that has to honor the prefix. Its sorting key is one column long.
+    CREATE TABLE target (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a
+        SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
+    -- What the alias will point at once the child plan is built: two columns, so the prefix
+    -- computed for the \`Merge\` is one longer than \`target\` can deliver.
+    CREATE TABLE target_wider_key (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b)
+        SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
+    -- The second child only exists to give the failpoint a second pause, i.e. a moment when the
+    -- alias child plan is already built. It is named so that it is planned after the alias.
+    CREATE TABLE z_plain (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b)
+        SETTINGS index_granularity = 4, min_bytes_for_wide_part = 0;
+
+    -- Several parts each, so that the read really merges streams by the sorting-key prefix.
+    INSERT INTO target SELECT number % 7, number % 11 FROM numbers(60);
+    INSERT INTO target SELECT number % 7, number % 11 FROM numbers(60);
+    INSERT INTO target SELECT number % 7, number % 11 FROM numbers(60);
+    INSERT INTO target_wider_key SELECT number % 7, number % 11 FROM numbers(60);
+    INSERT INTO z_plain SELECT number % 7, number % 11 FROM numbers(60);
+    INSERT INTO z_plain SELECT number % 7, number % 11 FROM numbers(60);
+    INSERT INTO z_plain SELECT number % 7, number % 11 FROM numbers(60);
+
+    CREATE TABLE a_alias ENGINE = Alias(currentDatabase(), 'target');
+    CREATE TABLE m (a UInt32, b UInt32) ENGINE = Merge(currentDatabase(), '^(a_alias|z_plain)\$');
+"
+
+$CLICKHOUSE_CLIENT --query "SYSTEM ENABLE FAILPOINT ${FP}"
+
+# read_in_order_two_level_merge_threshold = 0 and read_in_order_use_virtual_row_per_block = 0 pin
+# the preliminary merge that cuts the sorting key down to the announced prefix.
+$CLICKHOUSE_CLIENT --query_id="${QID}" --query "
+    SELECT a, b FROM m ORDER BY a, b LIMIT 5
+    SETTINGS optimize_read_in_order = 1, max_threads = 4, max_block_size = 8,
+             read_in_order_two_level_merge_threshold = 0, read_in_order_use_virtual_row_per_block = 0
+" > "${CLICKHOUSE_TMP}/05210_result.txt" 2> "${CLICKHOUSE_TMP}/05210_error.txt" &
+SELECT_PID=$!
+
+# Paused before the first child plan. Bound every wait, so a query that never pauses fails with a
+# diagnostic instead of consuming the per-test timeout.
+if ! timeout 60 $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" > /dev/null 2>&1; then
+    echo "FAIL: the query never paused before the first child plan"
+fi
+$CLICKHOUSE_CLIENT --query "SYSTEM NOTIFY FAILPOINT ${FP}"
+
+# Paused before the second child plan, so the alias child plan is built and holds a snapshot of
+# the one-column `target`.
+if ! timeout 60 $CLICKHOUSE_CLIENT --query "SYSTEM WAIT FAILPOINT ${FP} PAUSE" > /dev/null 2>&1; then
+    echo "FAIL: the query never paused before the second child plan"
+fi
+
+# Now `a_alias` resolves to a table with a two-column sorting key, while its already-built child
+# plan still reads the one-column table.
+$CLICKHOUSE_CLIENT --query "EXCHANGE TABLES target AND target_wider_key"
+
+$CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT ${FP}"
+timeout 120 tail --pid="${SELECT_PID}" -f /dev/null
+select_rc=0
+wait "${SELECT_PID}" || select_rc=$?
+
+# A non-zero status is how the crash showed: the server died mid-query. Do not print the stderr
+# contents - the harness may add `--send_logs_level`, so server log lines land there on success too.
+echo "select status: ${select_rc}"
+cat "${CLICKHOUSE_TMP}/05210_result.txt"
+rm -f "${CLICKHOUSE_TMP}/05210_result.txt" "${CLICKHOUSE_TMP}/05210_error.txt"
+
+# The order the children were planned in is what the test relies on: the alias child plan must be
+# built before the target is swapped. `createChildrenPlans` logs one line per child.
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS text_log"
+$CLICKHOUSE_CLIENT --max_rows_to_read 0 --query "
+    SELECT 'planned: ' || multiIf(message LIKE '%a_alias%', 'a_alias', message LIKE '%z_plain%', 'z_plain', 'unexpected')
+    FROM system.text_log
+    WHERE event_date >= yesterday() AND event_time >= now() - 600
+      AND query_id = '${QID}' AND message LIKE 'Building plan for child table%'
+    ORDER BY event_time_microseconds
+"
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE m;
+    DROP TABLE a_alias;
+    DROP TABLE z_plain;
+    DROP TABLE target;
+    DROP TABLE target_wider_key;
+"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/116364
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/116364

#116364 made `ReadFromMergeTree::requestReadingInOrder` refuse a prefix wider than the read's own
sorting key, but shipped with a preservation arm only: no SQL input was known to reach the guard, so
the test there passes on master by design and would not fail if the guard were reverted. This adds a
test that does fail.

### What reaches the guard

`spreadMarkRangesAmongStreamsWithOrder` cuts the sorting key down to the announced prefix with
`order_key_prefix_ast->children.resize(prefix_size)`, which *grows* the expression list with null
`ASTPtr`s when the prefix is longer than the key. `TreeRewriter::normalize` then walks them until one
of the `Customize*` visitors dereferences a node, and the server segfaults.

The channel the server-side fuzzer reached is **projections**. `ReadFromMerge` optimizes a child plan
when it creates it, so `optimizeUseNormalProjections` can already have replaced the read of the table
with a read of a projection by the time `ReadFromMerge::requestReadingInOrder` walks the plan, and
nothing relates the two sorting keys. In the `02784_projections_read_in_order_bug` fixture the table
is ordered by `(organisation_id, session_id, timestamp)`, so the prefix is 3, while the child plan
reads the `events_by_session` projection, ordered by `(session_id, timestamp)`:

```sql
SELECT id, timestamp, payload FROM merge(currentDatabase(), '^events$')
WHERE organisation_id = reinterpretAsUUID(1) AND session_id = reinterpretAsUUID(0)
ORDER BY timestamp ASC, payload ASC, id ASC NULLS LAST
-- read_in_order_two_level_merge_threshold = 1
```

That is the query from the master stress report below, and `EXPLAIN indexes = 1` over that fixture
confirms the child read is the projection (`PrimaryKey Keys: session_id`), not the table.

### What the test uses instead

Which projection the optimizer picks is not something a test should depend on, so the test takes the
second channel, which is deterministic. An `Alias` child resolves its target by name twice - once
when `createChildrenPlans` builds its child plan, once when `buildInputOrderFromSortDescription`
reads `getInMemoryMetadataPtr` to compute the prefix - so an `EXCHANGE TABLES` between the two
leaves a read with a one-column sorting key holding a two-column prefix. The already-present
`storage_merge_create_children_plans_pause` failpoint pins the moment, and the test asserts the order
the children were planned in so the choreography cannot silently stop covering the bug.

With the guard reverted, the server dies mid-query, frame for frame the reported stack:

```
Address: 0x10. Access: <not available>. Address not mapped to object.
boost::container::vector<boost::intrusive_ptr<DB::IAST>>::end()
DB::InDepthNodeVisitor<...CustomizeFunctionsData<countdistinct>...>::visitChildren<false>
DB::TreeRewriter::normalize
DB::ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder
DB::ReadFromMerge::buildPipeline
```

`read_in_order_two_level_merge_threshold = 0` and `read_in_order_use_virtual_row_per_block = 0` pin
the preliminary merge that consumes the prefix; without them `need_preliminary_merge` is false and
the vulnerable block does not run.

The test is `no-parallel` because it waits on a process-global `PAUSEABLE` failpoint, so a concurrent
instance pausing or resuming the same channel would break the synchronisation.

### The crash on public CI

Between 2026-09-05 and 2026-09-12 it was reported 12 times, on master and on 10 pull requests
(`STID: 2076-288c`, `2076-3a72`, `2447-4aac`):

```sql
SELECT pull_request_number, check_name, check_start_time, test_name
FROM default.checks
WHERE check_start_time > now() - INTERVAL 30 DAY
  AND test_status IN ('FAIL', 'ERROR')
  AND position(test_context_raw, 'spreadMarkRangesAmongStreamsWithOrder') > 0
  AND position(test_context_raw, 'InDepthNodeVisitor') > 0
ORDER BY check_start_time
```

Master report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=3476b12ea2ce2ab61713714166e91b4712105c74&name_0=MasterCI&name_1=Stress%20test%20%28arm_msan%29


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added a regression test for a read-in-order prefix wider than the sorting key of the read that has to honor it, reached through an `Alias` child of a `Merge` table.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119682&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119682](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119682+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.190` (included in `26.10` and later)
<!-- ch-version-info:end -->