### PR TITLE
Saturate an Iceberg decimal bound that cannot be widened inside its type

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergFieldParseHelpers.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergFieldParseHelpers.cpp
@@ -6,6 +6,7 @@
 
 #include <base/arithmeticOverflow.h>
 #include <Common/Exception.h>
+#include <Core/DecimalFunctions.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
@@ -147,10 +148,28 @@ std::optional<Field> deserializeDecimalBound(const String & str, UInt32 scale, b
         for (UInt32 i = 1; i < scale; ++i)
             scaler *= 10;
 
-        /// The bound is stored as raw bytes and is never checked against the declared precision, so
-        /// widening it can leave the type. A value that has no widened form is not a usable bound.
-        if (common::addOverflow(unscaled_value, scaler, unscaled_value))
-            return std::nullopt;
+        NativeType widened_value;
+        if (common::addOverflow(unscaled_value, scaler, widened_value))
+        {
+            /// Widening can leave the type: a `Decimal(38, 38)` bound of magnitude above roughly
+            /// 0.7 needs almost `2 * 10^38` while `Int128` holds `1.7 * 10^38`. A bound only has to
+            /// stay on the outer side of every value in the file, and the largest magnitude the
+            /// precision of the type allows is outside all of them, so it stands in for the widened
+            /// bound. Dropping the bound instead would cost min/max pruning for the whole column,
+            /// and `Decimal(38, 38)` is the one width where a bound the column can hold gets here.
+            ///
+            /// A bound is stored as raw bytes that are never checked against a precision, so it can
+            /// also be a magnitude the column cannot hold. Nothing then vouches for the values in
+            /// the file, so there is no stand-in for such a bound and it is not usable.
+            const NativeType limit
+                = DecimalUtils::scaleMultiplier<NativeType>(DecimalUtils::max_precision<DecimalType>) - NativeType(1);
+            if (unscaled_value > limit || unscaled_value < -limit)
+                return std::nullopt;
+
+            widened_value = lower_bound ? -limit : limit;
+        }
+
+        unscaled_value = widened_value;
     }
 
     return DecimalField<DecimalType>(unscaled_value, scale);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -539,9 +539,10 @@ ProcessedManifestFileEntryPtr ManifestFileIterator::processRow(size_t row_index)
                 auto right = deserializeFieldFromBinaryRepr(right_str, name_and_type.type, false);
                 if (!left || !right)
                 {
-                    /// Pruning is skipped either way, but at scale 38 a bound that only loses its widened
-                    /// form can still be a value the column holds, so this is not on its own a malformed
-                    /// manifest and stays out of the warning log.
+                    /// A bound that does not decode is either a magnitude outside the precision of
+                    /// its type, or narrower than the column is now, which is what Iceberg leaves
+                    /// behind for a promoted column. The second is well formed, so this stays out of
+                    /// the warning log.
                     LOG_DEBUG(
                         getLogger("ManifestFileIterator"),
                         "Manifest file '{}' declares a bound that cannot be read as a usable range border "

--- a/tests/queries/0_stateless/05210_iceberg_decimal38_bound_widening_116999.reference
+++ b/tests/queries/0_stateless/05210_iceberg_decimal38_bound_widening_116999.reference
@@ -1,0 +1,18 @@
+--- A0 a filter on the column returns every row that matches it ---
+2
+1
+1
+1
+1
+--- A1 a probe outside one file min/max-prunes it, and only it ---
+0
+0
+0
+0
+1
+1
+1
+1
+--- A2 a value inside both shifted bounds prunes nothing ---
+0
+0

--- a/tests/queries/0_stateless/05210_iceberg_decimal38_bound_widening_116999.sh
+++ b/tests/queries/0_stateless/05210_iceberg_decimal38_bound_widening_116999.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option)
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+ROOT="${CLICKHOUSE_USER_FILES}/${CLICKHOUSE_DATABASE}_dec38"
+rm -rf "${ROOT}"
+trap 'rm -rf "${ROOT}"' EXIT
+
+# Iceberg stores a decimal min/max bound rounded to the integral part, so the reader moves the
+# bound one integral unit outwards before pruning on it. At scale 38 that unit is `10^38` and the
+# bound lives in an `Int128`, which holds `1.7 * 10^38`: the shift leaves the type for every bound
+# of magnitude above roughly 0.7014. `high` holds one such value per data file and `low` holds two
+# that the shift keeps inside the type, so the two tables differ only in whether the shift saturates.
+#
+# One value per `INSERT`, so each table has two data files and a bound on one can exclude it.
+# Background Iceberg compaction, which the cloud build runs off a member flag rather than a query
+# setting, would rewrite these manifests, so it is pinned off per table.
+mk() { # mk <table> <value> <value>
+    cat <<SQL
+CREATE TABLE $1 (d Decimal(38, 38)) ENGINE = IcebergLocal('${ROOT}/$1/', 'Parquet')
+SETTINGS allow_experimental_iceberg_compaction = 0;
+INSERT INTO $1 VALUES (toDecimal128('$2', 38));
+INSERT INTO $1 VALUES (toDecimal128('$3', 38));
+SQL
+}
+
+# An inline VALUES list still consumes stdin, which blocks until EOF if the caller left it open.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --use_iceberg_metadata_files_cache=0 --query "
+$(mk high '0.99' '-0.99')
+$(mk low '0.1' '-0.1')
+" < /dev/null
+
+# One line per tag, in the order given: how many data files <counter> saw that probe prune.
+# Reading a counter back through `log_comment` keeps a probe from counting itself.
+report() { # report <counter> <tag>...
+    local counter=$1 tags="" t
+    shift
+    for t in "$@"; do tags="${tags:+${tags}, }'${CLICKHOUSE_DATABASE}_${t}'"; done
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT max(ProfileEvents['${counter}'])
+        FROM system.query_log
+        WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND log_comment IN (${tags})
+        GROUP BY log_comment
+        ORDER BY indexOf([${tags}], log_comment)
+        SETTINGS enable_parallel_replicas = 0"
+}
+
+echo '--- A0 a filter on the column returns every row that matches it ---'
+# A bound that comes back inverted prunes the data file that holds the row, so these lose rows.
+${CLICKHOUSE_CLIENT} --use_iceberg_metadata_files_cache=0 --query "
+    SELECT count() FROM high;
+    SELECT count() FROM high WHERE d = toDecimal128('0.99', 38);
+    SELECT count() FROM high WHERE d = toDecimal128('-0.99', 38);
+    SELECT count() FROM high WHERE d > toDecimal128('0.5', 38);
+    SELECT count() FROM high WHERE d < toDecimal128('-0.5', 38);"
+
+echo '--- A1 a probe outside one file min/max-prunes it, and only it ---'
+# `low` is the control: its shift stays inside `Int128` whatever the reader does with an overflow.
+# Each `high` probe sits outside exactly one of the two shifted bounds, so one file is pruned and
+# the other is read - the row counts say the surviving file is the one that could hold a match.
+${CLICKHOUSE_CLIENT} --use_iceberg_metadata_files_cache=0 --query "
+    SELECT count() FROM low WHERE d = toDecimal128('0.95', 38) SETTINGS log_comment = '${CLICKHOUSE_DATABASE}_low_pos';
+    SELECT count() FROM low WHERE d = toDecimal128('-0.95', 38) SETTINGS log_comment = '${CLICKHOUSE_DATABASE}_low_neg';
+    SELECT count() FROM high WHERE d = toDecimal128('0.5', 38) SETTINGS log_comment = '${CLICKHOUSE_DATABASE}_high_pos';
+    SELECT count() FROM high WHERE d = toDecimal128('-0.5', 38) SETTINGS log_comment = '${CLICKHOUSE_DATABASE}_high_neg';
+    SYSTEM FLUSH LOGS query_log;"
+report IcebergMinMaxIndexPrunedFiles low_pos low_neg high_pos high_neg
+
+echo '--- A2 a value inside both shifted bounds prunes nothing ---'
+${CLICKHOUSE_CLIENT} --use_iceberg_metadata_files_cache=0 --query "
+    SELECT count() FROM high WHERE d = toDecimal128('0.0', 38) SETTINGS log_comment = '${CLICKHOUSE_DATABASE}_high_zero';
+    SYSTEM FLUSH LOGS query_log;"
+report IcebergMinMaxIndexPrunedFiles high_zero
+
+${CLICKHOUSE_CLIENT} --query "
+    DROP TABLE IF EXISTS high SYNC;
+    DROP TABLE IF EXISTS low SYNC;"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/116999
Related: https://github.com/ClickHouse/ClickHouse/pull/116604
Related: https://github.com/ClickHouse/ClickHouse/pull/115832

Iceberg stores a decimal min/max bound rounded to the integral part, so the reader moves each bound one integral unit outwards before pruning on it. At scale 38 that unit is `10^38` and the bound lives in an `Int128`, which holds `1.7 * 10^38`, so the shift leaves the type for every bound of magnitude above roughly 0.70141. `Decimal(38, 38)` is the only width where that happens to a bound the column can hold: at the other three the largest value the precision allows plus `10^scale` still fits.

Until #116604 the shift wrapped, which inverted the pair reaching `KeyCondition::mayBeTrueInRange`, pruned the data file holding the matching rows and lost them silently (#116999). That pull request rejects such a bound instead, which is correct but gives the column no min/max condition at all - and for a `Decimal(38, 38)` column that is every bound of magnitude above 0.7, so those tables lost min/max pruning altogether.

A bound only has to stay on the outer side of every value in the file, and the largest magnitude the precision of the type allows is outside all of them, so it stands in for a widened bound that no longer fits. A bound that is itself outside that magnitude is one the column cannot hold: nothing vouches for the values in the file, so there is no stand-in for it and it stays unusable, which is the case `test_iceberg_inverted_decimal_manifest_bounds` pins for a `Decimal32` bound.

The new stateless test reads a `Decimal(38, 38)` column whose two data files hold `0.99` and `-0.99`: every filter on the column returns its rows, and a probe outside one of the two shifted bounds prunes that file and only it. A second table holds `0.1` and `-0.1`, where the shift stays inside `Int128` whatever the reader does with an overflow, so the two arms together say the pruning is lost to the overflow rather than to the shape of the test. On `master` the test fails on the two `Decimal(38, 38)` pruning arms only (`0` pruned files instead of `1`), and it passes with this change.

Note on released versions: the silent row loss that #116999 reports is fixed on `master` by #116604, but that fix is not in any release branch, while the change that introduced the overflow (#115832) was backported to 26.8 by #116860 and shipped in `v26.8.1.2041-lts` and `v26.8.2.7-lts`. Those releases still lose rows on a filter over a `Decimal(38, 38)` Iceberg column; that needs a backport of #116604 and is not addressed here.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Restore min/max pruning of Iceberg data files for a `Decimal(38, 38)` column. A manifest bound of magnitude above roughly 0.7 cannot be widened inside `Int128` and was dropped, which left the column without a min/max condition; it is now saturated at the largest magnitude the precision allows, which is still outside every value the file can hold.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119712&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119712](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119712+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
