### PR TITLE
Treat a Nullable null-map byte as a predicate, not a value

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionNull.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionNull.h
@@ -13,6 +13,7 @@
 #include <absl/container/inlined_vector.h>
 
 #include <array>
+#include <cstring>
 
 #include "config.h"
 
@@ -447,7 +448,8 @@ public:
             row_begin, row_end, this->nestedPlace(place), &nested_column, null_map, arena, if_argument_pos);
 
         if constexpr (result_is_nullable)
-            if (!memoryIsByte(null_map, row_begin, row_end, 1))
+            /// A zero null-map byte marks a row that has a value, so one zero means not NULL.
+            if (memchr(null_map + row_begin, 0, row_end - row_begin) != nullptr)
                 this->setFlag(place);
     }
 

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -59,7 +59,7 @@ std::string_view ColumnNullable::getDataAt(size_t n) const
 void ColumnNullable::updateHashWithValue(size_t n, SipHash & hash) const
 {
     const auto & arr = getNullMapData();
-    hash.update(arr[n]);
+    hash.update(static_cast<UInt8>(arr[n] != 0));
     if (arr[n] == 0)
         getNestedColumn().updateHashWithValue(n, hash);
 }
@@ -200,7 +200,7 @@ std::string_view ColumnNullable::serializeValueIntoArena(size_t n, Arena & arena
 
     /// First serialize the NULL map byte.
     auto * pos = arena.allocContinue(1, begin);
-    *pos = arr[n];
+    *pos = arr[n] != 0;
 
     /// If the value is NULL, that's it.
     if (arr[n])
@@ -217,7 +217,7 @@ char * ColumnNullable::serializeValueIntoMemory(size_t n, char * memory, const I
 {
     const auto & arr = getNullMapData();
 
-    *memory = arr[n];
+    *memory = arr[n] != 0;
     ++memory;
 
     if (arr[n])
@@ -931,8 +931,9 @@ void ColumnNullable::applyNullMapImpl(const NullMap & map, size_t offset)
             "Null map of size {} at offset {} does not match ColumnNullable of size {}",
             map.size(), offset, arr.size());
 
+    /// Negating a null map negates its nullness, not its bits: `1 ^ 2` would still be truthy.
     for (size_t i = 0, size = map.size(); i < size; ++i)
-        arr[offset + i] |= negative ^ map[i];
+        arr[offset + i] |= negative ^ (map[i] != 0);
 }
 
 void ColumnNullable::applyNullMap(const NullMap & map)
@@ -1214,7 +1215,8 @@ bool ColumnNullable::hasOnlyTypeDefaults() const
     const auto & data = getNullMapData();
     if (data.empty())
         return true;
-    return memoryIsByte(data.data(), 0, data.size(), 1);
+    /// Every row is NULL, the type default here, exactly when no null-map byte is zero.
+    return memchr(data.data(), 0, data.size()) == nullptr;
 }
 
 }

--- a/src/Columns/ColumnVariant.cpp
+++ b/src/Columns/ColumnVariant.cpp
@@ -1877,7 +1877,8 @@ void ColumnVariant::applyNullMapImpl(const ColumnVector<UInt8>::Container & null
         auto & discr = local_discriminators_data[i];
         if (discr != NULL_DISCRIMINATOR)
         {
-            if (null_map[i] ^ inverted)
+            /// Negating a null map negates its nullness, not its bits: `1 ^ 2` would still be truthy.
+            if ((null_map[i] != 0) ^ inverted)
             {
                 auto & variant_filter = variant_filters[discr];
                 /// We create filters lazily.

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -68,10 +68,8 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
 {
     size_t count = 0;
 
-    /** NOTE: In theory, `filt` should only contain zeros and ones.
-      * But, just in case, here the condition > 0 (to signed bytes) is used.
-      * It would be better to use != 0, then this does not allow SSE2.
-      */
+    /// `filt` and the null map are both predicates, and `toBits64` tests each byte for equality with
+    /// zero, so the vectorized path and the tail below agree on `!= 0` for every byte value.
 
     const Int8 * pos = reinterpret_cast<const Int8 *>(filt.data()) + start;
     const Int8 * pos2 = reinterpret_cast<const Int8 *>(null_map) + start;
@@ -86,8 +84,10 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
         /// TODO Add duff device for tail?
 #endif
 
+    /// Both operands are predicates: complementing a truthy null-map byte such as 2 leaves bit 0
+    /// clear, which would count that NULL row as present.
     for (; pos < end_pos; ++pos, ++pos2)
-        count += (*pos & ~*pos2) != 0;
+        count += static_cast<UInt8>(*pos != 0) & static_cast<UInt8>(*pos2 == 0);
 
     return count;
 }

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -947,7 +947,7 @@ ALWAYS_INLINE char * IColumnHelper<Derived, Parent>::serializeValueIntoMemoryWit
     const auto & self = static_cast<const Derived &>(*this);
     if (is_null)
     {
-        *memory = is_null[n];
+        *memory = is_null[n] != 0;
         ++memory;
         if (is_null[n])
             return memory;
@@ -972,7 +972,7 @@ void IColumnHelper<Derived, Parent>::batchSerializeValueIntoMemoryWithNull(
     size_t rows = self.size();
     for (size_t i = 0; i < rows; ++i)
     {
-        *memories[i] = is_null[i];
+        *memories[i] = is_null[i] != 0;
         ++memories[i];
         if (!is_null[i])
             memories[i] = self.serializeValueIntoMemory(i, memories[i], settings);

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -2,6 +2,7 @@
 
 #include <Columns/IColumn.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/ColumnsCommon.h>
 #include <Common/Exception.h>
 #include <Common/assert_cast.h>
 #include <Common/HashTable/HashTableKeyHolder.h>
@@ -220,7 +221,7 @@ public:
     {
         if constexpr (nullable)
         {
-            /// Per-block fast path: if a one-time `memchr` at construction proved that the block
+            /// Per-block fast path: if a one-time scan at construction proved that the block
             /// contains no nulls, the compiler can fold this branch away entirely. Otherwise we
             /// load the cached `null_map_data` directly, avoiding the virtual `IColumn::getBool`.
             if (!block_has_no_nulls && null_map_data[row]) [[unlikely]]
@@ -383,11 +384,11 @@ public:
 
 protected:
     Cache cache;
-    /// Cached raw pointer to the null map bytes for the current block. Each element is 0/1.
+    /// Cached raw pointer to the null map bytes for the current block. Any non-zero byte means NULL.
     /// Bypasses the virtual `IColumn` dispatch on the per-row hot path in `emplaceKey` / `findKey`.
     const UInt8 * null_map_data = nullptr;
-    /// Per-block flag set by a single `memchr` at construction time. When true, every row in the
-    /// block has a zero null-map byte, so the per-row null check can be statically skipped.
+    /// Per-block flag set by a single `memoryIsZero` scan at construction time. The block is null-free
+    /// exactly when every null-map byte is zero, so the per-row null check can be statically skipped.
     bool block_has_no_nulls = true;
     bool has_null_data = false;
 
@@ -411,14 +412,10 @@ protected:
             const auto & null_map_column = checkAndGetColumn<ColumnNullable>(*column).getNullMapColumn();
             const auto & null_map_container = null_map_column.getData();
             null_map_data = null_map_container.data();
-            /// Scan the null map once per block. `PaddedPODArray<UInt8>` stores 0/1 bytes, so
-            /// finding a single 0x01 byte is enough to know the block contains a null. We use
-            /// `memchr` which is typically vectorized in libc and amortizes well for blocks of
-            /// the usual aggregation size (`max_block_size` = 65505). For tiny blocks the cost
-            /// is dominated by the function-call overhead, but the per-row payload saves a
-            /// virtual call and a branch, so the break-even is small.
+            /// Scan the null map once per block. Any non-zero byte means NULL, so the block is
+            /// null-free exactly when every byte is zero.
             const size_t size = null_map_container.size();
-            block_has_no_nulls = (size == 0) || (std::memchr(null_map_data, 1, size) == nullptr);
+            block_has_no_nulls = memoryIsZero(null_map_data, 0, size);
         }
     }
 
@@ -604,7 +601,7 @@ protected:
             if (null_maps[k] != nullptr)
             {
                 const auto & null_map = assert_cast<const ColumnUInt8 &>(*null_maps[k]).getData();
-                if (null_map[row] == 1)
+                if (null_map[row] != 0)
                 {
                     size_t bucket = k / 8;
                     size_t offset = k % 8;

--- a/src/Functions/FunctionDictGetKeys.cpp
+++ b/src/Functions/FunctionDictGetKeys.cpp
@@ -41,6 +41,7 @@
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnsNumber.h>
+#include <Columns/FilterDescription.h>
 
 namespace DB
 {
@@ -192,16 +193,8 @@ protected:
         ColumnPtr filter_column
             = equals_function->execute(equals_args, equals_function->getResultType(), rows_in_chunk, false)->convertToFullColumnIfConst();
 
-        if (const auto * nullable = checkAndGetColumn<ColumnNullable>(filter_column.get()))
-        {
-            auto materialized = ColumnUInt8::create(rows_in_chunk);
-            auto & out = materialized->getData();
-            const auto & data = assert_cast<const ColumnUInt8 &>(nullable->getNestedColumn()).getData();
-            const auto & nullmap = nullable->getNullMapData();
-            for (size_t i = 0; i < rows_in_chunk; ++i)
-                out[i] = data[i] & ~nullmap[i];
-            filter_column = std::move(materialized);
-        }
+        /// Reduces a nullable comparison result to a plain filter: value AND not-null, both as predicates.
+        filter_column = FilterDescription::preprocessFilterColumn(filter_column);
 
         const auto & filter = assert_cast<const ColumnUInt8 &>(*filter_column).getData();
         const size_t matched_in_chunk = countBytesInFilter(filter);
@@ -762,16 +755,7 @@ private:
                 = equals_function->execute(equals_args, equals_function->getResultType(), rows_in_chunk, false)
                       ->convertToFullColumnIfConst();
 
-            if (const auto * nullable = checkAndGetColumn<ColumnNullable>(filter_column.get()))
-            {
-                auto materialized = ColumnUInt8::create(rows_in_chunk);
-                auto & filter_data = materialized->getData();
-                const auto & data = assert_cast<const ColumnUInt8 &>(nullable->getNestedColumn()).getData();
-                const auto & nullmap = nullable->getNullMapData();
-                for (size_t i = 0; i < rows_in_chunk; ++i)
-                    filter_data[i] = data[i] & ~nullmap[i];
-                filter_column = std::move(materialized);
-            }
+            filter_column = FilterDescription::preprocessFilterColumn(filter_column);
 
             const auto & filter = assert_cast<const ColumnUInt8 &>(*filter_column).getData();
 

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -1164,8 +1164,11 @@ FunctionCast::WrapperType FunctionCast::createTupleWrapper(const DataTypePtr & f
                     if (source_null_map_col)
                     {
                         const auto & source_null_map = assert_cast<const ColumnUInt8 &>(*source_null_map_col).getData();
+                        /// Both operands are predicates: complementing a truthy source byte such as
+                        /// 2 leaves bit 0 clear, which would read that NULL row as present.
                         for (size_t row = 0; row < input_rows_count; ++row)
-                            null_map_data[row] |= result_null_map[row] & ~source_null_map[row];
+                            null_map_data[row] |= static_cast<UInt8>(result_null_map[row] != 0)
+                                & static_cast<UInt8>(source_null_map[row] == 0);
                     }
                     else
                     {

--- a/src/Functions/multiIf.cpp
+++ b/src/Functions/multiIf.cpp
@@ -400,7 +400,9 @@ private:
                     /// Equivalent to below code. But it is able to utilize SIMD instructions.
                     /// if (!condition_null_map[row_i] && condition_nested_data[row_i])
                     ///     inserts[row_i] = i;
-                    inserts[row_i] += (~condition_null_map[row_i] & (!!condition_nested_data[row_i])) * (i - inserts[row_i]);
+                    const auto not_null = static_cast<UInt8>(!condition_null_map[row_i]);
+                    const auto is_true = static_cast<UInt8>(!!condition_nested_data[row_i]);
+                    inserts[row_i] += (not_null & is_true) * (i - inserts[row_i]);
                 }
             }
         }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/DataFileStatistics.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/DataFileStatistics.cpp
@@ -51,8 +51,9 @@ void DataFileStatistics::update(const Chunk & chunk)
         column_sizes[i] += col->byteSize();
         if (const auto * nullable_col = checkAndGetColumn<ColumnNullable>(col.get()))
         {
+            /// Any non-zero byte means NULL, so count the rows and not the byte values.
             for (UInt8 v : nullable_col->getNullMapData())
-                null_counts[i] += v;
+                null_counts[i] += (v != 0);
         }
         ranges[i] = uniteRanges(ranges[i], getExtremeRangeFromColumn(col));
     }

--- a/src/Storages/Statistics/StatisticsBasic.cpp
+++ b/src/Storages/Statistics/StatisticsBasic.cpp
@@ -61,7 +61,7 @@ UInt64 sumNonNullStringBytes(const ColumnPtr & column)
     {
         UInt64 non_null = column_size;
         if (null_map)
-            non_null -= std::count(null_map->begin(), null_map->end(), 1);
+            non_null -= std::count_if(null_map->begin(), null_map->end(), [](UInt8 byte) { return byte != 0; });
         return fs->getN() * non_null;
     }
     if (const auto * s = typeid_cast<const ColumnString *>(values.get()))

--- a/tests/queries/0_stateless/05210_nullable_non_canonical_null_map.reference
+++ b/tests/queries/0_stateless/05210_nullable_non_canonical_null_map.reference
@@ -1,0 +1,79 @@
+-- { echo }
+-- Random settings limits: compile_expressions=(0, 0); ratio_of_defaults_for_sparse_serialization=(1.0, 1.0)
+-- A null-map byte is a predicate, not a value: any non-zero byte means NULL. `if` passes its raw
+-- condition column on as the null map, so `number % 3` fills it with the bytes 0, 1 and 2. Byte 0
+-- marks the rows holding 'x'; the 1s and the 2s are equally NULL. Every reader below must agree
+-- with `isNullAt` and treat 1 and 2 alike.
+-- The aggregates read the DISTINCT result from the outside: an `ORDER BY` on the DISTINCT itself
+-- would sort the keys and answer from `compareAt`, which is nullness-based already.
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT if(number % 3, NULL, 'x') AS e FROM numbers(30));
+2	1	['x']
+SELECT 1 AS k, if(number % 3, NULL, 'x') AS e FROM numbers(30) GROUP BY k, e ORDER BY e NULLS FIRST;
+1	\N
+1	x
+-- Multiplying the condition by 2 leaves no byte equal to 1 in the null map. A reader that scans for
+-- the literal byte 1 then reports the block as NULL-free and merges the NULL rows into the value.
+SELECT e FROM (SELECT if(toUInt8((number % 3) * 2), NULL, 'x') AS e FROM numbers(30)) GROUP BY e ORDER BY e NULLS FIRST;
+\N
+x
+SELECT DISTINCT if(toUInt8((number % 3) * 2), NULL, toUInt32(7)) FROM numbers(30) ORDER BY 1 NULLS FIRST;
+\N
+7
+SELECT DISTINCT tuple(if(number % 3, NULL, 'x')) FROM numbers(30) ORDER BY 1;
+('x')
+(NULL)
+-- Negating a null map must negate its nullness, not its bits: `1 ^ 2` is truthy, which turned rows
+-- holding 'x' into NULLs. Only the group whose condition byte is 2 was affected.
+SELECT number % 3 AS c, countIf(v IS NULL) FROM (SELECT number, if(number % 3, toNullable('x'), NULL) AS v FROM numbers(30)) GROUP BY c ORDER BY c;
+0	10
+1	0
+2	0
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT if(number % 3, NULL, CAST('x' AS LowCardinality(Nullable(String)))) AS e FROM numbers(30));
+2	1	['x']
+-- A NULL condition selects no branch. Only a three-argument `multiIf` is rewritten to `if`
+-- (`MultiIfToIfPass`), so the five arguments here keep it on `multiIf`'s own columnar path.
+SELECT r, count() FROM (SELECT multiIf(if(number % 3, NULL, toUInt8(1)), toUInt32(11), number % 7 = 0, toUInt32(33), toUInt32(22)) AS r FROM numbers(30)) GROUP BY r ORDER BY r;
+11	10
+22	17
+33	3
+-- An aggregate whose result is Nullable must return NULL for a block in which every row is NULL. The
+-- bytes here are 2, 4 and 6, so a reader looking for the literal byte 1 finds none, calls the block
+-- non-NULL, and emits the nested aggregate's never-updated state.
+SELECT max(if(toUInt8((number % 3) * 2 + 2), NULL, 'x')) AS m, m IS NULL AS m_is_null FROM numbers(30);
+\N	1
+-- Two non-empty variants are needed to reach the general Variant null-map branch; with a single
+-- variant and no existing NULLs a separate fast path applies, which is nullness-based already.
+SELECT countIf(v IS NULL) FROM (SELECT if(number % 3, if(number % 2, 'x', toUInt8(7)), NULL) AS v FROM numbers(30));
+10
+-- Only a NULL that is NEW in the converted element is a conversion failure. 1000 overflows UInt8, so
+-- the byte-0 rows are the only failures; a source NULL must stay a tuple holding NULL, not a NULL
+-- tuple. The target element type must differ from the source, or the result map IS the source map.
+SELECT countIf(tp IS NULL) FROM (SELECT accurateCastOrNull(tuple(if(number % 3, NULL, toUInt16(1000))), 'Tuple(Nullable(UInt8))') AS tp FROM numbers(30));
+10
+-- Such a null map survives a write and read back, so it is not confined to expression results.
+CREATE TABLE t_null_map_bytes (e Nullable(String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_null_map_bytes SELECT if(number % 3, NULL, 'x') FROM numbers(30);
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT e FROM t_null_map_bytes);
+2	1	['x']
+DROP TABLE t_null_map_bytes;
+-- A DIRECT layout reads its source rows on demand and passes them through, so the stored null map
+-- reaches the reverse lookup's own comparison result. A NULL attribute must not match a value. The
+-- caching layouts rebuild the map, which is why only DIRECT exposes this.
+CREATE TABLE t_null_map_dict_src (id UInt64, attr Nullable(String)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_null_map_dict_src SELECT number, if(number % 3, NULL, 'x') FROM numbers(30);
+CREATE DICTIONARY d_null_map_direct (id UInt64, attr Nullable(String)) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 't_null_map_dict_src')) LAYOUT(DIRECT());
+SELECT length(dictGetKeys('d_null_map_direct', 'attr', 'x'));
+10
+DROP DICTIONARY d_null_map_direct;
+DROP TABLE t_null_map_dict_src;
+-- Controls: a canonical 0/1 null map must be unaffected.
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT if(number % 2, NULL, 'x') AS e FROM numbers(30));
+2	1	['x']
+SELECT number % 2 AS c, countIf(v IS NULL) FROM (SELECT number, if(number % 2, toNullable('x'), NULL) AS v FROM numbers(30)) GROUP BY c ORDER BY c;
+0	15
+1	0
+-- The reported query: DISTINCT and GROUP BY over one projection must agree.
+SELECT
+    (SELECT count() FROM (SELECT DISTINCT multiIf(number % -1, -9223372036854775808 < moduloLegacy(number, NULL), '^$') FROM numbers(150))) AS distinct_rows,
+    (SELECT count() FROM (SELECT multiIf(number % -1, -9223372036854775808 < moduloLegacy(number, NULL), '^$') AS e FROM numbers(150) GROUP BY e)) AS group_by_rows;
+2	2

--- a/tests/queries/0_stateless/05210_nullable_non_canonical_null_map.sql
+++ b/tests/queries/0_stateless/05210_nullable_non_canonical_null_map.sql
@@ -1,0 +1,54 @@
+-- { echo }
+-- Random settings limits: compile_expressions=(0, 0); ratio_of_defaults_for_sparse_serialization=(1.0, 1.0)
+-- A null-map byte is a predicate, not a value: any non-zero byte means NULL. `if` passes its raw
+-- condition column on as the null map, so `number % 3` fills it with the bytes 0, 1 and 2. Byte 0
+-- marks the rows holding 'x'; the 1s and the 2s are equally NULL. Every reader below must agree
+-- with `isNullAt` and treat 1 and 2 alike.
+-- The aggregates read the DISTINCT result from the outside: an `ORDER BY` on the DISTINCT itself
+-- would sort the keys and answer from `compareAt`, which is nullness-based already.
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT if(number % 3, NULL, 'x') AS e FROM numbers(30));
+SELECT 1 AS k, if(number % 3, NULL, 'x') AS e FROM numbers(30) GROUP BY k, e ORDER BY e NULLS FIRST;
+-- Multiplying the condition by 2 leaves no byte equal to 1 in the null map. A reader that scans for
+-- the literal byte 1 then reports the block as NULL-free and merges the NULL rows into the value.
+SELECT e FROM (SELECT if(toUInt8((number % 3) * 2), NULL, 'x') AS e FROM numbers(30)) GROUP BY e ORDER BY e NULLS FIRST;
+SELECT DISTINCT if(toUInt8((number % 3) * 2), NULL, toUInt32(7)) FROM numbers(30) ORDER BY 1 NULLS FIRST;
+SELECT DISTINCT tuple(if(number % 3, NULL, 'x')) FROM numbers(30) ORDER BY 1;
+-- Negating a null map must negate its nullness, not its bits: `1 ^ 2` is truthy, which turned rows
+-- holding 'x' into NULLs. Only the group whose condition byte is 2 was affected.
+SELECT number % 3 AS c, countIf(v IS NULL) FROM (SELECT number, if(number % 3, toNullable('x'), NULL) AS v FROM numbers(30)) GROUP BY c ORDER BY c;
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT if(number % 3, NULL, CAST('x' AS LowCardinality(Nullable(String)))) AS e FROM numbers(30));
+-- A NULL condition selects no branch. Only a three-argument `multiIf` is rewritten to `if`
+-- (`MultiIfToIfPass`), so the five arguments here keep it on `multiIf`'s own columnar path.
+SELECT r, count() FROM (SELECT multiIf(if(number % 3, NULL, toUInt8(1)), toUInt32(11), number % 7 = 0, toUInt32(33), toUInt32(22)) AS r FROM numbers(30)) GROUP BY r ORDER BY r;
+-- An aggregate whose result is Nullable must return NULL for a block in which every row is NULL. The
+-- bytes here are 2, 4 and 6, so a reader looking for the literal byte 1 finds none, calls the block
+-- non-NULL, and emits the nested aggregate's never-updated state.
+SELECT max(if(toUInt8((number % 3) * 2 + 2), NULL, 'x')) AS m, m IS NULL AS m_is_null FROM numbers(30);
+-- Two non-empty variants are needed to reach the general Variant null-map branch; with a single
+-- variant and no existing NULLs a separate fast path applies, which is nullness-based already.
+SELECT countIf(v IS NULL) FROM (SELECT if(number % 3, if(number % 2, 'x', toUInt8(7)), NULL) AS v FROM numbers(30));
+-- Only a NULL that is NEW in the converted element is a conversion failure. 1000 overflows UInt8, so
+-- the byte-0 rows are the only failures; a source NULL must stay a tuple holding NULL, not a NULL
+-- tuple. The target element type must differ from the source, or the result map IS the source map.
+SELECT countIf(tp IS NULL) FROM (SELECT accurateCastOrNull(tuple(if(number % 3, NULL, toUInt16(1000))), 'Tuple(Nullable(UInt8))') AS tp FROM numbers(30));
+-- Such a null map survives a write and read back, so it is not confined to expression results.
+CREATE TABLE t_null_map_bytes (e Nullable(String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_null_map_bytes SELECT if(number % 3, NULL, 'x') FROM numbers(30);
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT e FROM t_null_map_bytes);
+DROP TABLE t_null_map_bytes;
+-- A DIRECT layout reads its source rows on demand and passes them through, so the stored null map
+-- reaches the reverse lookup's own comparison result. A NULL attribute must not match a value. The
+-- caching layouts rebuild the map, which is why only DIRECT exposes this.
+CREATE TABLE t_null_map_dict_src (id UInt64, attr Nullable(String)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_null_map_dict_src SELECT number, if(number % 3, NULL, 'x') FROM numbers(30);
+CREATE DICTIONARY d_null_map_direct (id UInt64, attr Nullable(String)) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 't_null_map_dict_src')) LAYOUT(DIRECT());
+SELECT length(dictGetKeys('d_null_map_direct', 'attr', 'x'));
+DROP DICTIONARY d_null_map_direct;
+DROP TABLE t_null_map_dict_src;
+-- Controls: a canonical 0/1 null map must be unaffected.
+SELECT count(), countIf(e IS NULL), arraySort(groupUniqArray(e)) FROM (SELECT DISTINCT if(number % 2, NULL, 'x') AS e FROM numbers(30));
+SELECT number % 2 AS c, countIf(v IS NULL) FROM (SELECT number, if(number % 2, toNullable('x'), NULL) AS v FROM numbers(30)) GROUP BY c ORDER BY c;
+-- The reported query: DISTINCT and GROUP BY over one projection must agree.
+SELECT
+    (SELECT count() FROM (SELECT DISTINCT multiIf(number % -1, -9223372036854775808 < moduloLegacy(number, NULL), '^$') FROM numbers(150))) AS distinct_rows,
+    (SELECT count() FROM (SELECT multiIf(number % -1, -9223372036854775808 < moduloLegacy(number, NULL), '^$') AS e FROM numbers(150) GROUP BY e)) AS group_by_rows;

--- a/tests/queries/0_stateless/05211_iceberg_noncanonical_null_map_statistics.reference
+++ b/tests/queries/0_stateless/05211_iceberg_noncanonical_null_map_statistics.reference
@@ -1,0 +1,2 @@
+--- a null count is the number of NULL rows, never the sum of the null-map bytes ---
+30	20	0

--- a/tests/queries/0_stateless/05211_iceberg_noncanonical_null_map_statistics.sh
+++ b/tests/queries/0_stateless/05211_iceberg_noncanonical_null_map_statistics.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+TABLE_PATH="${CLICKHOUSE_USER_FILES}/lakehouses/${CLICKHOUSE_DATABASE}_null_map_bytes"
+rm -rf "${TABLE_PATH}"
+
+# `if` forwards its raw condition column as the null map, so the map here holds 0, 2 and 4: byte 0
+# marks the 10 rows holding 'x' and the 2s and 4s are the 20 rows that are equally NULL.
+${CLICKHOUSE_CLIENT} --query "
+    SET allow_experimental_insert_into_iceberg = 1;
+    SET max_insert_threads = 1;
+    CREATE TABLE t_null_map_bytes_iceberg (id UInt64, e Nullable(String))
+    ENGINE = IcebergLocal('${TABLE_PATH}', 'Parquet') ORDER BY (id);
+    INSERT INTO t_null_map_bytes_iceberg SELECT number, if(toUInt8((number % 3) * 2), NULL, 'x') FROM numbers(30);
+"
+
+echo '--- a null count is the number of NULL rows, never the sum of the null-map bytes ---'
+${CLICKHOUSE_CLIENT} --query "
+    SELECT
+        sum(record_count) AS rows,
+        sum(null_value_counts[2]) AS nulls,
+        countIf(null_value_counts[2] > record_count) AS impossible_entries
+    FROM system.iceberg_files
+    WHERE database = currentDatabase() AND table = 't_null_map_bytes_iceberg' AND content = 0;
+"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE t_null_map_bytes_iceberg;"
+rm -rf "${TABLE_PATH}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/119633
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes wrong results when a `Nullable` column's null map contains bytes other than 0 and 1, which the Native format explicitly permits. `DISTINCT` and `GROUP BY` treated different non-zero null-map bytes as different `NULL` keys, a `GROUP BY` key could silently lose its entire `NULL` group, `if(cond, x, NULL)` could replace a present value with `NULL`, and an Iceberg `INSERT` could record more `NULL`s in a data file's statistics than the file has rows. Closes #119633.

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/119633

Per `docs/reference/interfaces/specs/NativeFormat.mdx` the null map is a predicate, one byte per row: `0x00` present, **non-zero (canonically `0x01`) NULL**. `SerializationNullable` reads it back verbatim, so such a map is valid input, possibly already on disk; `isNullAt` implements `bytes[n] != 0`.

Eighteen readers instead treated it as a value: hashed, packed into a key, tested against the literal `1`, summed. `if` forwards its raw condition column as the null map, so `if(number % 3, NULL, 'x')` fills it with bytes 0, 1 and 2, where 1 and 2 are equally NULL. On `numbers(30)`, and after a MergeTree round trip:

- `DISTINCT` and `GROUP BY` return 3 rows where 2 is correct (the report). Not the nested placeholder: the key encoder hashes the null byte and stops;
- with no byte `1` in the map (`if(toUInt8((number % 3) * 2), NULL, 'x')`), a scan for that byte calls the block NULL-free and the **whole NULL group disappears**;
- `if(number % 3, toNullable('x'), NULL)` nulls 20 rows instead of 10, because `negative ^ map[i]` computes `1 ^ 2 = 3`: **a present value replaced by NULL**.

Every changed site now agrees with `isNullAt`: five key encoders, five literal-byte checks, three raw-arithmetic sites, five bitwise "present" expressions, all bit-identical on canonical data. `if.cpp` stays unchanged: its output is valid, and normalizing cannot repair an existing part. `isNull`, `.null` and the insert-deduplication block hash still see the raw byte: separate changes.

States written by an older server keep their raw bytes: an arena key still deserializes to `NULL`, so it merges into two `NULL` keys, while a hash-only state like `uniqExact(tuple(x))` has no key to normalize and stays over-counted. I add no state versioning.

Found by the AST fuzzer + correctness oracles fleet (#99980), `complete52-m0911`, DISTINCT-via-GROUP-BY oracle, inst 00 run 27, 2026-09-12 12:01 UTC.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=119729&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/119729](https://github.com/search?q=head%3Async-upstream%2Fpr%2F119729+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



