### PR TITLE
Enable `-fstack-protector-strong`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,14 @@ if (ARCH_AMD64)
     set(COMPILER_FLAGS "${COMPILER_FLAGS} ${BRANCHES_WITHIN_32B_BOUNDARIES}")
 endif()
 
+# Emit a stack-protector canary for every function that has a local array, a local whose address
+# is taken, or a variable-length allocation. An overflow of such a local then aborts in
+# `__stack_chk_fail` instead of silently corrupting the frame and, further out, the saved return
+# address. `-strong` rather than the plain `-fstack-protector`, which covers only character arrays
+# of at least eight bytes and so misses, for instance, a `memcpy` into an integer local whose
+# address was taken.
+set (COMPILER_FLAGS "${COMPILER_FLAGS} -fstack-protector-strong")
+
 # Disable floating-point expression contraction in order to get consistent floating point calculation results across platforms
 set (COMPILER_FLAGS "${COMPILER_FLAGS} -ffp-contract=off")
 


### PR DESCRIPTION
An overflow of a stack local currently corrupts the frame silently. Nothing in the build emits a canary, and `_FORTIFY_SOURCE` is not set either, so a `memcpy` with an unchecked length just writes through its destination and, about two kilobytes further on, through the saved return address.

`-fstack-protector-strong` instruments every function that has a local array, a local whose address is taken, or a variable-length allocation, which is the shape these bugs actually take. The plain `-fstack-protector` is not enough: it covers only character arrays of at least eight bytes, so it would **not** have instrumented the `BIT` column overflow fixed in https://github.com/ClickHouse/ClickHouse/pull/119680, whose destination was a `UInt64` whose address had been taken. I verified both claims by disassembling the real object files.

Measured per translation unit on an `aarch64` release build, using the actual compile commands:

| translation unit | text size | functions canaried |
| --- | --- | --- |
| `Columns/ColumnVector` | +1.92% | 1054/3717 (28%) |
| `Interpreters/Aggregator` | +2.13% | 1869/2593 (72%) |
| `Parsers/ExpressionElementParsers` | +2.63% | 97/299 (32%) |
| `Processors/Sources/MySQLSource` | +3.06% | 76/225 (34%) |

For reference, `-fstack-protector-all` costs +10.4% and +12.4% of text on the latter two.

Runtime, on Neoverse V2, minimum over five interleaved runs of fifteen repetitions:

| shape | baseline | `-fstack-protector-strong` | delta |
| --- | --- | --- | --- |
| non-inlined call, four-instruction body | 1.0908 ns/call | 1.9375 ns/call | +77.6% |
| same prologue, 65528 elements per call | 0.17976 ns/elem | 0.17968 ns/elem | -0.04% (noise) |

So the cost is +0.85 ns per instrumented call, invisible in vectorised code and real in call-bound code. ClickHouse spends its time in the former shape but has plenty of the latter in the parser and the analyzer, which is exactly what the performance tests are for - hence this draft.

One consequence to accept deliberately: this converts silent corruption into `SIGABRT`, so a latent overflow becomes a server restart rather than continued execution on a corrupted frame.

Related: https://github.com/ClickHouse/ClickHouse/pull/119680
Related: https://github.com/ClickHouse/ClickHouse/pull/119685

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Build with `-fstack-protector-strong`, so that an overflow of a stack local aborts immediately instead of silently corrupting the stack frame.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119684&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119684](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119684+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
