### PR TITLE
Fix rows silently dropped by a join runtime filter on a NaN or -0.0 float key

### DIFF
--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -15,6 +15,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeSet.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/IDataType.h>
 #include <DataTypes/hasNullable.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsLogical.h>
@@ -174,6 +175,18 @@ static constexpr Float64 RUNTIME_BLOOM_FILTER_TARGET_FILL_RATE = 0.5;
 
 namespace
 {
+/// Whether `equals` can answer differently from the bitwise comparison a hash table performs on keys:
+/// NaN is not equal to itself, and -0.0 is equal to 0.0. A JSON column counts as a whole, because a
+/// float can appear on a path discovered while reading, which is not among the type's static children.
+bool equalsCanDisagreeWithHashTable(const IDataType & type)
+{
+    bool result = false;
+    auto check = [&](const IDataType & nested) { result |= isFloat(nested) || isObject(nested); };
+    check(type);
+    type.forEachChild(check);
+    return result;
+}
+
 bool typeSupportsMinMaxRange(const DataTypePtr & type)
 {
     if (!type)
@@ -347,7 +360,9 @@ void ExactSetRuntimeFilter<negate>::finishInsert()
 
     /// If only one element is in the set then use `equals` instead of set lookup.
     /// If the argument is `Nullable`, use `Set` because it can handle `NULL` values.
-    if (set.getTotalRowCount() == 1 && !argument_can_have_nulls)
+    /// If `equals` can disagree with the hash table, use `Set`: this filter must not reject a row the join matches.
+    if (set.getTotalRowCount() == 1 && !argument_can_have_nulls
+        && !equalsCanDisagreeWithHashTable(*filter_column_target_type))
     {
         lookup_state = Single{set.getSetElements().front()};
         return;

--- a/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.reference
+++ b/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.reference
@@ -6,4 +6,8 @@ inner join, NaN Float64 key	1
 anti join, -0.0 inside an Array(Float64) key	1
 anti join, -0.0 on a JSON path key	1
 1
+1
+1
+1
+runtime filter ran on every float-bearing key	1
 control: Int64 key, filter built and rejecting rows	1

--- a/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.reference
+++ b/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.reference
@@ -1,0 +1,9 @@
+nan
+nan
+nan
+0
+inner join, NaN Float64 key	1
+anti join, -0.0 inside an Array(Float64) key	1
+anti join, -0.0 on a JSON path key	1
+1
+control: Int64 key, filter built and rejecting rows	1

--- a/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.sql
+++ b/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.sql
@@ -1,0 +1,74 @@
+-- A join runtime filter is a pre-filter, so it may only reject rows the join itself would not match.
+-- The join's hash table compares keys bitwise, while `equals` reports NaN unequal to itself and 0.0
+-- equal to -0.0, so a key that can carry a float must not take the single-element `equals` shortcut.
+
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET join_algorithm = 'hash';
+SET enable_join_runtime_filters = 1;
+SET join_runtime_filter_min_probe_rows = 0;
+SET query_plan_join_swap_table = 0;
+SET query_plan_optimize_join_order_algorithm = 'greedy';
+SET query_plan_optimize_join_order_limit = 1;
+SET allow_experimental_dynamic_type = 1;
+SET allow_dynamic_type_in_join_keys = 1;
+
+-- 1. The reported symptom: a correlated scalar subquery over an all-NaN column is decorrelated into a
+-- join, and the runtime filter emptied its probe side, so every scalar came back NULL.
+CREATE TABLE nan_scalar (id UInt64, f Float64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO nan_scalar SELECT number, nan FROM numbers(3);
+
+SELECT toString((SELECT f)) FROM nan_scalar ORDER BY id;
+SELECT count() FROM (SELECT id FROM nan_scalar WHERE ((SELECT f) IS NULL) OR (f < -1));
+
+-- The remaining scenarios compare the two `enable_join_runtime_filters` arms instead of a literal
+-- count, so they keep asserting the invariant if the join itself ever changes what it matches.
+
+-- 2. A plain INNER JOIN on a NaN key: the filter must not reject the row the join does match.
+CREATE TABLE nan_key (f Float64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO nan_key VALUES (nan);
+
+SELECT 'inner join, NaN Float64 key',
+       (SELECT count() FROM nan_key a JOIN nan_key b ON a.f = b.f SETTINGS enable_join_runtime_filters = 1)
+     = (SELECT count() FROM nan_key a JOIN nan_key b ON a.f = b.f SETTINGS enable_join_runtime_filters = 0) AS arms_agree;
+
+-- 3. ANTI JOIN, where the filter excludes instead of selecting, and the value is -0.0 rather than NaN.
+-- The float sits inside an Array, so the key type has to be inspected recursively.
+CREATE TABLE pos_zero (a Array(Float64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO pos_zero VALUES ([0.0]);
+CREATE TABLE neg_zero (a Array(Float64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO neg_zero VALUES ([-0.0]);
+
+SELECT 'anti join, -0.0 inside an Array(Float64) key',
+       (SELECT count() FROM pos_zero a ANTI LEFT JOIN neg_zero b ON a.a = b.a SETTINGS enable_join_runtime_filters = 1)
+     = (SELECT count() FROM pos_zero a ANTI LEFT JOIN neg_zero b ON a.a = b.a SETTINGS enable_join_runtime_filters = 0) AS arms_agree;
+
+-- 4. A JSON key. Its float paths are discovered while reading, so the whole type has to be rejected.
+CREATE TABLE json_pos_zero (j JSON) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO json_pos_zero VALUES ('{"x":0.0}');
+CREATE TABLE json_neg_zero (j JSON) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO json_neg_zero VALUES ('{"x":-0.0}');
+
+SELECT 'anti join, -0.0 on a JSON path key',
+       (SELECT count() FROM json_pos_zero a ANTI LEFT JOIN json_neg_zero b ON a.j = b.j SETTINGS enable_join_runtime_filters = 1)
+     = (SELECT count() FROM json_pos_zero a ANTI LEFT JOIN json_neg_zero b ON a.j = b.j SETTINGS enable_join_runtime_filters = 0) AS arms_agree;
+
+-- 5. Control on an Int64 key, where `equals` does agree with the hash table. It keeps the shortcut,
+-- and the profile events show the filter is still built and still rejects rows, which is also what
+-- makes the comparisons above non-vacuous.
+CREATE TABLE int_build (k Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO int_build VALUES (7);
+CREATE TABLE int_probe (k Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO int_probe SELECT number FROM numbers(1000);
+
+SELECT count() FROM int_probe a JOIN int_build b ON a.k = b.k
+SETTINGS log_comment = '05210_int_control', max_threads = 1;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT 'control: Int64 key, filter built and rejecting rows',
+       ProfileEvents['RuntimeFilterRowsChecked'] > 0
+   AND ProfileEvents['RuntimeFilterRowsPassed'] < ProfileEvents['RuntimeFilterRowsChecked'] AS filter_pruned
+FROM system.query_log
+WHERE type = 'QueryFinish' AND log_comment = '05210_int_control'
+  AND current_database = currentDatabase() AND event_date >= yesterday();

--- a/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.sql
+++ b/tests/queries/0_stateless/05210_join_runtime_filter_float_nan.sql
@@ -10,7 +10,6 @@ SET join_runtime_filter_min_probe_rows = 0;
 SET query_plan_join_swap_table = 0;
 SET query_plan_optimize_join_order_algorithm = 'greedy';
 SET query_plan_optimize_join_order_limit = 1;
-SET allow_experimental_dynamic_type = 1;
 SET allow_dynamic_type_in_join_keys = 1;
 
 -- 1. The reported symptom: a correlated scalar subquery over an all-NaN column is decorrelated into a
@@ -53,9 +52,20 @@ SELECT 'anti join, -0.0 on a JSON path key',
        (SELECT count() FROM json_pos_zero a ANTI LEFT JOIN json_neg_zero b ON a.j = b.j SETTINGS enable_join_runtime_filters = 1)
      = (SELECT count() FROM json_pos_zero a ANTI LEFT JOIN json_neg_zero b ON a.j = b.j SETTINGS enable_join_runtime_filters = 0) AS arms_agree;
 
+-- Liveness. The comparisons above would also pass with no runtime filter installed at all, because
+-- FunctionApplyFilter passes every row when the filter is absent, and the Int64 control below only
+-- exercises the `equals` shortcut that a float key no longer takes. Assert each filter really ran.
+SELECT count() FROM nan_key a JOIN nan_key b ON a.f = b.f
+SETTINGS log_comment = '05210_live_f64', max_threads = 1;
+
+SELECT count() FROM pos_zero a ANTI LEFT JOIN neg_zero b ON a.a = b.a
+SETTINGS log_comment = '05210_live_array', max_threads = 1;
+
+SELECT count() FROM json_pos_zero a ANTI LEFT JOIN json_neg_zero b ON a.j = b.j
+SETTINGS log_comment = '05210_live_json', max_threads = 1;
+
 -- 5. Control on an Int64 key, where `equals` does agree with the hash table. It keeps the shortcut,
--- and the profile events show the filter is still built and still rejects rows, which is also what
--- makes the comparisons above non-vacuous.
+-- and the profile events show the filter is still built and still rejects rows.
 CREATE TABLE int_build (k Int64) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO int_build VALUES (7);
 CREATE TABLE int_probe (k Int64) ENGINE = MergeTree ORDER BY tuple();
@@ -65,6 +75,13 @@ SELECT count() FROM int_probe a JOIN int_build b ON a.k = b.k
 SETTINGS log_comment = '05210_int_control', max_threads = 1;
 
 SYSTEM FLUSH LOGS query_log;
+
+SELECT 'runtime filter ran on every float-bearing key',
+       uniqExactIf(log_comment, ProfileEvents['RuntimeFilterRowsChecked'] > 0) = 3 AS all_engaged
+FROM system.query_log
+WHERE type = 'QueryFinish' AND current_database = currentDatabase()
+  AND log_comment IN ('05210_live_f64', '05210_live_array', '05210_live_json')
+  AND event_date >= yesterday();
 
 SELECT 'control: Int64 key, filter built and rejecting rows',
        ProfileEvents['RuntimeFilterRowsChecked'] > 0


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/119679


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a join runtime filter silently dropping rows whose join key is a float. When the build side had a single distinct value the filter replaced set membership with `equals`, but a hash join compares float keys bitwise, so `NaN` did not match itself and `0.0` matched `-0.0`. Affects joins on float-bearing or `JSON` keys with `enable_join_runtime_filters = 1`, the default since 26.2.


### Description

A join runtime filter is a pre-filter, so it may only reject rows the join itself would not match. `ExactSetRuntimeFilter::finishInsert` replaced set membership with `equals` (`notEquals` when negated) once the build side collapsed to one distinct key, and `equals` disagrees with the bitwise comparison a hash table performs on float keys: `NaN` is not equal to itself, and `0.0` is equal to `-0.0`.

At stock defaults on plain `MergeTree`:

```sql
CREATE TABLE t (f Float64) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES (nan);
SELECT count() FROM t a JOIN t b ON a.f = b.f; -- 0, expected 1
SELECT count() FROM t a JOIN t b ON a.f = b.f SETTINGS enable_join_runtime_filters = 0; -- 1
```

The reported query is the same defect one level up: `(SELECT f)` decorrelates into a join whose probe arm the filter empties, so the `Nullable` scalar takes NULL. The gating setting is `enable_join_runtime_filters`, not `query_plan_enable_optimizations`. 26.7 and 26.8 carry it too, so this is not a master regression.

The shortcut is now taken only where `equals` agrees with a bitwise comparison: one extra term beside the `Nullable` guard already there, the shape #118918 used for the sibling PK-range-sharding NaN bug. `Variant` and `Dynamic` need no term; the adjacent null guard covers them.

Validated: the new test reddens on base, 100/100 randomized runs, existing runtime-filter tests and gtests unchanged, `EXPLAIN PLAN actions=1` byte-identical.

Two calls for you. This gives up the shortcut for every float key; testing the single build value instead of its type would keep it when that value is neither `NaN` nor a zero, at the cost of walking a `Field` for nested keys. And `isSafePrimaryDataKeyType` (`PartsSplitter.h`) would save the new helper, but it answers "safe to range-split", so a later PK-only relaxation would quietly reintroduce this.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119720&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119720](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119720+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
