### PR TITLE
Fix flaky 02357_query_cancellation_race

### DIFF
--- a/tests/queries/0_stateless/02357_query_cancellation_race.sh
+++ b/tests/queries/0_stateless/02357_query_cancellation_race.sh
@@ -6,4 +6,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT -q "create table tab (x UInt64, y String) engine = MergeTree order by x"
-for _ in $(seq 1 100); do timeout -s 2 --kill-after=5 0.05 $CLICKHOUSE_CLIENT --interactive_delay 1000 -q "insert into tab select number, toString(number) from system.numbers" || true; done
+# The source is unbounded on purpose: only the SIGINT below may end this insert, never a read limit.
+for _ in $(seq 1 100); do timeout -s 2 --kill-after=5 0.05 $CLICKHOUSE_CLIENT --interactive_delay 1000 -q "insert into tab select number, toString(number) from system.numbers settings max_rows_to_read = 0, max_bytes_to_read = 0" || true; done


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed flaky test `02357_query_cancellation_race`, which could fail when the stateless CI read limit aborted its intentionally unbounded insert and the resulting error reached the test's stderr.


### Description

The test runs 100 iterations of an unbounded `insert into tab select number, toString(number) from system.numbers`, each stopped by a 0.05s `SIGINT`. `|| true` swallows the exit code, so stderr is the test's only failure channel.

The stateless CI profile puts a finite read limit on that unbounded read: `tests/config/users.d/limits.yaml` sets `max_rows_to_read = 20000000`. An iteration that outlives its signal keeps reading, `ReadProgressCallback::onProgress` calls `SizeLimits::check`, and `TOO_MANY_ROWS` is logged at `<Error>`. Because `$CLICKHOUSE_CLIENT` always carries `--send_logs_level=warning`, that line is streamed onto the test's stderr, and `clickhouse-test` fails any test whose stderr is non-empty. The test asserts nothing about read limits, so this is exposure, not a product defect.

I pin `max_rows_to_read = 0, max_bytes_to_read = 0` on that insert, so only the cancellation under test can end it. Both are checked by the same `SizeLimits::check` call, so pinning one would establish half the invariant. This is the existing idiom for cancellation tests over an unbounded `system.numbers` read (`04003_cancel_scalar_subquery.sh`, `04051_cancel_parallel_with.sh`, `04052_local_cancel_scalar_subquery.sh`); `02357` was the only one missing it. The oracle is not weakened: `<Fatal>` lines, crashes, logical errors and every other server exception still reach stderr and still fail the test.

Validation, at the profile's real `20000000` with the window widened to 3s to force the race: 3/3 runs fail without this change (`read_rows` 20015154, `Code: 158`), 0/3 with it. `system.query_log` then records `Settings['max_rows_to_read'] = 0` and 87844287 rows read, 4.4x past the limit. Unmodified test, randomization on: 50/50 pass, p50 6.77s against 6.80s before.

CI provenance, the first failure of this test in the retained window: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=119687&sha=5ad83a88e1eda5773c9e00c0a9c6ab7dbfe17f1a&name_0=PR

<details>
<summary>CIDB: every failure of this test in 90 days (query and result)</summary>

```sql
SELECT check_start_time, pull_request_number AS pr, check_name, test_status
FROM default.checks
WHERE test_name = '02357_query_cancellation_race' AND test_status IN ('FAIL','ERROR')
  AND check_start_time > now() - INTERVAL 90 DAY
ORDER BY check_start_time
```
```
┌────check_start_time─┬─────pr─┬─check_name───────────────────────────────────────────────────┬─test_status─┐
│ 2026-07-15 10:11:27 │ 110222 │ Stateless tests (amd_asan_ubsan, distributed plan, parallel) │ FAIL        │
│ 2026-07-15 11:56:59 │ 109920 │ Stateless tests (amd_asan_ubsan, distributed plan, parallel) │ FAIL        │
│ 2026-09-12 22:04:43 │ 119687 │ Stateless tests (amd_debug, parallel)                        │ FAIL        │
└─────────────────────┴────────┴──────────────────────────────────────────────────────────────┴─────────────┘
```
Against 207,700 `OK` rows over the same window. The two 2026-07-15 rows are a different class and are
not addressed here: both are `(total) memory limit exceeded ... current RSS 41.85 GiB, maximum 41.84 GiB`,
box-wide pressure that failed 90 and 62 tests respectively in those same two jobs. The 2026-09-12
failure is the one this fixes; it was 1 failure against 13,894 `OK` in its own job.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119716&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119716](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119716+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
