### PR TITLE
Tag 04511_reader_executor_disk_cache as no-parallel-replicas

### DIFF
--- a/tests/queries/0_stateless/04511_reader_executor_disk_cache.sql
+++ b/tests/queries/0_stateless/04511_reader_executor_disk_cache.sql
@@ -1,5 +1,8 @@
--- Tags: no-fasttest, no-parallel
+-- Tags: no-fasttest, no-parallel, no-parallel-replicas
 -- Tag no-fasttest: requires S3/minio-backed storage with a filesystem cache.
+-- Tag no-parallel-replicas: the checks below read the INITIATOR's `ProfileEvents` out of
+-- `system.query_log`, and parallel replicas move the reading to the remote replicas, whose events do
+-- not land in that row - so all three counters come back 0, not just the warm one.
 -- Tag no-parallel: the cold->warm assertion needs the cold read's populate to reserve cache space
 -- and survive to the warm read. The dedicated `s3_cache_04511` policy isolates it from other tests'
 -- background-merge cache traffic (which saturates the shared `s3_cache` with non-releasable segments
@@ -8,9 +11,18 @@
 
 DROP TABLE IF EXISTS t_re_disk_cache;
 
+-- `min_bytes_for_full_part_storage = 0` gives every file of the part its own object, and therefore
+-- its own cache key. A PACKED part - which the randomized MergeTree settings produce whenever
+-- `min_bytes_for_full_part_storage` lands above the part size - keeps the whole part in ONE object,
+-- so `primary.idx`, the marks and `k.bin` are slices of a single file segment. Those files are read
+-- concurrently even at `max_threads = 1`, so their readers contend for that one segment's fill role,
+-- and `DiskCacheWriter` appends only at the segment's live write offset: whichever reader loses the
+-- race reads its bytes from source and drops them, leaving the segment PARTIALLY populated after the
+-- cold read. The warm read then has to fetch the uncommitted tail from source, which breaks the
+-- `warm = 0` assertion below.
 CREATE TABLE t_re_disk_cache (k UInt64, v String)
 ENGINE = MergeTree ORDER BY k
-SETTINGS storage_policy = 's3_cache_04511', min_bytes_for_wide_part = 0;
+SETTINGS storage_policy = 's3_cache_04511', min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 
 -- No cache-on-write, so the first SELECT below is a genuine cold read that must populate the cache.
 INSERT INTO t_re_disk_cache SELECT number, toString(number) FROM numbers(200000)
@@ -27,13 +39,13 @@ SET remote_filesystem_read_method = 'read';
 SET enable_filesystem_cache = 1;
 SET read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0;
 
--- One reading thread, so the cold read populates the cache completely and the warm read is a pure
--- cache hit. With several threads each stream gets its own `ReaderExecutor` over the same file, and
--- `DiskCacheWriter` appends only at the segment's live write offset: whichever stream loses the
--- downloader race contributes nothing, so the cold read leaves the segment PARTIALLY populated. The
--- warm read then re-fetches such a segment from its start (`claimLeadRole`'s `available` prefix is
--- deliberately unused - see the "Coarse by design" note in `ReaderExecutor::readThroughCaches`), which
--- can cost MORE source bytes than the cold read did and made the assertion below flaky.
+-- One reading thread, so the column's data is read by a single `ReaderExecutor` and the cold read
+-- populates its segment completely. With several threads each stream gets its own executor over the
+-- same file and they contend for that segment's fill role exactly as the packed-part case above does:
+-- the loser contributes nothing, the segment stays PARTIALLY populated, and the warm read re-fetches
+-- it from its start (`claimLeadRole`'s `available` prefix is deliberately unused - see the "Coarse
+-- fetch, fine serve" note in `ReaderExecutor::readThroughCaches`), which can cost MORE source bytes
+-- than the cold read did.
 SET max_threads = 1;
 
 -- Cold read: nothing cached yet, so the executor reads from source and populates the cache. Warm read:


### PR DESCRIPTION
`04511_reader_executor_disk_cache` asserts that the warm reread of a table on a cached S3 disk touches the source not at all (`warm_served_from_cache`, i.e. `ReaderExecutorBytesFromSource = 0` for the second `SELECT`). It has been failing in two independent ways.

**The packed-part half of this pull request has already landed on master** through https://github.com/ClickHouse/ClickHouse/pull/119645, which pins `min_bytes_for_full_part_storage = 0` so that every stream of the part gets its own object and therefore its own cache key. This pull request has been merged with master and reduced to the remaining half.

**What is left: parallel replicas hide the counters.** The checks read the `ProfileEvents` of the two `SELECT`s out of `system.query_log`. With parallel replicas the reading moves off the initiator, and the executor's counters no longer land in the rows those checks sum, so *all three* come back `0` — not just the warm one:

```
-cold_read_from_source	1        +cold_read_from_source	0
-executor_populated_cache	1     +executor_populated_cache	0
-warm_served_from_cache	1       +warm_served_from_cache	0
```

That shape has been seen twice in the last 25 days, both times in `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, sequential)` (on https://github.com/ClickHouse/ClickHouse/pull/119613 and https://github.com/ClickHouse/ClickHouse/pull/119090), never on `master`. It is rare, but within a job instance it reproduced 3 out of 3 reruns. The fix adds the `no-parallel-replicas` tag, which makes `clickhouse-test` force `enable_parallel_replicas = 0` in the other jobs and excludes the test from the `ParallelReplicas` job. That matches what the test is for: it verifies the executor's read-through contract on the initiator, which parallel replicas bypass.

**Side finding, not fixed here.** A trace of the packed-part failure showed a real read amplification in `ReaderExecutor::readThroughCaches`: `fetch_lo` is taken from the miss tier's whole segment extent, so a window re-reads the segment's already-committed prefix from the source, and it does so even for a tier whose fill role another reader holds (where the bytes are then discarded). In the trace the warm read pulled 809626 bytes from S3 to serve 923, of which 808703 were already in the cache. Deriving `fetch_lo` from `claimLeadRole`'s `available` prefix, and skipping tiers with no held claim, would remove that; it is left out of this change because it does not affect the assertion above.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=13d97bd69753d7333edf99559c6facbc220a326c&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_release%2C%20sequential%2C%202%2F2%29

Related: https://github.com/ClickHouse/ClickHouse/pull/119645
Related: https://github.com/ClickHouse/ClickHouse/pull/118483
Related: https://github.com/ClickHouse/ClickHouse/pull/115664

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119711&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119711](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119711+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
