### PR TITLE
Fix restoring a Field dump of a nested or quoted container

### DIFF
--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -3,6 +3,7 @@
 #include <Common/FieldVisitorDump.h>
 #include <Common/FieldVisitorToString.h>
 #include <Common/FieldVisitorWriteBinary.h>
+#include <Common/checkStackSize.h>
 #include <Core/AccurateComparison.h>
 #include <Core/DecimalComparison.h>
 #include <Core/Field.h>
@@ -703,12 +704,116 @@ String Field::dump() const
     return applyVisitor(FieldVisitorDump(), *this);
 }
 
+namespace
+{
+
+[[noreturn]] void cannotRestoreFromDump(std::string_view dump)
+{
+    throw Exception(ErrorCodes::CANNOT_RESTORE_FROM_FIELD_DUMP, "Couldn't restore Field from dump: {}", String{dump});
+}
+
+/// Offset of the character that ends a leaf element of a container dump: a comma, or the
+/// container's own closing bracket. Quoted strings and bracketed payloads are skipped, so a
+/// separator inside them does not end the element. npos when the element is unterminated.
+size_t findEndOfLeafDump(std::string_view dump)
+{
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaped = false;
+    for (size_t i = 0; i < dump.size(); ++i)
+    {
+        char c = dump[i];
+        if (in_string)
+        {
+            if (escaped)
+                escaped = false;
+            else if (c == '\\')
+                escaped = true;
+            else if (c == '\'')
+                in_string = false;
+        }
+        else if (c == '\'')
+            in_string = true;
+        else if (c == '[' || c == '(')
+            ++depth;
+        else if (c == ']' || c == ')')
+        {
+            if (depth == 0)
+                return i;
+            --depth;
+        }
+        else if (c == ',' && depth == 0)
+            return i;
+    }
+    return std::string_view::npos;
+}
+
+Field restoreElementFromDump(std::string_view & tail, std::string_view whole_dump);
+
+/// `tail` starts just after the container's opening bracket and is left just after `closing`.
+template <typename Container>
+Container restoreContainerFromDump(std::string_view & tail, char closing, std::string_view whole_dump)
+{
+    Container container;
+    trimLeft(tail);
+    if (tail.starts_with(closing))
+    {
+        tail.remove_prefix(1);
+        return container;
+    }
+    while (true)
+    {
+        container.push_back(restoreElementFromDump(tail, whole_dump));
+        trimLeft(tail);
+        if (tail.empty())
+            cannotRestoreFromDump(whole_dump);
+        char separator = tail.front();
+        tail.remove_prefix(1);
+        if (separator == closing)
+            return container;
+        if (separator != ',')
+            cannotRestoreFromDump(whole_dump);
+        trimLeft(tail);
+    }
+}
+
+/// Consumes one element from the front of `tail`. A nested container is consumed here rather than
+/// delimited and then parsed again, so each byte of the dump is examined a bounded number of times.
+Field restoreElementFromDump(std::string_view & tail, std::string_view whole_dump)
+{
+    /// The grammar nests without a bound and the dumps reaching this parser are user supplied.
+    checkStackSize();
+    trimLeft(tail);
+
+    if (tail.starts_with("Array_["))
+    {
+        tail.remove_prefix(std::string_view{"Array_["}.length());
+        return restoreContainerFromDump<Array>(tail, ']', whole_dump);
+    }
+
+    if (tail.starts_with("Tuple_("))
+    {
+        tail.remove_prefix(std::string_view{"Tuple_("}.length());
+        return restoreContainerFromDump<Tuple>(tail, ')', whole_dump);
+    }
+
+    if (tail.starts_with("Map_("))
+    {
+        tail.remove_prefix(std::string_view{"Map_("}.length());
+        return restoreContainerFromDump<Map>(tail, ')', whole_dump);
+    }
+
+    size_t end = findEndOfLeafDump(tail);
+    std::string_view element = tail.substr(0, end == std::string_view::npos ? tail.length() : end);
+    tail.remove_prefix(element.length());
+    return Field::restoreFromDump(element);
+}
+
+}
+
 Field Field::restoreFromDump(std::string_view dump_)
 {
-    auto show_error = [&dump_]
-    {
-        throw Exception(ErrorCodes::CANNOT_RESTORE_FROM_FIELD_DUMP, "Couldn't restore Field from dump: {}", String{dump_});
-    };
+    auto show_error = [&dump_] { cannotRestoreFromDump(dump_); };
 
     std::string_view dump = dump_;
     trim(dump);
@@ -771,6 +876,8 @@ Field Field::restoreFromDump(std::string_view dump_)
         DecimalField<Decimal32> decimal;
         ReadBufferFromString buf{dump.substr(prefix.length())};
         readQuoted(decimal, buf);
+        if (!buf.eof())
+            show_error();
         return decimal;
     }
 
@@ -780,6 +887,8 @@ Field Field::restoreFromDump(std::string_view dump_)
         DecimalField<Decimal64> decimal;
         ReadBufferFromString buf{dump.substr(prefix.length())};
         readQuoted(decimal, buf);
+        if (!buf.eof())
+            show_error();
         return decimal;
     }
 
@@ -789,6 +898,8 @@ Field Field::restoreFromDump(std::string_view dump_)
         DecimalField<Decimal128> decimal;
         ReadBufferFromString buf{dump.substr(prefix.length())};
         readQuoted(decimal, buf);
+        if (!buf.eof())
+            show_error();
         return decimal;
     }
 
@@ -798,6 +909,8 @@ Field Field::restoreFromDump(std::string_view dump_)
         DecimalField<Decimal256> decimal;
         ReadBufferFromString buf{dump.substr(prefix.length())};
         readQuoted(decimal, buf);
+        if (!buf.eof())
+            show_error();
         return decimal;
     }
 
@@ -806,6 +919,8 @@ Field Field::restoreFromDump(std::string_view dump_)
         String str;
         ReadBufferFromString buf{dump};
         readQuoted(str, buf);
+        if (!buf.eof())
+            show_error();
         return str;
     }
 
@@ -816,88 +931,29 @@ Field Field::restoreFromDump(std::string_view dump_)
         return value;
     }
 
-    prefix = std::string_view{"Array_["};
-    if (dump.starts_with(prefix))
+    if (dump.starts_with("Array_[") || dump.starts_with("Tuple_(") || dump.starts_with("Map_("))
     {
-        std::string_view tail = dump.substr(prefix.length());
+        std::string_view tail = dump;
+        Field result = restoreElementFromDump(tail, dump_);
         trimLeft(tail);
-        Array array;
-        while (tail != "]")
-        {
-            size_t separator = tail.find_first_of(",]");
-            if (separator == std::string_view::npos)
-                show_error();
-            bool comma = (tail[separator] == ',');
-            std::string_view element = tail.substr(0, separator);
-            tail.remove_prefix(separator);
-            if (comma)
-                tail.remove_prefix(1);
-            trimLeft(tail);
-            if (!comma && tail != "]")
-                show_error();
-            array.push_back(Field::restoreFromDump(element));
-        }
-        return array;
-    }
-
-    prefix = std::string_view{"Tuple_("};
-    if (dump.starts_with(prefix))
-    {
-        std::string_view tail = dump.substr(prefix.length());
-        trimLeft(tail);
-        Tuple tuple;
-        while (tail != ")")
-        {
-            size_t separator = tail.find_first_of(",)");
-            if (separator == std::string_view::npos)
-                show_error();
-            bool comma = (tail[separator] == ',');
-            std::string_view element = tail.substr(0, separator);
-            tail.remove_prefix(separator);
-            if (comma)
-                tail.remove_prefix(1);
-            trimLeft(tail);
-            if (!comma && tail != ")")
-                show_error();
-            tuple.push_back(Field::restoreFromDump(element));
-        }
-        return tuple;
-    }
-
-    prefix = std::string_view{"Map_("};
-    if (dump.starts_with(prefix))
-    {
-        std::string_view tail = dump.substr(prefix.length());
-        trimLeft(tail);
-        Map map;
-        while (tail != ")")
-        {
-            size_t separator = tail.find_first_of(",)");
-            if (separator == std::string_view::npos)
-                show_error();
-            bool comma = (tail[separator] == ',');
-            std::string_view element = tail.substr(0, separator);
-            tail.remove_prefix(separator);
-            if (comma)
-                tail.remove_prefix(1);
-            trimLeft(tail);
-            if (!comma && tail != ")")
-                show_error();
-            map.push_back(Field::restoreFromDump(element));
-        }
-        return map;
+        if (!tail.empty())
+            show_error();
+        return result;
     }
 
     prefix = std::string_view{"AggregateFunctionState_("};
     if (dump.starts_with(prefix))
     {
         std::string_view after_prefix = dump.substr(prefix.length());
-        size_t comma = after_prefix.find(',');
-        size_t end = after_prefix.find(')', comma + 1);
-        if ((comma == std::string_view::npos) || (end != after_prefix.length() - 1))
+        size_t comma = findEndOfLeafDump(after_prefix);
+        if (comma == std::string_view::npos || after_prefix[comma] != ',')
             show_error();
         std::string_view name_view = after_prefix.substr(0, comma);
-        std::string_view data_view = after_prefix.substr(comma + 1, end - comma - 1);
+        std::string_view rest = after_prefix.substr(comma + 1);
+        size_t end = findEndOfLeafDump(rest);
+        if (end == std::string_view::npos || rest[end] != ')' || end != rest.length() - 1)
+            show_error();
+        std::string_view data_view = rest.substr(0, end);
         trim(name_view);
         trim(data_view);
         ReadBufferFromString name_buf{name_view};
@@ -905,6 +961,8 @@ Field Field::restoreFromDump(std::string_view dump_)
         AggregateFunctionStateData res;
         readQuotedString(res.name, name_buf);
         readQuotedString(res.data, data_buf);
+        if (!name_buf.eof() || !data_buf.eof())
+            show_error();
         return res;
     }
 

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -763,7 +763,14 @@ Container restoreContainerFromDump(std::string_view & tail, char closing, std::s
     }
     while (true)
     {
-        container.push_back(restoreElementFromDump(tail, whole_dump));
+        Field element = restoreElementFromDump(tail, whole_dump);
+        if constexpr (std::is_same_v<Container, Map>)
+        {
+            /// A Map element is a key-value pair: every consumer indexes it as a two element tuple.
+            if (element.getType() != Field::Types::Tuple || element.safeGet<Tuple>().size() != 2)
+                cannotRestoreFromDump(whole_dump);
+        }
+        container.push_back(std::move(element));
         trimLeft(tail);
         if (tail.empty())
             cannotRestoreFromDump(whole_dump);

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -784,8 +784,8 @@ Container restoreContainerFromDump(std::string_view & tail, char closing, std::s
     }
 }
 
-/// Consumes one element from the front of `tail`. A nested container is consumed here rather than
-/// delimited and then parsed again, so each byte of the dump is examined a bounded number of times.
+/// Consumes one element from the front of `tail`, a nested container included, so each byte of the
+/// dump is examined a bounded number of times.
 Field restoreElementFromDump(std::string_view & tail, std::string_view whole_dump)
 {
     /// The grammar nests without a bound and the dumps reaching this parser are user supplied.

--- a/src/Core/tests/gtest_field.cpp
+++ b/src/Core/tests/gtest_field.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <Common/Exception.h>
 #include <Core/Field.h>
 
 #include <limits>
@@ -221,4 +222,61 @@ GTEST_TEST(Field, CompareUUID)
 
     ASSERT_TRUE(one == one_again);
     ASSERT_FALSE(one == two);
+}
+
+
+GTEST_TEST(Field, RestoreFromDumpRoundTripsNestedAndQuotedContainers)
+{
+    /// The value shapes below cannot be built from SQL: the SET grammar accepts only a literal or a
+    /// flat map of string literals, so a stateless test cannot reach a nested container, an array
+    /// element or an aggregate state.
+    auto round_trip = [](const Field & field) { return Field::restoreFromDump(field.dump()); };
+
+    /// Nested containers. A Map element is always dumped as a nested Tuple_(...), so any non-empty
+    /// map exercises this.
+    {
+        Array inner{Field{UInt64{1}}, Field{UInt64{2}}};
+        Field nested_array{Array{Field{std::move(inner)}, Field{Tuple{Field{String{"x"}}, Field{Int64{-3}}}}}};
+        ASSERT_EQ(round_trip(nested_array), nested_array);
+
+        Field nested_map{Map{Field{Tuple{Field{String{"k"}}, Field{Map{Field{Tuple{Field{String{"a"}}, Field{String{"b"}}}}}}}}}};
+        ASSERT_EQ(round_trip(nested_map), nested_map);
+    }
+
+    /// String elements holding the separators and the escape characters of the dump grammar.
+    {
+        Field hostile{Array{Field{String{"a,b]c)d'e\\f"}}, Field{String{"("}}, Field{String{"'"}}}};
+        ASSERT_EQ(round_trip(hostile), hostile);
+    }
+
+    /// An aggregate state: the name may be parameterised, and the data is quoted but its brackets
+    /// and commas are not escaped.
+    {
+        Field state{AggregateFunctionStateData{.name = "quantiles(0.5, 0.9)", .data = "a)b,c'd\\e"}};
+        ASSERT_EQ(round_trip(state), state);
+    }
+
+    /// Empty containers.
+    {
+        ASSERT_EQ(round_trip(Field{Array{}}), Field{Array{}});
+        ASSERT_EQ(round_trip(Field{Tuple{}}), Field{Tuple{}});
+        ASSERT_EQ(round_trip(Field{Map{}}), Field{Map{}});
+    }
+
+    /// An element that parses only partially is an error, not a silently truncated container: a
+    /// hand written users.xml value of Map_('k':'v') must not restore as Map(String 'k').
+    ASSERT_THROW(Field::restoreFromDump("Map_('k':'v')"), DB::Exception);
+
+    /// A dump nests as deep as its text says, so the depth has to be bounded. Built as text
+    /// directly: dumping a Field this deep would recurse before the parser is reached.
+    {
+        static constexpr size_t depth = 100000;
+        String deep;
+        deep.reserve(depth * 8 + 16);
+        for (size_t i = 0; i < depth; ++i)
+            deep += "Array_[";
+        deep += "UInt64_1";
+        deep.append(depth, ']');
+        ASSERT_THROW(Field::restoreFromDump(deep), DB::Exception);
+    }
 }

--- a/src/Core/tests/gtest_field.cpp
+++ b/src/Core/tests/gtest_field.cpp
@@ -267,6 +267,11 @@ GTEST_TEST(Field, RestoreFromDumpRoundTripsNestedAndQuotedContainers)
     /// hand written users.xml value of Map_('k':'v') must not restore as Map(String 'k').
     ASSERT_THROW(Field::restoreFromDump("Map_('k':'v')"), DB::Exception);
 
+    /// A Map element is a key-value pair, so a dump that says otherwise must not restore: consumers
+    /// index the element as a two element tuple.
+    ASSERT_THROW(Field::restoreFromDump("Map_('k')"), DB::Exception);
+    ASSERT_THROW(Field::restoreFromDump("Map_(Tuple_('k'))"), DB::Exception);
+
     /// A dump nests as deep as its text says, so the depth has to be bounded. Built as text
     /// directly: dumping a Field this deep would recurse before the parser is reached.
     {

--- a/src/Parsers/ASTJSONReadHelpers.cpp
+++ b/src/Parsers/ASTJSONReadHelpers.cpp
@@ -321,10 +321,10 @@ Field JSONObjectReader::readFieldFromObjectImpl(const Poco::JSON::Object & obj, 
             "Expected a string 'value' (Field dump) for field type '{}' during AST JSON deserialization", field_type);
     String dump_str = obj.getValue<String>("value");
 
-    /// `Field::restoreFromDump` recursively parses nested `Array_`/`Tuple_`/`Map_` dumps
-    /// without an internal depth limit, so a hostile JSON payload could trigger unbounded
-    /// recursion even when the JSON object itself is shallow. Reject overly deep payloads
-    /// against the same depth bound used for AST node construction.
+    /// `Field::restoreFromDump` recursively parses nested `Array_`/`Tuple_`/`Map_` dumps and stops
+    /// only when the native stack runs low, so a hostile JSON payload could recurse deeply even when
+    /// the JSON object itself is shallow. Reject overly deep payloads against the same deterministic
+    /// depth bound used for AST node construction.
     if (size_t max_depth = getJSONDeserializationMaxDepth();
         computeFieldDumpNestingDepth(dump_str) > max_depth)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,

--- a/tests/queries/0_stateless/05210_custom_setting_map_field_dump_round_trip.reference
+++ b/tests/queries/0_stateless/05210_custom_setting_map_field_dump_round_trip.reference
@@ -1,0 +1,8 @@
+map survives the round trip	{'k':'v'}
+session is still usable	1
+remote shard reads the setting	1
+comma inside a quoted key	{'a,b':'v'}
+closing bracket inside a quoted value	{'k':'v)'}
+two keys	{'k':'v','k2':'v2'}
+empty map	{}
+scalar	plain string

--- a/tests/queries/0_stateless/05210_custom_setting_map_field_dump_round_trip.sql
+++ b/tests/queries/0_stateless/05210_custom_setting_map_field_dump_round_trip.sql
@@ -1,0 +1,28 @@
+-- Tags: shard
+
+-- A custom setting travels on the native protocol as the text dump of its Field, so a map valued
+-- one is sent as Map_(Tuple_('k', 'v')) and has to be restored by Field::restoreFromDump. The
+-- session arms below fail on the query that follows the SET, not on the SET itself; the remote arm
+-- fails on the shard, which reads the same dump out of the query's settings.
+
+SET SQL_05210_map = {'k':'v'};
+SELECT 'map survives the round trip', getSetting('SQL_05210_map');
+SELECT 'session is still usable', 1;
+SELECT 'remote shard reads the setting', count() FROM remote('127.0.0.1', system.one) SETTINGS SQL_05210_map = {'k':'v'};
+
+SET SQL_05210_comma_in_key = {'a,b':'v'};
+SELECT 'comma inside a quoted key', getSetting('SQL_05210_comma_in_key');
+
+SET SQL_05210_bracket_in_value = {'k':'v)'};
+SELECT 'closing bracket inside a quoted value', getSetting('SQL_05210_bracket_in_value');
+
+SET SQL_05210_two_keys = {'k':'v','k2':'v2'};
+SELECT 'two keys', getSetting('SQL_05210_two_keys');
+
+-- Control: an empty map restores on master too, and must keep restoring.
+SET SQL_05210_empty = {};
+SELECT 'empty map', getSetting('SQL_05210_empty');
+
+-- Control: a scalar custom setting is unaffected.
+SET SQL_05210_scalar = 'plain string';
+SELECT 'scalar', getSetting('SQL_05210_scalar');


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119646
Related: https://github.com/ClickHouse/ClickHouse/issues/119643
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed restoring a `Field` from its text dump when a container element is itself a container, or a quoted string containing a separator. A map valued custom setting is dumped as `Map_(Tuple_('k', 'v'))`, so after `SET SQL_a = {'k':'v'}` every later query in that session, and every query to a shard, failed with `CANNOT_RESTORE_FROM_FIELD_DUMP`. The element split is fixed for `Array_[`, `Tuple_(`, `Map_(` and `AggregateFunctionState_(`, and a partially parsed element, or a `Map_` element that is not a key-value tuple, is now an error instead of a silently invalid value. Closes #119646.


### Description

**What breaks.** `FieldVisitorDump` writes a recursive, quoted grammar whose `Map` elements are nested `Tuple_(...)`, but `Field::restoreFromDump` split elements with a flat `find_first_of(",]")` scan blind to nesting and quoting, so no non-empty map restored. Reproduced on 24.8, 25.8 and master.

**Change.** Container elements are consumed by one advancing cursor, so a nested payload is parsed once, not per level; a leaf is delimited by a quote and bracket aware scan. Four smaller fixes ride along: the same blindness in the `AggregateFunctionState_(` split; a partially parsed element was accepted, so `users.xml`'s `Map_('k':'v')` became `Map(String 'k')`; a `Map_` element must now be the key-value tuple its consumers already index; and `checkStackSize()` bounds the recursion this fix makes reachable (without it a 100000 level dump segfaults).

**Validation.** New stateless test `05210` fails on master with `Code: 536`; a gtest covers shapes SQL cannot build. Every component has a reddening arm: without the key-value check a `Map_(Tuple_('k'))` profile value loads and `getSetting` then aborts on `FieldToDataType`'s `chassert(tuple.size() == 2)`. The parse stays linear in the size of the dump.

**Behaviour change.** A malformed dump in a `users.xml` profile custom setting, now including a `Map_` element that is not a key-value tuple, is rejected while the profile is parsed: at startup the server refuses to start; on a reload the whole new users configuration is dropped, so loaded profiles keep working but a well-formed profile added in the same edit does not appear.

**Not fixed here.** The absent `UUID_`, `IPv4_`, `IPv6_`, `Object_(`, `+Inf` and `-Inf` arms are missing branches, not wrong ones (#119643); `CustomType_` stays out: #118993 relies on it being unrestorable; a `Decimal*_` dump never restores.

<details>
<summary>Parse time vs dump size</summary>

A single element chain nested D deep, timed through `Field::restoreFromDump` on a Debug build
(clang++-21) by a temporary gtest that is not part of this PR, run as
`unit_tests_dbms --gtest_filter=Field.ScratchRestoreLinearity`:

| depth | dump bytes | wall | ns per byte |
|---|---|---|---|
| 500 | 4008 | 74 usec | 18.5 |
| 1000 | 8008 | 147 usec | 18.4 |
| 2000 | 16008 | 269 usec | 16.8 |
| 4000 | 32008 | 546 usec | 17.1 |
| 8000 | 64008 | 1136 usec | 17.7 |
| 100000 | 800008 | 66 ms | rejected, `TOO_DEEP_RECURSION` |

Flat at about 17 ns per byte across a 16x range, and the over-deep dump is rejected quickly rather
than spinning. A delimit-then-recurse shape would instead rescan a nested element once per enclosing
level, and a settings string arrives through `readStringBinary`.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119687&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119687](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119687+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
