### PR TITLE
Stabilize storage memory profiler many-parts scenario

### DIFF
--- a/utils/storage-memory-profiler/scenarios/07_many_parts.sql
+++ b/utils/storage-memory-profiler/scenarios/07_many_parts.sql
@@ -19,6 +19,9 @@ SETTINGS
     max_bytes_to_merge_at_max_space_in_pool = 1,
     max_bytes_to_merge_at_min_space_in_pool = 1;
 
+-- Prevent background merge selection from crossing the heap-dump checkpoint.
+SYSTEM STOP MERGES test_many_parts;
+
 -- Insert 1000 rows - each goes to its own partition = 1000 parts
 INSERT INTO test_many_parts
 SELECT


### PR DESCRIPTION
Stops background merge selection in the storage memory profiler's many-parts scenario before inserting the parts. This prevents temporary background allocations from crossing heap-profile checkpoints and producing equal and opposite false differences in adjacent scenarios.

Related: https://github.com/ClickHouse/ClickHouse/pull/119480

CI report: https://s3.amazonaws.com/clickhouse-test-reports/PRs/119480/5d231d28a46818502ba21e1aea90437e3c99586e/pr/storage_memory_check/storage_memory_report.html

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prevent spurious storage memory profiler differences caused by background merge selection.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119706&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119706](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119706+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1385` (included in `26.9` and later)
<!-- ch-version-info:end -->