### PR TITLE
Fix a DETACH/ATTACH race in test_broken_projections and test_storage_kafka

### DIFF
--- a/tests/integration/test_broken_projections/test.py
+++ b/tests/integration/test_broken_projections/test.py
@@ -206,7 +206,7 @@ def optimize(node, table, final, no_wait):
 def reattach(node, table):
     node.query(
         f"""
-    DETACH TABLE {table};
+    DETACH TABLE {table} SYNC;
     ATTACH TABLE {table};
     """
     )
@@ -853,7 +853,7 @@ def test_check_table_broken_projection_columns(cluster):
         f"SELECT path FROM system.parts WHERE database = 'default' AND table = '{table_name}' AND active"
     ).strip()
 
-    node.query(f"DETACH TABLE {table_name}")
+    node.query(f"DETACH TABLE {table_name} SYNC")
     bash(node, f"printf 'garbage' > '{data_path}p1.proj/serialization.json'")
     # The attach legitimately logs the broken projection at error level (the original
     # stateless test had to silence server logs on the client side for that reason).
@@ -894,7 +894,7 @@ def test_check_table_broken_projection_columns(cluster):
         f"SELECT path FROM system.parts WHERE database = 'default' AND table = '{table_name}' AND active"
     ).strip()
 
-    node.query(f"DETACH TABLE {table_name}")
+    node.query(f"DETACH TABLE {table_name} SYNC")
     bash(node, f"printf 'garbage' > '{data_path}p1.proj/serialization.json'")
     node.query(f"ATTACH TABLE {table_name}")
 

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -2876,7 +2876,7 @@ def test_kafka_engine_put_errors_to_stream(kafka_cluster, create_query_generator
                _error AS error
                FROM test.{kafka_table} WHERE length(_error) > 0;
 
-        DETACH TABLE test.{kafka_table};
+        DETACH TABLE test.{kafka_table} SYNC;
         ATTACH TABLE test.{kafka_table};
         """
     )
@@ -2964,7 +2964,7 @@ def test_kafka_engine_put_errors_to_stream_with_random_malformed_json(
                _error AS error
                FROM test.{kafka_table} WHERE length(_error) > 0;
 
-        DETACH TABLE test.{kafka_table};
+        DETACH TABLE test.{kafka_table} SYNC;
         ATTACH TABLE test.{kafka_table};
     """)
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -317,7 +317,7 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
                 SELECT {raw_message} as raw_message, _error as error, _topic as topic, _partition as partition, _offset as offset FROM test.kafka_{format_name}
                 WHERE length(_error) > 0;
 
-            DETACH TABLE test.kafka_{format_name};
+            DETACH TABLE test.kafka_{format_name} SYNC;
             ATTACH TABLE test.kafka_{format_name};
             """
         )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `DETACH TABLE ... SYNC` in the integration tests that immediately re-`ATTACH` the table, so a concurrent query holding the detached table cannot fail the `ATTACH`.

### Description

`DETACH TABLE t` on an Atomic database takes no exclusive table lock, so it can return while an
in-flight query still holds the detached `StoragePtr`. `DatabaseAtomic` parks that pointer in
`detached_tables`, and `assertDetachedTableNotInUse` refuses the immediate re-`ATTACH`:

```
Code: 57. DB::Exception: Cannot attach table with UUID <uuid>, because it was
detached but still used by some query. Retry later. (TABLE_ALREADY_EXISTS)
```

The message says "Retry later", and that wait already exists behind the `SYNC` keyword
(`InterpreterDropQuery::executeToTable` -> `DatabaseAtomic::waitDetachedTableNotInUse`). These
tests never asked for it, so a documented transient surfaced as a red shard on
`ATTACH TABLE test.kafka_TSVWithNames;` ([failing master run](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d8bf9a01b85be2e40ff892287632dd878aeef8c9&name_0=MasterCI)).

Integration tests only: `install.sh:357` links
`users.d/database_atomic_drop_detach_sync.xml`, which turns on
`database_atomic_wait_for_drop_and_detach_synchronously`, making a bare stateless `DETACH`
implicitly `SYNC`. The integration harness installs nothing equivalent and the
setting defaults to `false`. Two of these sites arrived that way in #114070, which moved
`t_broken_proj_check` out of `0_stateless`.

I add `SYNC` to every bare `DETACH` whose `ATTACH` is the next statement, in the two modules where
this signature has failed: six one-word edits, three files, no `src/` change. A same-table
adjacency scan over both modules then finds nothing left; pairs with an intervening query (8 in
`test_storage_kafka`) are outside that boundary and unchanged.

43 pairs match that detector in 27 other modules, some on non-Atomic engines where both hooks are
empty default virtuals (`IDatabase.h:509-510`) so the pair cannot fail. None has an observed
failure and each wants its own validation run, so I left them; happy to sweep on request.

Validated by a deterministic A/B on a local server: with an in-flight `INSERT` holding the
`StoragePtr`, the bare pair fails with `Code: 57` every run, while `DETACH ... SYNC` succeeds after
a measured 10.7 s wait. Both modules pass, and each edited `DETACH` takes the wait path in their
logs, none when reverted.

<details>
<summary>The master occurrence (CIDB query and its single row)</summary>

```sql
SELECT check_start_time, pull_request_number, head_ref, commit_sha, check_name, test_name
FROM default.checks
WHERE check_start_time > now() - INTERVAL 120 DAY
  AND test_status IN ('FAIL','ERROR')
  AND position(test_context_raw, 'detached but still used by some query') > 0
```

Exactly one row in 120 days:

| check_start_time | head_ref | commit_sha | check_name | test_name |
|---|---|---|---|---|
| 2026-08-21 15:23:33 | master | d8bf9a01b85be2e40ff892287632dd878aeef8c9 | Integration tests (amd_asan_ubsan, db disk, old analyzer, 4/6) | test_storage_kafka/test_batch_slow_0.py::test_kafka_formats_with_broken_message[generate_old_create_table_query] |

The failing statement in that report is `ATTACH TABLE test.kafka_TSVWithNames;`.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119705&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119705](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119705+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1398` (included in `26.9` and later)
<!-- ch-version-info:end -->