### PR TITLE
Fix data loss backing up a Log family table with a zero-byte data file

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -1399,7 +1399,11 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
     if (size_and_checksum.first == 0)
     {
         /// Entry's data is empty.
-        if (write_mode == WriteMode::Rewrite)
+        /// The destination must exist afterwards either way: the non-empty path below writes through
+        /// writeFile(), which creates a missing file, while createFile() throws on an existing one.
+        const bool create_destination
+            = (write_mode == WriteMode::Rewrite) || !destination_disk->existsFile(destination_path);
+        if (create_destination)
         {
             if (sync)
             {

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -1212,6 +1212,25 @@ void StorageLog::updateTotalRows(const WriteLock &)
         total_rows = 0;
 }
 
+bool StorageLog::hasNothingToBackUp() const
+{
+    if (!num_data_files)
+        return true;
+
+    /// Recorded bytes in any column mean there is something to preserve, whatever the row signal says:
+    /// a leading column can serialize to nothing while a later one holds the rows, and a table whose
+    /// marks file went missing still has its data on disk.
+    for (const auto & data_file : data_files)
+        if (file_checker.getFileSize(data_file.path))
+            return false;
+
+    /// No column occupies bytes, which is legitimate for a column of empty aggregate states. For `Log`
+    /// the marks are then what say whether there are rows; `TinyLog` keeps none and cannot tell.
+    return !use_marks_file
+        || data_files[INDEX_WITH_REAL_ROW_COUNT].marks.empty()
+        || data_files[INDEX_WITH_REAL_ROW_COUNT].marks.back().rows == 0;
+}
+
 std::optional<UInt64> StorageLog::totalRows(ContextPtr) const
 {
     if (use_marks_file && marks_loaded)
@@ -1238,7 +1257,7 @@ void StorageLog::backupData(BackupEntriesCollector & backup_entries_collector, c
     if (!lock)
         throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Lock timeout exceeded");
 
-    if (!num_data_files || !file_checker.getFileSize(data_files[INDEX_WITH_REAL_ROW_COUNT].path))
+    if (hasNothingToBackUp())
         return;
 
     fs::path data_path_in_backup_fs = data_path_in_backup;

--- a/src/Storages/StorageLog.h
+++ b/src/Storages/StorageLog.h
@@ -120,6 +120,10 @@ private:
     /// Recalculates the number of rows stored in this table.
     void updateTotalRows(const WriteLock &);
 
+    /// Whether this table holds nothing on disk: no recorded bytes, and no rows according to the
+    /// engine's row signal. Must be called under the rwlock, after loadMarks().
+    bool hasNothingToBackUp() const;
+
     /// Restores the data of this table from backup.
     void restoreDataImpl(const BackupPtr & backup, const String & data_path_in_backup, std::chrono::seconds lock_timeout);
 

--- a/tests/queries/0_stateless/05211_backup_log_zero_byte_data_file.reference
+++ b/tests/queries/0_stateless/05211_backup_log_zero_byte_data_file.reference
@@ -1,0 +1,30 @@
+-- Log, the zero-byte column is the only data file
+source total_rows	100
+BACKUP_CREATED
+RESTORED
+restored total_rows	100
+-- Log, a normal column comes first
+BACKUP_CREATED
+RESTORED
+restored sum(k)	4950
+restored s reads as source	1
+-- restoring that backup onto the non-empty source table appends to it
+RESTORED
+total_rows after appending	200
+-- TinyLog, a normal column comes first
+BACKUP_CREATED
+RESTORED
+restored sum(k)	4950
+restored s reads as source	1
+-- TinyLog, the zero-byte column comes first
+BACKUP_CREATED
+RESTORED
+restored total_bytes matches source	1
+-- TinyLog, the zero-byte column alone: it keeps no row count on disk, so the rows are gone
+BACKUP_CREATED
+RESTORED
+restored count()	0
+-- a Log table that was never inserted into carries no data to back up
+BACKUP_CREATED
+RESTORED
+restored count()	0

--- a/tests/queries/0_stateless/05211_backup_log_zero_byte_data_file.sh
+++ b/tests/queries/0_stateless/05211_backup_log_zero_byte_data_file.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tags: log-engine
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# A column of aggregate function states can occupy zero bytes on disk while the table has rows:
+# countResample(10, 5, 1) covers an empty range, so every state serializes to nothing. A BACKUP of a
+# Log family table must not read that as "the table has no rows", and a RESTORE must recreate the
+# zero-byte data file instead of leaving the column's file missing.
+#
+# The row counts below are compared between the source and the restored table rather than against a
+# literal: reading a column of empty states is a separate defect, so the absolute count changes when
+# that is fixed, while the equality holds either way.
+
+STATE="countResampleState(10, 5, 1)(number, number)"
+COLUMN="AggregateFunction(countResample(10, 5, 1), UInt64, UInt64)"
+
+backup() { echo "Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_$1')"; }
+
+total_rows() {
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT '$2', ifNull(toString(total_rows), 'not counted') FROM system.tables
+        WHERE database = currentDatabase() AND name = '$1'"
+}
+
+reads_as_source() {
+    ${CLICKHOUSE_CLIENT} --query "
+        SELECT 'restored s reads as source',
+            (SELECT count() FROM $1 WHERE NOT ignore(s)) = (SELECT count() FROM $2 WHERE NOT ignore(s))"
+}
+
+echo '-- Log, the zero-byte column is the only data file'
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE t1 (s $COLUMN) ENGINE = Log;
+    INSERT INTO t1 SELECT $STATE FROM numbers(100) GROUP BY number;"
+total_rows t1 'source total_rows'
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE t1 TO $(backup 1)" | grep -o BACKUP_CREATED
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE t1 AS t1r FROM $(backup 1)" | grep -o RESTORED
+total_rows t1r 'restored total_rows'
+
+echo '-- Log, a normal column comes first'
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE t2 (k UInt64, s $COLUMN) ENGINE = Log;
+    INSERT INTO t2 SELECT number, $STATE FROM numbers(100) GROUP BY number;"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE t2 TO $(backup 2)" | grep -o BACKUP_CREATED
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE t2 AS t2r FROM $(backup 2)" | grep -o RESTORED
+${CLICKHOUSE_CLIENT} --query "SELECT 'restored sum(k)', sum(k) FROM t2r"
+reads_as_source t2r t2
+
+echo '-- restoring that backup onto the non-empty source table appends to it'
+${CLICKHOUSE_CLIENT} --query "
+    RESTORE TABLE t2 FROM $(backup 2) SETTINGS allow_non_empty_tables = 1" | grep -o RESTORED
+total_rows t2 'total_rows after appending'
+
+echo '-- TinyLog, a normal column comes first'
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE t3 (k UInt64, s $COLUMN) ENGINE = TinyLog;
+    INSERT INTO t3 SELECT number, $STATE FROM numbers(100) GROUP BY number;"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE t3 TO $(backup 3)" | grep -o BACKUP_CREATED
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE t3 AS t3r FROM $(backup 3)" | grep -o RESTORED
+${CLICKHOUSE_CLIENT} --query "SELECT 'restored sum(k)', sum(k) FROM t3r"
+reads_as_source t3r t3
+
+# The oracle here is total_bytes, not a row count: TinyLog reads rows from the size of its first data
+# file too, so both the source and the restored table read as empty and any count is the same either way.
+echo '-- TinyLog, the zero-byte column comes first'
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE t6 (s $COLUMN, k UInt64) ENGINE = TinyLog;
+    INSERT INTO t6 SELECT $STATE, number FROM numbers(100) GROUP BY number;"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE t6 TO $(backup 6)" | grep -o BACKUP_CREATED
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE t6 AS t6r FROM $(backup 6)" | grep -o RESTORED
+${CLICKHOUSE_CLIENT} --query "
+    SELECT 'restored total_bytes matches source',
+        (SELECT total_bytes FROM system.tables WHERE database = currentDatabase() AND name = 't6r')
+      = (SELECT total_bytes FROM system.tables WHERE database = currentDatabase() AND name = 't6')"
+
+echo '-- TinyLog, the zero-byte column alone: it keeps no row count on disk, so the rows are gone'
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE t4 (s $COLUMN) ENGINE = TinyLog;
+    INSERT INTO t4 SELECT $STATE FROM numbers(100) GROUP BY number;"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE t4 TO $(backup 4)" | grep -o BACKUP_CREATED
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE t4 AS t4r FROM $(backup 4)" | grep -o RESTORED
+${CLICKHOUSE_CLIENT} --query "SELECT 'restored count()', count() FROM t4r"
+
+echo '-- a Log table that was never inserted into carries no data to back up'
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE t5 (k UInt64) ENGINE = Log"
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE t5 TO $(backup 5)" | grep -o BACKUP_CREATED
+${CLICKHOUSE_CLIENT} --query "RESTORE TABLE t5 AS t5r FROM $(backup 5)" | grep -o RESTORED
+${CLICKHOUSE_CLIENT} --query "SELECT 'restored count()', count() FROM t5r"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/119700


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `BACKUP` and `RESTORE` of a `Log` or `TinyLog` table one of whose columns occupies zero bytes on disk while the table has rows, such as an `Array`, `Map` or `Nested` column that is empty in every row, or a column of `countResample` states over an empty range. When that column came first the backup silently left out the whole data directory, so the restored table held no rows at all; otherwise it left out the zero-byte data file, so every query reading that column failed with `FILE_DOESNT_EXIST` on a table whose `RESTORE` had been reported successful. One case stays lossy: a `TinyLog` table in which no column occupies any bytes restores empty, because such a table records no row count on disk anywhere.

### Description

Two sites read "no bytes" as "no rows".

`StorageLog::backupData` used the size of the first data file as a proxy for an empty table. With such a column first, the whole data directory (every `.bin`, the marks and the size metadata) was left out of the backup and `restoreDataFromBackup` restored nothing: 100 rows in, 0 rows out, with `BACKUP_CREATED`, `RESTORED` and `CHECK TABLE` all passing. Emptiness is now decided from the recorded size of every column first, and only then from the engine's row signal, which for `Log` is the marks `totalRows()` already counts from. Asking about every column also covers the mirror case, where the zero-byte column comes first and a later one holds the bytes. `TinyLog` keeps no marks, so the single state it still cannot tell apart is a table in which no column occupies any bytes; no row count exists on disk to recover there, so that is left as it is.

`BackupImpl::copyFileToDisk` materialised the destination of a zero-size entry only in `Rewrite` mode, while the `Log` and `StripeLog` restores are its only `Append` callers. Their zero-byte file was therefore never created, and reads of that column failed permanently, past a restart. The non-empty path below reaches `writeFile()`, which does create a missing file, so an empty entry now does the same. The `existsFile()` guard is required rather than defensive: `createFile()` opens with `O_EXCL`, so without it a restore onto a table that already holds data would fail.

Neither change is observable alone, so they are one commit. `StripeLog` and `MergeTree` were measured not to be carriers. The test pins what must not change too: a `TinyLog` table holding only such a column still restores empty, and a never-inserted table still backs up nothing.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119722&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119722](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119722+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1417` (included in `26.9` and later)
<!-- ch-version-info:end -->
