### PR TITLE
Perf(JOIN): Skip filtering for all-ones join masks

### DIFF
--- a/src/Processors/Transforms/CreateSetAndFilterOnTheFlyTransform.cpp
+++ b/src/Processors/Transforms/CreateSetAndFilterOnTheFlyTransform.cpp
@@ -7,6 +7,7 @@
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 #include <Columns/IColumn.h>
+#include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnSparse.h>
 #include <Core/ColumnWithTypeAndName.h>
 #include <base/types.h>
@@ -184,6 +185,9 @@ void FilterBySetOnTheFlyTransform::transform(Chunk & chunk)
         auto key_columns = getColumnsByIndices(key_sample_block, chunk, key_column_indices);
         ColumnPtr mask_col = set->execute(key_columns, false);
         const auto & mask = assert_cast<const ColumnUInt8 *>(mask_col.get())->getData();
+
+        if (memoryIsByte(mask.data(), 0, mask.size(), 1))
+            return;
 
         stat.result_rows -= chunk.getNumRows();
 

--- a/tests/performance/filter_by_set_on_the_fly.xml
+++ b/tests/performance/filter_by_set_on_the_fly.xml
@@ -1,0 +1,45 @@
+<test>
+    <settings>
+        <enable_analyzer>1</enable_analyzer>
+        <max_threads>1</max_threads>
+        <max_block_size>65536</max_block_size>
+    </settings>
+
+    <query>
+        SELECT sum(length(l.payload1) + length(l.payload2) + length(l.payload3))
+        FROM
+        (
+            SELECT
+                number % 100000 AS k,
+                concat(toString(number), repeat('a', 64)) AS payload1,
+                concat(toString(number + 1), repeat('b', 64)) AS payload2,
+                concat(toString(number + 2), repeat('c', 64)) AS payload3
+            FROM numbers(2000000)
+        ) AS l
+        INNER JOIN (SELECT number AS k FROM numbers(100000)) AS r ON l.k = r.k
+        FORMAT Null
+        SETTINGS
+            join_algorithm = 'full_sorting_merge',
+            max_rows_in_set_to_optimize_join = 1000000,
+            query_plan_join_swap_table = 0
+    </query>
+
+    <query>
+        SELECT sum(length(l.payload1) + length(l.payload2) + length(l.payload3))
+        FROM
+        (
+            SELECT
+                number % 100000 AS k,
+                concat(toString(number), repeat('a', 64)) AS payload1,
+                concat(toString(number + 1), repeat('b', 64)) AS payload2,
+                concat(toString(number + 2), repeat('c', 64)) AS payload3
+            FROM numbers(2000000)
+        ) AS l
+        INNER JOIN (SELECT number * 2 AS k FROM numbers(100000)) AS r ON l.k = r.k
+        FORMAT Null
+        SETTINGS
+            join_algorithm = 'full_sorting_merge',
+            max_rows_in_set_to_optimize_join = 1000000,
+            query_plan_join_swap_table = 0
+    </query>
+</test>

--- a/tests/queries/0_stateless/02382_join_and_filtering_set.reference
+++ b/tests/queries/0_stateless/02382_join_and_filtering_set.reference
@@ -5,6 +5,8 @@
 42
 24
 10
+-- all rows match the on-the-fly set
+5000
 bug with constant columns in join keys
 a	a
 1

--- a/tests/queries/0_stateless/02382_join_and_filtering_set.sql
+++ b/tests/queries/0_stateless/02382_join_and_filtering_set.sql
@@ -20,6 +20,11 @@ SELECT count() FROM t1 JOIN t2 ON t1.x = t2.x WHERE t2.x % 2 == 0;
 SELECT count() FROM t1 JOIN t2 ON t1.x = t2.x WHERE t1.y % 2 == 0 AND t2.y % 2 == 0;
 SELECT count() FROM t1 JOIN t2 ON t1.x = t2.x WHERE t1.x % 2 == 0 AND t2.x % 2 == 0 AND t1.y % 2 == 0 AND t2.y % 2 == 0;
 
+SELECT '-- all rows match the on-the-fly set';
+SELECT count()
+FROM (SELECT number % 100 AS x FROM numbers(5000)) AS l
+INNER JOIN (SELECT number AS x FROM numbers(100)) AS r ON l.x = r.x;
+
 SELECT 'bug with constant columns in join keys';
 
 SELECT * FROM ( SELECT 'a' AS key ) AS t1
@@ -40,5 +45,4 @@ SELECT count() == 0 FROM (EXPLAIN PIPELINE
     ON t1.key = t2.key
 ) WHERE explain ilike '%FilterBySetOnTheFlyTransform%'
 ;
-
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Skip filtering when all rows match an on-the-fly join set.

**What changed**

- Check the set mask before detaching the chunk columns.
- Return the original chunk when the mask contains only ones.
- Keep the existing filtering path for partial matches.

**Why**

- An all-ones mask cannot change the chunk.
- The old path still filtered and copied every column.
- This is useful for wide joined blocks.

**Tests and benchmark**

- Added an all-match case to `02382_join_and_filtering_set`.
- Added `tests/performance/filter_by_set_on_the_fly.xml`.
- The benchmark compares:
  - all rows matching the set
  - a selective mask
  - three wide String payload columns
  - one thread with `FORMAT Null`

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119698&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119698](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119698+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
