### PR TITLE
Enable `-mbranch-protection=pac-ret` on ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,20 @@ if (ARCH_AMD64)
     set(COMPILER_FLAGS "${COMPILER_FLAGS} ${BRANCHES_WITHIN_32B_BOUNDARIES}")
 endif()
 
+if (OS_LINUX AND ARCH_AARCH64)
+    # Sign the return address in the prologue and authenticate it before returning, so that
+    # overwriting a saved return address cannot redirect control flow. `paciasp` and `autiasp`
+    # live in the `NOP` encoding space: they are real operations on a core implementing
+    # `FEAT_PAuth` (ARMv8.3 and later, which covers Graviton3 and Graviton4) and decode as no-ops
+    # on older cores, so one binary still runs everywhere - just unprotected on the older ones.
+    # Leaf functions are left unsigned, which is the default and free, because they do not spill
+    # the return address to the stack.
+    # `bti` is deliberately left out. The linker keeps the BTI property only when every input
+    # object carries it, including hand-written assembly and every contrib, so enabling it needs
+    # its own audit; without one it would cost code size and enforce nothing.
+    set (COMPILER_FLAGS "${COMPILER_FLAGS} -mbranch-protection=pac-ret")
+endif()
+
 # Disable floating-point expression contraction in order to get consistent floating point calculation results across platforms
 set (COMPILER_FLAGS "${COMPILER_FLAGS} -ffp-contract=off")
 


### PR DESCRIPTION
Nothing currently protects a saved return address. An overflow of a stack local that reaches far enough rewrites it and control transfers wherever the overflow data points - demonstrated in https://github.com/ClickHouse/ClickHouse/pull/119680, where a 2200-byte MySQL `BIT` value moved control to `0x4141414141414141`.

With `pac-ret` the prologue signs the return address with `paciasp` and the epilogue authenticates it, so a return address rewritten through memory no longer validates. Both instructions sit in the `NOP` encoding space, so the same binary keeps running on cores without `FEAT_PAuth` - unprotected there, but not broken. Graviton3 and Graviton4 implement it (`paca` and `pacg` in `/proc/cpuinfo`).

Measured on Neoverse V2:

| translation unit | text size | `pac` instructions |
| --- | --- | --- |
| `Parsers/ExpressionElementParsers` | +0.78% | 408 |
| `Processors/Sources/MySQLSource` | +1.36% | 415 |

| shape | baseline | `pac-ret` | delta |
| --- | --- | --- | --- |
| non-inlined call, four-instruction body | 1.0908 ns/call | 1.2936 ns/call | +18.6% |
| same prologue, 65528 elements per call | 0.17976 ns/elem | 0.17964 ns/elem | -0.07% (noise) |

That is +0.20 ns per signed call. The microbenchmark signs leaf functions to measure them at all (`pac-ret+leaf`); the flag as proposed leaves leaves unsigned, which is the default and free, since they do not spill the return address - so the real blended cost is below what the table shows.

Three limits worth stating plainly:

- **This hardens only the ARM builds, and within them only the code the compiler generates from the `C` and `C++` sources it is given, plus the assembly sources that opt in themselves through the feature macro it defines.** Anything compiled with a flag set of its own, assembled without that opt-in, or built by another compiler keeps unsigned return addresses - see the three cases below. `-mbranch-protection` is `aarch64`-only; the x86-64 counterpart is `-fcf-protection=return`, which needs CET in both hardware and kernel, and is a separate question. The Rust objects the default `aarch64` binary links - `skim`, `delta-kernel`, `chdig`, `wasmtime` - keep unsigned return addresses, because `rustc` treats `-Zbranch-protection` as ABI-affecting and refuses it outright while `std` comes precompiled without it:

  ```
  error: mixing `-Zbranch-protection` will cause an ABI mismatch in crate `lib`
    = note: `-Zbranch-protection=pac-ret` in this crate is incompatible with unset `-Zbranch-protection` in dependency `std`
  ```

  Signing them needs either `std` built from source with the same flag (non-sanitizer builds do not pass `-Zbuild-std`) or an explicit `-Cunsafe-allow-abi-mismatch=branch-protection`, so it wants its own change rather than riding along here.

  The raw `.s` inputs are not signed either, for a duller reason: `-mbranch-protection` is a code-generation option and says nothing about an input that is assembled rather than compiled. A `.s` file assembles to a byte-identical object with and without the flag (584 bytes either way, no `paciasp` in either), while a non-leaf C function in the same build gains `paciasp`/`autiasp`. So `longjmp.s` and `syscall.s` under `base/glibc-compatibility/musl/aarch64` keep unsigned return addresses, as does every prebuilt library we link.

  Preprocessed `.S` sources are the one case that goes the other way, and they do it themselves rather than through code generation. `COMPILER_FLAGS` also feeds `CMAKE_ASM_FLAGS`, and the flag defines `__ARM_FEATURE_PAC_DEFAULT`, which is exactly what `crypto/arm_arch.h` keys `AARCH64_SIGN_LINK_REGISTER` and `AARCH64_VALIDATE_LINK_REGISTER` on. 13 of the 19 AArch64 OpenSSL sources this build assembles include that header, so they gain signed returns and the AArch64 PAC property note. `clang -c` on `contrib/openssl-cmake/asm/crypto/chacha/chacha-armv8.S` with the toolchain of this build:

  | | `paciasp` | `autiasp` | object size | PAC property note |
  | --- | --- | --- | --- | --- |
  | without the flag | 0 | 0 | 8616 | absent |
  | with the flag | 4 | 6 | 8752 | present |

  And the in-tree `compiler-rt` runtimes are not signed: `contrib/compiler-rt-cmake` filters the inherited flags down to an allowlist (`_compiler_rt_keep_re`) which drops the hardening ones. That filter is also why their unwinder does not strip the signature - `sanitizer_ptrauth.h` gates stripping on `__ARM_FEATURE_PAC_DEFAULT`, and `clang -mbranch-protection=pac-ret -dM -E` shows that is exactly the macro this flag defines. So adding `-mbranch-protection` to that allowlist would both sign those objects and make ASan and LSan reports readable under the flag, which is how the `NOT SANITIZE` exclusion above can be retired. Not done here: it rebuilds every ARM sanitizer runtime and wants its own round of validation.
- **`bti` is deliberately excluded.** The linker keeps `GNU_PROPERTY_AARCH64_FEATURE_1_BTI` only when every input object carries it, including hand-written assembly and every contrib; otherwise it is dropped for the whole image and you pay the size for nothing. It measured a further 1.7 to 3.6 points of text, so it wants its own audit rather than riding along here.
- **Sanitizer builds are excluded** (`NOT SANITIZE`), because a signed return address on the stack is only readable by an unwinder that strips the signature, and the sanitizer runtimes shipped with the toolchain do not. `compiler-rt`'s frame-pointer unwinder `BufferedStackTrace::UnwindFast` collects the allocation and deallocation stacks behind every ASan and LSan report, and the `STRIP_PAC_PC` it applies to a saved return address expands to the identity unless `compiler-rt` itself was compiled with `-mbranch-protection`: `sanitizer_ptrauth.h` gates the `xpaclri` path on `__ARM_FEATURE_PAC_DEFAULT`. `UnwindFast` is byte-for-byte the same 87 instructions in the `arm_asan_ubsan` binaries of both this branch and master, and neither contains an `xpaclri`, so the signature travels into the report unchanged - it occupies the bits above the virtual address, and 17 of these 21 frames are gone:

  ```
  ==1423636==ERROR: AddressSanitizer: requested allocation size 0xde0b6b3a763ffff exceeds maximum supported size of 0x800000000 (thread T0)
      #0 0xb4c12b593bb8 in malloc
      #1 0xb4c14aec3ef0 in DB::SystemAllocatedMemoryHolder::Memory::Memory(unsigned long) src/Common/SystemAllocatedMemoryHolder.h:26:20
      #2 0xb4c14aec3ef0 in DB::SystemAllocatedMemoryHolder::alloc(unsigned long) src/Common/SystemAllocatedMemoryHolder.h:55:16
      #3 0x7bb4c14ae77dd4  (<unknown module>)
      #4 0x46b4c14ada1718  (<unknown module>)
      #5 0x19b4c14ad972bc  (<unknown module>)
      ... 12 more (<unknown module>)
      #16 0xb4c138b224f4 in mainEntryClickHouseLocal(int, char**) programs/local/LocalServer.cpp:2229:20
      #17 0x54b4c12b5d23b4  (<unknown module>)
  ```
  The same query against the `arm_asan_ubsan` binary of master `d9049413` - same toolchain, same runtime, and `UnwindFast` disassembles to the same 87 instructions in both - prints the whole chain instead, all 26 frames from `malloc` through `DB::InterpreterSystemQuery::execute` down to `main`, with only the final frame-pointer-less libc frame missing.

  It is also a memory leak in disguise. `paciasp` mixes `SP` into the signature, so one call site yields a different value at every stack depth and each one takes a fresh entry in the stack depot, which is never freed. That is what killed `Stateless tests (arm_asan_ubsan, azure, parallel)` on `db7f4493`: both of its runs peaked at 80.8 and 81.9 GiB where 30 consecutive master runs of the same job peaked at 64 to 74 GiB, the server crossed the memory-pressure threshold of `clickhouse-test` 11 times, the worker pool drained from 12 workers to 1, and the job hit its 9000 s budget at 8955 of 13957 tests with every test `OK` and no `FAIL` line. The drain never reverses (issue https://github.com/ClickHouse/ClickHouse/issues/119791, fix https://github.com/ClickHouse/ClickHouse/pull/119793), which is what turned the extra memory into a timeout rather than a slowdown.

  Our own unwinding is unaffected, which is why nothing else in CI noticed: `StackTrace` and jemalloc's profiler go through `unw_backtrace`, whose DWARF stepper follows `DW_CFA_AARCH64_negate_ra_state`, and the frame-pointer walk that `StackTrace::tryCapture` uses under TSan is abseil's, which strips the signature with `xpaclri` unconditionally.

Related: https://github.com/ClickHouse/ClickHouse/pull/119680
Related: https://github.com/ClickHouse/ClickHouse/pull/119684

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Build the `C` and `C++` code of the ARM binaries with `-mbranch-protection=pac-ret`, which signs the return address so that overwriting it on the stack cannot redirect control flow; the AArch64 `.S` sources that key off `__ARM_FEATURE_PAC_DEFAULT` opt into the same signing. Sanitizer builds are excluded, because the sanitizer runtimes do not strip the signature when they unwind.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119685&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119685](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119685+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


