### PR TITLE
Fix flaky `01780_column_sparse`: order the `arrayFilter` result before limiting it

### DIFF
--- a/tests/queries/0_stateless/01780_column_sparse.reference
+++ b/tests/queries/0_stateless/01780_column_sparse.reference
@@ -132,7 +132,7 @@ SELECT id % 7, sum(u) FROM t_sparse GROUP BY id % 7 ORDER BY id % 7;
 4	190
 5	330
 6	270
-SELECT arrayFilter(x -> x % 2 = 1, arr2) FROM t_sparse WHERE arr2 != [] LIMIT 5;
+SELECT arrayFilter(x -> x % 2 = 1, arr2) FROM t_sparse WHERE arr2 != [] ORDER BY id LIMIT 5;
 [1]
 [1,3]
 [1,3,5]

--- a/tests/queries/0_stateless/01780_column_sparse.sql
+++ b/tests/queries/0_stateless/01780_column_sparse.sql
@@ -27,7 +27,7 @@ SELECT * FROM t_sparse WHERE arr2 != [] ORDER BY id;
 SELECT sum(u) FROM t_sparse;
 SELECT id % 7, sum(u) FROM t_sparse GROUP BY id % 7 ORDER BY id % 7;
 
-SELECT arrayFilter(x -> x % 2 = 1, arr2) FROM t_sparse WHERE arr2 != [] LIMIT 5;
+SELECT arrayFilter(x -> x % 2 = 1, arr2) FROM t_sparse WHERE arr2 != [] ORDER BY id LIMIT 5;
 
 CREATE TABLE t_sparse_1 (id UInt64, v Int64)
 ENGINE = MergeTree ORDER BY tuple()


### PR DESCRIPTION
`01780_column_sparse` ends with

```sql
SELECT arrayFilter(x -> x % 2 = 1, arr2) FROM t_sparse WHERE arr2 != [] LIMIT 5;
```

`t_sparse` is `ORDER BY tuple()`, so there is no implicit row order to fall back on, and once the table is read by more than one stream the five rows that survive `LIMIT` arrive in an arbitrary order.

Every "result differs with reference" failure of this test over the last 400 days — six of them — is the same permutation of that one statement's output, across `Stateless tests (amd_debug, distributed plan, s3 storage, parallel)`, `(amd_debug, AsyncInsert, s3 storage, parallel)`, `(amd_tsan, s3 storage, parallel)`, `(amd_binary, ParallelReplicas, s3 storage, parallel)` and `Fast test`. Two of them were on master pushes rather than pull requests; the 2026-04-08 one ran with a randomized `index_granularity` of 3, which maximises the number of marks and hence of reading streams:

```
 SELECT arrayFilter(x -> x % 2 = 1, arr2) FROM t_sparse WHERE arr2 != [] LIMIT 5;
-[1]
+[1,3,5,7]
 [1,3]
 [1,3,5]
-[1,3,5,7]
+[1]
```

`ORDER BY id` makes the choice of rows deterministic. It is the order the reference already records, so only the echoed query text changes. The statement was added without an ordering in 2022 and the file has not been touched since; the test is untracked by any flakiness issue.

Found while triaging the CI of an unrelated pull request, where the most recent instance appeared.

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119686&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119686](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119686+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
